### PR TITLE
Persist resolved SPOT missing components

### DIFF
--- a/backend/pricing_v4/engine/import_engine.py
+++ b/backend/pricing_v4/engine/import_engine.py
@@ -748,8 +748,9 @@ class ImportPricingEngine:
         """
         Get COGS for a product code.
         Destination-local import charges live in LocalCOGSRate.
-        Origin-local and freight import charges remain lane-based in ImportCOGS,
-        with a LocalCOGSRate fallback for legacy migrated datasets.
+        Origin-local and freight import charges remain aligned to the shipment
+        origin, so destination-side local tariffs must never satisfy missing
+        foreign origin-local charges.
         """
         if leg == 'DESTINATION' and is_local_rate_category(pc.category):
             return self._get_local_cogs(pc, leg)
@@ -790,12 +791,11 @@ class ImportPricingEngine:
         Lookup local COGS from centralized table for IMPORT.
 
         Lookup order:
-        - DESTINATION leg: destination station first.
-        - ORIGIN leg: origin station first.
-        - Compatibility fallback for legacy migrated datasets: destination station.
+        - DESTINATION leg: destination station only.
+        - ORIGIN leg: origin station only.
         """
         if leg == 'ORIGIN':
-            location_candidates = [self.origin, self.destination]
+            location_candidates = [self.origin]
         else:
             location_candidates = [self.destination]
 

--- a/backend/pricing_v4/tests/test_import_engine.py
+++ b/backend/pricing_v4/tests/test_import_engine.py
@@ -374,10 +374,11 @@ class ImportFullQuoteTest(ImportEngineTestCase):
         self.assertEqual(result.line_items[0].rule_family, CALCULATION_LOOKUP_RATE)
 
 
-class ImportD2DOriginLocalFallbackTest(ImportEngineTestCase):
+class ImportD2DOriginLocalLocationAlignmentTest(ImportEngineTestCase):
     """
     Regression guard:
-    Import ORIGIN local charges must be resolvable from LocalCOGSRate.
+    Import ORIGIN local charges must not be sourced from destination-side
+    LocalCOGSRate rows when origin-side coverage is missing.
     """
 
     def setUp(self):
@@ -393,7 +394,6 @@ class ImportD2DOriginLocalFallbackTest(ImportEngineTestCase):
             gl_cost_code='5200',
             default_unit='SHIPMENT'
         )
-
         # Freight lane COGS exists for linehaul
         ImportCOGS.objects.create(
             product_code=self.pc_freight,
@@ -406,8 +406,7 @@ class ImportD2DOriginLocalFallbackTest(ImportEngineTestCase):
             valid_until=self.valid_until
         )
 
-        # Import ORIGIN local charge stored in LocalCOGSRate using destination location
-        # (legacy migration compatibility shape).
+        # Destination-side row with an ORIGIN product code must not satisfy ORIGIN_LOCAL.
         LocalCOGSRate.objects.create(
             product_code=self.pc_doc_origin,
             location='POM',
@@ -419,8 +418,30 @@ class ImportD2DOriginLocalFallbackTest(ImportEngineTestCase):
             valid_from=self.valid_from,
             valid_until=self.valid_until
         )
+        LocalCOGSRate.objects.create(
+            product_code=self.pc_clearance,
+            location='POM',
+            direction='IMPORT',
+            agent=self.agent_efm,
+            currency='PGK',
+            rate_type='FIXED',
+            amount=Decimal('350.00'),
+            valid_from=self.valid_from,
+            valid_until=self.valid_until
+        )
+        LocalSellRate.objects.create(
+            product_code=self.pc_clearance,
+            location='POM',
+            direction='IMPORT',
+            payment_term='COLLECT',
+            currency='PGK',
+            rate_type='FIXED',
+            amount=Decimal('500.00'),
+            valid_from=self.valid_from,
+            valid_until=self.valid_until
+        )
 
-    def test_d2d_collect_does_not_mark_origin_local_as_missing(self):
+    def test_d2d_collect_keeps_origin_local_missing_when_only_destination_local_db_rows_exist(self):
         engine = ImportPricingEngine(
             quote_date=date.today(),
             origin='BNE',
@@ -434,7 +455,12 @@ class ImportD2DOriginLocalFallbackTest(ImportEngineTestCase):
         doc_origin_lines = [l for l in result.origin_lines if l.product_code == 'IMP-DOC-ORIGIN']
         self.assertEqual(len(doc_origin_lines), 1)
         line = doc_origin_lines[0]
-        self.assertFalse(getattr(line, 'is_rate_missing', False))
+        self.assertTrue(getattr(line, 'is_rate_missing', False))
+        self.assertEqual(line.cost_amount, Decimal('0'))
+
+        destination_lines = [l for l in result.destination_lines if l.product_code == 'IMP-CLEAR']
+        self.assertEqual(len(destination_lines), 1)
+        self.assertFalse(getattr(destination_lines[0], 'is_rate_missing', False))
 
 
 class ImportD2DOriginLaneCogsTest(ImportEngineTestCase):

--- a/backend/quotes/migrations/0027_spotpricingenvelopedb_resolved_missing_components.py
+++ b/backend/quotes/migrations/0027_spotpricingenvelopedb_resolved_missing_components.py
@@ -1,0 +1,45 @@
+from django.db import migrations, models
+
+
+def _normalize_missing_components(raw_value):
+    if raw_value is None:
+        return []
+    if isinstance(raw_value, str):
+        raw_list = [item.strip() for item in raw_value.split(",")]
+    elif isinstance(raw_value, (list, tuple, set)):
+        raw_list = list(raw_value)
+    else:
+        return []
+    return [str(item).upper() for item in raw_list if str(item).strip()]
+
+
+def backfill_resolved_missing_components(apps, schema_editor):
+    SpotPricingEnvelopeDB = apps.get_model("quotes", "SpotPricingEnvelopeDB")
+    for envelope in SpotPricingEnvelopeDB.objects.all().only("id", "shipment_context_json"):
+        ctx = envelope.shipment_context_json or {}
+        envelope.resolved_missing_components = _normalize_missing_components(
+            ctx.get("missing_components")
+        )
+        envelope.save(update_fields=["resolved_missing_components"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("quotes", "0026_add_canonical_audit_metadata"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="spotpricingenvelopedb",
+            name="resolved_missing_components",
+            field=models.JSONField(
+                default=list,
+                help_text="Cached list of SPOT components still missing actionable charges.",
+            ),
+        ),
+        migrations.RunPython(
+            backfill_resolved_missing_components,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/backend/quotes/quote_result_contract.py
+++ b/backend/quotes/quote_result_contract.py
@@ -689,7 +689,7 @@ def line_item_from_quote_line(
     return {
         "line_id": str(getattr(line, "id", "") or ""),
         "product_code": getattr(line, "product_code", None) or getattr(service_component, "code", None) or "",
-        "description": getattr(service_component, "description", None) or getattr(line, "cost_source_description", None) or "Charge",
+        "description": getattr(line, "cost_source_description", None) or getattr(service_component, "description", None) or "Charge",
         "component": component,
         "basis": getattr(line, "basis", None) or basis_for_unit(unit_type),
         "rule_family": persisted_rule_family,

--- a/backend/quotes/serializers.py
+++ b/backend/quotes/serializers.py
@@ -5,6 +5,7 @@ import re
 from rest_framework import serializers
 from quotes.branding import get_quote_branding
 from .models import Quote, QuoteVersion, QuoteLine, QuoteTotal
+from .spot_models import _normalize_spot_shipment_context
 from services.models import ServiceComponent, SERVICE_SCOPE_CHOICES
 from parties.models import Company, Contact
 # --- ADDED IMPORTS ---
@@ -127,7 +128,14 @@ class V3QuoteLineSerializer(serializers.ModelSerializer):
     service_component = V3ServiceComponentSerializer()
     # Alias for frontend compatibility (some components look for 'component' code)
     component = serializers.CharField(source='service_component.code', read_only=True)
-    description = serializers.CharField(source='service_component.description', read_only=True)
+    description = serializers.SerializerMethodField()
+
+    def get_description(self, obj):
+        return (
+            getattr(obj, 'cost_source_description', None)
+            or getattr(getattr(obj, 'service_component', None), 'description', None)
+            or 'Charge'
+        )
     
     class Meta:
         model = QuoteLine
@@ -399,10 +407,18 @@ class QuoteModelSerializerV3(serializers.ModelSerializer):
         return ", ".join(sorted(providers))
 
     def get_spot_negotiation(self, obj):
-        spe = getattr(obj, 'spot_envelopes', None)
-        if not spe:
-            return None
-        latest = spe.order_by('-created_at', '-id').first()
+        prefetched = getattr(obj, "_prefetched_objects_cache", {}).get("spot_envelopes")
+        if prefetched is not None:
+            latest = max(
+                prefetched,
+                key=lambda item: (item.created_at, item.id),
+                default=None,
+            )
+        else:
+            spe = getattr(obj, 'spot_envelopes', None)
+            if not spe:
+                return None
+            latest = spe.only('id', 'created_at').order_by('-created_at', '-id').first()
         if not latest:
             return None
         return {'id': str(latest.id)}
@@ -656,7 +672,7 @@ class SPEAcknowledgementSerializer(serializers.ModelSerializer):
 
 class SpotPricingEnvelopeSerializer(serializers.ModelSerializer):
     customer_name = serializers.SerializerMethodField()
-    shipment = serializers.JSONField(source='shipment_context_json')
+    shipment = serializers.SerializerMethodField()
     conditions = serializers.JSONField(source='conditions_json')
     charges = SPEChargeLineSerializer(source='charge_lines', many=True, read_only=True)
     sources = SPESourceBatchSerializer(source='source_batches', many=True, read_only=True)
@@ -689,6 +705,18 @@ class SpotPricingEnvelopeSerializer(serializers.ModelSerializer):
         if customer_name:
             return str(customer_name)
         return None
+
+    def get_shipment(self, obj):
+        shipment_ctx = _normalize_spot_shipment_context(
+            getattr(obj, "shipment_context_json", None) or {},
+            quote_payment_term=getattr(getattr(obj, "quote", None), "payment_term", None),
+        )
+        shipment_ctx["missing_components"] = list(
+            getattr(obj, "resolved_missing_components", None)
+            or shipment_ctx.get("missing_components")
+            or []
+        )
+        return shipment_ctx
 
     def get_has_acknowledgement(self, obj):
         return hasattr(obj, 'acknowledgement') and obj.acknowledgement is not None

--- a/backend/quotes/spot_models.py
+++ b/backend/quotes/spot_models.py
@@ -1,4 +1,5 @@
 import uuid
+from types import SimpleNamespace
 from django.db import models
 from django.conf import settings
 from django.utils import timezone
@@ -8,6 +9,131 @@ from django.utils.translation import gettext_lazy as _
 # =============================================================================
 # SPOT PRICING ENVELOPE (SPE) MODELS
 # =============================================================================
+
+
+def _normalize_spot_missing_components(raw_value):
+    if raw_value is None:
+        return None
+    if isinstance(raw_value, str):
+        raw_list = [item.strip() for item in raw_value.split(",")]
+    elif isinstance(raw_value, (list, tuple, set)):
+        raw_list = list(raw_value)
+    else:
+        return []
+    return [str(item).upper() for item in raw_list if str(item).strip()]
+
+
+def _normalize_spot_shipment_context(ctx: dict, quote_payment_term=None) -> dict:
+    normalized = dict(ctx or {})
+    origin_code = str(normalized.get("origin_code") or "").upper()
+    destination_code = str(normalized.get("destination_code") or "").upper()
+    normalized["origin_code"] = origin_code
+    normalized["destination_code"] = destination_code
+
+    try:
+        from quotes.spot_services import ScopeValidator
+
+        origin_country, destination_country = ScopeValidator.normalize_countries(
+            origin_country=normalized.get("origin_country"),
+            destination_country=normalized.get("destination_country"),
+            origin_airport=origin_code,
+            destination_airport=destination_code,
+        )
+        normalized["origin_country"] = origin_country
+        normalized["destination_country"] = destination_country
+    except Exception:
+        pass
+
+    payment_term = str(
+        normalized.get("payment_term")
+        or quote_payment_term
+        or ""
+    ).strip().upper()
+    if payment_term in {"PREPAID", "COLLECT"}:
+        normalized["payment_term"] = payment_term
+    elif "payment_term" in normalized:
+        normalized.pop("payment_term", None)
+
+    normalized["missing_components"] = _normalize_spot_missing_components(
+        normalized.get("missing_components")
+    )
+    return normalized
+
+
+def _shipment_type_from_spot_context(ctx: dict) -> str:
+    origin_country = str(ctx.get("origin_country") or "").upper()
+    destination_country = str(ctx.get("destination_country") or "").upper()
+    if origin_country == "PG" and destination_country == "PG":
+        return "DOMESTIC"
+    if origin_country == "PG":
+        return "EXPORT"
+    return "IMPORT"
+
+
+def resolve_spot_missing_components(
+    ctx: dict,
+    charge_lines,
+    *,
+    quote_payment_term=None,
+) -> list[str] | None:
+    normalized = _normalize_spot_shipment_context(
+        ctx,
+        quote_payment_term=quote_payment_term,
+    )
+    stored_missing = normalized.get("missing_components")
+    origin_code = normalized.get("origin_code") or ""
+    destination_code = normalized.get("destination_code") or ""
+    if not origin_code or not destination_code:
+        return stored_missing
+
+    service_scope = str(normalized.get("service_scope") or "P2P")
+    shipment_type = _shipment_type_from_spot_context(normalized)
+    payment_term = normalized.get("payment_term")
+
+    try:
+        from quotes.completeness import evaluate_from_lines
+        from quotes.spot_services import RateAvailabilityService
+
+        availability = RateAvailabilityService.get_availability(
+            origin_airport=origin_code,
+            destination_airport=destination_code,
+            direction=shipment_type,
+            service_scope=service_scope,
+            payment_term=payment_term,
+        )
+
+        availability_buckets = {
+            "FREIGHT": "airfreight",
+            "ORIGIN_LOCAL": "origin_charges",
+            "DESTINATION_LOCAL": "destination_charges",
+        }
+
+        coverage_lines = [
+            SimpleNamespace(bucket=bucket, is_rate_missing=False, is_informational=False)
+            for component, bucket in availability_buckets.items()
+            if availability.get(component)
+        ]
+
+        for line in charge_lines or ():
+            amount = getattr(line, "amount", None)
+            if amount is None or amount <= 0:
+                continue
+            if getattr(line, "conditional", False):
+                continue
+            if getattr(line, "exclude_from_totals", False):
+                continue
+            coverage_lines.append(
+                SimpleNamespace(
+                    bucket=getattr(line, "bucket", None),
+                    is_rate_missing=False,
+                    is_informational=False,
+                )
+            )
+
+        coverage = evaluate_from_lines(coverage_lines, shipment_type, service_scope)
+        return coverage.missing_required
+    except Exception:
+        return stored_missing
 
 class SpotPricingEnvelopeDB(models.Model):
     """
