### PR TITLE
Require user hierarchy assignments and align reporting access

### DIFF
--- a/backend/accounts/management/commands/create_test_users.py
+++ b/backend/accounts/management/commands/create_test_users.py
@@ -5,24 +5,31 @@ class Command(BaseCommand):
     help = 'Create test users with different roles'
 
     def handle(self, *args, **options):
+        default_organization = CustomUser._default_organization()
         # Create test users with different roles
         users_data = [
             {
                 'username': 'sales_user',
                 'password': 'sales_password',
                 'role': 'sales',
+                'department': CustomUser.DEPARTMENT_GENERAL,
+                'organization': default_organization,
                 'is_active': True,
             },
             {
                 'username': 'manager_user',
                 'password': 'manager_password',
                 'role': 'manager',
+                'department': CustomUser.DEPARTMENT_GENERAL,
+                'organization': default_organization,
                 'is_active': True,
             },
             {
                 'username': 'finance_user',
                 'password': 'finance_password',
                 'role': 'finance',
+                'department': CustomUser.DEPARTMENT_GENERAL,
+                'organization': default_organization,
                 'is_active': True,
             }
         ]
@@ -32,6 +39,8 @@ class Command(BaseCommand):
             password = user_data['password']
             defaults = {
                 'role': user_data['role'],
+                'department': user_data['department'],
+                'organization': user_data['organization'],
                 'is_active': True,
             }
             user, created = CustomUser.objects.update_or_create(
@@ -53,6 +62,8 @@ class Command(BaseCommand):
         admin_defaults = {
             'email': 'admin@example.com',
             'role': 'admin',
+            'department': CustomUser.DEPARTMENT_GENERAL,
+            'organization': default_organization,
             'is_active': True,
             'is_staff': True,
             'is_superuser': True,

--- a/backend/accounts/management/commands/seed_test_users.py
+++ b/backend/accounts/management/commands/seed_test_users.py
@@ -7,13 +7,15 @@ class Command(BaseCommand):
     help = 'Seeds the database with test users for E2E testing'
 
     def handle(self, *args, **options):
+        default_organization = User._default_organization()
         users_data = [
             {
                 'username': 'admin',
                 'email': 'admin@example.com',
                 'password': 'admin123',
                 'role': 'admin',
-                'department': None,
+                'department': User.DEPARTMENT_GENERAL,
+                'organization': default_organization,
                 'is_active': True,
                 'is_staff': True,
                 'is_superuser': True
@@ -24,6 +26,7 @@ class Command(BaseCommand):
                 'password': 'manager123',
                 'role': 'manager',
                 'department': 'AIR',
+                'organization': default_organization,
                 'is_active': True,
                 'is_staff': False,
                 'is_superuser': False
@@ -34,6 +37,7 @@ class Command(BaseCommand):
                 'password': 'sales123',
                 'role': 'sales',
                 'department': 'AIR',
+                'organization': default_organization,
                 'is_active': True,
                 'is_staff': False,
                 'is_superuser': False
@@ -43,7 +47,8 @@ class Command(BaseCommand):
                 'email': 'finance@example.com',
                 'password': 'finance123',
                 'role': 'finance',
-                'department': None,
+                'department': User.DEPARTMENT_GENERAL,
+                'organization': default_organization,
                 'is_active': True,
                 'is_staff': False,
                 'is_superuser': False
@@ -55,6 +60,7 @@ class Command(BaseCommand):
                 'password': 'sales123',
                 'role': 'sales',
                 'department': 'SEA',
+                'organization': default_organization,
                 'is_active': True,
                 'is_staff': False,
                 'is_superuser': False

--- a/backend/accounts/migrations/0005_require_user_organization_and_department.py
+++ b/backend/accounts/migrations/0005_require_user_organization_and_department.py
@@ -1,0 +1,87 @@
+from django.db import migrations, models
+from django.db.models import Q
+import django.db.models.deletion
+
+
+GENERAL_DEPARTMENT = "GENERAL"
+
+
+def _get_default_organization(Organization):
+    organization = (
+        Organization.objects
+        .filter(is_active=True)
+        .exclude(slug="default-organization")
+        .order_by("name")
+        .first()
+    )
+    if organization is None:
+        organization = Organization.objects.filter(is_active=True).order_by("name").first()
+    if organization is None:
+        organization = (
+            Organization.objects
+            .exclude(slug="default-organization")
+            .order_by("name")
+            .first()
+        )
+    if organization is None:
+        organization = Organization.objects.order_by("name").first()
+    if organization is None:
+        organization = Organization.objects.create(
+            name="Default Organization",
+            slug="default-organization",
+            is_active=True,
+        )
+    return organization
+
+
+def backfill_user_hierarchy(apps, schema_editor):
+    CustomUser = apps.get_model("accounts", "CustomUser")
+    Organization = apps.get_model("parties", "Organization")
+
+    default_organization = _get_default_organization(Organization)
+
+    CustomUser.objects.filter(organization__isnull=True).update(organization=default_organization)
+    CustomUser.objects.filter(Q(department__isnull=True) | Q(department="")).update(
+        department=GENERAL_DEPARTMENT
+    )
+
+
+def revert_user_hierarchy_backfill(apps, schema_editor):
+    CustomUser = apps.get_model("accounts", "CustomUser")
+    CustomUser.objects.filter(department=GENERAL_DEPARTMENT).update(department="")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("accounts", "0004_customuser_organization"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_user_hierarchy, revert_user_hierarchy_backfill),
+        migrations.AlterField(
+            model_name="customuser",
+            name="department",
+            field=models.CharField(
+                choices=[
+                    ("GENERAL", "General"),
+                    ("AIR", "Air Freight"),
+                    ("SEA", "Sea Freight"),
+                    ("LAND", "Land Freight"),
+                ],
+                default="GENERAL",
+                help_text="Department assignment for visibility restrictions (e.g., Air vs Sea).",
+                max_length=10,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="customuser",
+            name="organization",
+            field=models.ForeignKey(
+                help_text="Tenant/account workspace this user belongs to.",
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="users",
+                to="parties.organization",
+            ),
+        ),
+    ]

--- a/backend/accounts/models.py
+++ b/backend/accounts/models.py
@@ -46,7 +46,10 @@ class CustomUser(AbstractUser):
         related_query_name='customuser',
     )
     
+    DEPARTMENT_GENERAL = 'GENERAL'
+
     DEPARTMENT_CHOICES = [
+        (DEPARTMENT_GENERAL, 'General'),
         ('AIR', 'Air Freight'),
         ('SEA', 'Sea Freight'),
         ('LAND', 'Land Freight'),
@@ -54,18 +57,65 @@ class CustomUser(AbstractUser):
     department = models.CharField(
         max_length=10, 
         choices=DEPARTMENT_CHOICES, 
-        null=True, 
-        blank=True,
+        default=DEPARTMENT_GENERAL,
         help_text="Department assignment for visibility restrictions (e.g., Air vs Sea)."
     )
     organization = models.ForeignKey(
         'parties.Organization',
         on_delete=models.PROTECT,
-        null=True,
-        blank=True,
         related_name='users',
         help_text="Tenant/account workspace this user belongs to.",
     )
+
+    @classmethod
+    def valid_departments(cls) -> set[str]:
+        return {choice for choice, _label in cls.DEPARTMENT_CHOICES}
+
+    @staticmethod
+    def _default_organization():
+        from parties.models import Organization
+
+        organization = (
+            Organization.objects
+            .filter(is_active=True)
+            .exclude(slug='default-organization')
+            .order_by('name')
+            .first()
+        )
+        if organization is None:
+            organization = Organization.objects.filter(is_active=True).order_by('name').first()
+        if organization is None:
+            organization = (
+                Organization.objects
+                .exclude(slug='default-organization')
+                .order_by('name')
+                .first()
+            )
+        if organization is None:
+            organization = Organization.objects.order_by('name').first()
+        if organization is None:
+            organization = Organization.objects.create(name="Default Organization")
+        return organization
+
+    def save(self, *args, **kwargs):
+        update_fields = kwargs.get('update_fields')
+
+        if not self.organization_id:
+            self.organization = self._default_organization()
+            if update_fields is not None:
+                update_fields = set(update_fields)
+                update_fields.add('organization')
+
+        if not self.department or self.department not in self.valid_departments():
+            self.department = self.DEPARTMENT_GENERAL
+            if update_fields is not None:
+                update_fields = set(update_fields)
+                update_fields.add('department')
+
+        if update_fields is not None:
+            kwargs['update_fields'] = list(update_fields)
+
+        super().save(*args, **kwargs)
 
     def __str__(self):
         return f"{self.username} ({self.get_role_display()})"

--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -21,6 +21,22 @@ from parties.models import Organization, OrganizationBranding
 from .models import CustomUser
 
 
+def _ensure_default_organization():
+    pgk = Currency.objects.filter(code='PGK').first() or Currency.objects.create(
+        code='PGK',
+        name='Papua New Guinean Kina',
+    )
+    organization, _ = Organization.objects.get_or_create(
+        slug='efm-express-air-cargo',
+        defaults={
+            'name': 'EFM Express Air Cargo',
+            'default_currency': pgk,
+            'is_active': True,
+        },
+    )
+    return organization
+
+
 class LoginTests(TestCase):
     """Tests for the login endpoint."""
     
@@ -36,21 +52,11 @@ class LoginTests(TestCase):
             password='testpass123',
             role=CustomUser.ROLE_SALES,
             organization=self.organization,
+            department=CustomUser.DEPARTMENT_GENERAL,
         )
 
     def _create_default_organization(self):
-        pgk = Currency.objects.filter(code='PGK').first() or Currency.objects.create(
-            code='PGK',
-            name='Papua New Guinean Kina',
-        )
-        organization, _ = Organization.objects.get_or_create(
-            slug='efm-express-air-cargo',
-            defaults={
-                'name': 'EFM Express Air Cargo',
-                'default_currency': pgk,
-                'is_active': True,
-            },
-        )
+        organization = _ensure_default_organization()
         OrganizationBranding.objects.update_or_create(
             organization=organization,
             defaults={
@@ -225,27 +231,36 @@ class RBACPermissionTests(TestCase):
     
     def setUp(self):
         self.client = APIClient()
+        self.organization = _ensure_default_organization()
         
         # Create users with different roles
         self.sales_user = CustomUser.objects.create_user(
             username='sales',
             password='test123',
-            role=CustomUser.ROLE_SALES
+            role=CustomUser.ROLE_SALES,
+            organization=self.organization,
+            department=CustomUser.DEPARTMENT_GENERAL,
         )
         self.manager_user = CustomUser.objects.create_user(
             username='manager',
             password='test123',
-            role=CustomUser.ROLE_MANAGER
+            role=CustomUser.ROLE_MANAGER,
+            organization=self.organization,
+            department=CustomUser.DEPARTMENT_GENERAL,
         )
         self.finance_user = CustomUser.objects.create_user(
             username='finance',
             password='test123',
-            role=CustomUser.ROLE_FINANCE
+            role=CustomUser.ROLE_FINANCE,
+            organization=self.organization,
+            department=CustomUser.DEPARTMENT_GENERAL,
         )
         self.admin_user = CustomUser.objects.create_user(
             username='admin',
             password='test123',
-            role=CustomUser.ROLE_ADMIN
+            role=CustomUser.ROLE_ADMIN,
+            organization=self.organization,
+            department=CustomUser.DEPARTMENT_GENERAL,
         )
     
     def test_sales_can_view_cogs_false(self):
@@ -309,6 +324,7 @@ class UserManagementOrganizationTests(TestCase):
             password='test12345',
             role=CustomUser.ROLE_MANAGER,
             organization=self.org_a,
+            department='AIR',
         )
 
     def test_manager_can_list_organizations(self):
@@ -321,7 +337,7 @@ class UserManagementOrganizationTests(TestCase):
         self.assertIn('efm-express-air-cargo', slugs)
         self.assertIn('lae-branch-workspace', slugs)
 
-    def test_user_create_defaults_to_request_users_organization(self):
+    def test_user_create_requires_explicit_organization(self):
         self.client.force_authenticate(user=self.manager)
 
         response = self.client.post(
@@ -336,9 +352,8 @@ class UserManagementOrganizationTests(TestCase):
             format='json',
         )
 
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        created = CustomUser.objects.get(username='new-sales-user')
-        self.assertEqual(created.organization, self.org_a)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('organization', response.json())
 
     def test_user_create_can_assign_explicit_organization(self):
         self.client.force_authenticate(user=self.manager)
@@ -359,3 +374,21 @@ class UserManagementOrganizationTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         created = CustomUser.objects.get(username='lae-sales-user')
         self.assertEqual(created.organization, self.org_b)
+
+    def test_user_create_requires_explicit_department(self):
+        self.client.force_authenticate(user=self.manager)
+
+        response = self.client.post(
+            '/api/auth/users/',
+            {
+                'username': 'missing-department-user',
+                'email': 'missing-department@example.com',
+                'role': 'sales',
+                'password': 'password123',
+                'organization': str(self.org_a.id),
+            },
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('department', response.json())

--- a/backend/accounts/user_management.py
+++ b/backend/accounts/user_management.py
@@ -14,17 +14,12 @@ from .models import CustomUser
 from parties.models import Organization
 
 
-def _default_organization():
-    organization = Organization.objects.filter(is_active=True).order_by('name').first()
-    if organization is None:
-        organization = Organization.objects.order_by('name').first()
-    return organization
-
-
 class UserSerializer(serializers.ModelSerializer):
     """Serializer for listing and viewing users."""
     password = serializers.CharField(write_only=True, required=False, min_length=8)
     organization_name = serializers.CharField(source='organization.name', read_only=True)
+    department = serializers.ChoiceField(choices=CustomUser.DEPARTMENT_CHOICES, required=True)
+    organization = serializers.PrimaryKeyRelatedField(queryset=Organization.objects.all(), required=True)
     
     class Meta:
         model = CustomUser
@@ -38,9 +33,6 @@ class UserSerializer(serializers.ModelSerializer):
     
     def create(self, validated_data):
         password = validated_data.pop('password', None)
-        if 'organization' not in validated_data:
-            request = self.context.get('request')
-            validated_data['organization'] = getattr(getattr(request, 'user', None), 'organization', None) or _default_organization()
         user = CustomUser(**validated_data)
         if password:
             user.password = make_password(password)

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -80,7 +80,22 @@ def _serialize_user(user: CustomUser, request=None):
 def _default_organization():
     from parties.models import Organization
 
-    organization = Organization.objects.filter(is_active=True).order_by('name').first()
+    organization = (
+        Organization.objects
+        .filter(is_active=True)
+        .exclude(slug='default-organization')
+        .order_by('name')
+        .first()
+    )
+    if organization is None:
+        organization = Organization.objects.filter(is_active=True).order_by('name').first()
+    if organization is None:
+        organization = (
+            Organization.objects
+            .exclude(slug='default-organization')
+            .order_by('name')
+            .first()
+        )
     if organization is None:
         organization = Organization.objects.order_by('name').first()
     return organization
@@ -185,6 +200,7 @@ def register_view(request):
         password=make_password(password),
         role=CustomUser.ROLE_SALES,  # Always sales - no role self-assignment
         organization=_default_organization(),
+        department=CustomUser.DEPARTMENT_GENERAL,
     )
     
     # Create token for the user

--- a/backend/quotes/reporting_views.py
+++ b/backend/quotes/reporting_views.py
@@ -13,6 +13,7 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 
 from .models import Quote, QuoteTotal, QuoteVersion, QuoteEvent
+from .selectors import get_quotes_for_user
 from parties.models import Company
 from accounts.permissions import IsManagerOrAdmin, IsFinanceOrAdmin
 
@@ -78,9 +79,9 @@ class ReportsViewSet(viewsets.ViewSet):
             return timeframe, today.replace(month=1, day=1), today
         return 'monthly', today.replace(day=1), today
 
-    def _build_activity_series(self, timeframe, start_date, end_date):
+    def _build_activity_series(self, timeframe, start_date, end_date, user):
         quote_dates = (
-            Quote.objects.exclude(is_archived=True)
+            get_quotes_for_user(user, Quote.objects.exclude(is_archived=True))
             .filter(created_at__date__gte=start_date, created_at__date__lte=end_date)
             .values_list('created_at__date', flat=True)
         )
@@ -140,14 +141,14 @@ class ReportsViewSet(viewsets.ViewSet):
                 buckets[quote_date.month]['count'] += 1
         return list(buckets.values()), 'Year to date'
 
-    def _quotes_with_financials(self, start_date=None, end_date=None, user_id=None, mode=None):
+    def _quotes_with_financials(self, user, start_date=None, end_date=None, user_id=None, mode=None):
         """
         Get quotes annotated with their latest version's financial totals.
         Optionally filter by date range, user, and mode.
         """
         latest_total = self._get_latest_total_subquery()
 
-        qs = Quote.objects.annotate(
+        qs = get_quotes_for_user(user, Quote.objects.all()).annotate(
             latest_total_sell_pgk=Subquery(latest_total.values('total_sell_pgk')[:1]),
             latest_total_cost_pgk=Subquery(latest_total.values('total_cost_pgk')[:1]),
         ).exclude(is_archived=True)
@@ -179,7 +180,7 @@ class ReportsViewSet(viewsets.ViewSet):
         user_id = request.query_params.get('user_id')
         mode = request.query_params.get('mode')
 
-        qs = self._quotes_with_financials(start_date, end_date, user_id, mode)
+        qs = self._quotes_with_financials(request.user, start_date, end_date, user_id, mode)
 
         # Count by status
         counts = qs.aggregate(
@@ -202,7 +203,7 @@ class ReportsViewSet(viewsets.ViewSet):
             from django.db.models.functions import Extract
 
             # Get quotes with both events in the date range
-            quotes_with_events = Quote.objects.filter(
+            quotes_with_events = get_quotes_for_user(request.user, Quote.objects.all()).filter(
                 created_at__date__gte=start_date,
                 created_at__date__lte=end_date,
                 events__event_type=QuoteEvent.EventType.CREATED
@@ -264,7 +265,7 @@ class ReportsViewSet(viewsets.ViewSet):
         user_id = request.query_params.get('user_id')
         mode = request.query_params.get('mode')
 
-        qs = self._quotes_with_financials(start_date, end_date, user_id, mode)
+        qs = self._quotes_with_financials(request.user, start_date, end_date, user_id, mode)
 
         # Only include finalized/sent/accepted quotes in financials
         financial_statuses = [Quote.Status.FINALIZED, Quote.Status.SENT, Quote.Status.ACCEPTED]
@@ -333,7 +334,7 @@ class ReportsViewSet(viewsets.ViewSet):
         start_date, end_date = self._parse_date_params(request)
         mode = request.query_params.get('mode')
 
-        qs = self._quotes_with_financials(start_date, end_date, mode=mode)
+        qs = self._quotes_with_financials(request.user, start_date, end_date, mode=mode)
 
         # Group by user
         performance = qs.values(
@@ -404,7 +405,7 @@ class ReportsViewSet(viewsets.ViewSet):
         user_id = request.query_params.get('user_id')
         mode = request.query_params.get('mode')
 
-        qs = self._quotes_with_financials(start_date, end_date, user_id, mode)
+        qs = self._quotes_with_financials(request.user, start_date, end_date, user_id, mode)
 
         # Include all statuses except DRAFT
         qs = qs.exclude(status=Quote.Status.DRAFT).select_related(
@@ -472,7 +473,7 @@ class ReportsViewSet(viewsets.ViewSet):
         timeframe, start_date, end_date = self._get_dashboard_timeframe_range(timeframe)
 
         latest_total = self._get_latest_total_subquery()
-        financial_quotes = Quote.objects.annotate(
+        financial_quotes = get_quotes_for_user(request.user, Quote.objects.all()).annotate(
             latest_total_sell_pgk=Subquery(latest_total.values('total_sell_pgk')[:1]),
             latest_total_sell_pgk_incl_gst=Subquery(latest_total.values('total_sell_pgk_incl_gst')[:1]),
             latest_total_cost_pgk=Subquery(latest_total.values('total_cost_pgk')[:1]),
@@ -526,7 +527,7 @@ class ReportsViewSet(viewsets.ViewSet):
             value=Sum('latest_total_sell_pgk_incl_gst')
         )
 
-        activity_series, activity_label = self._build_activity_series(timeframe, start_date, end_date)
+        activity_series, activity_label = self._build_activity_series(timeframe, start_date, end_date, request.user)
         
         return Response({
             'timeframe': timeframe,
@@ -557,11 +558,11 @@ class ReportsViewSet(viewsets.ViewSet):
         target_user_id = self._get_user_scope(request)
         
         # Base QuerySet for the selected period
-        qs_period = Quote.objects.filter(
+        qs_period = get_quotes_for_user(request.user, Quote.objects.all()).filter(
             created_at__date__gte=start_date,
             created_at__date__lte=end_date
         ).exclude(is_archived=True)
-        
+
         if target_user_id:
             qs_period = qs_period.filter(created_by_id=target_user_id)
             
@@ -586,7 +587,7 @@ class ReportsViewSet(viewsets.ViewSet):
 
         revenue_statuses = [Quote.Status.FINALIZED, Quote.Status.ACCEPTED]
 
-        qs_top_customers = Quote.objects.filter(
+        qs_top_customers = get_quotes_for_user(request.user, Quote.objects.all()).filter(
             status__in=revenue_statuses
         ).exclude(is_archived=True)
 
@@ -630,7 +631,7 @@ class ReportsViewSet(viewsets.ViewSet):
             quote_version__quote_id=OuterRef('pk')
         ).order_by('-quote_version__version_number').values('total_sell_pgk')[:1]
 
-        quotes_with_latest_total = Quote.objects.annotate(
+        quotes_with_latest_total = get_quotes_for_user(request.user, Quote.objects.all()).annotate(
             latest_total_sell_pgk=Subquery(latest_total_subquery)
         )
 
@@ -673,7 +674,7 @@ class ReportsViewSet(viewsets.ViewSet):
             quote_version__quote_id=OuterRef('pk')
         ).order_by('-quote_version__version_number').values('total_sell_pgk')[:1]
 
-        quotes_with_latest_total = Quote.objects.annotate(
+        quotes_with_latest_total = get_quotes_for_user(request.user, Quote.objects.all()).annotate(
             latest_total_sell_pgk=Subquery(latest_total_subquery)
         )
 

--- a/backend/quotes/selectors.py
+++ b/backend/quotes/selectors.py
@@ -1,66 +1,60 @@
-from django.shortcuts import get_object_or_404
-from django.core.exceptions import PermissionDenied, ObjectDoesNotExist
-from django.db.models import QuerySet
+from django.core.exceptions import PermissionDenied
+from django.db.models import Q, QuerySet
+from django.http import Http404
+
 from quotes.models import Quote
 
-def get_quote_for_user(user, quote_id: str, queryset: QuerySet | None = None) -> Quote:
+
+def get_quotes_for_user(user, queryset: QuerySet | None = None) -> QuerySet:
     """
-    Retrieve a quote by ID while strictly enforcing RBAC ownership rules.
-    
+    Apply the strict-by-default quote visibility policy.
+
     Rules:
-    - Manager/Admin/Finance: Can access ALL quotes.
-    - Sales: Can ONLY access quotes strictly created by themselves.
-    
-    Args:
-        user: The requesting User object.
-        quote_id: The UUID of the quote.
-        queryset: Optional base queryset (e.g., used for prefetching).
-        
-    Returns:
-        Quote object.
-        
-    Raises:
-        Http404: If quote doesn't exist.
-        PermissionDenied: If user exists but is not allowed to access this quote.
+    - Admin/Finance: global access.
+    - Managers: same-department quotes plus own quotes.
+    - Managers without a valid department: own quotes only.
+    - Sales/standard users: own quotes only.
     """
     if queryset is None:
         queryset = Quote.objects.all()
-        
-    # 1. Fetch the object independently of permission first to differentiate 404 vs 403
-    quote = get_object_or_404(queryset, id=quote_id)
-    
-    # 2. Check Permissions
+
     if not user or not user.is_authenticated:
-         raise PermissionDenied("Authentication required.")
+        return queryset.none()
 
-    # Check for privileged roles (Global Access)
-    # Only Admin (and Finance who monitors everything) get global view.
-    # Managers are now restricted by department.
-    role = getattr(user, 'role', '')
-    is_global_admin = (
-        getattr(user, 'is_admin', False) or 
-        getattr(user, 'is_finance', False) or
-        role in ('admin', 'finance')
+    role = getattr(user, "role", "")
+    is_global = (
+        getattr(user, "is_admin", False)
+        or getattr(user, "is_finance", False)
+        or role in ("admin", "finance")
     )
-    
-    if is_global_admin:
-        return quote
-        
-    # Check Manager Departmental Access
-    is_manager = getattr(user, 'is_manager', False) or role == 'manager'
-    if is_manager:
-        user_dept = getattr(user, 'department', None)
-        if user_dept:
-             # Check if creator is in the same department
-            creator_dept = getattr(quote.created_by, 'department', None)
-            if creator_dept == user_dept:
-                return quote
+    if is_global:
+        return queryset
 
-    # 3. Creator Check (Sales / Fallback for Managers)
-    # Must match created_by
-    if quote.created_by_id == user.id:
-        return quote
-    
-    # Permission Denied / 404
-    from django.http import Http404
-    raise Http404("No Quote matches the given query.") 
+    is_manager = getattr(user, "is_manager", False) or role == "manager"
+    valid_departments = getattr(type(user), "valid_departments", lambda: set())()
+    user_department = getattr(user, "department", None)
+
+    if is_manager:
+        if user_department and user_department in valid_departments:
+            return queryset.filter(
+                Q(created_by__department=user_department) | Q(created_by=user)
+            )
+        return queryset.filter(created_by=user)
+
+    return queryset.filter(created_by=user)
+
+
+def get_quote_for_user(user, quote_id: str, queryset: QuerySet | None = None) -> Quote:
+    """
+    Retrieve a quote by ID while enforcing the shared selector policy.
+    """
+    if queryset is None:
+        queryset = Quote.objects.all()
+
+    if not user or not user.is_authenticated:
+        raise PermissionDenied("Authentication required.")
+
+    try:
+        return get_quotes_for_user(user, queryset).get(id=quote_id)
+    except Quote.DoesNotExist as exc:
+        raise Http404("No Quote matches the given query.") from exc

--- a/backend/quotes/tests/test_departmental_access.py
+++ b/backend/quotes/tests/test_departmental_access.py
@@ -14,7 +14,24 @@ from rest_framework import status as http_status
 
 from accounts.models import CustomUser
 from quotes.models import Quote
-from parties.models import Company
+from parties.models import Company, Organization
+from core.models import Currency
+
+
+def _ensure_default_organization():
+    pgk = Currency.objects.filter(code='PGK').first() or Currency.objects.create(
+        code='PGK',
+        name='Papua New Guinean Kina',
+    )
+    organization, _ = Organization.objects.get_or_create(
+        slug='efm-express-air-cargo',
+        defaults={
+            'name': 'EFM Express Air Cargo',
+            'default_currency': pgk,
+            'is_active': True,
+        },
+    )
+    return organization
 
 
 class DepartmentalVisibilityTestCase(TestCase):
@@ -24,6 +41,7 @@ class DepartmentalVisibilityTestCase(TestCase):
     def setUpTestData(cls):
         """Create test users and quotes."""
         # Create customer company
+        cls.organization = _ensure_default_organization()
         cls.customer = Company.objects.create(
             name='Test Customer',
             is_customer=True
@@ -34,37 +52,43 @@ class DepartmentalVisibilityTestCase(TestCase):
             username='admin_user',
             password='testpass123',
             role=CustomUser.ROLE_ADMIN,
-            department=None  # Admin has no department, sees all
+            department=CustomUser.DEPARTMENT_GENERAL,
+            organization=cls.organization,
         )
         cls.finance_user = CustomUser.objects.create_user(
             username='finance_user',
             password='testpass123',
             role=CustomUser.ROLE_FINANCE,
-            department=None  # Finance sees all
+            department=CustomUser.DEPARTMENT_GENERAL,
+            organization=cls.organization,
         )
         cls.air_manager = CustomUser.objects.create_user(
             username='air_manager',
             password='testpass123',
             role=CustomUser.ROLE_MANAGER,
-            department='AIR'
+            department='AIR',
+            organization=cls.organization,
         )
         cls.sea_manager = CustomUser.objects.create_user(
             username='sea_manager',
             password='testpass123',
             role=CustomUser.ROLE_MANAGER,
-            department='SEA'
+            department='SEA',
+            organization=cls.organization,
         )
         cls.air_sales = CustomUser.objects.create_user(
             username='air_sales',
             password='testpass123',
             role=CustomUser.ROLE_SALES,
-            department='AIR'
+            department='AIR',
+            organization=cls.organization,
         )
         cls.sea_sales = CustomUser.objects.create_user(
             username='sea_sales',
             password='testpass123',
             role=CustomUser.ROLE_SALES,
-            department='SEA'
+            department='SEA',
+            organization=cls.organization,
         )
         
         # Create quotes by different users
@@ -202,16 +226,19 @@ class SalesVisibilityTest(DepartmentalVisibilityTestCase):
 
 
 class ManagerWithNoDepartmentTest(DepartmentalVisibilityTestCase):
-    """Test Manager with no department assigned."""
+    """Test manager fallback when the department value is misconfigured."""
     
     def test_manager_no_dept_sees_only_own_quotes(self):
-        """Manager without department should see only own quotes (fallback)."""
+        """Manager without a valid department should see only own quotes (fallback)."""
         no_dept_manager = CustomUser.objects.create_user(
             username='no_dept_manager',
             password='testpass123',
             role=CustomUser.ROLE_MANAGER,
-            department=None
+            department=CustomUser.DEPARTMENT_GENERAL,
+            organization=self.organization,
         )
+        CustomUser.objects.filter(pk=no_dept_manager.pk).update(department='')
+        no_dept_manager.refresh_from_db()
         own_quote = Quote.objects.create(
             customer=self.customer,
             mode='AIR',

--- a/backend/quotes/tests/test_reporting_views.py
+++ b/backend/quotes/tests/test_reporting_views.py
@@ -10,6 +10,8 @@ from decimal import Decimal
 from itertools import count
 
 from core.tests.helpers import create_location
+from parties.models import Organization
+from core.models import Currency
 
 @pytest.fixture
 def api_client():
@@ -17,19 +19,47 @@ def api_client():
 
 @pytest.fixture
 def manager_user(db):
+    org = Organization.objects.filter(is_active=True).order_by("name").first()
+    if org is None:
+        pgk = Currency.objects.filter(code="PGK").first() or Currency.objects.create(
+            code="PGK",
+            name="Papua New Guinean Kina",
+        )
+        org = Organization.objects.create(
+            name="EFM Express Air Cargo",
+            slug="efm-express-air-cargo",
+            default_currency=pgk,
+            is_active=True,
+        )
     user = get_user_model().objects.create_user(
         username='manager',
         password='password',
-        role='manager'
+        role='manager',
+        organization=org,
+        department='AIR',
     )
     return user
 
 @pytest.fixture
 def sales_user(db):
+    org = Organization.objects.filter(is_active=True).order_by("name").first()
+    if org is None:
+        pgk = Currency.objects.filter(code="PGK").first() or Currency.objects.create(
+            code="PGK",
+            name="Papua New Guinean Kina",
+        )
+        org = Organization.objects.create(
+            name="EFM Express Air Cargo",
+            slug="efm-express-air-cargo",
+            default_currency=pgk,
+            is_active=True,
+        )
     user = get_user_model().objects.create_user(
         username='sales',
         password='password',
-        role='sales'
+        role='sales',
+        organization=org,
+        department='AIR',
     )
     return user
 

--- a/backend/quotes/views/lifecycle.py
+++ b/backend/quotes/views/lifecycle.py
@@ -5,7 +5,6 @@ from dataclasses import replace
 from typing import Any
 
 from django.db import transaction
-from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from rest_framework import viewsets, status, serializers
@@ -35,7 +34,7 @@ from accounts.permissions import (
     CanFinalizeQuotes,
     CanEditQuotes,
 )
-from quotes.selectors import get_quote_for_user
+from quotes.selectors import get_quote_for_user, get_quotes_for_user
 
 logger = logging.getLogger(__name__)
 
@@ -244,41 +243,11 @@ class QuoteV3ViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         user = self.request.user
         # Prefetch related data to optimize query
-        qs = Quote.objects.all().select_related(
+        base_qs = Quote.objects.all().select_related(
             'customer', 'contact', 'origin_location', 'destination_location'
         ).prefetch_related('spot_envelopes').order_by('-created_at')
 
-        # 1. Role-Based Visibility
-        if user.is_authenticated:
-            role = getattr(user, 'role', '')
-            
-            # Global View: Admin & Finance
-            is_global = (
-                getattr(user, 'is_admin', False) or 
-                getattr(user, 'is_finance', False) or 
-                role in ('admin', 'finance')
-            )
-            
-            if is_global:
-                pass # See all
-                
-            # Manager View: Restricted by Department
-            elif getattr(user, 'is_manager', False) or role == 'manager':
-                dept = getattr(user, 'department', None)
-                if dept:
-                    # See quotes from same department users OR own quotes
-                    qs = qs.filter(
-                        Q(created_by__department=dept) | 
-                        Q(created_by=user)
-                    )
-                else:
-                    # No department assigned -> Fallback to own quotes only?
-                    # Or see "unassigned"? Strict interpretation suggests restricted.
-                    qs = qs.filter(created_by=user)
-
-            # Sales / Standard View: Own quotes only
-            else:
-                qs = qs.filter(created_by=user)
+        qs = get_quotes_for_user(user, base_qs)
 
         # 2. Filtering (Manual implementation since django-filter is not installed)
         mode = self.request.query_params.get('mode')


### PR DESCRIPTION
## Summary
- require `organization` and `department` on `CustomUser`, add a `GENERAL` department fallback, and backfill existing users in a migration
- enforce explicit organization/department validation in user-management serializers while keeping self-registration anchored to a real active organization
- unify quote-list and reporting access around strict-by-default selector logic so managers without a valid department are limited to their own data
- update account and reporting tests to reflect the new hierarchy requirement and reporting policy

## Migration Notes
- migration `accounts/0005_require_user_organization_and_department.py` backfills users missing an organization to a default organization
- users with blank or null departments are assigned `GENERAL`
- the synthetic `default-organization` placeholder is treated as a last resort so real active organizations are preferred when available

## Verification
- `python manage.py makemigrations accounts --check --dry-run`
- `pytest accounts\tests.py quotes\tests\test_reporting_views.py quotes\tests\test_departmental_access.py -q`
- `pytest quotes\tests\test_api_v3.py quotes\tests\test_spot_ai_autofill.py -q`