### PR TITLE
🧹 Code Health: Remove unused timedelta import

### DIFF
--- a/backend/core/fx_serializers.py
+++ b/backend/core/fx_serializers.py
@@ -6,7 +6,6 @@ Serializers for FX Rate Management API.
 from decimal import Decimal
 from rest_framework import serializers
 from django.utils import timezone
-from datetime import timedelta
 
 
 class CurrencyRateInputSerializer(serializers.Serializer):


### PR DESCRIPTION
🎯 **What:** Removed unused `timedelta` import from `backend/core/fx_serializers.py`.
💡 **Why:** To improve code health by removing dead code. Static analysis identified it as unused.
✅ **Verification:** Verified by code review and executing backend tests to ensure `fx_serializers.py` evaluates correctly and functionality is preserved. 
✨ **Result:** Improved maintainability and clarity.

---
*PR created automatically by Jules for task [8708464230027065216](https://jules.google.com/task/8708464230027065216) started by @nace-martin*