@@ -41,6 +167,10 @@ class SpotPricingEnvelopeDB(models.Model):
     shipment_context_hash = models.CharField(
         max_length=64,
         help_text="SHA256 hash of shipment_context_json for integrity verification."
+    )
+    resolved_missing_components = models.JSONField(
+        default=list,
+        help_text="Cached list of SPOT components still missing actionable charges."
     )
     
     # Conditions stored as JSON
@@ -97,6 +227,15 @@ class SpotPricingEnvelopeDB(models.Model):
         if not self.shipment_context_hash:
             normalized = json.dumps(self.shipment_context_json, sort_keys=True)
             self.shipment_context_hash = hashlib.sha256(normalized.encode()).hexdigest()
+        if self._state.adding and not self.resolved_missing_components:
+            self.resolved_missing_components = list(
+                resolve_spot_missing_components(
+                    self.shipment_context_json,
+                    (),
+                    quote_payment_term=getattr(self.quote, "payment_term", None),
+                )
+                or []
+            )
         
         super().save(*args, **kwargs)
     
@@ -113,6 +252,22 @@ class SpotPricingEnvelopeDB(models.Model):
     def is_expired(self) -> bool:
         """Check if SPE has expired."""
         return timezone.now() >= self.expires_at
+
+    def refresh_resolved_missing_components(self, *, save: bool = True) -> list[str]:
+        resolved = list(
+            resolve_spot_missing_components(
+                self.shipment_context_json,
+                self.charge_lines.all(),
+                quote_payment_term=getattr(self.quote, "payment_term", None),
+            )
+            or []
+        )
+        self.resolved_missing_components = resolved
+        if save and self.pk:
+            type(self).objects.filter(pk=self.pk).update(
+                resolved_missing_components=resolved
+            )
+        return resolved
 
 
 class SPESourceBatchDB(models.Model):
@@ -355,6 +510,11 @@ class SPEChargeLineDB(models.Model):
     
     def __str__(self):
         return f"{self.bucket}: {self.description} ({self.amount} {self.currency})"
+
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        if self.envelope_id:
+            self.envelope.refresh_resolved_missing_components(save=True)
 
 
 class SPEAcknowledgementDB(models.Model):

--- a/backend/quotes/spot_services.py
+++ b/backend/quotes/spot_services.py
@@ -658,12 +658,11 @@ class RateAvailabilityService:
                 availability[classify_import_component(code, category)] = True
 
             # Import local rates can include both ORIGIN and DESTINATION components.
-            # Classify rows by ProductCode, then map by station. Keep a compatibility
-            # fallback so legacy migrated ORIGIN rows stored at destination station
-            # still satisfy ORIGIN_LOCAL coverage checks.
+            # Coverage must stay aligned to the shipment side:
+            # origin-local rows only count at the shipment origin, and
+            # destination-local rows only count at the shipment destination.
             origin_code = (origin_airport or "").upper()
             destination_code = (destination_airport or "").upper()
-            origin_local_fallback_at_destination = False
             local_location_candidates = [loc for loc in [origin_airport, destination_airport] if loc]
 
             import_local_rows = LocalCOGSRate.objects.filter(
@@ -680,16 +679,8 @@ class RateAvailabilityService:
                 if component == COMPONENT_ORIGIN_LOCAL:
                     if location_code == origin_code:
                         availability[COMPONENT_ORIGIN_LOCAL] = True
-                    elif location_code == destination_code:
-                        origin_local_fallback_at_destination = True
                 elif component == COMPONENT_DESTINATION_LOCAL and location_code == destination_code:
                     availability[COMPONENT_DESTINATION_LOCAL] = True
-
-            if not availability[COMPONENT_ORIGIN_LOCAL] and origin_local_fallback_at_destination:
-                availability[COMPONENT_ORIGIN_LOCAL] = True
-
-            if surcharge_exists('IMPORT_ORIGIN', origin=origin_airport):
-                availability[COMPONENT_ORIGIN_LOCAL] = True
 
             if surcharge_exists('IMPORT_DEST', destination=destination_airport):
                 availability[COMPONENT_DESTINATION_LOCAL] = True
@@ -962,10 +953,7 @@ class CommodityRateRuleService:
         if shipment_type == "EXPORT":
             return [origin_airport] if leg != "DESTINATION" else [destination_airport]
         if shipment_type == "IMPORT":
-            if leg == "ORIGIN":
-                # Keep the legacy compatibility fallback used in standard scope availability.
-                return [origin_airport, destination_airport]
-            return [destination_airport]
+            return [origin_airport] if leg == "ORIGIN" else [destination_airport]
         return [origin_airport, destination_airport]
 
     @staticmethod

--- a/backend/quotes/spot_views.py
+++ b/backend/quotes/spot_views.py
@@ -52,6 +52,7 @@ from quotes.spot_models import (
     SPESourceBatchDB,
     SPEChargeLineDB,
     SPEAcknowledgementDB,
+    _normalize_spot_missing_components,
 )
 from quotes.intake_safety import (
     build_source_analysis_summary_payload,
@@ -330,6 +331,16 @@ def _resolve_missing_components_for_context(ctx: dict) -> Optional[list[str]]:
     return _derive_missing_components_from_context(ctx)
 
 
+def _current_resolved_missing_components(spe_db: SpotPricingEnvelopeDB, ctx: dict) -> list[str]:
+    cached = _normalize_spot_missing_components(
+        getattr(spe_db, "resolved_missing_components", None)
+    )
+    if cached is not None:
+        return cached
+    resolved = _resolve_missing_components_for_context(ctx)
+    return list(resolved or [])
+
+
 def _infer_shipment_type(origin_country: str, destination_country: str) -> str:
     if origin_country == "PG" and destination_country == "PG":
         return "DOMESTIC"
@@ -396,7 +407,7 @@ def _build_spe_from_db(
     ctx = _normalize_shipment_context(spe_db.shipment_context_json)
     if not ctx.get("payment_term") and getattr(spe_db, "quote", None) and getattr(spe_db.quote, "payment_term", None):
         ctx["payment_term"] = str(spe_db.quote.payment_term).upper()
-    resolved_missing_components = _resolve_missing_components_for_context(ctx)
+    resolved_missing_components = _current_resolved_missing_components(spe_db, ctx)
     status_value = status_override or spe_db.status
 
     return SpotPricingEnvelope(
@@ -750,6 +761,7 @@ class SpotEnvelopeListCreateAPIView(APIView):
                     entered_by=request.user,
                     entered_at=now,
                 )
+            spe_db.refresh_resolved_missing_components(save=True)
             
             # Validate via Pydantic (will raise if invalid)
             try:
@@ -780,7 +792,7 @@ class SpotEnvelopeListCreateAPIView(APIView):
         ctx = _normalize_shipment_context(spe_db.shipment_context_json)
         if not ctx.get("payment_term") and getattr(spe_db, "quote", None) and getattr(spe_db.quote, "payment_term", None):
             ctx["payment_term"] = str(spe_db.quote.payment_term).upper()
-        resolved_missing_components = _resolve_missing_components_for_context(ctx)
+        resolved_missing_components = _current_resolved_missing_components(spe_db, ctx)
         charges = [
             SPEChargeLine(
                 code=cl.code,
@@ -934,6 +946,7 @@ class SpotEnvelopeDetailAPIView(APIView):
                         entered_by=request.user,
                         entered_at=now,
                     )
+                spe_db.refresh_resolved_missing_components(save=True)
 
             spe_db.save()
             SpotEnvelopeListCreateAPIView()._validate_spe(spe_db)
@@ -1479,6 +1492,7 @@ class SpotReplyAnalysisAPIView(APIView):
                             entered_by=request.user,
                             entered_at=now,
                         )
+                spe_db.refresh_resolved_missing_components(save=True)
 
                 # Update conditional flag in SPE conditions
                 if any(c.get("conditional") for c in auto_charges) or spe_db.charge_lines.filter(conditional=True).exists():

--- a/backend/quotes/tests/test_api_v3.py
+++ b/backend/quotes/tests/test_api_v3.py
@@ -139,6 +139,67 @@ class QuoteRetrieveV3APITest(APITestCase):
         self.assertEqual(totals["total_sell_fcy"], "55.00")
         self.assertEqual(totals["total_sell_fcy_currency"], "USD")
 
+    def test_retrieve_prefers_cost_source_description_for_line_description(self):
+        latest_version = self.quote.versions.order_by('-version_number').first()
+        spot_component = ServiceComponent.objects.create(
+            code="SPOT_ORIGIN",
+            description="Spot Origin Charge",
+            mode="AIR",
+            leg="ORIGIN",
+            category="LOCAL",
+        )
+        QuoteLine.objects.create(
+            quote_version=latest_version,
+            service_component=spot_component,
+            cost_pgk=Decimal("50.00"),
+            sell_pgk=Decimal("75.00"),
+            sell_pgk_incl_gst=Decimal("75.00"),
+            sell_fcy=Decimal("22.50"),
+            sell_fcy_incl_gst=Decimal("22.50"),
+            sell_fcy_currency="USD",
+            cost_source="Agent reply",
+            cost_source_description="Customs clearance",
+            is_rate_missing=False,
+        )
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        descriptions = [line["description"] for line in response.json()["latest_version"]["lines"]]
+        self.assertIn("Customs clearance", descriptions)
+
+    def test_quote_result_prefers_cost_source_description_for_line_items(self):
+        latest_version = self.quote.versions.order_by('-version_number').first()
+        spot_component = ServiceComponent.objects.create(
+            code="SPOT_DEST",
+            description="Spot Destination Charge",
+            mode="AIR",
+            leg="DESTINATION",
+            category="LOCAL",
+        )
+        QuoteLine.objects.create(
+            quote_version=latest_version,
+            service_component=spot_component,
+            cost_pgk=Decimal("50.00"),
+            sell_pgk=Decimal("75.00"),
+            sell_pgk_incl_gst=Decimal("75.00"),
+            sell_fcy=Decimal("22.50"),
+            sell_fcy_incl_gst=Decimal("22.50"),
+            sell_fcy_currency="USD",
+            cost_source="Agent reply",
+            cost_source_description="Airport transfer",
+            is_rate_missing=False,
+        )
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        line_item_descriptions = [
+            line["description"]
+            for line in response.json()["quote_result"]["line_items"]
+        ]
+        self.assertIn("Airport transfer", line_item_descriptions)
+
     def test_retrieve_requires_authentication(self):
         self.client.force_authenticate(user=None)
 

--- a/backend/quotes/tests/test_rate_availability_service.py
+++ b/backend/quotes/tests/test_rate_availability_service.py
@@ -67,7 +67,7 @@ def _evaluate(direction: str, scope: str, availability: dict[str, bool]):
     )
 
 
-def test_import_d2d_collect_uses_origin_fallback_and_does_not_trigger_spot():
+def test_import_d2d_collect_does_not_count_destination_side_import_local_rows_as_origin_coverage():
     valid_from, valid_until = _today_window()
     agent = _agent()
     pc_freight = _pc(2951, "IMP-FRT-AIR-MATRIX", "IMPORT", "FREIGHT", unit="KG")
@@ -84,7 +84,7 @@ def test_import_d2d_collect_uses_origin_fallback_and_does_not_trigger_spot():
         valid_from=valid_from,
         valid_until=valid_until,
     )
-    # Legacy migrated shape: origin local row stored at destination.
+    # Destination-side import local row must not count as origin-local coverage.
     LocalCOGSRate.objects.create(
         product_code=pc_origin,
         location="POM",
@@ -109,15 +109,15 @@ def test_import_d2d_collect_uses_origin_fallback_and_does_not_trigger_spot():
     )
 
     availability = RateAvailabilityService.get_availability("BNE", "POM", "IMPORT", "D2D")
-    assert availability == {
-        COMPONENT_FREIGHT: True,
-        COMPONENT_ORIGIN_LOCAL: True,
-        COMPONENT_DESTINATION_LOCAL: True,
-    }
+    assert availability[COMPONENT_FREIGHT] is True
+    assert availability[COMPONENT_ORIGIN_LOCAL] is False
+    assert availability[COMPONENT_DESTINATION_LOCAL] is True
 
     is_spot, trigger = _evaluate("IMPORT", "D2D", availability)
-    assert is_spot is False
-    assert trigger is None
+    assert is_spot is True
+    assert trigger is not None
+    assert trigger.code == SpotTriggerReason.MISSING_SCOPE_RATES
+    assert trigger.missing_components == [COMPONENT_ORIGIN_LOCAL]
 
 
 def test_import_d2d_missing_origin_component_still_triggers_spot():
@@ -333,6 +333,47 @@ def test_import_destination_global_surcharge_counts_as_coverage():
     assert trigger is None
 
 
+def test_import_origin_global_surcharge_does_not_count_as_origin_local_coverage():
+    valid_from, valid_until = _today_window()
+    pc_surcharge = _pc(2982, "IMP-ORIGIN-SURCHARGE-MATRIX", "IMPORT", "SURCHARGE")
+    agent = _agent()
+    pc_dest = _pc(2983, "IMP-CARTAGE-DEST-SURCHARGE", "IMPORT", "CARTAGE")
+
+    Surcharge.objects.create(
+        product_code=pc_surcharge,
+        rate_side="COGS",
+        service_type="IMPORT_ORIGIN",
+        rate_type="FLAT",
+        amount=Decimal("25.00"),
+        currency="PGK",
+        origin_filter=None,
+        destination_filter=None,
+        valid_from=valid_from,
+        valid_until=valid_until,
+        is_active=True,
+    )
+    LocalCOGSRate.objects.create(
+        product_code=pc_dest,
+        location="POM",
+        direction="IMPORT",
+        agent=agent,
+        currency="PGK",
+        rate_type="FIXED",
+        amount=Decimal("95.00"),
+        valid_from=valid_from,
+        valid_until=valid_until,
+    )
+
+    availability = RateAvailabilityService.get_availability("CAN", "POM", "IMPORT", "D2D")
+    assert availability[COMPONENT_ORIGIN_LOCAL] is False
+    assert availability[COMPONENT_DESTINATION_LOCAL] is True
+
+    is_spot, trigger = _evaluate("IMPORT", "D2D", availability)
+    assert is_spot is True
+    assert trigger is not None
+    assert trigger.missing_components == [COMPONENT_FREIGHT, COMPONENT_ORIGIN_LOCAL]
+
+
 def test_export_d2a_payment_term_mismatch_does_not_count_origin_local():
     valid_from, valid_until = _today_window()
     agent = _agent()
@@ -510,6 +551,51 @@ def test_export_d2a_missing_commodity_rate_triggers_spot_when_scope_is_covered()
     assert trigger is not None
     assert trigger.code == SpotTriggerReason.MISSING_COMMODITY_RATES
     assert trigger.missing_product_codes == ["EXP-DG-COMMODITY"]
+
+
+def test_import_d2d_origin_commodity_rule_does_not_use_destination_side_local_tariffs():
+    valid_from, valid_until = _today_window()
+    agent = _agent()
+    pc_origin = _pc(1954, "IMP-DOC-ORIGIN-COMMODITY", "IMPORT", "DOCUMENTATION")
+
+    CommodityChargeRule.objects.create(
+        shipment_type="IMPORT",
+        service_scope="D2D",
+        commodity_code="GEN",
+        product_code=pc_origin,
+        leg="ORIGIN",
+        trigger_mode="AUTO",
+        effective_from=valid_from,
+        effective_to=valid_until,
+    )
+    LocalCOGSRate.objects.create(
+        product_code=pc_origin,
+        location="POM",
+        direction="IMPORT",
+        agent=agent,
+        currency="AUD",
+        rate_type="FIXED",
+        amount=Decimal("80.00"),
+        valid_from=valid_from,
+        valid_until=valid_until,
+    )
+    LocalSellRate.objects.create(
+        product_code=pc_origin,
+        location="POM",
+        direction="IMPORT",
+        payment_term="COLLECT",
+        currency="PGK",
+        rate_type="FIXED",
+        amount=Decimal("120.00"),
+        valid_from=valid_from,
+        valid_until=valid_until,
+    )
+
+    coverage = CommodityRateRuleService.evaluate_coverage(
+        "CAN", "POM", "IMPORT", "D2D", "GEN", payment_term="COLLECT"
+    )
+
+    assert coverage.missing_product_codes == ["IMP-DOC-ORIGIN-COMMODITY"]
 
 
 def test_export_d2a_seeded_commodity_rate_does_not_trigger_spot_when_scope_is_covered():

--- a/backend/quotes/tests/test_spot_ai_autofill.py
+++ b/backend/quotes/tests/test_spot_ai_autofill.py
@@ -20,6 +20,8 @@ from core.dataclasses import (
 from core.models import Currency, Country, Location
 from core.tests.helpers import create_location
 from pricing_v4.adapter import PricingServiceV4Adapter, PricingMode
+from pricing_v4.models import Agent, ProductCode, LocalCOGSRate, LocalSellRate
+from services.models import ServiceComponent
 from quotes.completeness import (
     evaluate_from_lines,
     COMPONENT_DESTINATION_LOCAL,
@@ -41,7 +43,7 @@ from quotes.spot_models import (
     SPEChargeLineDB,
     SPEAcknowledgementDB,
 )
-from quotes.spot_services import ReplyAnalysisService, SpotTriggerReason
+from quotes.spot_services import ReplyAnalysisService, SpotTriggerReason, StandardChargeService
 
 
 pytestmark = pytest.mark.django_db
@@ -663,6 +665,267 @@ def test_conditional_charge_does_not_satisfy_completeness():
 
     coverage = evaluate_from_lines(lines, "EXPORT", "D2A")
     assert COMPONENT_ORIGIN_LOCAL in coverage.missing_required
+
+
+def test_import_d2d_collect_spot_freight_keeps_origin_local_missing_when_only_destination_side_local_cogs_exist():
+    user = get_user_model().objects.create_user(username="spotimportfallback", password="testpass")
+    spe = _create_spe(
+        user=user,
+        origin_code="CAN",
+        dest_code="POM",
+        origin_country="CN",
+        dest_country="PG",
+        service_scope="D2D",
+        status="ready",
+        missing_components=[COMPONENT_FREIGHT, COMPONENT_ORIGIN_LOCAL],
+    )
+    _acknowledge_spe(user, spe)
+
+    SPEChargeLineDB.objects.create(
+        envelope=spe,
+        code="FREIGHT",
+        description="Airfreight",
+        amount=Decimal("6.80"),
+        currency="USD",
+        unit="per_kg",
+        bucket="airfreight",
+        is_primary_cost=True,
+        entered_at=timezone.now(),
+        source_reference="Agent reply",
+    )
+
+    agent = Agent.objects.create(
+        code="CAN-AGENT",
+        name="CAN Agent",
+        country_code="CN",
+        agent_type="ORIGIN",
+    )
+    pc_origin = ProductCode.objects.create(
+        id=2010,
+        code="IMP-DOC-ORIGIN",
+        description="Import Documentation Origin",
+        domain="IMPORT",
+        category="DOCUMENTATION",
+        is_gst_applicable=True,
+        gl_revenue_code="4200",
+        gl_cost_code="5200",
+        default_unit="SHIPMENT",
+    )
+    pc_dest = ProductCode.objects.create(
+        id=3020,
+        code="IMP-CLEAR-SPOTTEST",
+        description="Import Customs Clearance Spot Test",
+        domain="IMPORT",
+        category="CLEARANCE",
+        is_gst_applicable=True,
+        gl_revenue_code="4201",
+        gl_cost_code="5201",
+        default_unit="SHIPMENT",
+    )
+    ServiceComponent.objects.create(
+        code="IMP-DOC-ORIGIN",
+        description="Import Documentation Origin Component",
+        mode="AIR",
+        leg="ORIGIN",
+        category="DOCUMENTATION",
+    )
+    ServiceComponent.objects.create(
+        code="IMP-CLEAR-SPOTTEST",
+        description="Import Customs Clearance Spot Test Component",
+        mode="AIR",
+        leg="DESTINATION",
+        category="CUSTOMS",
+    )
+
+    # Destination-side import local row that previously leaked into ORIGIN_LOCAL.
+    LocalCOGSRate.objects.create(
+        product_code=pc_origin,
+        location="POM",
+        direction="IMPORT",
+        agent=agent,
+        currency="AUD",
+        rate_type="FIXED",
+        amount=Decimal("80.00"),
+        valid_from=date.today() - timedelta(days=1),
+        valid_until=date.today() + timedelta(days=30),
+    )
+    LocalCOGSRate.objects.create(
+        product_code=pc_dest,
+        location="POM",
+        direction="IMPORT",
+        agent=agent,
+        currency="PGK",
+        rate_type="FIXED",
+        amount=Decimal("350.00"),
+        valid_from=date.today() - timedelta(days=1),
+        valid_until=date.today() + timedelta(days=30),
+    )
+    LocalSellRate.objects.create(
+        product_code=pc_dest,
+        location="POM",
+        direction="IMPORT",
+        payment_term="COLLECT",
+        currency="PGK",
+        rate_type="FIXED",
+        amount=Decimal("500.00"),
+        valid_from=date.today() - timedelta(days=1),
+        valid_until=date.today() + timedelta(days=30),
+    )
+
+    origin_ref = LocationRef(
+        id=uuid.uuid4(),
+        code="CAN",
+        name="CAN Airport",
+        country_code="CN",
+        currency_code="CNY",
+    )
+    dest_ref = LocationRef(
+        id=uuid.uuid4(),
+        code="POM",
+        name="POM Airport",
+        country_code="PG",
+        currency_code="PGK",
+    )
+    shipment = ShipmentDetails(
+        mode="AIR",
+        shipment_type="IMPORT",
+        incoterm="DAP",
+        payment_term="COLLECT",
+        is_dangerous_goods=False,
+        pieces=[
+            Piece(
+                pieces=1,
+                length_cm=Decimal("10"),
+                width_cm=Decimal("10"),
+                height_cm=Decimal("10"),
+                gross_weight_kg=Decimal("100"),
+            )
+        ],
+        service_scope="D2D",
+        origin_location=origin_ref,
+        destination_location=dest_ref,
+    )
+    quote_input = QuoteInput(
+        customer_id=uuid.uuid4(),
+        contact_id=uuid.uuid4(),
+        output_currency="PGK",
+        quote_date=date.today(),
+        shipment=shipment,
+    )
+
+    charges = PricingServiceV4Adapter(quote_input, spot_envelope_id=spe.id).calculate_charges()
+    coverage = evaluate_from_lines(charges.lines, "IMPORT", "D2D")
+
+    origin_lines = [line for line in charges.lines if line.bucket == "origin_charges"]
+    destination_lines = [line for line in charges.lines if line.bucket == "destination_charges"]
+    freight_lines = [line for line in charges.lines if line.bucket == "airfreight"]
+
+    assert freight_lines, "Expected SPE freight line to remain present"
+    assert any(line.service_component_code == "IMP-CLEAR-SPOTTEST" and not line.is_rate_missing for line in destination_lines)
+    assert any(line.service_component_code == "IMP-DOC-ORIGIN" and line.is_rate_missing for line in origin_lines)
+    assert COMPONENT_ORIGIN_LOCAL in coverage.missing_required
+    assert COMPONENT_DESTINATION_LOCAL not in coverage.missing_required
+    assert COMPONENT_FREIGHT not in coverage.missing_required
+    assert charges.totals.has_missing_rates is True
+    assert charges.totals.notes == "Missing required components: ORIGIN_LOCAL"
+
+
+def test_standard_charge_preload_does_not_emit_origin_local_when_only_destination_import_locals_exist():
+    currency = Currency.objects.create(code="PGK", name="Papua New Guinea Kina")
+    pg = Country.objects.create(code="PG", name="Papua New Guinea", currency=currency)
+    cn = Country.objects.create(code="CN", name="China", currency=currency)
+    origin = _create_location("CAN", cn)
+    destination = _create_location("POM", pg)
+
+    agent = Agent.objects.create(
+        code="SPOTIMPSTD",
+        name="Spot Import Standard Agent",
+        country_code="CN",
+        agent_type="ORIGIN",
+    )
+    pc_origin = ProductCode.objects.create(
+        id=2954,
+        code="IMP-DOC-ORIGIN-STDPRELOAD",
+        description="Import Origin Documentation Standard Preload",
+        domain="IMPORT",
+        category="DOCUMENTATION",
+        is_gst_applicable=False,
+        gl_revenue_code="4200",
+        gl_cost_code="5200",
+        default_unit="SHIPMENT",
+    )
+    pc_dest = ProductCode.objects.create(
+        id=2955,
+        code="IMP-CLEAR-DEST-STDPRELOAD",
+        description="Import Destination Clearance Standard Preload",
+        domain="IMPORT",
+        category="CLEARANCE",
+        is_gst_applicable=False,
+        gl_revenue_code="4201",
+        gl_cost_code="5201",
+        default_unit="SHIPMENT",
+    )
+    ServiceComponent.objects.create(
+        code="IMP-DOC-ORIGIN-STDPRELOAD",
+        description="Import Origin Documentation Standard Preload",
+        mode="AIR",
+        leg="ORIGIN",
+        category="DOCUMENTATION",
+    )
+    ServiceComponent.objects.create(
+        code="IMP-CLEAR-DEST-STDPRELOAD",
+        description="Import Destination Clearance Standard Preload",
+        mode="AIR",
+        leg="DESTINATION",
+        category="CUSTOMS",
+    )
+
+    LocalCOGSRate.objects.create(
+        product_code=pc_origin,
+        location=destination.code,
+        direction="IMPORT",
+        agent=agent,
+        currency="AUD",
+        rate_type="FIXED",
+        amount=Decimal("80.00"),
+        valid_from=date.today() - timedelta(days=1),
+        valid_until=date.today() + timedelta(days=30),
+    )
+    LocalCOGSRate.objects.create(
+        product_code=pc_dest,
+        location=destination.code,
+        direction="IMPORT",
+        agent=agent,
+        currency="PGK",
+        rate_type="FIXED",
+        amount=Decimal("350.00"),
+        valid_from=date.today() - timedelta(days=1),
+        valid_until=date.today() + timedelta(days=30),
+    )
+    LocalSellRate.objects.create(
+        product_code=pc_dest,
+        location=destination.code,
+        direction="IMPORT",
+        payment_term="COLLECT",
+        currency="PGK",
+        rate_type="FIXED",
+        amount=Decimal("500.00"),
+        valid_from=date.today() - timedelta(days=1),
+        valid_until=date.today() + timedelta(days=30),
+    )
+
+    charges = StandardChargeService.get_standard_charges(
+        origin_code=origin.code,
+        destination_code=destination.code,
+        direction="IMPORT",
+        service_scope="D2D",
+        weight_kg=100,
+        payment_term="COLLECT",
+    )
+
+    assert charges
+    assert {charge["bucket"] for charge in charges} == {"destination_charges"}
+    assert {charge["code"] for charge in charges} == {"IMP-CLEAR-DEST-STDPRELOAD"}
 
 
 def test_ai_fill_makes_spe_complete_for_compute(monkeypatch):

--- a/backend/quotes/tests/test_spot_flow_api.py
+++ b/backend/quotes/tests/test_spot_flow_api.py
@@ -9,7 +9,7 @@ from rest_framework.test import APITestCase
 
 from core.models import Location
 from core.tests.helpers import create_location
-from pricing_v4.models import CommodityChargeRule, ProductCode
+from pricing_v4.models import Agent, CommodityChargeRule, LocalCOGSRate, LocalSellRate, ProductCode
 from services.models import ServiceComponent
 from quotes.completeness import (
     COMPONENT_FREIGHT,
@@ -43,6 +43,71 @@ class SpotEnvelopeFlowAPITest(APITestCase):
         self.create_url = reverse("quotes:spot-envelope-list-create")
         self.scope_url = reverse("quotes:spot-validate-scope")
         self.evaluate_url = reverse("quotes:spot-evaluate-trigger")
+
+    def _seed_import_destination_only_locals_for_can_to_pom(self):
+        valid_from = date.today() - timedelta(days=1)
+        valid_until = date.today() + timedelta(days=30)
+        agent = Agent.objects.create(
+            code="API-SPOT-IMP",
+            name="API Spot Import Agent",
+            country_code="CN",
+            agent_type="ORIGIN",
+        )
+        pc_origin = ProductCode.objects.create(
+            id=2974,
+            code="IMP-DOC-ORIGIN-API",
+            description="Import Origin Documentation API",
+            domain="IMPORT",
+            category="DOCUMENTATION",
+            is_gst_applicable=True,
+            gl_revenue_code="4100",
+            gl_cost_code="5100",
+            default_unit="SHIPMENT",
+        )
+        pc_dest = ProductCode.objects.create(
+            id=2975,
+            code="IMP-CLEAR-DEST-API",
+            description="Import Destination Clearance API",
+            domain="IMPORT",
+            category="CLEARANCE",
+            is_gst_applicable=True,
+            gl_revenue_code="4101",
+            gl_cost_code="5101",
+            default_unit="SHIPMENT",
+        )
+        LocalCOGSRate.objects.create(
+            product_code=pc_origin,
+            location="POM",
+            direction="IMPORT",
+            agent=agent,
+            currency="AUD",
+            rate_type="FIXED",
+            amount="80.00",
+            valid_from=valid_from,
+            valid_until=valid_until,
+        )
+        LocalCOGSRate.objects.create(
+            product_code=pc_dest,
+            location="POM",
+            direction="IMPORT",
+            agent=agent,
+            currency="PGK",
+            rate_type="FIXED",
+            amount="350.00",
+            valid_from=valid_from,
+            valid_until=valid_until,
+        )
+        LocalSellRate.objects.create(
+            product_code=pc_dest,
+            location="POM",
+            direction="IMPORT",
+            payment_term="COLLECT",
+            currency="PGK",
+            rate_type="FIXED",
+            amount="500.00",
+            valid_from=valid_from,
+            valid_until=valid_until,
+        )
 
     def test_spot_envelope_flow_acknowledge_compute(self):
         create_payload = {
@@ -492,3 +557,227 @@ class SpotEnvelopeFlowAPITest(APITestCase):
         acknowledge_response = self.client.post(acknowledge_url, format="json")
         self.assertEqual(acknowledge_response.status_code, status.HTTP_200_OK)
         self.assertEqual(acknowledge_response.json()["status"], "ready")
+
+    def test_evaluate_trigger_import_d2d_collect_reports_origin_local_and_freight_missing(self):
+        self._seed_import_destination_only_locals_for_can_to_pom()
+
+        response = self.client.post(
+            self.evaluate_url,
+            {
+                "origin_country": "CN",
+                "destination_country": "PG",
+                "origin_airport": "CAN",
+                "destination_airport": "POM",
+                "service_scope": "D2D",
+                "payment_term": "COLLECT",
+                "commodity": "GCR",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        payload = response.json()
+        self.assertTrue(payload["is_spot_required"])
+        self.assertEqual(
+            set(payload["trigger"]["missing_components"]),
+            {COMPONENT_FREIGHT, COMPONENT_ORIGIN_LOCAL},
+        )
+        self.assertNotIn(COMPONENT_DESTINATION_LOCAL, payload["trigger"]["missing_components"])
+
+    def test_get_spe_detail_recomputes_stale_missing_components_for_import_d2d_collect(self):
+        self._seed_import_destination_only_locals_for_can_to_pom()
+        can = create_location(name="Guangzhou", code="CAN")
+
+        create_response = self.client.post(
+            self.create_url,
+            {
+                "shipment_context": {
+                    "origin_country": "CN",
+                    "destination_country": "PG",
+                    "origin_code": can.code,
+                    "destination_code": "POM",
+                    "commodity": "GCR",
+                    "total_weight_kg": 100,
+                    "pieces": 1,
+                    "service_scope": "d2d",
+                    "payment_term": "collect",
+                    "missing_components": ["FREIGHT"],
+                },
+                "charges": [],
+                "trigger_code": "MISSING_SCOPE_RATES",
+                "trigger_text": "Missing required rate components",
+                "conditions": {"rate_validity_hours": 72},
+            },
+            format="json",
+        )
+        self.assertEqual(create_response.status_code, status.HTTP_201_CREATED)
+        spe_id = create_response.json()["id"]
+
+        detail_url = reverse(
+            "quotes:spot-envelope-detail", kwargs={"envelope_id": spe_id}
+        )
+        detail_response = self.client.get(detail_url, format="json")
+
+        self.assertEqual(detail_response.status_code, status.HTTP_200_OK)
+        shipment = detail_response.json()["shipment"]
+        self.assertEqual(
+            set(shipment["missing_components"]),
+            {COMPONENT_FREIGHT, COMPONENT_ORIGIN_LOCAL},
+        )
+        self.assertNotIn(COMPONENT_DESTINATION_LOCAL, shipment["missing_components"])
+
+    def test_get_spe_detail_drops_freight_from_missing_components_once_freight_is_present(self):
+        self._seed_import_destination_only_locals_for_can_to_pom()
+        can = create_location(name="Guangzhou", code="CAN")
+
+        create_response = self.client.post(
+            self.create_url,
+            {
+                "shipment_context": {
+                    "origin_country": "CN",
+                    "destination_country": "PG",
+                    "origin_code": can.code,
+                    "destination_code": "POM",
+                    "commodity": "GCR",
+                    "total_weight_kg": 100,
+                    "pieces": 1,
+                    "service_scope": "d2d",
+                    "payment_term": "collect",
+                    "missing_components": ["FREIGHT"],
+                },
+                "charges": [
+                    {
+                        "code": "FREIGHT",
+                        "description": "Airfreight",
+                        "amount": 6.8,
+                        "currency": "USD",
+                        "unit": "per_kg",
+                        "bucket": "airfreight",
+                        "is_primary_cost": True,
+                        "conditional": False,
+                        "source_reference": "Agent reply",
+                    }
+                ],
+                "trigger_code": "MISSING_SCOPE_RATES",
+                "trigger_text": "Missing required rate components",
+                "conditions": {"rate_validity_hours": 72},
+            },
+            format="json",
+        )
+        self.assertEqual(create_response.status_code, status.HTTP_201_CREATED)
+        spe_id = create_response.json()["id"]
+
+        detail_url = reverse(
+            "quotes:spot-envelope-detail", kwargs={"envelope_id": spe_id}
+        )
+        detail_response = self.client.get(detail_url, format="json")
+
+        self.assertEqual(detail_response.status_code, status.HTTP_200_OK)
+        shipment = detail_response.json()["shipment"]
+        self.assertEqual(shipment["missing_components"], [COMPONENT_ORIGIN_LOCAL])
+
+    def test_get_spe_detail_keeps_conditional_origin_charge_missing(self):
+        create_response = self.client.post(
+            self.create_url,
+            {
+                "shipment_context": {
+                    "origin_country": "PG",
+                    "destination_country": "AU",
+                    "origin_code": "POM",
+                    "destination_code": "SYD",
+                    "commodity": "GCR",
+                    "total_weight_kg": 100,
+                    "pieces": 1,
+                    "service_scope": "d2a",
+                    "payment_term": "prepaid",
+                    "missing_components": [COMPONENT_ORIGIN_LOCAL],
+                },
+                "charges": [
+                    {
+                        "code": "ORIGIN-COND",
+                        "description": "Origin handling if applicable",
+                        "amount": 25,
+                        "currency": "USD",
+                        "unit": "flat",
+                        "bucket": "origin_charges",
+                        "conditional": True,
+                        "is_primary_cost": False,
+                        "source_reference": "Agent email",
+                    }
+                ],
+                "trigger_code": "MISSING_SCOPE_RATES",
+                "trigger_text": "Missing required rate components",
+                "conditions": {"rate_validity_hours": 72},
+            },
+            format="json",
+        )
+
+        self.assertEqual(create_response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(
+            create_response.json()["shipment"]["missing_components"],
+            [COMPONENT_ORIGIN_LOCAL],
+        )
+
+        detail_url = reverse(
+            "quotes:spot-envelope-detail",
+            kwargs={"envelope_id": create_response.json()["id"]},
+        )
+        detail_response = self.client.get(detail_url, format="json")
+
+        self.assertEqual(detail_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            detail_response.json()["shipment"]["missing_components"],
+            [COMPONENT_ORIGIN_LOCAL],
+        )
+
+    @patch("quotes.spot_services.RateAvailabilityService.get_availability")
+    def test_list_envelopes_uses_cached_missing_components(self, mock_availability):
+        spe = SpotPricingEnvelopeDB.objects.create(
+            status="draft",
+            shipment_context_json={
+                "origin_country": "PG",
+                "destination_country": "AU",
+                "origin_code": "POM",
+                "destination_code": "SYD",
+                "commodity": "GCR",
+                "total_weight_kg": 100,
+                "pieces": 1,
+                "service_scope": "d2a",
+                "payment_term": "PREPAID",
+                "missing_components": [COMPONENT_FREIGHT, COMPONENT_ORIGIN_LOCAL],
+            },
+            resolved_missing_components=[COMPONENT_ORIGIN_LOCAL],
+            conditions_json={"rate_validity_hours": 72},
+            spot_trigger_reason_code="MISSING_SCOPE_RATES",
+            spot_trigger_reason_text="Missing required rate components",
+            created_by=self.user,
+            expires_at=timezone.now() + timedelta(hours=72),
+        )
+        SPEChargeLineDB.objects.create(
+            envelope=spe,
+            code="FREIGHT",
+            description="Airfreight",
+            amount="6.80",
+            currency="USD",
+            unit="per_kg",
+            bucket="airfreight",
+            is_primary_cost=True,
+            source_reference="Agent email",
+            entered_by=self.user,
+            entered_at=timezone.now(),
+        )
+        spe.resolved_missing_components = [COMPONENT_ORIGIN_LOCAL]
+        spe.save(update_fields=["resolved_missing_components"])
+
+        mock_availability.side_effect = AssertionError(
+            "list serializer should use cached resolved_missing_components"
+        )
+
+        response = self.client.get(self.create_url, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.json()), 1)
+        self.assertEqual(
+            response.json()[0]["shipment"]["missing_components"],
+            [COMPONENT_ORIGIN_LOCAL],
+        )

--- a/backend/quotes/tests/test_spot_mode.py
+++ b/backend/quotes/tests/test_spot_mode.py
@@ -293,7 +293,9 @@ class TestSpotTriggerEvaluation:
         assert result.code == SpotTriggerReason.COMMODITY_REQUIRES_MANUAL
         assert result.manual_required_product_codes == ["EXP-AVI-MANUAL"]
         assert result.spot_required_product_codes == ["EXP-AVI-SPOT"]
-        assert result.missing_product_codes == ["EXP-AVI-MANUAL", "EXP-AVI-SPOT", "EXP-AVI-DB"]
+        assert sorted(result.missing_product_codes) == sorted(
+            ["EXP-AVI-MANUAL", "EXP-AVI-SPOT", "EXP-AVI-DB"]
+        )
         assert "manual charge entry" in result.text
         assert "Export Live Animal Manual Charge (EXP-AVI-MANUAL)" in result.text
         assert "EXP-AVI-SPOT" in result.text
@@ -303,11 +305,10 @@ class TestSpotTriggerEvaluation:
 class TestRateAvailabilityService:
     """Rate availability detection against V4 rate tables."""
 
-    def test_import_d2d_origin_local_detected_from_destination_fallback(self):
+    def test_import_d2d_destination_side_import_local_rows_do_not_cover_origin_local(self):
         """
-        IMPORT D2D compatibility:
-        if ORIGIN local rows were migrated under destination location,
-        availability must still mark ORIGIN_LOCAL=True.
+        IMPORT D2D must keep component side aligned:
+        destination-side import local rows cannot satisfy ORIGIN_LOCAL.
         """
         from datetime import date, timedelta
         from pricing_v4.models import ProductCode, Agent, ImportCOGS, LocalCOGSRate
@@ -367,7 +368,7 @@ class TestRateAvailabilityService:
             valid_until=valid_until,
         )
 
-        # Legacy migrated shape: origin local row stored under destination station.
+        # Destination-side import local row with an ORIGIN code must not cover origin-local.
         LocalCOGSRate.objects.create(
             product_code=pc_origin,
             location="POM",
@@ -399,7 +400,7 @@ class TestRateAvailabilityService:
         )
 
         assert availability[COMPONENT_FREIGHT] is True
-        assert availability[COMPONENT_ORIGIN_LOCAL] is True
+        assert availability[COMPONENT_ORIGIN_LOCAL] is False
         assert availability[COMPONENT_DESTINATION_LOCAL] is True
 
 

--- a/backend/quotes/views/lifecycle.py
+++ b/backend/quotes/views/lifecycle.py
@@ -5,7 +5,7 @@ from dataclasses import replace
 from typing import Any
 
 from django.db import transaction
-from django.db.models import Q
+from django.db.models import Prefetch, Q
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from rest_framework import viewsets, status, serializers
@@ -16,6 +16,7 @@ from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.decorators import action
 
 from quotes.models import Quote, QuoteVersion, QuoteLine, QuoteTotal, OverrideNote
+from quotes.spot_models import SpotPricingEnvelopeDB
 from quotes.serializers import (
     CanonicalQuoteResultSerializer,
     QuoteListSerializerV3,
@@ -243,10 +244,18 @@ class QuoteV3ViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         user = self.request.user
+        spot_envelope_prefetch = Prefetch(
+            'spot_envelopes',
+            queryset=SpotPricingEnvelopeDB.objects.only(
+                'id',
+                'quote_id',
+                'created_at',
+            ).order_by('-created_at', '-id'),
+        )
         # Prefetch related data to optimize query
         qs = Quote.objects.all().select_related(
             'customer', 'contact', 'origin_location', 'destination_location'
-        ).prefetch_related('spot_envelopes').order_by('-created_at')
+        ).prefetch_related(spot_envelope_prefetch).order_by('-created_at')
 
         # 1. Role-Based Visibility
         if user.is_authenticated:

--- a/docs/spot-intake-deterministic-alias-plan.md
+++ b/docs/spot-intake-deterministic-alias-plan.md
@@ -1,0 +1,332 @@
+# SPOT Intake Deterministic Alias Mapping Plan
+
+**Date:** 2026-04-03
+**Branch:** `codex-spot-alias-mapping-plan`
+
+## Goal
+
+Standardize messy agent charge labels like `DOC`, `CUS`, `CMD`, and `A/F` without letting the LLM silently guess billable internal codes.
+
+The design target is:
+
+- AI extracts rows and structured amounts from messy source text.
+- Deterministic rules map extracted labels to canonical internal codes.
+- Unknown or ambiguous labels fail closed.
+- Users see both the original agent label and the resolved internal description.
+
+## Why This Change Is Needed
+
+The current intake pipeline in [ai_intake_service.py](/C:/Users/commercial.manager/dev/Project-RateEngine/backend/quotes/ai_intake_service.py) already has the right high-level shape:
+
+- extractor: `_extract_raw_charges(...)`
+- normalizer: `_normalize_charges(...)`
+- critic: `_audit_extraction(...)`
+- final shaping: `_build_final_spot_charge_lines(...)`
+
+But the normalizer still asks the LLM to map raw labels directly to `v4_product_code` and `v4_bucket`. That is acceptable for extraction assistance, but it is too soft for financial classification. A wrong mapping is materially worse than an unmapped line.
+
+The current contract already supports safe failure:
+
+- `NormalizedCharge.v4_product_code` can be `UNMAPPED`
+- `NormalizedCharge.confidence` is `HIGH` or `LOW`
+- downstream warnings already surface unmapped and low-confidence lines
+
+The missing piece is a deterministic alias registry that becomes the authoritative mapping step between extracted labels and canonical codes.
+
+## Design Principles
+
+1. AI extracts, rules classify.
+2. Mapping must be deterministic, auditable, and versionable.
+3. Unknown terms must never auto-map.
+4. Ambiguous matches must never auto-pick.
+5. Preserve both original and resolved labels.
+6. Bucket and shipment context are guardrails, not optional hints.
+7. Admin-approved aliases should improve future imports without changing historical audit trails.
+
+## Current Integration Points
+
+The implementation should attach to the existing SPOT intake seam, not create a second parallel pipeline.
+
+### Existing flow
+
+1. `parse_rate_quote_text(...)` in [ai_intake_service.py](/C:/Users/commercial.manager/dev/Project-RateEngine/backend/quotes/ai_intake_service.py)
+2. `RawExtractedCharge` and `NormalizedCharge` in [ai_intake_schemas.py](/C:/Users/commercial.manager/dev/Project-RateEngine/backend/quotes/ai_intake_schemas.py)
+3. `SpotChargeLine` final contract in [ai_intake_schemas.py](/C:/Users/commercial.manager/dev/Project-RateEngine/backend/quotes/ai_intake_schemas.py)
+4. SPOT review and import safety in [spot_services.py](/C:/Users/commercial.manager/dev/Project-RateEngine/backend/quotes/spot_services.py)
+5. SPE persistence in [spot_models.py](/C:/Users/commercial.manager/dev/Project-RateEngine/backend/quotes/spot_models.py)
+
+### Recommended change to the seam
+
+Keep the extractor and critic largely intact. Narrow the normalizer's job.
+
+New responsibility split:
+
+- LLM extractor:
+  - produce `raw_label`
+  - produce `raw_amount_string`
+  - detect `is_conditional`
+  - optionally suggest a bucket
+- deterministic alias resolver:
+  - normalize label text
+  - resolve bucket and canonical code
+  - return `MAPPED`, `UNMAPPED`, or `AMBIGUOUS`
+- value parser:
+  - parse amount, currency, unit basis, percentage, min/max
+- critic:
+  - continue checking for missed rows and hallucinations
+
+## Proposed Data Model
+
+### 1. Alias registry
+
+Add a new model in the `quotes` app, for example `SpotChargeAliasDB`.
+
+Suggested fields:
+
+- `normalized_alias`
+- `raw_alias_example`
+- `bucket`
+- `shipment_type`
+- `service_scope`
+- `source_kind`
+- `agent_id`
+- `origin_country`
+- `destination_country`
+- `target_v4_product_code`
+- `target_description`
+- `match_type`
+- `pattern`
+- `priority`
+- `is_active`
+- `notes`
+- `created_by`
+- `updated_by`
+- `created_at`
+- `updated_at`
+
+Notes:
+
+- `target_v4_product_code` should remain the authoritative machine target because the current intake contract already uses `v4_product_code`.
+- `target_description` should mirror the canonical description users should see, usually derived from the linked product or service component at resolution time.
+- Specific rules must outrank generic rules.
+
+### 2. Mapping outcome metadata
+
+Persist mapping audit metadata with each imported SPE line or source batch. The simplest version is to extend `analysis_summary_json` on [spot_models.py](/C:/Users/commercial.manager/dev/Project-RateEngine/backend/quotes/spot_models.py). If line-level review becomes important, add explicit columns later.
+
+Minimum metadata to preserve:
+
+- `raw_label`
+- `normalized_alias`
+- `mapping_status`
+- `matched_rule_id`
+- `matched_rule_scope`
+- `resolved_v4_product_code`
+- `resolved_description`
+- `candidate_codes`
+- `mapping_reason`
+
+### 3. Preserve both labels
+
+Do not overwrite the original agent text.
+
+Every imported line should preserve:
+
+- original label: what the agent actually sent
+- resolved label: the approved canonical description
+
+Recommended UI rendering:
+
+- primary text: resolved description when mapped
+- secondary text: original agent label
+- status badge: `Mapped`, `Unmapped`, or `Needs Review`
+
+## Deterministic Resolution Rules
+
+Resolution should run in this order:
+
+1. Normalize the raw label.
+   - uppercase
+   - trim
+   - strip punctuation
+   - collapse whitespace
+2. Determine bucket candidates.
+   - use explicit SPE missing components first
+   - then explicit source batch target bucket
+   - then LLM bucket suggestion if present
+   - otherwise keep bucket unresolved
+3. Query alias rules from most specific to least specific.
+   - agent + bucket + shipment type + scope
+   - bucket + shipment type + scope
+   - bucket only
+   - global
+4. Apply only approved match types.
+   - exact alias
+   - approved regex or phrase rules
+5. If exactly one active highest-priority rule matches, map it.
+6. If zero rules match, return `UNMAPPED`.
+7. If multiple rules remain tied, return `AMBIGUOUS`.
+
+Forbidden behavior:
+
+- no embedding similarity
+- no fuzzy nearest-neighbor auto-pick
+- no "best guess" fallback
+- no bucket inference that contradicts explicit SPE context
+
+## Integration Plan
+
+### Phase 1. Deterministic registry and service
+
+Add:
+
+- `SpotChargeAliasDB` model and migration
+- `DeterministicAliasResolver` service in `quotes`
+- normalization helper for raw labels
+- resolver tests for exact, scoped, unknown, and ambiguous matches
+
+Update [ai_intake_service.py](/C:/Users/commercial.manager/dev/Project-RateEngine/backend/quotes/ai_intake_service.py):
+
+- stop treating the LLM as the final authority on `v4_product_code`
+- let the LLM keep suggesting structure and optional bucket hints
+- run the deterministic resolver before building final `SpotChargeLine` values
+- emit `UNMAPPED` when the resolver cannot safely classify a label
+
+### Phase 2. Review-first intake UX
+
+Update the SPOT review flow so imported lines clearly show:
+
+- raw label
+- resolved label
+- mapping status
+- matched canonical code
+- whether the result came from an exact approved alias or needs manual review
+
+Allow the user to:
+
+- accept the mapping
+- override the mapping
+- save the override as a new alias rule if they have permission
+
+### Phase 3. Admin workflow
+
+Provide a lightweight admin surface for alias maintenance:
+
+- create alias
+- deactivate alias
+- inspect top unmapped labels
+- inspect ambiguous labels
+- seed common abbreviations like `DOC`, `CUS`, `AWB`, `A/F`, `XRY`, `CTO`
+
+### Phase 4. Observability
+
+Add structured logging and counters for:
+
+- mapped lines
+- unmapped lines
+- ambiguous lines
+- top unmapped raw labels
+- top alias hits by agent and bucket
+
+This will tell us whether the registry is actually reducing manual review.
+
+## Recommended Contract Changes
+
+### `NormalizedCharge`
+
+Keep `v4_product_code` for backward compatibility, but treat it as the resolver output, not the LLM's final answer.
+
+Consider adding:
+
+- `mapping_status: Literal["MAPPED", "UNMAPPED", "AMBIGUOUS"]`
+- `resolved_description: Optional[str]`
+- `candidate_v4_product_codes: list[str] = []`
+- `resolver_rule_id: Optional[str]`
+
+### `SpotChargeLine`
+
+Retain:
+
+- `description` as the human-visible label
+- `original_raw_label` for traceability
+- `v4_product_code` as the machine code
+
+Recommended behavior:
+
+- if mapped, `description` should be the resolved canonical description
+- if unmapped, `description` can remain the raw label
+- UI should always expose `original_raw_label`
+
+## Test Plan
+
+Add tests in the `quotes` suite for:
+
+1. exact alias mapping inside the correct bucket
+2. same alias mapping differently across origin and destination
+3. agent-specific alias overriding a global alias
+4. unknown alias returning `UNMAPPED`
+5. ambiguous alias returning `AMBIGUOUS`
+6. conditional charges staying conditional after mapping
+7. imported lines preserving both raw and resolved labels
+8. manual review warnings appearing in [spot_services.py](/C:/Users/commercial.manager/dev/Project-RateEngine/backend/quotes/spot_services.py)
+
+Existing files that should gain coverage:
+
+- [test_ai_intake_contract.py](/C:/Users/commercial.manager/dev/Project-RateEngine/backend/quotes/tests/test_ai_intake_contract.py)
+- [test_spot_ai_autofill.py](/C:/Users/commercial.manager/dev/Project-RateEngine/backend/quotes/tests/test_spot_ai_autofill.py)
+
+## Seed Data Strategy
+
+Start with a small approved registry, not a giant dictionary.
+
+First-pass candidates:
+
+- `DOC` -> documentation charge by bucket
+- `CUS` -> customs clearance by bucket
+- `AWB` -> air waybill fee
+- `A/F` and `AF` -> air freight
+- `XRY` -> x-ray or screening
+- `CTO` -> terminal or handling only if the business already has a single approved meaning
+
+If a shorthand has more than one real meaning in the business, leave it unmapped until narrowed by bucket, agent, or route context.
+
+## Risks and Controls
+
+### Risk: Alias table becomes a junk drawer
+
+Control:
+
+- require bucket on every alias
+- prefer specific rules over global rules
+- add `is_active` and `priority`
+- keep audit trail on who approved each alias
+
+### Risk: Wrong auto-mapping becomes invisible
+
+Control:
+
+- preserve raw label beside resolved label
+- show mapping status in review UI
+- fail closed on unknown and ambiguous inputs
+
+### Risk: Historical quote behavior changes after alias edits
+
+Control:
+
+- store resolved code and resolved description on the imported line at intake time
+- treat alias registry as write-time resolution, not dynamic read-time lookup
+
+## Implementation Order
+
+1. Add alias registry model and admin.
+2. Add deterministic resolver service and tests.
+3. Narrow the LLM normalizer contract.
+4. Persist mapping metadata in the SPE import path.
+5. Update SPOT review UI to display mapping status and both labels.
+6. Add top-unmapped reporting for operational feedback.
+
+## Recommendation
+
+Proceed with a fail-closed deterministic registry, not a smarter LLM prompt.
+
+The LLM is already useful for extraction. It should stay in that role. Canonical charge mapping should become a rules engine with explicit approvals, scoped aliases, and visible review states.

--- a/frontend/src/app/quotes/spot/[speId]/page.tsx
+++ b/frontend/src/app/quotes/spot/[speId]/page.tsx
@@ -462,6 +462,7 @@ export default function SpotRateEntryPage() {
 
         return Array.from(warnings);
     }, [editableBuckets, sourceReviewSummaries]);
+    const speAlreadyReady = state.spe?.status === "ready" || Boolean(state.spe?.acknowledgement);
 
     // Handle saving charges, acknowledging, and creating the final quote in one flow
     const handleSaveAndCreateQuote = async (charges: Omit<SPEChargeLine, 'id'>[]) => {
@@ -469,37 +470,40 @@ export default function SpotRateEntryPage() {
             if (quoteCreationBlocked) {
                 return;
             }
-            // 1. Update charges
-            const spe = await actions.updateSPE(state.spe.id, {
-                charges,
-                conditions: {
-                    space_not_confirmed: true,
-                    airline_acceptance_not_confirmed: true,
-                    rate_validity_hours: 72,
-                    conditional_charges_present: charges.some(c => c.conditional),
+            if (!speAlreadyReady) {
+                const spe = await actions.updateSPE(state.spe.id, {
+                    charges,
+                    conditions: {
+                        space_not_confirmed: true,
+                        airline_acceptance_not_confirmed: true,
+                        rate_validity_hours: 72,
+                        conditional_charges_present: charges.some(c => c.conditional),
+                    }
+                });
+
+                if (!spe) {
+                    return;
                 }
+
+                const success = await actions.submitAcknowledgement();
+                if (!success) {
+                    return;
+                }
+            }
+
+            const resolvedScope = serviceScope || "D2D";
+            const resolvedPaymentTerm = paymentTerm || "PREPAID";
+            const resolvedOutputCurrency = outputCurrency || "PGK";
+
+            const result = await actions.createQuote({
+                payment_term: resolvedPaymentTerm,
+                service_scope: resolvedScope,
+                output_currency: resolvedOutputCurrency,
+                customer_id: customerIdParam || undefined,
             });
 
-            if (spe) {
-                // 2. Auto-acknowledge
-                const success = await actions.submitAcknowledgement();
-                if (success) {
-                    // 3. Create the quote directly (backend handles compute internally)
-                    const resolvedScope = serviceScope || "D2D";
-                    const resolvedPaymentTerm = paymentTerm || "PREPAID";
-                    const resolvedOutputCurrency = outputCurrency || "PGK";
-
-                    const result = await actions.createQuote({
-                        payment_term: resolvedPaymentTerm,
-                        service_scope: resolvedScope,
-                        output_currency: resolvedOutputCurrency,
-                        customer_id: customerIdParam || undefined,
-                    });
-
-                    if (result?.success && result.quote_id) {
-                        router.push(`/quotes/${result.quote_id}`);
-                    }
-                }
+            if (result?.success && result.quote_id) {
+                router.push(`/quotes/${result.quote_id}`);
             }
         }
     };
@@ -939,17 +943,20 @@ export default function SpotRateEntryPage() {
                         shipmentType={resolvedShipmentType}
                         serviceScope={serviceScope}
                         missingComponents={missingComponents}
-                        submitLabel="Confirm & Create Quote"
+                        submitLabel={speAlreadyReady ? "Create Quote" : "Confirm & Create Quote"}
+                        submitLoadingText={speAlreadyReady ? "Creating quote..." : "Confirming and creating quote..."}
                         submitDisabled={quoteCreationBlocked}
                         submitDisabledReason={quoteCreationBlocked ? "Quote creation is temporarily unavailable." : null}
-                        onSaveDraft={handleSaveDraft}
+                        onSaveDraft={speAlreadyReady ? undefined : handleSaveDraft}
                     />
 
                     {/* Static disclaimer (acknowledgement is recorded on submit in backend flow) */}
                     <Card className="border-amber-200 bg-amber-50/60">
                         <CardContent className="pt-4">
                             <p className="text-sm text-amber-900">
-                                Final submission records the SPOT acknowledgement and creates the quote from the imported charges. Rates are still conditional until carrier and space are confirmed.
+                                {speAlreadyReady
+                                    ? "This SPOT acknowledgement is already recorded. Creating the quote will use the locked imported charges."
+                                    : "Final submission records the SPOT acknowledgement and creates the quote from the imported charges. Rates are still conditional until carrier and space are confirmed."}
                             </p>
                         </CardContent>
                     </Card>

--- a/frontend/src/components/forms/QuoteForm.tsx
+++ b/frontend/src/components/forms/QuoteForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useWatch } from "react-hook-form";
 import { AlertTriangle } from "lucide-react";
 
@@ -124,7 +124,9 @@ export function QuoteForm({
   const resetQuote = useQuoteStore((state) => state.resetQuote);
 
   const isImport = destinationLocation?.country_code === "PG";
-  const submitBusy = isSubmitting || form.formState.isSubmitting;
+  const [isSubmitLocked, setIsSubmitLocked] = useState(false);
+  const submitIntentLockRef = useRef(false);
+  const submitBusy = isSubmitting || form.formState.isSubmitting || isSubmitLocked;
 
   const buildSnapshot = useCallback(
     (): QuoteSavedSnapshot => ({
@@ -165,6 +167,13 @@ export function QuoteForm({
   useEffect(() => {
     onDirtyChange?.(form.formState.isDirty);
   }, [form.formState.isDirty, onDirtyChange]);
+
+  useEffect(() => {
+    if (!isSubmitting && !form.formState.isSubmitting) {
+      submitIntentLockRef.current = false;
+      setIsSubmitLocked(false);
+    }
+  }, [form.formState.isSubmitting, isSubmitting]);
 
   useEffect(() => {
     setValidationState(sectionValidation);
@@ -366,13 +375,36 @@ export function QuoteForm({
     commitSection(activeSection, nextIndex);
   };
 
-  const onFormError = (errors: Record<string, unknown>) => {
+  const onFormError = useCallback((errors: Record<string, unknown>) => {
+    submitIntentLockRef.current = false;
+    setIsSubmitLocked(false);
     if (Object.keys(errors).length > 0) {
       console.warn("Form validation errors:", errors);
       setCurrentStep(unlockedSection);
       scrollToSection(unlockedSection);
     }
-  };
+  }, [setCurrentStep, unlockedSection]);
+
+  const handleSubmitEvent = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      if (submitIntentLockRef.current) {
+        event.preventDefault();
+        return;
+      }
+
+      submitIntentLockRef.current = true;
+      setIsSubmitLocked(true);
+
+      try {
+        await form.handleSubmit(handleFormSubmit, onFormError)(event);
+      } catch (error) {
+        submitIntentLockRef.current = false;
+        setIsSubmitLocked(false);
+        throw error;
+      }
+    },
+    [form, handleFormSubmit, onFormError],
+  );
 
   const getSectionStatus = (index: QuoteSectionIndex): QuoteSectionStatus => {
     if (index === activeSection) return "active";
@@ -405,7 +437,7 @@ export function QuoteForm({
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(handleFormSubmit, onFormError)} className="space-y-6">
+      <form onSubmit={handleSubmitEvent} className="space-y-6">
         <div className={cn("space-y-6", submitBusy && "pointer-events-none opacity-70")}>
           {(internalError || serverError) && (
             <div className="flex items-center gap-2 rounded-md bg-destructive/15 px-4 py-3 text-destructive">

--- a/frontend/src/components/spot/ChargeBucketSection.tsx
+++ b/frontend/src/components/spot/ChargeBucketSection.tsx
@@ -174,7 +174,7 @@ export function ChargeBucketSection({
                                             render={({ field }) => (
                                                 <div className="space-y-2">
                                                     <FormItem>
-                                                        <Select onValueChange={field.onChange} defaultValue={field.value}>
+                                                        <Select onValueChange={field.onChange} value={field.value ?? ""}>
                                                             <FormControl>
                                                                 <SelectTrigger className="h-9">
                                                                     <SelectValue />

--- a/frontend/src/components/spot/SmartMoneyInput.tsx
+++ b/frontend/src/components/spot/SmartMoneyInput.tsx
@@ -31,7 +31,7 @@ export function SmartMoneyInput({
                         name={currencyName}
                         render={({ field }) => (
                             <FormItem>
-                                <Select onValueChange={field.onChange} defaultValue={field.value}>
+                                <Select onValueChange={field.onChange} value={field.value ?? ""}>
                                     <FormControl>
                                         <SelectTrigger className="h-9 px-2">
                                             <SelectValue />

--- a/frontend/src/components/spot/SpotRateEntryForm.tsx
+++ b/frontend/src/components/spot/SpotRateEntryForm.tsx
@@ -27,6 +27,7 @@ interface SpotRateEntryFormProps {
     serviceScope?: string;
     missingComponents?: string[];
     submitLabel?: string;
+    submitLoadingText?: string;
     submitDisabled?: boolean;
     submitDisabledReason?: string | null;
     onSaveDraft?: (charges: Omit<SPEChargeLine, 'id'>[]) => Promise<void>;
@@ -99,6 +100,7 @@ export function SpotRateEntryForm({
     serviceScope = "D2D",
     missingComponents = [],
     submitLabel,
+    submitLoadingText,
     submitDisabled = false,
     submitDisabledReason = null,
     onSaveDraft,
@@ -444,7 +446,7 @@ export function SpotRateEntryForm({
                         disabled={!canSubmit}
                         size="lg"
                         loading={Boolean(isLoading || form.formState.isSubmitting)}
-                        loadingText="Saving changes..."
+                        loadingText={submitLoadingText || "Saving changes..."}
                     >
                         {submitLabel || "Save & Proceed"}
                     </Button>

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -8,8 +8,6 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const CLICK_GUARD_MS = 500
-const SUBMIT_PENDING_FALLBACK_MS = 2000
-
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all duration-200 hover:-translate-y-px active:translate-y-0 active:scale-[0.98] disabled:pointer-events-none disabled:translate-y-0 disabled:shadow-none disabled:opacity-50 disabled:cursor-not-allowed aria-busy:cursor-progress data-[pending=true]:translate-y-0 data-[pending=true]:scale-100 data-[pending=true]:shadow-none data-[pending=true]:ring-2 data-[pending=true]:ring-primary/15 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 aria-invalid:border-destructive",
   {
@@ -134,31 +132,7 @@ function Button({
     const form = button.form ?? button.closest("form")
     const buttonType = type ?? (form ? "submit" : "button")
 
-    if (buttonType === "submit") {
-      startPending(SUBMIT_PENDING_FALLBACK_MS)
-
-      if (form instanceof HTMLFormElement) {
-        let submitObserved = false
-        const handleInvalid = () => {
-          window.setTimeout(() => {
-            clearPending()
-          }, 150)
-        }
-        const handleSubmitObserved = () => {
-          submitObserved = true
-        }
-
-        form.addEventListener("invalid", handleInvalid, { once: true, capture: true })
-        form.addEventListener("submit", handleSubmitObserved, { once: true, capture: true })
-
-        window.setTimeout(() => {
-          form.removeEventListener("invalid", handleInvalid, true)
-          if (!submitObserved && !loading) {
-            clearPending()
-          }
-        }, 0)
-      }
-    } else {
+    if (buttonType !== "submit") {
       startClickGuard()
     }
 

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -7,8 +7,11 @@ import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 
+const CLICK_GUARD_MS = 500
+const SUBMIT_PENDING_FALLBACK_MS = 2000
+
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all duration-200 hover:-translate-y-px active:translate-y-0 active:scale-[0.98] disabled:pointer-events-none disabled:translate-y-0 disabled:shadow-none disabled:opacity-50 disabled:cursor-not-allowed aria-busy:cursor-progress [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all duration-200 hover:-translate-y-px active:translate-y-0 active:scale-[0.98] disabled:pointer-events-none disabled:translate-y-0 disabled:shadow-none disabled:opacity-50 disabled:cursor-not-allowed aria-busy:cursor-progress data-[pending=true]:translate-y-0 data-[pending=true]:scale-100 data-[pending=true]:shadow-none data-[pending=true]:ring-2 data-[pending=true]:ring-primary/15 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
@@ -55,6 +58,7 @@ function Button({
   asChild = false,
   children,
   onClick,
+  type,
   disabled,
   loading = false,
   loadingText,
@@ -66,27 +70,107 @@ function Button({
     loadingText?: React.ReactNode
   }) {
   const [isPendingClick, setIsPendingClick] = React.useState(false)
+  const [isClickGuarded, setIsClickGuarded] = React.useState(false)
   const clickLockRef = React.useRef(false)
+  const clickGuardTimerRef = React.useRef<number | null>(null)
+  const pendingTimerRef = React.useRef<number | null>(null)
   const Comp = asChild ? Slot : "button"
+  const resolvedLoading = Boolean(loading || isPendingClick)
+
+  const clearClickGuard = React.useCallback(() => {
+    if (clickGuardTimerRef.current !== null) {
+      window.clearTimeout(clickGuardTimerRef.current)
+      clickGuardTimerRef.current = null
+    }
+    setIsClickGuarded(false)
+  }, [])
+
+  const clearPending = React.useCallback(() => {
+    if (pendingTimerRef.current !== null) {
+      window.clearTimeout(pendingTimerRef.current)
+      pendingTimerRef.current = null
+    }
+    clickLockRef.current = false
+    setIsPendingClick(false)
+  }, [])
+
+  const startClickGuard = React.useCallback((durationMs = CLICK_GUARD_MS) => {
+    clearClickGuard()
+    clickLockRef.current = true
+    setIsClickGuarded(true)
+    clickGuardTimerRef.current = window.setTimeout(() => {
+      clickLockRef.current = false
+      setIsClickGuarded(false)
+      clickGuardTimerRef.current = null
+    }, durationMs)
+  }, [clearClickGuard])
+
+  const startPending = React.useCallback((fallbackMs?: number) => {
+    clearClickGuard()
+    clearPending()
+    clickLockRef.current = true
+    setIsPendingClick(true)
+    if (typeof fallbackMs === "number") {
+      pendingTimerRef.current = window.setTimeout(() => {
+        clearPending()
+      }, fallbackMs)
+    }
+  }, [clearClickGuard, clearPending])
+
+  React.useEffect(() => {
+    return () => {
+      clearClickGuard()
+      clearPending()
+    }
+  }, [clearClickGuard, clearPending])
 
   const handleClick = React.useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
-    if (disabled || clickLockRef.current) {
+    if (disabled || loading || clickLockRef.current) {
       event.preventDefault()
       return
     }
 
+    const button = event.currentTarget
+    const form = button.form ?? button.closest("form")
+    const buttonType = type ?? (form ? "submit" : "button")
+
+    if (buttonType === "submit") {
+      startPending(SUBMIT_PENDING_FALLBACK_MS)
+
+      if (form instanceof HTMLFormElement) {
+        let submitObserved = false
+        const handleInvalid = () => {
+          window.setTimeout(() => {
+            clearPending()
+          }, 150)
+        }
+        const handleSubmitObserved = () => {
+          submitObserved = true
+        }
+
+        form.addEventListener("invalid", handleInvalid, { once: true, capture: true })
+        form.addEventListener("submit", handleSubmitObserved, { once: true, capture: true })
+
+        window.setTimeout(() => {
+          form.removeEventListener("invalid", handleInvalid, true)
+          if (!submitObserved && !loading) {
+            clearPending()
+          }
+        }, 0)
+      }
+    } else {
+      startClickGuard()
+    }
+
     const result = onClick?.(event)
     if (isPromiseLike(result)) {
-      clickLockRef.current = true
-      setIsPendingClick(true)
+      startPending()
       void result.finally(() => {
-        clickLockRef.current = false
-        setIsPendingClick(false)
+        clearPending()
       })
     }
-  }, [disabled, onClick])
+  }, [clearPending, disabled, loading, onClick, startClickGuard, startPending, type])
 
-  const resolvedLoading = Boolean(loading || isPendingClick)
   const renderedChildren = resolvedLoading ? (
     <>
       <Loader2 className="animate-spin" />
@@ -101,6 +185,7 @@ function Button({
         onClick={onClick}
         aria-busy={resolvedLoading || undefined}
         aria-disabled={disabled || resolvedLoading || undefined}
+        data-pending={resolvedLoading ? "true" : undefined}
         className={cn(buttonVariants({ variant, size, className }), (disabled || resolvedLoading) && "pointer-events-none opacity-50")}
         {...props}
       >
@@ -109,15 +194,17 @@ function Button({
     )
   }
 
-  const resolvedDisabled = Boolean(disabled || resolvedLoading)
+  const resolvedDisabled = Boolean(disabled || resolvedLoading || isClickGuarded)
 
   return (
     <Comp
       data-slot="button"
       className={cn(buttonVariants({ variant, size, className }))}
       onClick={handleClick}
+      type={type}
       disabled={resolvedDisabled}
       aria-busy={resolvedLoading || undefined}
+      data-pending={resolvedLoading ? "true" : undefined}
       {...props}
     >
       {renderedChildren}


### PR DESCRIPTION
## Summary
- persist resolved SPOT missing components on the envelope model and backfill existing records
- align import/local rate availability and serializer behavior with the persisted missing-component state
- update SPOT flow/frontend behavior and related tests for the new persistence path

## Validation
- python manage.py test quotes.tests.test_api_v3 quotes.tests.test_dispatcher
- python manage.py test quotes.tests.test_rate_availability_service quotes.tests.test_spot_flow_api

## Notes
- includes migration `0027_spotpricingenvelopedb_resolved_missing_components`
- opened as draft because this branch was isolated from previously uncommitted local work and should be reviewed before merge