### PR TITLE
[codex] Domestic selector and SPOT trigger cleanup

### DIFF
--- a/backend/pricing_v4/adapter.py
+++ b/backend/pricing_v4/adapter.py
@@ -189,6 +189,111 @@ class PricingServiceV4Adapter:
         except Exception as e:
             logger.warning(f"Failed to load customer discounts: {e}")
             return {}
+
+    def _discount_amount_to_pgk(
+        self,
+        amount: Decimal,
+        currency: Optional[str],
+        fx_rates: dict,
+    ) -> Decimal:
+        curr = (currency or 'PGK').upper()
+        if curr == 'PGK':
+            return amount
+
+        fx_sell = self._get_fx_sell_rate(curr, fx_rates)
+        if fx_sell <= 0:
+            logger.warning("Invalid FX sell rate for discount currency %s; using 1.0", curr)
+            fx_sell = Decimal('1')
+        return amount * fx_sell
+
+    def _product_code_ids_by_service_component(
+        self,
+        lines: List[CalculatedChargeLine],
+    ) -> Dict[str, int]:
+        sc_codes = [line.service_component_code for line in lines]
+        pc_map: Dict[str, int] = {}
+
+        try:
+            for pc in ProductCode.objects.filter(code__in=sc_codes):
+                pc_map[pc.code] = pc.id
+        except Exception as e:
+            logger.warning(f"Failed to map ServiceComponent to ProductCode: {e}")
+            return {}
+
+        return pc_map
+
+    def _discounted_sell_pgk(
+        self,
+        line: CalculatedChargeLine,
+        discount: 'CustomerDiscount',
+        original_sell: Decimal,
+        fx_rates: dict,
+    ) -> Optional[Decimal]:
+        if discount.discount_type == CustomerDiscount.TYPE_PERCENTAGE:
+            discount_pct = discount.discount_value / Decimal('100')
+            return original_sell * (Decimal('1') - discount_pct)
+
+        if discount.discount_type == CustomerDiscount.TYPE_FLAT_AMOUNT:
+            discount_amount_pgk = self._discount_amount_to_pgk(
+                discount.discount_value,
+                discount.currency,
+                fx_rates,
+            )
+            return max(Decimal('0'), original_sell - discount_amount_pgk)
+
+        if discount.discount_type == CustomerDiscount.TYPE_FIXED_CHARGE:
+            return self._discount_amount_to_pgk(discount.discount_value, discount.currency, fx_rates)
+
+        if discount.discount_type == CustomerDiscount.TYPE_RATE_REDUCTION:
+            logger.warning(
+                f"RATE_REDUCTION discount for {line.service_component_code} "
+                "cannot be applied at this stage (requires weight context)"
+            )
+            return None
+
+        if discount.discount_type == CustomerDiscount.TYPE_MARGIN_OVERRIDE:
+            custom_margin = discount.discount_value / Decimal('100')
+            cost = line.cost_pgk
+            if cost > 0:
+                return cost * (Decimal('1') + custom_margin)
+
+            logger.warning(
+                f"MARGIN_OVERRIDE for {line.service_component_code} "
+                "cannot be applied (no cost data)"
+            )
+            return None
+
+        return original_sell
+
+    def _update_line_sell_amounts(
+        self,
+        line: CalculatedChargeLine,
+        discount: 'CustomerDiscount',
+        original_sell: Decimal,
+        discounted_sell: Decimal,
+    ) -> None:
+        gst_amount = line.sell_pgk_incl_gst - line.sell_pgk
+        gst_rate = gst_amount / original_sell if original_sell > 0 else Decimal('0')
+        new_gst = discounted_sell * gst_rate
+
+        try:
+            line.sell_pgk = discounted_sell
+            line.sell_pgk_incl_gst = discounted_sell + new_gst
+
+            if line.sell_fcy_currency != 'PGK' and original_sell > 0:
+                ratio = discounted_sell / original_sell
+                line.sell_fcy = line.sell_fcy * ratio
+                line.sell_fcy_incl_gst = line.sell_fcy_incl_gst * ratio
+            else:
+                line.sell_fcy = discounted_sell
+                line.sell_fcy_incl_gst = discounted_sell + new_gst
+
+            logger.debug(
+                f"Applied {discount.discount_type} discount to {line.service_component_code}: "
+                f"{original_sell} -> {discounted_sell}"
+            )
+        except AttributeError:
+            logger.warning(f"Cannot apply discount to frozen line: {line.service_component_code}")
     
     def _apply_customer_discounts(self, lines: List[CalculatedChargeLine]) -> List[CalculatedChargeLine]:
         """
@@ -207,98 +312,23 @@ class PricingServiceV4Adapter:
             return lines
 
         fx_rates = self._get_fx_rates_dict()
-
-        def discount_amount_to_pgk(amount: Decimal, currency: Optional[str]) -> Decimal:
-            curr = (currency or 'PGK').upper()
-            if curr == 'PGK':
-                return amount
-            fx_sell = self._get_fx_sell_rate(curr, fx_rates)
-            if fx_sell <= 0:
-                logger.warning("Invalid FX sell rate for discount currency %s; using 1.0", curr)
-                fx_sell = Decimal('1')
-            return amount * fx_sell
-        
-        # Build a mapping from ServiceComponent code to ProductCode ID
-        sc_codes = [l.service_component_code for l in lines]
-        pc_map = {}
-        try:
-            for pc in ProductCode.objects.filter(code__in=sc_codes):
-                pc_map[pc.code] = pc.id
-        except Exception as e:
-            logger.warning(f"Failed to map ServiceComponent to ProductCode: {e}")
+        pc_map = self._product_code_ids_by_service_component(lines)
+        if not pc_map:
             return lines
-        
+
         for line in lines:
             pc_id = pc_map.get(line.service_component_code)
-            if pc_id and pc_id in discounts:
-                discount = discounts[pc_id]
-                original_sell = line.sell_pgk
-                discounted_sell = original_sell
-                
-                # Apply discount based on type
-                if discount.discount_type == CustomerDiscount.TYPE_PERCENTAGE:
-                    discount_pct = discount.discount_value / Decimal('100')
-                    discounted_sell = original_sell * (Decimal('1') - discount_pct)
-                    
-                elif discount.discount_type == CustomerDiscount.TYPE_FLAT_AMOUNT:
-                    discount_amount_pgk = discount_amount_to_pgk(discount.discount_value, discount.currency)
-                    discounted_sell = max(Decimal('0'), original_sell - discount_amount_pgk)
-                    
-                elif discount.discount_type == CustomerDiscount.TYPE_FIXED_CHARGE:
-                    # Replace the entire sell price with fixed charge (normalized to PGK).
-                    discounted_sell = discount_amount_to_pgk(discount.discount_value, discount.currency)
-                    
-                elif discount.discount_type == CustomerDiscount.TYPE_RATE_REDUCTION:
-                    # Rate reduction requires weight context - log warning and skip
-                    logger.warning(
-                        f"RATE_REDUCTION discount for {line.service_component_code} "
-                        "cannot be applied at this stage (requires weight context)"
-                    )
-                    continue
-                    
-                elif discount.discount_type == CustomerDiscount.TYPE_MARGIN_OVERRIDE:
-                    # Recalculate sell from cost using custom margin rate
-                    # discount_value is the margin % (e.g., 15.00 for 15%)
-                    custom_margin = discount.discount_value / Decimal('100')
-                    cost = line.cost_pgk
-                    if cost > 0:
-                        discounted_sell = cost * (Decimal('1') + custom_margin)
-                    else:
-                        # No cost info - can't apply margin override
-                        logger.warning(
-                            f"MARGIN_OVERRIDE for {line.service_component_code} "
-                            "cannot be applied (no cost data)"
-                        )
-                        continue
-                
-                if discounted_sell == original_sell:
-                    continue  # No change
-                
-                # Recalculate GST on discounted amount
-                gst_amount = line.sell_pgk_incl_gst - line.sell_pgk
-                gst_rate = gst_amount / original_sell if original_sell > 0 else Decimal('0')
-                new_gst = discounted_sell * gst_rate
-                
-                try:
-                    line.sell_pgk = discounted_sell
-                    line.sell_pgk_incl_gst = discounted_sell + new_gst
-                    
-                    # Update FCY if applicable
-                    if line.sell_fcy_currency != 'PGK' and original_sell > 0:
-                        ratio = discounted_sell / original_sell
-                        line.sell_fcy = line.sell_fcy * ratio
-                        line.sell_fcy_incl_gst = line.sell_fcy_incl_gst * ratio
-                    else:
-                        line.sell_fcy = discounted_sell
-                        line.sell_fcy_incl_gst = discounted_sell + new_gst
-                        
-                    logger.debug(
-                        f"Applied {discount.discount_type} discount to {line.service_component_code}: "
-                        f"{original_sell} -> {discounted_sell}"
-                    )
-                except AttributeError:
-                    logger.warning(f"Cannot apply discount to frozen line: {line.service_component_code}")
-        
+            if not pc_id or pc_id not in discounts:
+                continue
+
+            discount = discounts[pc_id]
+            original_sell = line.sell_pgk
+            discounted_sell = self._discounted_sell_pgk(line, discount, original_sell, fx_rates)
+            if discounted_sell is None or discounted_sell == original_sell:
+                continue
+
+            self._update_line_sell_amounts(line, discount, original_sell, discounted_sell)
+
         return lines
 
     def calculate_charges(self) -> QuoteCharges:

--- a/backend/pricing_v4/engine/domestic_engine.py
+++ b/backend/pricing_v4/engine/domestic_engine.py
@@ -14,6 +14,7 @@ from pricing_v4.services.rate_selector import (
     RateSelectionContext,
     select_domestic_cogs_rate,
     select_domestic_sell_rate,
+    serialize_rate_candidate,
 )
 from core.charge_rules import (
     CALCULATION_LOOKUP_RATE,
@@ -37,6 +38,8 @@ class BillableCharge:
     agent_name: Optional[str] = None
     rule_family: str = CALCULATION_LOOKUP_RATE
     is_rate_missing: bool = False
+    cost_source: Optional[str] = None
+    calculation_notes: Optional[str] = None
 
 class DomesticPricingEngine:
     """
@@ -71,6 +74,7 @@ class DomesticPricingEngine:
         self.preferred_agent_id = preferred_agent_id
         self.preferred_carrier_id = preferred_carrier_id
         self.buy_currency = (buy_currency or "").strip().upper() or None
+        self._selected_rate_metadata: list[dict] = []
         
         # Validation: Door service only available in specific ports
         self.DOOR_PORTS = ['POM', 'LAE']
@@ -131,6 +135,11 @@ class DomesticPricingEngine:
             total_sell_pgk=sum((item.sell_amount for item in line_items), Decimal('0.00')),
             fx_applied=False,
             tax_breakdown=build_tax_breakdown(line_items, default_labels=['service_in_PNG']),
+            audit_metadata=(
+                {"selected_rates": self._selected_rate_metadata}
+                if self._selected_rate_metadata
+                else {}
+            ),
             origin=self.origin,
             destination=self.destination,
             quote_date=self.quote_date,
@@ -178,6 +187,14 @@ class DomesticPricingEngine:
             cost_eval = self._evaluate_rate_record(cogs)
             if cost_eval.amount > 0:
                 agent_name = cogs.agent.name if cogs.agent else None
+                counterparty_name = cogs.agent.name if cogs.agent else (cogs.carrier.name if cogs.carrier else None)
+                self._selected_rate_metadata.append(
+                    {
+                        "component": "FREIGHT",
+                        "selector_model": "DomesticCOGS",
+                        "rate": serialize_rate_candidate(cogs),
+                    }
+                )
                 cogs_breakdown.append(
                     BillableCharge(
                         "Air Freight (Cost)",
@@ -185,6 +202,11 @@ class DomesticPricingEngine:
                         product_code='DOM-FRT-AIR',
                         agent_name=agent_name,
                         rule_family=cost_eval.rule_family,
+                        cost_source=f"DomesticCOGS #{cogs.pk}",
+                        calculation_notes=(
+                            f"Selected DomesticCOGS #{cogs.pk}"
+                            + (f" for {counterparty_name}" if counterparty_name else "")
+                        ),
                     )
                 )
             
@@ -335,10 +357,11 @@ class DomesticPricingEngine:
             )
             item.cost_amount += charge.amount
             item.cost_currency = 'PGK'
-            item.cost_source = QuoteCostSource.DB_TARIFF if not charge.is_rate_missing else 'N/A'
+            item.cost_source = charge.cost_source or (QuoteCostSource.DB_TARIFF if not charge.is_rate_missing else 'N/A')
             item.rate_source = QuoteRateSource.DB_TARIFF if not charge.is_rate_missing else 'N/A'
             item.agent_name = charge.agent_name
             item.rule_family = charge.rule_family
+            item.calculation_notes = charge.calculation_notes or item.calculation_notes
             if charge.is_rate_missing:
                 item.is_rate_missing = True
                 item.included_in_total = False

--- a/backend/pricing_v4/management/commands/seed_launch_domestic_tariffs.py
+++ b/backend/pricing_v4/management/commands/seed_launch_domestic_tariffs.py
@@ -121,13 +121,13 @@ COGS_SURCHARGES = (
     ("DOM-DOC", "FLAT", "35.00", None),
     ("DOM-TERMINAL", "FLAT", "35.00", None),
     ("DOM-SECURITY", "PER_KG", "0.20", "5.00"),
-    ("DOM-FSC", "PER_KG", "0.25", None),
+    ("DOM-FSC", "PER_KG", "0.50", None),
 )
 
 SELL_SURCHARGES = (
     ("DOM-AWB", "FLAT", "70.00", None),
     ("DOM-SECURITY", "PER_KG", "0.20", "5.00"),
-    ("DOM-FSC", "PER_KG", "0.35", None),
+    ("DOM-FSC", "PER_KG", "0.70", None),
     ("DOM-DG-HANDLING", "FLAT", "195.00", None),
 )
 

--- a/backend/pricing_v4/management/commands/seed_launch_domestic_tariffs.py
+++ b/backend/pricing_v4/management/commands/seed_launch_domestic_tariffs.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, timedelta
 from decimal import Decimal
 
 from django.core.management.base import BaseCommand, CommandError
@@ -191,6 +191,7 @@ class Command(BaseCommand):
         cogs_surcharge_created = cogs_surcharge_updated = 0
         sell_surcharge_created = sell_surcharge_updated = 0
         legacy_surcharges_disabled = 0
+        legacy_cogs_retired = 0
 
         with transaction.atomic():
             for route in COGS_ROUTE_RATES:
@@ -276,6 +277,10 @@ class Command(BaseCommand):
                 valid_from=valid_from,
                 valid_until=valid_until,
             )
+            legacy_cogs_retired += self._retire_overlapping_px_carrier_cogs(
+                freight_pc=freight_pc,
+                valid_from=valid_from,
+            )
 
         self.stdout.write("")
         self.stdout.write(
@@ -285,7 +290,8 @@ class Command(BaseCommand):
                 f"SELL freight created/updated={sell_freight_created}/{sell_freight_updated}; "
                 f"COGS surcharges created/updated={cogs_surcharge_created}/{cogs_surcharge_updated}; "
                 f"SELL surcharges created/updated={sell_surcharge_created}/{sell_surcharge_updated}; "
-                f"legacy surcharges disabled={legacy_surcharges_disabled}"
+                f"legacy surcharges disabled={legacy_surcharges_disabled}; "
+                f"legacy PX carrier COGS retired={legacy_cogs_retired}"
             )
         )
 
@@ -362,6 +368,29 @@ class Command(BaseCommand):
             ).update(is_active=False, valid_until=valid_until)
             disabled += updated
         return disabled
+
+    def _retire_overlapping_px_carrier_cogs(
+        self,
+        *,
+        freight_pc: ProductCode,
+        valid_from: date,
+    ) -> int:
+        launch_routes = {(route.origin, route.destination) for route in COGS_ROUTE_RATES}
+        retired = 0
+        retire_until = valid_from - timedelta(days=1)
+
+        for origin, destination in launch_routes:
+            retired += DomesticCOGS.objects.filter(
+                product_code=freight_pc,
+                origin_zone=origin,
+                destination_zone=destination,
+                carrier__code="PX",
+                agent__isnull=True,
+                valid_from__lt=valid_from,
+                valid_until__gte=valid_from,
+            ).update(valid_until=retire_until)
+
+        return retired
 
     def _get_product_code(self, code: str) -> ProductCode:
         product_code = ProductCode.objects.filter(code=code).first()

--- a/backend/pricing_v4/tests/test_domestic_engine.py
+++ b/backend/pricing_v4/tests/test_domestic_engine.py
@@ -26,6 +26,7 @@ from pricing_v4.models import (
 )
 from pricing_v4.engine.domestic_engine import DomesticPricingEngine
 from pricing_v4.engine.result_types import QuoteLineItem, QuoteResult
+from pricing_v4.services.rate_selector import RateAmbiguityError
 
 
 EXPECTED_QUOTE_RESULT_FIELDS = {field.name for field in fields(QuoteResult)}
@@ -178,6 +179,70 @@ class DomesticFreightTest(DomesticEngineTestCase):
         self.assertTrue(freight_line.is_rate_missing)
         self.assertFalse(freight_line.included_in_total)
         self.assertEqual(result.tax_breakdown, {'service_in_PNG': Decimal('0.00')})
+
+    def test_multiple_domestic_cogs_without_counterparty_raises_ambiguity(self):
+        agent = Agent.objects.create(
+            code='DOM-AG',
+            name='Domestic Agent',
+            country_code='PG',
+            agent_type='ORIGIN',
+        )
+        DomesticCOGS.objects.create(
+            product_code=self.pc_freight,
+            origin_zone='POM',
+            destination_zone='LAE',
+            agent=agent,
+            currency='PGK',
+            rate_per_kg=Decimal('7.00'),
+            min_charge=Decimal('100.00'),
+            valid_from=self.valid_from,
+            valid_until=self.valid_until,
+        )
+
+        engine = DomesticPricingEngine(
+            cogs_origin='POM',
+            destination='LAE',
+            weight_kg=50,
+            service_scope='A2A',
+        )
+
+        with self.assertRaises(RateAmbiguityError):
+            engine.calculate_quote()
+
+    def test_selected_domestic_cogs_counterparty_resolves_rate(self):
+        agent = Agent.objects.create(
+            code='DOM-AG-SEL',
+            name='Domestic Agent Selected',
+            country_code='PG',
+            agent_type='ORIGIN',
+        )
+        selected = DomesticCOGS.objects.create(
+            product_code=self.pc_freight,
+            origin_zone='POM',
+            destination_zone='LAE',
+            agent=agent,
+            currency='PGK',
+            rate_per_kg=Decimal('7.00'),
+            min_charge=Decimal('100.00'),
+            valid_from=self.valid_from,
+            valid_until=self.valid_until,
+        )
+
+        engine = DomesticPricingEngine(
+            cogs_origin='POM',
+            destination='LAE',
+            weight_kg=50,
+            service_scope='A2A',
+            preferred_agent_id=agent.id,
+        )
+        result = engine.calculate_quote()
+
+        self.assertEqual(result.cogs_breakdown[0].amount, Decimal('350.00'))
+        self.assertEqual(result.line_items[0].cost_source, f'DomesticCOGS #{selected.pk}')
+        self.assertEqual(
+            result.audit_metadata['selected_rates'][0]['rate']['id'],
+            selected.pk,
+        )
 
 
 class DomesticWeightBreaksTest(DomesticEngineTestCase):

--- a/backend/pricing_v4/tests/test_quote_counterparty_hints_api.py
+++ b/backend/pricing_v4/tests/test_quote_counterparty_hints_api.py
@@ -5,7 +5,7 @@ from django.contrib.auth import get_user_model
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from pricing_v4.models import Agent, Carrier, ImportCOGS, ProductCode
+from pricing_v4.models import Agent, Carrier, DomesticCOGS, ImportCOGS, ProductCode
 
 
 class QuoteCounterpartyHintsAPITests(APITestCase):
@@ -133,6 +133,54 @@ class QuoteCounterpartyHintsAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["available_counterparty_types"], ["agent"])
         self.assertEqual(response.data["carriers"], [])
+
+    def test_domestic_lane_with_single_pxdom_path_returns_one_hint_for_hidden_selector(self):
+        domestic_agent = Agent.objects.create(
+            code="PX-DOM",
+            name="Air Niugini (Domestic)",
+            country_code="PG",
+            agent_type="CARRIER",
+        )
+        domestic_freight = ProductCode.objects.create(
+            id=3801,
+            code="DOM-FRT-HINT",
+            description="Domestic Freight Hint",
+            domain="DOMESTIC",
+            category="FREIGHT",
+            default_unit="KG",
+            is_gst_applicable=True,
+            gst_rate=Decimal("0.10"),
+            gl_revenue_code="4100",
+            gl_cost_code="5100",
+        )
+        DomesticCOGS.objects.create(
+            product_code=domestic_freight,
+            origin_zone="POM",
+            destination_zone="LAE",
+            agent=domestic_agent,
+            currency="PGK",
+            rate_per_kg=Decimal("6.10"),
+            valid_from=self.valid_from,
+            valid_until=self.valid_until,
+        )
+
+        self.client.force_authenticate(self.manager)
+        response = self.client.get(
+            "/api/v4/quote/counterparty-hints/",
+            {
+                "direction": "DOMESTIC",
+                "service_scope": "D2D",
+                "origin_airport": "POM",
+                "destination_airport": "LAE",
+                "buy_currency": "PGK",
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["available_counterparty_types"], ["agent"])
+        self.assertEqual(response.data["recommended_counterparty_type"], "agent")
+        self.assertEqual(response.data["carriers"], [])
+        self.assertEqual([agent["code"] for agent in response.data["agents"]], ["PX-DOM"])
 
     def test_sales_users_cannot_access_counterparty_hints(self):
         self.client.force_authenticate(self.sales)

--- a/backend/pricing_v4/tests/test_rollover_local_sell_rates_command.py
+++ b/backend/pricing_v4/tests/test_rollover_local_sell_rates_command.py
@@ -12,7 +12,7 @@ class RolloverLocalSellRatesCommandTests(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.pc_export = ProductCode.objects.create(
-            id=1901,
+            id=11901,
             code="EXP-ROLL-DOC",
             description="Export rollover doc",
             domain="EXPORT",
@@ -23,7 +23,7 @@ class RolloverLocalSellRatesCommandTests(TestCase):
             default_unit="SHIPMENT",
         )
         cls.pc_import = ProductCode.objects.create(
-            id=2901,
+            id=22901,
             code="IMP-ROLL-CLEAR",
             description="Import rollover clearance",
             domain="IMPORT",

--- a/backend/pricing_v4/tests/test_seed_launch_domestic_tariffs_command.py
+++ b/backend/pricing_v4/tests/test_seed_launch_domestic_tariffs_command.py
@@ -67,7 +67,7 @@ class SeedLaunchDomesticTariffsCommandTest(TestCase):
             rate_side="COGS",
             valid_from="2026-01-01",
         )
-        self.assertEqual(str(fuel_cogs.amount), "0.2500")
+        self.assertEqual(str(fuel_cogs.amount), "0.5000")
 
         fuel_sell = Surcharge.objects.get(
             product_code__code="DOM-FSC",
@@ -75,7 +75,7 @@ class SeedLaunchDomesticTariffsCommandTest(TestCase):
             rate_side="SELL",
             valid_from="2026-01-01",
         )
-        self.assertEqual(str(fuel_sell.amount), "0.3500")
+        self.assertEqual(str(fuel_sell.amount), "0.7000")
 
         awb_sell = Surcharge.objects.get(
             product_code__code="DOM-AWB",

--- a/backend/pricing_v4/tests/test_seed_launch_domestic_tariffs_command.py
+++ b/backend/pricing_v4/tests/test_seed_launch_domestic_tariffs_command.py
@@ -4,7 +4,7 @@ from datetime import date
 from django.core.management import call_command
 from django.test import TestCase
 
-from pricing_v4.models import DomesticCOGS, DomesticSellRate, ProductCode, Surcharge
+from pricing_v4.models import Carrier, DomesticCOGS, DomesticSellRate, ProductCode, Surcharge
 
 
 class SeedLaunchDomesticTariffsCommandTest(TestCase):
@@ -48,6 +48,8 @@ class SeedLaunchDomesticTariffsCommandTest(TestCase):
             valid_from="2026-01-01",
         )
         self.assertEqual(str(pom_lae_cogs.rate_per_kg), "6.1000")
+        self.assertEqual(pom_lae_cogs.agent.code, "PX-DOM")
+        self.assertIsNone(pom_lae_cogs.carrier_id)
         self.assertEqual(str(pom_lae_sell.rate_per_kg), "7.3000")
         self.assertEqual(str(lae_pom_sell.rate_per_kg), "7.1000")
 
@@ -158,3 +160,45 @@ class SeedLaunchDomesticTariffsCommandTest(TestCase):
 
         self.assertFalse(legacy_doc.is_active)
         self.assertFalse(legacy_security.is_active)
+
+    def test_command_retires_overlapping_legacy_px_carrier_domestic_cogs(self):
+        freight_pc = ProductCode.objects.get(code="DOM-FRT-AIR")
+        px_carrier = Carrier.objects.create(
+            code="PX",
+            name="Air Niugini",
+            carrier_type="AIRLINE",
+        )
+        legacy_px_cogs = DomesticCOGS.objects.create(
+            product_code=freight_pc,
+            origin_zone="POM",
+            destination_zone="LAE",
+            carrier=px_carrier,
+            currency="PGK",
+            rate_per_kg="6.10",
+            valid_from=date(2025, 1, 1),
+            valid_until=date(2026, 12, 31),
+        )
+
+        call_command("seed_launch_domestic_tariffs", year=2026, stdout=StringIO())
+
+        legacy_px_cogs.refresh_from_db()
+        self.assertEqual(legacy_px_cogs.valid_until, date(2025, 12, 31))
+        self.assertFalse(
+            DomesticCOGS.objects.filter(
+                product_code=freight_pc,
+                origin_zone="POM",
+                destination_zone="LAE",
+                carrier=px_carrier,
+                valid_from__lte=date(2026, 5, 6),
+                valid_until__gte=date(2026, 5, 6),
+            ).exists()
+        )
+
+        active_launch = DomesticCOGS.objects.get(
+            product_code=freight_pc,
+            origin_zone="POM",
+            destination_zone="LAE",
+            agent__code="PX-DOM",
+            valid_from=date(2026, 1, 1),
+        )
+        self.assertEqual(str(active_launch.rate_per_kg), "6.1000")

--- a/backend/quotes/intake_safety.py
+++ b/backend/quotes/intake_safety.py
@@ -216,6 +216,27 @@ def mark_source_analysis_review(
     return summary
 
 
+def sync_source_analysis_summary_counts(
+    value: Any,
+    *,
+    unmapped_line_count: int,
+    low_confidence_line_count: int,
+    conditional_charge_count: int,
+) -> dict[str, Any]:
+    """
+    Update a source analysis summary with current counts and re-derive risk flags.
+    Used when charge lines are manually resolved or updated.
+    """
+    raw = value if isinstance(value, dict) else {}
+    updated = dict(raw)
+    updated["unmapped_line_count"] = int(unmapped_line_count)
+    updated["low_confidence_line_count"] = int(low_confidence_line_count)
+    updated["conditional_charge_count"] = int(conditional_charge_count)
+
+    # normalize will re-derive risk_flags, risk_level etc. from these new counts
+    return normalize_source_analysis_summary(updated)
+
+
 def evaluate_envelope_intake_safety(source_batches: Iterable[Any]) -> dict[str, Any]:
     blocking_issues: list[str] = []
     pending_source_batch_ids: list[str] = []

--- a/backend/quotes/spot_schemas.py
+++ b/backend/quotes/spot_schemas.py
@@ -234,7 +234,7 @@ class SPEShipmentContext(BaseModel):
     total_weight_kg: float = Field(default=0, description="Total Weight in KG")
     volume_cbm: Optional[float] = Field(default=None, description="Total Volume in CBM")
     pieces: int = Field(default=1, description="Number of pieces")
-    service_scope: Literal['p2p', 'd2a', 'a2d', 'd2d'] = Field(default='p2p', description="Service Scope")
+    service_scope: Literal['p2p', 'a2a', 'd2a', 'a2d', 'd2d'] = Field(default='p2p', description="Service Scope")
     payment_term: Optional[Literal['prepaid', 'collect']] = Field(default=None, description="Payment term")
     missing_components: Optional[List[str]] = Field(default=None, description="Components explicitly missing rates")
 

--- a/backend/quotes/spot_services.py
+++ b/backend/quotes/spot_services.py
@@ -737,14 +737,15 @@ class RateAvailabilityService:
             return cls._missing_rate_outcome(component)
 
         if direction == 'DOMESTIC':
-            domestic_rows = list(
+            domestic_cogs_rows = list(
                 DomesticCOGS.objects.filter(
                     origin_zone=origin_airport,
                     destination_zone=destination_airport,
                     valid_from__lte=today,
                     valid_until__gte=today,
                 ).select_related('product_code')
-            ) + list(
+            )
+            domestic_sell_rows = list(
                 DomesticSellRate.objects.filter(
                     origin_zone=origin_airport,
                     destination_zone=destination_airport,
@@ -752,12 +753,24 @@ class RateAvailabilityService:
                     valid_until__gte=today,
                 ).select_related('product_code')
             )
-            freight_outcomes = [
+            cogs_freight_outcomes = [
                 evaluate_row(COMPONENT_FREIGHT, row)
-                for row in domestic_rows
+                for row in domestic_cogs_rows
                 if row.product_code.category == ProductCode.CATEGORY_FREIGHT
             ]
-            outcomes[COMPONENT_FREIGHT] = choose_best(COMPONENT_FREIGHT, freight_outcomes)
+            sell_freight_outcomes = [
+                evaluate_row(COMPONENT_FREIGHT, row)
+                for row in domestic_sell_rows
+                if row.product_code.category == ProductCode.CATEGORY_FREIGHT
+            ]
+            best_cogs = choose_best(COMPONENT_FREIGHT, cogs_freight_outcomes)
+            if best_cogs['status'] in {cls.STATUS_MISSING_DIMENSION, cls.STATUS_AMBIGUOUS}:
+                outcomes[COMPONENT_FREIGHT] = best_cogs
+            else:
+                outcomes[COMPONENT_FREIGHT] = choose_best(
+                    COMPONENT_FREIGHT,
+                    [best_cogs, *sell_freight_outcomes],
+                )
             return outcomes
 
         if direction == 'EXPORT':

--- a/backend/quotes/spot_views.py
+++ b/backend/quotes/spot_views.py
@@ -67,6 +67,7 @@ from quotes.quote_result_contract import (
     build_persisted_line_item_metadata,
     build_persisted_quote_total_metadata,
 )
+from quotes.completeness import required_components
 from quotes.selectors import get_quote_for_user
 from quotes.currency_rules import determine_quote_currency
 from quotes.services.charge_normalization import resolve_charge_alias
@@ -270,6 +271,19 @@ def _normalize_reconciliation_amount(value) -> str:
     except (InvalidOperation, ValueError, TypeError):
         return str(value).strip()
     return format(amount.normalize(), "f")
+
+
+def _parse_optional_int(value, field_name: str) -> tuple[Optional[int], Optional[Response]]:
+    if value in (None, ""):
+        return None, None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None, Response(
+            {"error": f"{field_name} must be an integer."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    return parsed, None
 
 
 def _source_line_fingerprint_payload(charge: dict) -> dict:
@@ -1039,6 +1053,19 @@ class SpotTriggerEvaluateAPIView(APIView):
                 {'error': "payment_term is required and must be PREPAID or COLLECT"},
                 status=status.HTTP_400_BAD_REQUEST
             )
+
+        agent_id, error_response = _parse_optional_int(request.data.get('agent_id'), 'agent_id')
+        if error_response is not None:
+            return error_response
+        carrier_id, error_response = _parse_optional_int(request.data.get('carrier_id'), 'carrier_id')
+        if error_response is not None:
+            return error_response
+        if agent_id is not None and carrier_id is not None:
+            return Response(
+                {'error': "Provide either agent_id or carrier_id, not both."},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+        buy_currency = str(request.data.get('buy_currency') or '').strip().upper() or None
         
         from quotes.spot_services import CommodityRateRuleService, RateAvailabilityService
         component_outcomes = RateAvailabilityService.get_component_outcomes(
@@ -1047,7 +1074,39 @@ class SpotTriggerEvaluateAPIView(APIView):
             direction=direction,
             service_scope=service_scope,
             payment_term=payment_term,
+            agent_id=agent_id,
+            carrier_id=carrier_id,
+            buy_currency=buy_currency,
         )
+        selector_blockers = {
+            component: outcome
+            for component, outcome in component_outcomes.items()
+            if component in required_components(direction, service_scope)
+            and outcome.get('status') in {
+                RateAvailabilityService.STATUS_MISSING_DIMENSION,
+                RateAvailabilityService.STATUS_AMBIGUOUS,
+            }
+        }
+        if selector_blockers:
+            component, outcome = next(iter(selector_blockers.items()))
+            return Response({
+                'is_spot_required': False,
+                'trigger': None,
+                'selector_issue': {
+                    'detail': outcome.get('detail') or (
+                        "A matching DB rate exists, but a selector dimension is required."
+                    ),
+                    'component': component,
+                    'selector_model': outcome.get('selector_model'),
+                    'selector_context': outcome.get('selector_context', {}),
+                    'missing_dimensions': outcome.get('missing_dimensions', []),
+                    'conflicting_rows': outcome.get('conflicting_rows', []),
+                    'suggested_remediation': (
+                        "Select the buy-side carrier or agent for this quote."
+                    ),
+                },
+                'component_outcomes': component_outcomes,
+            })
         component_availability = {
             component: outcome.get('status') in {'covered_exact', 'covered_fallback'}
             for component, outcome in component_outcomes.items()

--- a/backend/quotes/spot_views.py
+++ b/backend/quotes/spot_views.py
@@ -120,12 +120,12 @@ def _sync_batch_analysis_summary(batch: SPESourceBatchDB):
         if l.normalization_status == SPEChargeLineDB.NormalizationStatus.UNMAPPED
         and l.manual_resolution_status != SPEChargeLineDB.ManualResolutionStatus.RESOLVED
     )
-    
+
     # We don't currently store normalization_confidence on the charge line model,
     # so we preserve the original AI-detected count for now.
     summary = normalize_source_analysis_summary(batch.analysis_summary_json)
     low_conf = summary.get("low_confidence_line_count", 0)
-    
+
     conditional = sum(1 for l in lines if l.conditional and not l.conditional_acknowledged)
 
     batch.analysis_summary_json = sync_source_analysis_summary_counts(
@@ -1045,7 +1045,31 @@ class SpotTriggerEvaluateAPIView(APIView):
         }
     """
     permission_classes = [IsAuthenticated]
-    
+
+    @staticmethod
+    def _optional_int(value):
+        if value in (None, ""):
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _selector_issue_from_outcomes(
+        *,
+        component_outcomes: dict,
+        direction: str,
+        service_scope: str,
+    ) -> Optional[dict]:
+        from quotes.completeness import required_components
+
+        for component in sorted(required_components(direction, service_scope)):
+            outcome = component_outcomes.get(component) or {}
+            if outcome.get("status") in {"missing_dimension", "ambiguous"}:
+                return outcome
+        return None
+
     def post(self, request):
         # Calculate direction
         origin_airport = request.data.get('origin_airport', '')
@@ -1074,9 +1098,24 @@ class SpotTriggerEvaluateAPIView(APIView):
             direction=direction,
             service_scope=service_scope,
             payment_term=payment_term,
+            agent_id=self._optional_int(request.data.get("agent_id")),
+            carrier_id=self._optional_int(request.data.get("carrier_id")),
+            buy_currency=request.data.get("buy_currency"),
+            quote_currency=request.data.get("quote_currency"),
+        )
+        selector_issue = self._selector_issue_from_outcomes(
+            component_outcomes=component_outcomes,
+            direction=direction,
+            service_scope=service_scope,
         )
         component_availability = {
-            component: outcome.get('status') in {'covered_exact', 'covered_fallback'}
+            component: (
+                outcome.get('status') in {'covered_exact', 'covered_fallback'}
+                or (
+                    selector_issue is outcome
+                    and outcome.get('status') in {'missing_dimension', 'ambiguous'}
+                )
+            )
             for component, outcome in component_outcomes.items()
         }
         commodity = str(request.data.get('commodity') or 'GCR').upper()
@@ -1119,7 +1158,7 @@ class SpotTriggerEvaluateAPIView(APIView):
             is_spot,
         )
         
-        return Response({
+        response_payload = {
             'is_spot_required': is_spot,
             'trigger': {
                 'code': trigger.code,
@@ -1130,7 +1169,11 @@ class SpotTriggerEvaluateAPIView(APIView):
                 'manual_required_product_codes': trigger.manual_required_product_codes,
             } if trigger else None,
             'component_outcomes': component_outcomes,
-        })
+        }
+        if selector_issue is not None:
+            response_payload['selector_issue'] = selector_issue
+
+        return Response(response_payload)
 
 
 # =============================================================================

--- a/backend/quotes/spot_views.py
+++ b/backend/quotes/spot_views.py
@@ -61,13 +61,13 @@ from quotes.intake_safety import (
     evaluate_envelope_intake_safety,
     mark_source_analysis_review,
     normalize_source_analysis_summary,
+    sync_source_analysis_summary_counts,
 )
 from quotes.serializers import SpotPricingEnvelopeSerializer, SPEChargeLineSerializer
 from quotes.quote_result_contract import (
     build_persisted_line_item_metadata,
     build_persisted_quote_total_metadata,
 )
-from quotes.completeness import required_components
 from quotes.selectors import get_quote_for_user
 from quotes.currency_rules import determine_quote_currency
 from quotes.services.charge_normalization import resolve_charge_alias
@@ -109,6 +109,32 @@ def _spe_queryset():
         'source_batches__charge_lines',
         'acknowledgement',
     )
+
+
+def _sync_batch_analysis_summary(batch: SPESourceBatchDB):
+    """Update batch analysis summary based on current charge line status."""
+    lines = list(batch.charge_lines.all())
+    unmapped = sum(
+        1
+        for l in lines
+        if l.normalization_status == SPEChargeLineDB.NormalizationStatus.UNMAPPED
+        and l.manual_resolution_status != SPEChargeLineDB.ManualResolutionStatus.RESOLVED
+    )
+    
+    # We don't currently store normalization_confidence on the charge line model,
+    # so we preserve the original AI-detected count for now.
+    summary = normalize_source_analysis_summary(batch.analysis_summary_json)
+    low_conf = summary.get("low_confidence_line_count", 0)
+    
+    conditional = sum(1 for l in lines if l.conditional and not l.conditional_acknowledged)
+
+    batch.analysis_summary_json = sync_source_analysis_summary_counts(
+        batch.analysis_summary_json,
+        unmapped_line_count=unmapped,
+        low_confidence_line_count=low_conf,
+        conditional_charge_count=conditional,
+    )
+    batch.save(update_fields=["analysis_summary_json", "updated_at"])
 
 
 def _resolve_country_pair(
@@ -271,19 +297,6 @@ def _normalize_reconciliation_amount(value) -> str:
     except (InvalidOperation, ValueError, TypeError):
         return str(value).strip()
     return format(amount.normalize(), "f")
-
-
-def _parse_optional_int(value, field_name: str) -> tuple[Optional[int], Optional[Response]]:
-    if value in (None, ""):
-        return None, None
-    try:
-        parsed = int(value)
-    except (TypeError, ValueError):
-        return None, Response(
-            {"error": f"{field_name} must be an integer."},
-            status=status.HTTP_400_BAD_REQUEST,
-        )
-    return parsed, None
 
 
 def _source_line_fingerprint_payload(charge: dict) -> dict:
@@ -1053,19 +1066,6 @@ class SpotTriggerEvaluateAPIView(APIView):
                 {'error': "payment_term is required and must be PREPAID or COLLECT"},
                 status=status.HTTP_400_BAD_REQUEST
             )
-
-        agent_id, error_response = _parse_optional_int(request.data.get('agent_id'), 'agent_id')
-        if error_response is not None:
-            return error_response
-        carrier_id, error_response = _parse_optional_int(request.data.get('carrier_id'), 'carrier_id')
-        if error_response is not None:
-            return error_response
-        if agent_id is not None and carrier_id is not None:
-            return Response(
-                {'error': "Provide either agent_id or carrier_id, not both."},
-                status=status.HTTP_400_BAD_REQUEST
-            )
-        buy_currency = str(request.data.get('buy_currency') or '').strip().upper() or None
         
         from quotes.spot_services import CommodityRateRuleService, RateAvailabilityService
         component_outcomes = RateAvailabilityService.get_component_outcomes(
@@ -1074,39 +1074,7 @@ class SpotTriggerEvaluateAPIView(APIView):
             direction=direction,
             service_scope=service_scope,
             payment_term=payment_term,
-            agent_id=agent_id,
-            carrier_id=carrier_id,
-            buy_currency=buy_currency,
         )
-        selector_blockers = {
-            component: outcome
-            for component, outcome in component_outcomes.items()
-            if component in required_components(direction, service_scope)
-            and outcome.get('status') in {
-                RateAvailabilityService.STATUS_MISSING_DIMENSION,
-                RateAvailabilityService.STATUS_AMBIGUOUS,
-            }
-        }
-        if selector_blockers:
-            component, outcome = next(iter(selector_blockers.items()))
-            return Response({
-                'is_spot_required': False,
-                'trigger': None,
-                'selector_issue': {
-                    'detail': outcome.get('detail') or (
-                        "A matching DB rate exists, but a selector dimension is required."
-                    ),
-                    'component': component,
-                    'selector_model': outcome.get('selector_model'),
-                    'selector_context': outcome.get('selector_context', {}),
-                    'missing_dimensions': outcome.get('missing_dimensions', []),
-                    'conflicting_rows': outcome.get('conflicting_rows', []),
-                    'suggested_remediation': (
-                        "Select the buy-side carrier or agent for this quote."
-                    ),
-                },
-                'component_outcomes': component_outcomes,
-            })
         component_availability = {
             component: outcome.get('status') in {'covered_exact', 'covered_fallback'}
             for component, outcome in component_outcomes.items()
@@ -1519,6 +1487,10 @@ class SpotEnvelopeDetailAPIView(APIView):
                     shipment_context=spe_db.shipment_context_json,
                 )
 
+                # Sync summaries for all batches after manual charge reconciliation
+                for batch in spe_db.source_batches.all():
+                    _sync_batch_analysis_summary(batch)
+
             spe_db.save()
             SpotEnvelopeListCreateAPIView()._validate_spe(spe_db)
         except Exception as exc:
@@ -1606,6 +1578,9 @@ class SpotChargeLineManualResolutionAPIView(APIView):
             ]
         )
 
+        if charge_line.source_batch:
+            _sync_batch_analysis_summary(charge_line.source_batch)
+
         charge_line.refresh_from_db()
         serializer = SPEChargeLineSerializer(charge_line)
         return Response(serializer.data)
@@ -1656,8 +1631,13 @@ class SpotChargeLineConditionalResolutionAPIView(APIView):
                     "conditional_acknowledged_at",
                 ]
             )
+            if charge_line.source_batch:
+                _sync_batch_analysis_summary(charge_line.source_batch)
         elif action == "REMOVE":
+            batch = charge_line.source_batch
             charge_line.delete()
+            if batch:
+                _sync_batch_analysis_summary(batch)
         else:
             return Response(
                 {'error': "action must be KEEP or REMOVE."},

--- a/backend/quotes/tests/test_pdf_export.py
+++ b/backend/quotes/tests/test_pdf_export.py
@@ -241,7 +241,7 @@ class QuotePDFExportTest(TestCase):
         )
         version = QuoteVersion.objects.create(quote=quote, version_number=1)
         wrong_component = ServiceComponent.objects.create(
-            code="IMP-AGENCY-ORIGIN-TEST",
+            code="IMP-AGY-ORIG-TEST",
             description="Import Origin Agency Test",
             mode="AIR",
             leg="DESTINATION",

--- a/backend/quotes/tests/test_public_quote_api.py
+++ b/backend/quotes/tests/test_public_quote_api.py
@@ -194,6 +194,13 @@ class QuotePublicDetailAPITest(APITestCase):
             leg="ORIGIN",
             category="DOCUMENTATION",
         )
+        terminal_component = ServiceComponent.objects.create(
+            code="DOM-TERMINAL",
+            description="Terminal Fee",
+            mode="AIR",
+            leg="ORIGIN",
+            category="HANDLING",
+        )
 
         QuoteLine.objects.create(
             quote_version=version,
@@ -215,6 +222,18 @@ class QuotePublicDetailAPITest(APITestCase):
             sell_fcy_incl_gst=Decimal("0.00"),
             cost_pgk=Decimal("35.00"),
             cost_source_description="Documentation Fee",
+            leg="ORIGIN",
+            bucket="origin_charges",
+        )
+        QuoteLine.objects.create(
+            quote_version=version,
+            service_component=terminal_component,
+            sell_pgk=Decimal("0.00"),
+            sell_fcy=Decimal("0.00"),
+            sell_fcy_currency="PGK",
+            sell_fcy_incl_gst=Decimal("0.00"),
+            cost_pgk=Decimal("35.00"),
+            cost_source_description="Terminal Fee",
             leg="ORIGIN",
             bucket="origin_charges",
         )

--- a/backend/quotes/tests/test_quote_compute_selector_validation.py
+++ b/backend/quotes/tests/test_quote_compute_selector_validation.py
@@ -331,7 +331,6 @@ class QuoteComputeSelectorValidationTests(APITestCase):
         self._seed_domestic_surcharge(code="DOM-FSC", rate_side="SELL", rate_type="PER_KG", amount="0.70")
 
         payload = self._domestic_payload(
-            agent_id=self.domestic_agent.id,
             dimensions=[
                 {
                     "pieces": 1,

--- a/backend/quotes/tests/test_quote_compute_selector_validation.py
+++ b/backend/quotes/tests/test_quote_compute_selector_validation.py
@@ -8,7 +8,7 @@ from rest_framework.test import APITestCase
 from core.models import Country, Currency
 from core.tests.helpers import create_location
 from parties.models import Company, Contact
-from pricing_v4.models import Agent, Carrier, DomesticCOGS, DomesticSellRate, ImportCOGS, ProductCode
+from pricing_v4.models import Agent, Carrier, DomesticCOGS, DomesticSellRate, ImportCOGS, ProductCode, Surcharge
 from services.models import ServiceComponent
 
 
@@ -94,6 +94,35 @@ class QuoteComputeSelectorValidationTests(APITestCase):
             unit="KG",
             audience="BOTH",
         )
+        self.domestic_product_codes = {}
+        for product_id, code, description, category, unit in [
+            (3661, "DOM-AWB", "AWB Fee", "DOCUMENTATION", "SHIPMENT"),
+            (3662, "DOM-DOC", "Documentation Fee", "DOCUMENTATION", "SHIPMENT"),
+            (3663, "DOM-TERMINAL", "Terminal Fee", "HANDLING", "SHIPMENT"),
+            (3664, "DOM-SECURITY", "Security Surcharge", "SCREENING", "KG"),
+            (3665, "DOM-FSC", "Fuel Surcharge", "SURCHARGE", "KG"),
+        ]:
+            self.domestic_product_codes[code] = ProductCode.objects.create(
+                id=product_id,
+                code=code,
+                description=description,
+                domain="DOMESTIC",
+                category=category,
+                is_gst_applicable=True,
+                gst_rate=Decimal("0.10"),
+                gl_revenue_code="4100",
+                gl_cost_code="5100",
+                default_unit="KG" if unit == "KG" else "SHIPMENT",
+            )
+            ServiceComponent.objects.create(
+                code=code,
+                description=description,
+                mode="AIR",
+                leg="ORIGIN",
+                category="DOCUMENTATION" if code in {"DOM-AWB", "DOM-DOC"} else "ACCESSORIAL",
+                unit=unit,
+                audience="BOTH",
+            )
         self.valid_from = date.today() - timedelta(days=1)
         self.valid_until = date.today() + timedelta(days=30)
 
@@ -156,6 +185,28 @@ class QuoteComputeSelectorValidationTests(APITestCase):
             min_charge=Decimal("100.00"),
             valid_from=self.valid_from,
             valid_until=self.valid_until,
+        )
+
+    def _seed_domestic_surcharge(
+        self,
+        *,
+        code: str,
+        rate_side: str,
+        rate_type: str,
+        amount: str,
+        min_charge: str | None = None,
+    ):
+        return Surcharge.objects.create(
+            product_code=self.domestic_product_codes[code],
+            service_type="DOMESTIC_AIR",
+            rate_side=rate_side,
+            rate_type=rate_type,
+            amount=Decimal(amount),
+            min_charge=Decimal(min_charge) if min_charge else None,
+            currency="PGK",
+            valid_from=self.valid_from,
+            valid_until=self.valid_until,
+            is_active=True,
         )
 
     def test_quote_compute_requires_buy_currency_when_import_cogs_are_multicurrency(self):
@@ -238,6 +289,86 @@ class QuoteComputeSelectorValidationTests(APITestCase):
         line = response.data["latest_version"]["lines"][0]
         self.assertEqual(line["cost_source"], f"DomesticCOGS #{selected.pk}")
         self.assertEqual(line["cost_pgk"], "175.00")
+
+    def test_domestic_quote_includes_standard_domestic_air_surcharges(self):
+        selected = DomesticCOGS.objects.create(
+            product_code=self.domestic_freight_pc,
+            origin_zone="POM",
+            destination_zone="LAE",
+            agent=self.domestic_agent,
+            currency="PGK",
+            rate_per_kg=Decimal("6.10"),
+            valid_from=self.valid_from,
+            valid_until=self.valid_until,
+        )
+        DomesticSellRate.objects.create(
+            product_code=self.domestic_freight_pc,
+            origin_zone="POM",
+            destination_zone="LAE",
+            currency="PGK",
+            rate_per_kg=Decimal("7.30"),
+            valid_from=self.valid_from,
+            valid_until=self.valid_until,
+        )
+        self._seed_domestic_surcharge(code="DOM-DOC", rate_side="COGS", rate_type="FLAT", amount="35.00")
+        self._seed_domestic_surcharge(code="DOM-TERMINAL", rate_side="COGS", rate_type="FLAT", amount="35.00")
+        self._seed_domestic_surcharge(
+            code="DOM-SECURITY",
+            rate_side="COGS",
+            rate_type="PER_KG",
+            amount="0.20",
+            min_charge="5.00",
+        )
+        self._seed_domestic_surcharge(code="DOM-FSC", rate_side="COGS", rate_type="PER_KG", amount="0.50")
+        self._seed_domestic_surcharge(code="DOM-AWB", rate_side="SELL", rate_type="FLAT", amount="70.00")
+        self._seed_domestic_surcharge(
+            code="DOM-SECURITY",
+            rate_side="SELL",
+            rate_type="PER_KG",
+            amount="0.20",
+            min_charge="5.00",
+        )
+        self._seed_domestic_surcharge(code="DOM-FSC", rate_side="SELL", rate_type="PER_KG", amount="0.70")
+
+        payload = self._domestic_payload(
+            agent_id=self.domestic_agent.id,
+            dimensions=[
+                {
+                    "pieces": 1,
+                    "length_cm": "10",
+                    "width_cm": "10",
+                    "height_cm": "10",
+                    "gross_weight_kg": "10",
+                    "package_type": "Box",
+                }
+            ],
+        )
+        response = self.client.post("/api/v3/quotes/compute/", payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        lines = {
+            line["service_component"]["code"]: line
+            for line in response.data["latest_version"]["lines"]
+        }
+
+        self.assertEqual(lines["DOM-FRT-AIR"]["cost_source"], f"DomesticCOGS #{selected.pk}")
+        self.assertEqual(lines["DOM-FRT-AIR"]["cost_pgk"], "61.00")
+        self.assertEqual(lines["DOM-FRT-AIR"]["sell_pgk"], "73.00")
+        self.assertEqual(lines["DOM-AWB"]["sell_pgk"], "70.00")
+        self.assertEqual(lines["DOM-AWB"]["cost_pgk"], "0.00")
+        self.assertEqual(lines["DOM-DOC"]["cost_pgk"], "35.00")
+        self.assertEqual(lines["DOM-DOC"]["sell_pgk"], "0.00")
+        self.assertEqual(lines["DOM-TERMINAL"]["cost_pgk"], "35.00")
+        self.assertEqual(lines["DOM-TERMINAL"]["sell_pgk"], "0.00")
+        self.assertEqual(lines["DOM-SECURITY"]["cost_pgk"], "5.00")
+        self.assertEqual(lines["DOM-SECURITY"]["sell_pgk"], "5.00")
+        self.assertEqual(lines["DOM-FSC"]["cost_pgk"], "5.00")
+        self.assertEqual(lines["DOM-FSC"]["sell_pgk"], "7.00")
+
+        totals = response.data["latest_version"]["totals"]
+        self.assertEqual(totals["total_cost_pgk"], "141.00")
+        self.assertEqual(totals["total_sell_pgk"], "155.00")
+        self.assertEqual(totals["total_sell_pgk_incl_gst"], "170.50")
 
     def test_quote_compute_requires_agent_when_counterparty_specific_import_cogs_exist(self):
         for agent in [self.agent_a, self.agent_b]:

--- a/backend/quotes/tests/test_quote_compute_selector_validation.py
+++ b/backend/quotes/tests/test_quote_compute_selector_validation.py
@@ -8,7 +8,8 @@ from rest_framework.test import APITestCase
 from core.models import Country, Currency
 from core.tests.helpers import create_location
 from parties.models import Company, Contact
-from pricing_v4.models import Agent, ImportCOGS, ProductCode
+from pricing_v4.models import Agent, Carrier, DomesticCOGS, DomesticSellRate, ImportCOGS, ProductCode
+from services.models import ServiceComponent
 
 
 class QuoteComputeSelectorValidationTests(APITestCase):
@@ -28,6 +29,8 @@ class QuoteComputeSelectorValidationTests(APITestCase):
 
         self.origin = create_location(code="SYD", name="Sydney", country=au, is_active=True)
         self.destination = create_location(code="POM", name="Port Moresby", country=pg, is_active=True)
+        self.domestic_origin = create_location(code="POM", name="Port Moresby Domestic", country=pg, is_active=True)
+        self.domestic_destination = create_location(code="LAE", name="Lae", country=pg, is_active=True)
         self.customer = Company.objects.create(name="Selector Customer", company_type="CUSTOMER", is_customer=True)
         self.contact = Contact.objects.create(
             company=self.customer,
@@ -47,6 +50,17 @@ class QuoteComputeSelectorValidationTests(APITestCase):
             country_code="AU",
             agent_type="ORIGIN",
         )
+        self.domestic_agent = Agent.objects.create(
+            code="VAL-DOM-AG",
+            name="Domestic Validation Agent",
+            country_code="PG",
+            agent_type="ORIGIN",
+        )
+        self.domestic_carrier = Carrier.objects.create(
+            code="VAL-PX",
+            name="Validation Air Niugini",
+            carrier_type="AIRLINE",
+        )
         self.freight_pc = ProductCode.objects.create(
             id=2660,
             code="IMP-FRT-VALIDATION",
@@ -58,6 +72,27 @@ class QuoteComputeSelectorValidationTests(APITestCase):
             gl_revenue_code="4100",
             gl_cost_code="5100",
             default_unit="KG",
+        )
+        self.domestic_freight_pc = ProductCode.objects.create(
+            id=3660,
+            code="DOM-FRT-AIR",
+            description="Domestic Air Freight",
+            domain="DOMESTIC",
+            category="FREIGHT",
+            is_gst_applicable=True,
+            gst_rate=Decimal("0.10"),
+            gl_revenue_code="4100",
+            gl_cost_code="5100",
+            default_unit="KG",
+        )
+        ServiceComponent.objects.create(
+            code="DOM-FRT-AIR",
+            description="Domestic Air Freight",
+            mode="AIR",
+            leg="MAIN",
+            category="TRANSPORT",
+            unit="KG",
+            audience="BOTH",
         )
         self.valid_from = date.today() - timedelta(days=1)
         self.valid_until = date.today() + timedelta(days=30)
@@ -86,6 +121,43 @@ class QuoteComputeSelectorValidationTests(APITestCase):
         payload.update(overrides)
         return payload
 
+    def _domestic_payload(self, **overrides):
+        payload = self._payload(
+            service_scope="D2D",
+            origin_location_id=str(self.domestic_origin.id),
+            destination_location_id=str(self.domestic_destination.id),
+            incoterm="DAP",
+            payment_term="PREPAID",
+        )
+        payload.update(overrides)
+        return payload
+
+    def _seed_domestic_sell(self):
+        return DomesticSellRate.objects.create(
+            product_code=self.domestic_freight_pc,
+            origin_zone="POM",
+            destination_zone="LAE",
+            currency="PGK",
+            rate_per_kg=Decimal("9.00"),
+            min_charge=Decimal("120.00"),
+            valid_from=self.valid_from,
+            valid_until=self.valid_until,
+        )
+
+    def _seed_domestic_cogs(self, *, agent=None, carrier=None, rate="7.00"):
+        return DomesticCOGS.objects.create(
+            product_code=self.domestic_freight_pc,
+            origin_zone="POM",
+            destination_zone="LAE",
+            agent=agent,
+            carrier=carrier,
+            currency="PGK",
+            rate_per_kg=Decimal(rate),
+            min_charge=Decimal("100.00"),
+            valid_from=self.valid_from,
+            valid_until=self.valid_until,
+        )
+
     def test_quote_compute_requires_buy_currency_when_import_cogs_are_multicurrency(self):
         for currency, amount in [("AUD", "4.80"), ("PGK", "12.50")]:
             ImportCOGS.objects.create(
@@ -107,6 +179,65 @@ class QuoteComputeSelectorValidationTests(APITestCase):
         self.assertEqual(response.data["missing_dimensions"], ["buy_currency"])
         self.assertEqual(response.data["resolved_dimensions"]["agent_id"], self.agent_a.id)
         self.assertIsNone(response.data["resolved_dimensions"]["buy_currency"])
+
+    def test_domestic_quote_with_one_matching_cogs_rate_succeeds(self):
+        selected = self._seed_domestic_cogs(carrier=self.domestic_carrier, rate="7.00")
+        self._seed_domestic_sell()
+
+        response = self.client.post("/api/v3/quotes/compute/", self._domestic_payload(), format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(
+            response.data["latest_version"]["payload_json"]["resolved_dimensions"]["carrier_id"],
+            self.domestic_carrier.id,
+        )
+        line = response.data["latest_version"]["lines"][0]
+        self.assertEqual(line["cost_source"], f"DomesticCOGS #{selected.pk}")
+
+    def test_domestic_quote_with_multiple_cogs_rates_requires_counterparty(self):
+        self._seed_domestic_cogs(carrier=self.domestic_carrier, rate="7.00")
+        self._seed_domestic_cogs(agent=self.domestic_agent, rate="8.00")
+        self._seed_domestic_sell()
+
+        response = self.client.post("/api/v3/quotes/compute/", self._domestic_payload(), format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("Multiple Domestic COGS rates matched", response.data["detail"])
+        self.assertEqual(response.data["component"], "FREIGHT")
+        self.assertEqual(response.data["missing_dimensions"], ["agent_id", "carrier_id"])
+        self.assertEqual(response.data["conflicting_rows"][0]["currency"], "PGK")
+
+    def test_domestic_quote_with_selected_counterparty_resolves(self):
+        self._seed_domestic_cogs(carrier=self.domestic_carrier, rate="7.00")
+        selected = self._seed_domestic_cogs(agent=self.domestic_agent, rate="8.00")
+        self._seed_domestic_sell()
+
+        response = self.client.post(
+            "/api/v3/quotes/compute/",
+            self._domestic_payload(agent_id=self.domestic_agent.id),
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        line = response.data["latest_version"]["lines"][0]
+        self.assertEqual(line["cost_source"], f"DomesticCOGS #{selected.pk}")
+        self.assertEqual(line["cost_pgk"], "200.00")
+
+    def test_domestic_quote_with_selected_carrier_resolves_when_multiple_cogs_match(self):
+        selected = self._seed_domestic_cogs(carrier=self.domestic_carrier, rate="7.00")
+        self._seed_domestic_cogs(agent=self.domestic_agent, rate="8.00")
+        self._seed_domestic_sell()
+
+        response = self.client.post(
+            "/api/v3/quotes/compute/",
+            self._domestic_payload(carrier_id=self.domestic_carrier.id),
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        line = response.data["latest_version"]["lines"][0]
+        self.assertEqual(line["cost_source"], f"DomesticCOGS #{selected.pk}")
+        self.assertEqual(line["cost_pgk"], "175.00")
 
     def test_quote_compute_requires_agent_when_counterparty_specific_import_cogs_exist(self):
         for agent in [self.agent_a, self.agent_b]:

--- a/backend/quotes/tests/test_rate_availability_service.py
+++ b/backend/quotes/tests/test_rate_availability_service.py
@@ -196,7 +196,7 @@ def test_import_d2d_missing_origin_component_still_triggers_spot():
     valid_from, valid_until = _today_window()
     agent = _agent()
     pc_freight = _pc(2961, "IMP-FRT-AIR-MISS-ORIGIN", "IMPORT", "FREIGHT", unit="KG")
-    pc_dest = _pc(2962, "IMP-CARTAGE-DEST-MISS-ORIGIN", "IMPORT", "CARTAGE")
+    pc_dest = _pc(2962, "IMP-CARTAGE-DEST-MISSORG", "IMPORT", "CARTAGE")
 
     ImportCOGS.objects.create(
         product_code=pc_freight,
@@ -695,7 +695,7 @@ def test_import_a2d_special_local_sell_rate_allows_standard_quote_without_spot(
 ):
     valid_from, valid_until = _today_window()
     agent = _agent()
-    pc_dest = _pc(2963, "IMP-CARTAGE-DEST-COMMODITY-BASE", "IMPORT", "CARTAGE")
+    pc_dest = _pc(2963, "IMP-CARTAGE-DEST-COMM-BASE", "IMPORT", "CARTAGE")
     pc_special = _pc(product_id, product_code, "IMPORT", "HANDLING")
 
     LocalCOGSRate.objects.create(

--- a/backend/quotes/tests/test_spot_compute_completeness.py
+++ b/backend/quotes/tests/test_spot_compute_completeness.py
@@ -613,4 +613,51 @@ def test_spot_create_quote_blocks_unacknowledged_conditional_matched_line(monkey
     )
 
     assert response.status_code == 400
+    assert response.json()["error"] == "Resolve SPOT charge exceptions before creating quote."
     assert "Conditional destination fee: Conditional" in response.json()["blocking_issues"]
+
+
+def test_spot_create_quote_allows_acknowledged_conditional_matched_line(monkeypatch):
+    user, origin, destination = _setup_user_and_locations()
+    spe = _create_ready_spe(
+        user=user,
+        origin_code=origin.code,
+        dest_code=destination.code,
+        origin_country="AU",
+        dest_country="PG",
+        service_scope="A2D",
+    )
+    SPEChargeLineDB.objects.create(
+        envelope=spe,
+        code="DESTINATION_LOCAL",
+        description="Conditional destination fee",
+        amount=Decimal("75.00"),
+        currency="USD",
+        unit="flat",
+        bucket="destination_charges",
+        conditional=True,
+        conditional_acknowledged=True,
+        conditional_acknowledged_by=user,
+        conditional_acknowledged_at=timezone.now(),
+        source_reference="Agent reply",
+        normalization_status=SPEChargeLineDB.NormalizationStatus.MATCHED,
+        normalization_method=SPEChargeLineDB.NormalizationMethod.EXACT_ALIAS,
+        entered_at=timezone.now(),
+    )
+    monkeypatch.setattr(
+        PricingServiceV4Adapter,
+        "calculate_charges",
+        lambda self: _quote_charges_for_buckets(["airfreight", "destination_charges"]),
+    )
+    customer = Company.objects.create(name="Acknowledged Conditional Customer", is_customer=True, company_type="CUSTOMER")
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.post(
+        f"/api/v3/spot/envelopes/{spe.id}/create-quote/",
+        {"quote_request": {"service_scope": "A2D", "payment_term": "PREPAID", "customer_id": str(customer.id)}},
+        format="json",
+    )
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True

--- a/backend/quotes/tests/test_spot_flow_api.py
+++ b/backend/quotes/tests/test_spot_flow_api.py
@@ -3,13 +3,23 @@ from django.urls import reverse
 from unittest.mock import patch
 from django.utils import timezone
 from datetime import date, timedelta
+from decimal import Decimal
 
 from rest_framework import status
 from rest_framework.test import APITestCase
 
 from core.models import Location
 from core.tests.helpers import create_location
-from pricing_v4.models import ChargeAlias, CommodityChargeRule, ProductCode
+from pricing_v4.models import (
+    Agent,
+    Carrier,
+    ChargeAlias,
+    CommodityChargeRule,
+    DomesticCOGS,
+    DomesticSellRate,
+    ProductCode,
+    Surcharge,
+)
 from services.models import ServiceComponent
 from quotes.completeness import (
     COMPONENT_FREIGHT,
@@ -84,6 +94,93 @@ class SpotEnvelopeFlowAPITest(APITestCase):
             alias_source=ChargeAlias.AliasSource.ADMIN,
             review_status=ChargeAlias.ReviewStatus.APPROVED,
         )
+
+    def _product_code(self, product_id: int, code: str, description: str, category: str, unit: str = "SHIPMENT"):
+        return ProductCode.objects.create(
+            id=product_id,
+            code=code,
+            description=description,
+            domain="DOMESTIC",
+            category=category,
+            default_unit=unit,
+            is_gst_applicable=True,
+            gst_rate=Decimal("0.10"),
+            gl_revenue_code="4100",
+            gl_cost_code="5100",
+        )
+
+    def _seed_domestic_air_rates(self, *, include_carrier: bool = True):
+        valid_from = date.today() - timedelta(days=1)
+        valid_until = date.today() + timedelta(days=30)
+        freight = self._product_code(9701, "DOM-FRT-AIR", "Domestic Air Freight", ProductCode.CATEGORY_FREIGHT, "KG")
+        awb = self._product_code(9702, "DOM-AWB", "AWB Fee", ProductCode.CATEGORY_DOCUMENTATION)
+        doc = self._product_code(9703, "DOM-DOC", "Documentation Fee", ProductCode.CATEGORY_DOCUMENTATION)
+        terminal = self._product_code(9704, "DOM-TERMINAL", "Terminal Fee", ProductCode.CATEGORY_HANDLING)
+        security = self._product_code(9705, "DOM-SECURITY", "Security Surcharge", ProductCode.CATEGORY_SCREENING, "KG")
+        fuel = self._product_code(9706, "DOM-FSC", "Fuel Surcharge", ProductCode.CATEGORY_SURCHARGE, "KG")
+        agent = Agent.objects.create(
+            code="PX-DOM-API",
+            name="PX Domestic API",
+            country_code="PG",
+            agent_type="DOMESTIC",
+        )
+        carrier = Carrier.objects.create(
+            code="PX-CAR-API",
+            name="PX Carrier API",
+            carrier_type="AIR",
+        )
+        DomesticCOGS.objects.create(
+            product_code=freight,
+            origin_zone="POM",
+            destination_zone="LAE",
+            agent=agent,
+            currency="PGK",
+            rate_per_kg=Decimal("6.10"),
+            valid_from=valid_from,
+            valid_until=valid_until,
+        )
+        if include_carrier:
+            DomesticCOGS.objects.create(
+                product_code=freight,
+                origin_zone="POM",
+                destination_zone="LAE",
+                carrier=carrier,
+                currency="PGK",
+                rate_per_kg=Decimal("6.50"),
+                valid_from=valid_from,
+                valid_until=valid_until,
+            )
+        DomesticSellRate.objects.create(
+            product_code=freight,
+            origin_zone="POM",
+            destination_zone="LAE",
+            currency="PGK",
+            rate_per_kg=Decimal("7.30"),
+            valid_from=valid_from,
+            valid_until=valid_until,
+        )
+        for product, side, rate_type, amount, minimum in [
+            (doc, "COGS", "FLAT", "35.00", None),
+            (terminal, "COGS", "FLAT", "35.00", None),
+            (security, "COGS", "PER_KG", "0.20", "5.00"),
+            (fuel, "COGS", "PER_KG", "0.50", None),
+            (awb, "SELL", "FLAT", "70.00", None),
+            (security, "SELL", "PER_KG", "0.20", "5.00"),
+            (fuel, "SELL", "PER_KG", "0.70", None),
+        ]:
+            Surcharge.objects.create(
+                product_code=product,
+                service_type="DOMESTIC_AIR",
+                rate_side=side,
+                rate_type=rate_type,
+                amount=Decimal(amount),
+                min_charge=Decimal(minimum) if minimum else None,
+                currency="PGK",
+                valid_from=valid_from,
+                valid_until=valid_until,
+                is_active=True,
+        )
+        return agent, carrier
 
     def test_spot_envelope_flow_acknowledge_compute(self):
         self._create_exact_alias(
@@ -838,6 +935,115 @@ class SpotEnvelopeFlowAPITest(APITestCase):
         self.assertFalse(response.json()["is_spot_required"])
         kwargs = mock_outcomes.call_args.kwargs
         self.assertEqual(kwargs["payment_term"], "COLLECT")
+
+    def test_evaluate_trigger_passes_counterparty_to_availability(self):
+        agent, _carrier = self._seed_domestic_air_rates()
+
+        response = self.client.post(
+            self.evaluate_url,
+            {
+                "origin_country": "PG",
+                "destination_country": "PG",
+                "origin_airport": "POM",
+                "destination_airport": "LAE",
+                "service_scope": "D2D",
+                "payment_term": "PREPAID",
+                "commodity": "GCR",
+                "agent_id": agent.id,
+                "buy_currency": "PGK",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        payload = response.json()
+        self.assertFalse(payload["is_spot_required"])
+        self.assertIsNone(payload["trigger"])
+        self.assertNotIn("selector_issue", payload)
+        self.assertEqual(payload["component_outcomes"][COMPONENT_FREIGHT]["status"], "covered_exact")
+
+    def test_evaluate_trigger_domestic_single_pxdom_path_does_not_trigger_spot(self):
+        self._seed_domestic_air_rates(include_carrier=False)
+
+        response = self.client.post(
+            self.evaluate_url,
+            {
+                "origin_country": "PG",
+                "destination_country": "PG",
+                "origin_airport": "POM",
+                "destination_airport": "LAE",
+                "service_scope": "D2D",
+                "payment_term": "PREPAID",
+                "commodity": "GCR",
+                "buy_currency": "PGK",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        payload = response.json()
+        self.assertFalse(payload["is_spot_required"])
+        self.assertIsNone(payload["trigger"])
+        self.assertNotIn("selector_issue", payload)
+        self.assertEqual(payload["component_outcomes"][COMPONENT_FREIGHT]["status"], "covered_exact")
+
+    def test_evaluate_trigger_domestic_selected_carrier_does_not_trigger_spot(self):
+        _agent, carrier = self._seed_domestic_air_rates()
+
+        response = self.client.post(
+            self.evaluate_url,
+            {
+                "origin_country": "PG",
+                "destination_country": "PG",
+                "origin_airport": "POM",
+                "destination_airport": "LAE",
+                "service_scope": "D2D",
+                "payment_term": "PREPAID",
+                "commodity": "GCR",
+                "carrier_id": carrier.id,
+                "buy_currency": "PGK",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        payload = response.json()
+        self.assertFalse(payload["is_spot_required"])
+        self.assertIsNone(payload["trigger"])
+        self.assertNotIn("selector_issue", payload)
+        self.assertEqual(payload["component_outcomes"][COMPONENT_FREIGHT]["status"], "covered_exact")
+
+    def test_evaluate_trigger_domestic_cogs_ambiguity_returns_selector_issue_not_spot(self):
+        self._seed_domestic_air_rates()
+
+        response = self.client.post(
+            self.evaluate_url,
+            {
+                "origin_country": "PG",
+                "destination_country": "PG",
+                "origin_airport": "POM",
+                "destination_airport": "LAE",
+                "service_scope": "D2D",
+                "payment_term": "PREPAID",
+                "commodity": "GCR",
+                "buy_currency": "PGK",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        payload = response.json()
+        self.assertFalse(payload["is_spot_required"])
+        self.assertIsNone(payload["trigger"])
+        self.assertEqual(payload["component_outcomes"][COMPONENT_FREIGHT]["status"], "missing_dimension")
+        self.assertEqual(
+            payload["selector_issue"]["missing_dimensions"],
+            ["agent_id", "carrier_id"],
+        )
+        self.assertNotEqual(
+            payload.get("trigger", {}).get("code") if payload.get("trigger") else None,
+            "MISSING_SCOPE_RATES",
+        )
 
     @patch("quotes.spot_services.RateAvailabilityService.get_component_outcomes")
     def test_evaluate_trigger_returns_missing_commodity_rates(self, mock_outcomes):

--- a/backend/quotes/tests/test_spot_mode.py
+++ b/backend/quotes/tests/test_spot_mode.py
@@ -322,7 +322,7 @@ class TestRateAvailabilityService:
         )
 
         pc_freight = ProductCode.objects.create(
-            id=2901,
+            id=22911,
             code="IMP-FRT-AIR-SPOTTEST",
             description="Import Air Freight (SPOT test)",
             domain="IMPORT",
@@ -333,7 +333,7 @@ class TestRateAvailabilityService:
             default_unit="KG",
         )
         pc_origin = ProductCode.objects.create(
-            id=2902,
+            id=22912,
             code="IMP-ORIGIN-HANDLING-SPOTTEST",
             description="Import Origin Handling (SPOT test)",
             domain="IMPORT",
@@ -344,7 +344,7 @@ class TestRateAvailabilityService:
             default_unit="SHIPMENT",
         )
         pc_destination = ProductCode.objects.create(
-            id=2903,
+            id=22913,
             code="IMP-CARTAGE-DEST-SPOTTEST",
             description="Import Destination Cartage (SPOT test)",
             domain="IMPORT",

--- a/backend/quotes/tests/test_spot_regression_create_quote.py
+++ b/backend/quotes/tests/test_spot_regression_create_quote.py
@@ -18,17 +18,18 @@ from quotes.spot_schemas import SpotPricingEnvelope, SPEShipmentContext, SPEStat
 
 pytestmark = pytest.mark.django_db
 
+
 def _setup_test_data():
     User = get_user_model()
     user = User.objects.create_user(username="testuser", password="testpass")
-    
+
     currency = Currency.objects.create(code="PGK", name="Papua New Guinea Kina")
     pg = Country.objects.create(code="PG", name="Papua New Guinea", currency=currency)
     au = Country.objects.create(code="AU", name="Australia", currency=currency)
-    
+
     origin = create_location(code="POM", name="Port Moresby", country=pg)
     dest = create_location(code="SYD", name="Sydney", country=au)
-    
+
     product_code = ProductCode.objects.create(
         id=5001,
         code="EXP-FRT-TEST",
@@ -41,14 +42,15 @@ def _setup_test_data():
         gl_revenue_code="4100",
         gl_cost_code="5100",
     )
-    
+
     return user, origin, dest, product_code
+
 
 def test_manual_resolution_syncs_batch_analysis_summary():
     user, origin, dest, pc = _setup_test_data()
     client = APIClient()
     client.force_authenticate(user=user)
-    
+
     # 1. Create SPE with an unsafe batch (unmapped line)
     spe = SpotPricingEnvelopeDB.objects.create(
         created_by=user,
@@ -67,7 +69,7 @@ def test_manual_resolution_syncs_batch_analysis_summary():
         spot_trigger_reason_code=SpotTriggerReason.MISSING_SCOPE_RATES,
         spot_trigger_reason_text="Missing required rate components",
     )
-    
+
     batch = SPESourceBatchDB.objects.create(
         envelope=spe,
         source_kind='AGENT',
@@ -81,7 +83,7 @@ def test_manual_resolution_syncs_batch_analysis_summary():
             'is_safe_to_quote': False
         }
     )
-    
+
     cl = SPEChargeLineDB.objects.create(
         envelope=spe,
         source_batch=batch,
@@ -96,12 +98,12 @@ def test_manual_resolution_syncs_batch_analysis_summary():
         entered_by=user,
         source_reference='Test'
     )
-    
+
     # Verify initial state is unsafe
     detail_url = reverse("quotes:spot-envelope-detail", kwargs={"envelope_id": spe.id})
     resp = client.get(detail_url)
     assert resp.json()["intake_safety"]["is_safe_to_quote"] is False
-    
+
     # 2. Resolve the line via API
     resolution_url = reverse(
         "quotes:spot-charge-line-manual-resolution",
@@ -109,14 +111,15 @@ def test_manual_resolution_syncs_batch_analysis_summary():
     )
     resp = client.patch(resolution_url, {"manual_resolved_product_code_id": pc.id}, format="json")
     assert resp.status_code == 200
-    
+
     # 3. Verify batch summary is synced and SPE is now safe
     batch.refresh_from_db()
     assert batch.analysis_summary_json["unmapped_line_count"] == 0
     assert batch.analysis_summary_json["risk_level"] == "LOW"
-    
+
     resp = client.get(detail_url)
     assert resp.json()["intake_safety"]["is_safe_to_quote"] is True
+
 
 def test_a2a_service_scope_schema_support():
     """Verify that 'a2a' service scope is supported in the Pydantic schema."""
@@ -131,7 +134,7 @@ def test_a2a_service_scope_schema_support():
         service_scope="a2a", # This should not raise ValidationError now
     )
     assert context.service_scope == "a2a"
-    
+
     spe = SpotPricingEnvelope(
         id=str(uuid.uuid4()),
         status=SPEStatus.DRAFT,

--- a/backend/quotes/tests/test_spot_regression_create_quote.py
+++ b/backend/quotes/tests/test_spot_regression_create_quote.py
@@ -1,0 +1,147 @@
+import uuid
+from datetime import timedelta
+from decimal import Decimal
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+from rest_framework.test import APIClient
+from django.urls import reverse
+
+from core.models import Currency, Country, Location
+from core.tests.helpers import create_location
+from pricing_v4.models import ProductCode
+from quotes.spot_models import SpotPricingEnvelopeDB, SPEChargeLineDB, SPESourceBatchDB
+from quotes.spot_services import SpotTriggerReason
+from quotes.spot_schemas import SpotPricingEnvelope, SPEShipmentContext, SPEStatus
+
+
+pytestmark = pytest.mark.django_db
+
+def _setup_test_data():
+    User = get_user_model()
+    user = User.objects.create_user(username="testuser", password="testpass")
+    
+    currency = Currency.objects.create(code="PGK", name="Papua New Guinea Kina")
+    pg = Country.objects.create(code="PG", name="Papua New Guinea", currency=currency)
+    au = Country.objects.create(code="AU", name="Australia", currency=currency)
+    
+    origin = create_location(code="POM", name="Port Moresby", country=pg)
+    dest = create_location(code="SYD", name="Sydney", country=au)
+    
+    product_code = ProductCode.objects.create(
+        id=5001,
+        code="EXP-FRT-TEST",
+        description="Export Freight Test",
+        domain="EXPORT",
+        category="FREIGHT",
+        default_unit="KG",
+        is_gst_applicable=False,
+        gst_rate=Decimal("0.00"),
+        gl_revenue_code="4100",
+        gl_cost_code="5100",
+    )
+    
+    return user, origin, dest, product_code
+
+def test_manual_resolution_syncs_batch_analysis_summary():
+    user, origin, dest, pc = _setup_test_data()
+    client = APIClient()
+    client.force_authenticate(user=user)
+    
+    # 1. Create SPE with an unsafe batch (unmapped line)
+    spe = SpotPricingEnvelopeDB.objects.create(
+        created_by=user,
+        status="draft",
+        expires_at=timezone.now() + timedelta(days=7),
+        shipment_context_json={
+            'origin_country': 'PG',
+            'destination_country': 'AU',
+            'origin_code': 'POM',
+            'destination_code': 'SYD',
+            'total_weight_kg': 100,
+            'pieces': 1,
+            'commodity': 'GCR',
+            'service_scope': 'D2D'
+        },
+        spot_trigger_reason_code=SpotTriggerReason.MISSING_SCOPE_RATES,
+        spot_trigger_reason_text="Missing required rate components",
+    )
+    
+    batch = SPESourceBatchDB.objects.create(
+        envelope=spe,
+        source_kind='AGENT',
+        source_type='TEXT',
+        label='Test Batch',
+        analysis_summary_json={
+            'can_proceed': True,
+            'unmapped_line_count': 1,
+            'risk_flags': ['unmapped_lines'],
+            'risk_level': 'MEDIUM',
+            'is_safe_to_quote': False
+        }
+    )
+    
+    cl = SPEChargeLineDB.objects.create(
+        envelope=spe,
+        source_batch=batch,
+        code='UNMAPPED',
+        description='Test Unmapped Charge',
+        amount=100,
+        currency='USD',
+        unit='flat',
+        bucket='airfreight',
+        normalization_status='UNMAPPED',
+        entered_at=timezone.now(),
+        entered_by=user,
+        source_reference='Test'
+    )
+    
+    # Verify initial state is unsafe
+    detail_url = reverse("quotes:spot-envelope-detail", kwargs={"envelope_id": spe.id})
+    resp = client.get(detail_url)
+    assert resp.json()["intake_safety"]["is_safe_to_quote"] is False
+    
+    # 2. Resolve the line via API
+    resolution_url = reverse(
+        "quotes:spot-charge-line-manual-resolution",
+        kwargs={"envelope_id": spe.id, "charge_line_id": cl.id}
+    )
+    resp = client.patch(resolution_url, {"manual_resolved_product_code_id": pc.id}, format="json")
+    assert resp.status_code == 200
+    
+    # 3. Verify batch summary is synced and SPE is now safe
+    batch.refresh_from_db()
+    assert batch.analysis_summary_json["unmapped_line_count"] == 0
+    assert batch.analysis_summary_json["risk_level"] == "LOW"
+    
+    resp = client.get(detail_url)
+    assert resp.json()["intake_safety"]["is_safe_to_quote"] is True
+
+def test_a2a_service_scope_schema_support():
+    """Verify that 'a2a' service scope is supported in the Pydantic schema."""
+    context = SPEShipmentContext(
+        origin_country="PG",
+        destination_country="AU",
+        origin_code="POM",
+        destination_code="SYD",
+        commodity="GCR",
+        total_weight_kg=100,
+        pieces=1,
+        service_scope="a2a", # This should not raise ValidationError now
+    )
+    assert context.service_scope == "a2a"
+    
+    spe = SpotPricingEnvelope(
+        id=str(uuid.uuid4()),
+        status=SPEStatus.DRAFT,
+        shipment=context,
+        charges=[],
+        conditions={},
+        spot_trigger_reason_code="TEST",
+        spot_trigger_reason_text="Test",
+        created_by_user_id="1",
+        created_at=timezone.now(),
+        expires_at=timezone.now() + timedelta(days=7),
+    )
+    assert spe.shipment.service_scope == "a2a"

--- a/backend/quotes/views/calculation.py
+++ b/backend/quotes/views/calculation.py
@@ -33,6 +33,10 @@ from quotes.services.rate_resolution import (
     resolve_quote_rate_dimensions,
     serialize_resolved_rate_dimensions,
 )
+from pricing_v4.services.rate_selector import (
+    RateAmbiguityError,
+    build_rate_selection_error_payload,
+)
 
 from crm.services import create_auto_quote_opportunity_interaction, resolve_quote_opportunity
 from services.models import ServiceComponent
@@ -278,6 +282,19 @@ class QuoteComputeV3APIView(generics.CreateAPIView):
             # Dispatcher routing errors -> 400 Bad Request
             logger.warning(f"Pricing dispatcher routing error: {e}")
             return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+        except RateAmbiguityError as e:
+            payload = build_rate_selection_error_payload(e, component='FREIGHT')
+            if e.model_name == 'DomesticCOGS' and 'counterparty' in e.unresolved_dimensions:
+                payload['detail'] = (
+                    'Multiple Domestic COGS rates matched this route and currency. '
+                    'Select the buy-side carrier or agent for this Domestic Air quote.'
+                )
+                payload['suggested_remediation'] = (
+                    'Choose the matching Domestic COGS counterparty, or retire/revise overlapping active Domestic COGS rows.'
+                )
+            logger.warning("Quote compute rate selection ambiguity: %s", payload)
+            return Response(payload, status=status.HTTP_409_CONFLICT)
             
         except (ValueError, NotImplementedError) as e:
             # Domain logic errors (e.g., "Unsupported shipment type") -> 400 Bad Request
@@ -406,7 +423,10 @@ class QuoteComputeV3APIView(generics.CreateAPIView):
                 continue
 
             return {
-                'detail': outcome.get('detail') or 'Rate selection could not be resolved deterministically.',
+                'detail': self._selector_detail_message(
+                    shipment_type=shipment_type,
+                    outcome=outcome,
+                ),
                 'error_code': (
                     'RATE_SELECTION_AMBIGUOUS'
                     if outcome.get('status') == RateAvailabilityService.STATUS_AMBIGUOUS
@@ -422,6 +442,20 @@ class QuoteComputeV3APIView(generics.CreateAPIView):
             }
 
         return None
+
+    @staticmethod
+    def _selector_detail_message(*, shipment_type: str, outcome: dict) -> str:
+        missing_dimensions = outcome.get('missing_dimensions') or []
+        if (
+            shipment_type == Quote.ShipmentType.DOMESTIC
+            and outcome.get('selector_model') == 'DomesticCOGS'
+            and any(item in {'agent_id', 'carrier_id', 'counterparty'} for item in missing_dimensions)
+        ):
+            return (
+                'Multiple Domestic COGS rates matched this route and currency. '
+                'Select the buy-side carrier or agent for this Domestic Air quote.'
+            )
+        return outcome.get('detail') or 'Rate selection could not be resolved deterministically.'
 
     @staticmethod
     def _selector_remediation_message(missing_dimensions: list[str]) -> str:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
+    "typecheck": "tsc --noEmit",
     "lint": "eslint",
     "test:quote-store": "node --experimental-strip-types --experimental-specifier-resolution=node scripts/quote-store.test.mjs",
     "test:quote-workflow": "node scripts/quote-workflow-roundtrip.test.mjs",

--- a/frontend/scripts/spot-finalization.test.mjs
+++ b/frontend/scripts/spot-finalization.test.mjs
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import ts from "typescript";
+
+const frontendRoot = path.resolve(process.cwd());
+const sourcePath = path.join(frontendRoot, "src", "lib", "spot-finalization.ts");
+
+async function loadModule() {
+  const source = await readFile(sourcePath, "utf8");
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName: sourcePath,
+  }).outputText;
+
+  const tempDir = await mkdtemp(path.join(tmpdir(), "spot-finalization-test-"));
+  const modulePath = path.join(tempDir, "spot-finalization.mjs");
+
+  try {
+    await writeFile(modulePath, transpiled, "utf8");
+    return await import(`file://${modulePath}`);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+const { getSpotFinalizeDisabledReason } = await loadModule();
+
+const baseSpe = {
+  acknowledgement: null,
+  can_proceed: true,
+  intake_safety: {
+    is_safe_to_quote: true,
+    blocking_issues: [],
+    pending_source_batch_ids: [],
+    pending_source_labels: [],
+    review_note_required_batch_ids: [],
+  },
+  is_expired: false,
+  missing_mandatory_fields: [],
+  status: "draft",
+};
+
+assert.equal(
+  getSpotFinalizeDisabledReason({
+    spe: {
+      ...baseSpe,
+      status: "ready",
+      acknowledgement: {
+        acknowledged_by_user_id: "1",
+        acknowledged_at: "2026-05-09T00:00:00Z",
+        statement: "I acknowledge this is a conditional SPOT quote and not guaranteed",
+      },
+    },
+    unresolvedReviewIssueCount: 0,
+  }),
+  null,
+  "acknowledged SPOT envelope should be allowed to create quote",
+);
+
+assert.match(
+  getSpotFinalizeDisabledReason({
+    spe: baseSpe,
+    unresolvedReviewIssueCount: 2,
+  }) || "",
+  /Resolve 2 issues before creating quote/,
+  "unresolved charge blockers should expose a clear disabled reason",
+);
+
+assert.equal(
+  getSpotFinalizeDisabledReason({
+    spe: {
+      ...baseSpe,
+      can_proceed: false,
+      missing_mandatory_fields: ["rate"],
+    },
+    unresolvedReviewIssueCount: 0,
+  }),
+  null,
+  "draft SPOT envelopes should still allow submit so entered charges can be saved before acknowledgement",
+);
+
+assert.match(
+  getSpotFinalizeDisabledReason({
+    spe: {
+      ...baseSpe,
+      status: "ready",
+      can_proceed: false,
+      missing_mandatory_fields: ["currency"],
+    },
+    unresolvedReviewIssueCount: 0,
+  }) || "",
+  /acknowledgement is required/,
+  "ready envelopes without acknowledgement should expose the invalid acknowledgement state first",
+);
+
+assert.equal(
+  getSpotFinalizeDisabledReason({
+    spe: {
+      ...baseSpe,
+      status: "ready",
+      acknowledgement: {
+        acknowledged_by_user_id: "1",
+        acknowledged_at: "2026-05-09T00:00:00Z",
+        statement: "I acknowledge this is a conditional SPOT quote and not guaranteed",
+      },
+      intake_safety: {
+        is_safe_to_quote: false,
+        blocking_issues: ["Uploaded PDF: Scanned-PDF fallback extraction was used; verify the imported lines carefully."],
+        pending_source_batch_ids: ["source-1"],
+        pending_source_labels: ["Uploaded PDF"],
+        review_note_required_batch_ids: [],
+      },
+    },
+    unresolvedReviewIssueCount: 0,
+  }),
+  null,
+  "unsafe extraction fallback should not silently disable create when acknowledgement already permits backend proceed",
+);
+
+assert.match(
+  getSpotFinalizeDisabledReason({
+    spe: {
+      ...baseSpe,
+      intake_safety: {
+        is_safe_to_quote: false,
+        blocking_issues: ["Agent reply: Possible missed charges: destination handling"],
+        pending_source_batch_ids: ["source-1"],
+        pending_source_labels: ["Agent reply"],
+        review_note_required_batch_ids: ["source-1"],
+      },
+    },
+    unresolvedReviewIssueCount: 0,
+  }) || "",
+  /Possible missed charges/,
+  "unacknowledged source blockers should show the backend blocking issue",
+);
+
+console.log("spot finalization gating checks passed");

--- a/frontend/src/app/public/quote/page.tsx
+++ b/frontend/src/app/public/quote/page.tsx
@@ -82,20 +82,23 @@ const withAlpha = (hex: string, alphaHex: string) => {
   return `${value}${alphaHex}`;
 };
 
+type PublicQuoteSearchParams = {
+  token?: string | string[];
+  version?: string | string[];
+  summary?: string | string[];
+};
+
 type PublicQuotePageProps = {
-  searchParams?: {
-    token?: string | string[];
-    version?: string | string[];
-    summary?: string | string[];
-  };
+  searchParams?: Promise<PublicQuoteSearchParams>;
 };
 
 export default async function PublicQuotePage({ searchParams }: PublicQuotePageProps) {
-  const tokenParam = searchParams?.token;
+  const resolvedSearchParams = await searchParams;
+  const tokenParam = resolvedSearchParams?.token;
   const token = Array.isArray(tokenParam) ? tokenParam[0] : tokenParam;
-  const versionParam = searchParams?.version;
+  const versionParam = resolvedSearchParams?.version;
   const version = Array.isArray(versionParam) ? versionParam[0] : versionParam;
-  const summaryParam = searchParams?.summary;
+  const summaryParam = resolvedSearchParams?.summary;
   const summaryValue = Array.isArray(summaryParam) ? summaryParam[0] : summaryParam;
   const summaryOnly = summaryValue ? ["1", "true", "yes"].includes(summaryValue.toLowerCase()) : false;
   if (!token) {

--- a/frontend/src/app/quotes/spot/[speId]/page.tsx
+++ b/frontend/src/app/quotes/spot/[speId]/page.tsx
@@ -4,7 +4,7 @@
  * SPOT Rate Entry Page
  * 
  * SPOT workflow:
- * 1. Import - Paste agent reply or upload source data
+ * 1. Intake - Paste agent reply or upload source data
  * 2. Review - Resolve imported-rate exceptions
  * 3. Confirm - Create quote from reviewed charges
  */
@@ -49,7 +49,7 @@ type Step = "intake" | "review";
 type DisplayStep = Step | "confirm";
 
 const STEPS: { id: DisplayStep; label: string; description: string }[] = [
-    { id: "intake", label: "1. Import", description: "Paste or upload rates" },
+    { id: "intake", label: "1. Intake", description: "Paste or upload rates" },
     { id: "review", label: "2. Review", description: "Resolve exceptions" },
     { id: "confirm", label: "3. Confirm", description: "Create quote" },
 ];
@@ -1254,7 +1254,7 @@ export default function SpotRateEntryPage() {
                         }}
                         className="mb-4"
                     >
-                        {"<-"} Back to Import
+                        {"<-"} Back to Intake
                     </Button>
 
                     <Card className="overflow-hidden border-slate-200 bg-white shadow-sm">

--- a/frontend/src/app/quotes/spot/[speId]/page.tsx
+++ b/frontend/src/app/quotes/spot/[speId]/page.tsx
@@ -33,6 +33,7 @@ import type { SPEChargeLine, SPECommodity } from "@/lib/spot-types";
 import type { ReplyAnalysisResult } from "@/lib/spot-types";
 import { getSpotStandardCharges } from "@/lib/api";
 import { getEffectiveProductCode, getSpotChargeDisplayLabel } from "@/lib/spot-charge-display";
+import { getSpotFinalizeDisabledReason } from "@/lib/spot-finalization";
 import {
     Breadcrumb,
     BreadcrumbItem,
@@ -716,8 +717,6 @@ export default function SpotRateEntryPage() {
         });
     }, [editableBuckets, state.spe?.charges, state.spe?.sources, visibleReviewFormCharges]);
 
-    const intakeSafety = state.spe?.intake_safety;
-    const quoteCreationBlocked = Boolean(intakeSafety && !intakeSafety.is_safe_to_quote);
     const totalImportedLines = sourceReviewSummaries.reduce((count, summary) => count + summary.lineCount, 0);
     const importedReviewCounts = useMemo(
         () =>
@@ -888,17 +887,17 @@ export default function SpotRateEntryPage() {
         openManualReview: boolean;
         requestKey: number;
     } | null>(null);
+    const [finalizeError, setFinalizeError] = useState<string | null>(null);
     const [reviewMode, setReviewMode] = useState<ReviewMode>("issues");
     const [activeIssueDetails, setActiveIssueDetails] = useState<ImportedReviewLine | null>(null);
     const [sourceComparisonOpen, setSourceComparisonOpen] = useState(false);
     const [selectedSourceChargeKey, setSelectedSourceChargeKey] = useState<string | null>(null);
     const unresolvedReviewIssueCount = reviewLines.affected.length;
-    const quoteSubmitDisabled = quoteCreationBlocked || unresolvedReviewIssueCount > 0;
-    const quoteSubmitDisabledReason = unresolvedReviewIssueCount > 0
-        ? `Resolve ${unresolvedReviewIssueCount} issue${unresolvedReviewIssueCount === 1 ? "" : "s"} before creating quote.`
-        : quoteCreationBlocked
-            ? "Quote creation is temporarily unavailable."
-            : null;
+    const quoteSubmitDisabledReason = getSpotFinalizeDisabledReason({
+        spe: state.spe,
+        unresolvedReviewIssueCount,
+    });
+    const quoteSubmitDisabled = Boolean(quoteSubmitDisabledReason);
     const hasReviewActions =
         importedReviewCounts.unmapped > 0 ||
         importedReviewCounts.lowConfidence > 0 ||
@@ -911,40 +910,50 @@ export default function SpotRateEntryPage() {
         charges: Array<Omit<SPEChargeLine, 'id'> & { charge_line_id?: string }>
     ) => {
         if (state.spe) {
-            if (quoteCreationBlocked) {
+            if (quoteSubmitDisabledReason) {
+                setFinalizeError(quoteSubmitDisabledReason);
                 return;
             }
-            // 1. Update charges
-            const spe = await actions.updateSPE(state.spe.id, {
-                charges,
-                conditions: {
-                    space_not_confirmed: true,
-                    airline_acceptance_not_confirmed: true,
-                    rate_validity_hours: 72,
-                    conditional_charges_present: charges.some(c => c.conditional),
+
+            setFinalizeError(null);
+            let spe = state.spe;
+
+            if (spe.status === "draft") {
+                const updatedSpe = await actions.updateSPE(spe.id, {
+                    charges,
+                    conditions: {
+                        space_not_confirmed: true,
+                        airline_acceptance_not_confirmed: true,
+                        rate_validity_hours: 72,
+                        conditional_charges_present: charges.some(c => c.conditional),
+                    }
+                });
+                if (!updatedSpe) {
+                    return;
                 }
+                spe = updatedSpe;
+            }
+
+            if (!spe.acknowledgement && spe.status !== "ready") {
+                const success = await actions.submitAcknowledgement();
+                if (!success) {
+                    return;
+                }
+            }
+
+            const resolvedScope = serviceScope || "D2D";
+            const resolvedPaymentTerm = paymentTerm || "PREPAID";
+            const resolvedOutputCurrency = outputCurrency || "PGK";
+
+            const result = await actions.createQuote({
+                payment_term: resolvedPaymentTerm,
+                service_scope: resolvedScope,
+                output_currency: resolvedOutputCurrency,
+                customer_id: customerIdParam || undefined,
             });
 
-            if (spe) {
-                // 2. Auto-acknowledge
-                const success = await actions.submitAcknowledgement();
-                if (success) {
-                    // 3. Create the quote directly (backend handles compute internally)
-                    const resolvedScope = serviceScope || "D2D";
-                    const resolvedPaymentTerm = paymentTerm || "PREPAID";
-                    const resolvedOutputCurrency = outputCurrency || "PGK";
-
-                    const result = await actions.createQuote({
-                        payment_term: resolvedPaymentTerm,
-                        service_scope: resolvedScope,
-                        output_currency: resolvedOutputCurrency,
-                        customer_id: customerIdParam || undefined,
-                    });
-
-                    if (result?.success && result.quote_id) {
-                        router.push(`/quotes/${result.quote_id}`);
-                    }
-                }
+            if (result?.success && result.quote_id) {
+                router.push(`/quotes/${result.quote_id}`);
             }
         }
     };
@@ -1203,9 +1212,9 @@ export default function SpotRateEntryPage() {
             </Card>
 
             {/* Error display */}
-            {state.error && (
+            {(state.error || finalizeError) && (
                 <div className="mb-6 rounded-md border border-red-200 bg-red-50 p-4">
-                    <p className="text-sm font-medium text-red-800">{state.error}</p>
+                    <p className="text-sm font-medium text-red-800">{state.error || finalizeError}</p>
                     {state.quoteResult?.has_missing_rates && (
                         <div className="mt-2 text-sm text-red-700">
                             {formatMissingComponents(state.quoteResult.missing_components)?.length ? (

--- a/frontend/src/components/forms/QuoteForm.tsx
+++ b/frontend/src/components/forms/QuoteForm.tsx
@@ -488,7 +488,7 @@ export function QuoteForm({
                 onAction={getSectionStatus(2) === "completed" ? () => openSection(2) : undefined}
               >
                 <div className="space-y-6">
-                  <QuoteTermsSection />
+                  <QuoteTermsSection user={user} />
 
                   <QuoteWorkflowActionBar
                     secondaryAction={renderSectionDiscardAction()}

--- a/frontend/src/components/forms/quote-sections/QuoteTermsSection.tsx
+++ b/frontend/src/components/forms/quote-sections/QuoteTermsSection.tsx
@@ -33,15 +33,30 @@ interface QuoteTermsSectionProps {
   user?: User | null;
 }
 
+const DOMESTIC_AIRPORT_COUNTRY_MAP: Record<string, string> = {
+  POM: "PG",
+  LAE: "PG",
+};
+
+const resolveCountryCode = (location: { country_code?: string | null; code?: string | null } | null) => {
+  const explicit = (location?.country_code || "").trim().toUpperCase();
+  if (explicit) return explicit;
+  const code = (location?.code || "").trim().toUpperCase();
+  return DOMESTIC_AIRPORT_COUNTRY_MAP[code] || "";
+};
+
 export default function QuoteTermsSection({ user }: QuoteTermsSectionProps) {
   const form = useFormContext<QuoteFormSchemaV3>();
+  const { control, setValue } = form;
   const originLocation = useQuoteStore((state) => state.originLocation);
   const destinationLocation = useQuoteStore((state) => state.destinationLocation);
-  const serviceScope = useWatch({ control: form.control, name: "service_scope" });
-  const paymentTerm = useWatch({ control: form.control, name: "payment_term" });
-  const pricingCounterparty = useWatch({ control: form.control, name: "pricing_counterparty" });
-  const isImport = destinationLocation?.country_code === "PG" && originLocation?.country_code !== "PG";
-  const isDomestic = originLocation?.country_code === "PG" && destinationLocation?.country_code === "PG";
+  const serviceScope = useWatch({ control, name: "service_scope" });
+  const paymentTerm = useWatch({ control, name: "payment_term" });
+  const pricingCounterparty = useWatch({ control, name: "pricing_counterparty" });
+  const originCountry = resolveCountryCode(originLocation);
+  const destinationCountry = resolveCountryCode(destinationLocation);
+  const isImport = destinationCountry === "PG" && originCountry !== "PG";
+  const isDomestic = originCountry === "PG" && destinationCountry === "PG";
   const canLoadCounterpartyHints = user?.role === "manager" || user?.role === "admin";
   const [counterpartyHints, setCounterpartyHints] = useState<QuoteCounterpartyHints | null>(null);
   const [isLoadingCounterparties, setIsLoadingCounterparties] = useState(false);
@@ -64,6 +79,10 @@ export default function QuoteTermsSection({ user }: QuoteTermsSectionProps) {
       })),
     ];
   }, [counterpartyHints]);
+  const counterpartyOptionValues = useMemo(
+    () => counterpartyOptions.map((option) => option.value).join("|"),
+    [counterpartyOptions],
+  );
 
   useEffect(() => {
     let isActive = true;
@@ -71,7 +90,9 @@ export default function QuoteTermsSection({ user }: QuoteTermsSectionProps) {
     if (!isDomestic || !canLoadCounterpartyHints || !originLocation?.code || !destinationLocation?.code) {
       setCounterpartyHints(null);
       setIsLoadingCounterparties(false);
-      form.setValue("pricing_counterparty", undefined, { shouldDirty: false, shouldValidate: true });
+      if (pricingCounterparty) {
+        setValue("pricing_counterparty", undefined, { shouldDirty: false, shouldValidate: true });
+      }
       return () => {
         isActive = false;
       };
@@ -107,36 +128,34 @@ export default function QuoteTermsSection({ user }: QuoteTermsSectionProps) {
   }, [
     canLoadCounterpartyHints,
     destinationLocation?.code,
-    form,
     isDomestic,
     originLocation?.code,
+    pricingCounterparty,
+    setValue,
     serviceScope,
   ]);
 
   useEffect(() => {
-    if (!isDomestic) {
+    if (!isDomestic || !pricingCounterparty) {
       return;
     }
-    const hasCurrentOption = counterpartyOptions.some((option) => option.value === pricingCounterparty);
-    if (pricingCounterparty && !hasCurrentOption) {
-      form.setValue("pricing_counterparty", undefined, {
+
+    const validValues = counterpartyOptionValues ? counterpartyOptionValues.split("|") : [];
+    const shouldClearSelection =
+      validValues.length <= 1 || !validValues.includes(pricingCounterparty);
+
+    if (shouldClearSelection) {
+      setValue("pricing_counterparty", undefined, {
         shouldDirty: true,
         shouldValidate: true,
       });
-      return;
     }
-    if (counterpartyOptions.length === 1 && !pricingCounterparty) {
-      form.setValue("pricing_counterparty", counterpartyOptions[0].value, {
-        shouldDirty: true,
-        shouldValidate: true,
-      });
-    }
-  }, [counterpartyOptions, form, isDomestic, pricingCounterparty]);
+  }, [counterpartyOptionValues, isDomestic, pricingCounterparty, setValue]);
 
   return (
     <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
       <FormField
-        control={form.control}
+        control={control}
         name="payment_term"
         render={({ field }) => (
           <FormItem>
@@ -164,7 +183,7 @@ export default function QuoteTermsSection({ user }: QuoteTermsSectionProps) {
       />
 
       <FormField
-        control={form.control}
+        control={control}
         name="incoterm"
         render={({ field }) => (
           <FormItem>
@@ -197,7 +216,7 @@ export default function QuoteTermsSection({ user }: QuoteTermsSectionProps) {
 
       {isDomestic && canLoadCounterpartyHints && counterpartyOptions.length > 1 ? (
         <FormField
-          control={form.control}
+          control={control}
           name="pricing_counterparty"
           render={({ field }) => (
             <FormItem>

--- a/frontend/src/components/forms/quote-sections/QuoteTermsSection.tsx
+++ b/frontend/src/components/forms/quote-sections/QuoteTermsSection.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 
+import { getQuoteCounterpartyHints, type QuoteCounterpartyHints } from "@/lib/api";
 import {
   FormControl,
   FormDescription,
@@ -25,19 +26,112 @@ import {
   V3_INCOTERMS,
   V3_PAYMENT_TERMS,
 } from "@/lib/schemas/quoteSchema";
+import type { User } from "@/lib/types";
 import { useQuoteStore } from "@/store/useQuoteStore";
 
-export default function QuoteTermsSection() {
+interface QuoteTermsSectionProps {
+  user?: User | null;
+}
+
+export default function QuoteTermsSection({ user }: QuoteTermsSectionProps) {
   const form = useFormContext<QuoteFormSchemaV3>();
+  const originLocation = useQuoteStore((state) => state.originLocation);
   const destinationLocation = useQuoteStore((state) => state.destinationLocation);
   const serviceScope = useWatch({ control: form.control, name: "service_scope" });
   const paymentTerm = useWatch({ control: form.control, name: "payment_term" });
-  const isImport = destinationLocation?.country_code === "PG";
+  const pricingCounterparty = useWatch({ control: form.control, name: "pricing_counterparty" });
+  const isImport = destinationLocation?.country_code === "PG" && originLocation?.country_code !== "PG";
+  const isDomestic = originLocation?.country_code === "PG" && destinationLocation?.country_code === "PG";
+  const canLoadCounterpartyHints = user?.role === "manager" || user?.role === "admin";
+  const [counterpartyHints, setCounterpartyHints] = useState<QuoteCounterpartyHints | null>(null);
+  const [isLoadingCounterparties, setIsLoadingCounterparties] = useState(false);
 
   const validIncoterms = useMemo(
     () => getValidIncoterms(isImport, serviceScope, paymentTerm),
     [isImport, paymentTerm, serviceScope],
   );
+  const counterpartyOptions = useMemo(() => {
+    if (!counterpartyHints) return [];
+
+    return [
+      ...counterpartyHints.agents.map((agent) => ({
+        value: `agent:${agent.id}`,
+        label: `Agent - ${agent.code} ${agent.name}`,
+      })),
+      ...counterpartyHints.carriers.map((carrier) => ({
+        value: `carrier:${carrier.id}`,
+        label: `Carrier - ${carrier.code} ${carrier.name}`,
+      })),
+    ];
+  }, [counterpartyHints]);
+
+  useEffect(() => {
+    let isActive = true;
+
+    if (!isDomestic || !canLoadCounterpartyHints || !originLocation?.code || !destinationLocation?.code) {
+      setCounterpartyHints(null);
+      setIsLoadingCounterparties(false);
+      form.setValue("pricing_counterparty", undefined, { shouldDirty: false, shouldValidate: true });
+      return () => {
+        isActive = false;
+      };
+    }
+
+    setIsLoadingCounterparties(true);
+    getQuoteCounterpartyHints({
+      direction: "DOMESTIC",
+      serviceScope,
+      originAirport: originLocation.code,
+      destinationAirport: destinationLocation.code,
+      buyCurrency: "PGK",
+    })
+      .then((hints) => {
+        if (isActive) {
+          setCounterpartyHints(hints);
+        }
+      })
+      .catch(() => {
+        if (isActive) {
+          setCounterpartyHints(null);
+        }
+      })
+      .finally(() => {
+        if (isActive) {
+          setIsLoadingCounterparties(false);
+        }
+      });
+
+    return () => {
+      isActive = false;
+    };
+  }, [
+    canLoadCounterpartyHints,
+    destinationLocation?.code,
+    form,
+    isDomestic,
+    originLocation?.code,
+    serviceScope,
+  ]);
+
+  useEffect(() => {
+    if (!isDomestic) {
+      return;
+    }
+    const hasCurrentOption = counterpartyOptions.some((option) => option.value === pricingCounterparty);
+    if (pricingCounterparty && !hasCurrentOption) {
+      form.setValue("pricing_counterparty", undefined, {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
+      return;
+    }
+    if (counterpartyOptions.length === 1 && !pricingCounterparty) {
+      form.setValue("pricing_counterparty", counterpartyOptions[0].value, {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
+    }
+  }, [counterpartyOptions, form, isDomestic, pricingCounterparty]);
 
   return (
     <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
@@ -100,6 +194,40 @@ export default function QuoteTermsSection() {
           </FormItem>
         )}
       />
+
+      {isDomestic && canLoadCounterpartyHints && counterpartyOptions.length > 1 ? (
+        <FormField
+          control={form.control}
+          name="pricing_counterparty"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Buy Counterparty</FormLabel>
+              <Select
+                onValueChange={field.onChange}
+                value={field.value || undefined}
+                disabled={isLoadingCounterparties}
+              >
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select carrier or agent" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {counterpartyOptions.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormDescription>
+                Required when multiple Domestic COGS rows match this lane.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/hooks/useQuoteLogic.ts
+++ b/frontend/src/hooks/useQuoteLogic.ts
@@ -66,6 +66,18 @@ const resolveCountryCode = (
     return AIRPORT_COUNTRY_MAP[code] || "OTHER";
 };
 
+const parsePricingCounterparty = (
+    value?: string,
+): { agent_id?: number; carrier_id?: number } => {
+    const match = value?.match(/^(agent|carrier):(\d+)$/);
+    if (!match) return {};
+
+    const id = Number(match[2]);
+    if (!Number.isFinite(id)) return {};
+
+    return match[1] === "agent" ? { agent_id: id } : { carrier_id: id };
+};
+
 interface UseQuoteLogicProps {
     defaultValues?: Partial<QuoteFormSchemaV3>;
     initialCustomer?: CompanySearchResult;
@@ -176,7 +188,9 @@ export function useQuoteLogic({
     // --- Side Effects & Derived State ---
 
     // Auto-update Incoterms
-    const isImport = destinationLocation?.country_code === 'PG';
+    const originCountryForTerms = resolveCountryCode(originLocation, originLocation?.code);
+    const destinationCountryForTerms = resolveCountryCode(destinationLocation, destinationLocation?.code);
+    const isImport = destinationCountryForTerms === 'PG' && originCountryForTerms !== 'PG';
     const validIncoterms = useMemo(() => {
         return getValidIncoterms(isImport, serviceScope, paymentTerm);
     }, [isImport, serviceScope, paymentTerm]);
@@ -273,6 +287,7 @@ export function useQuoteLogic({
                     data.payment_term === 'COLLECT' ? 'COLLECT' : 'PREPAID';
                 const paymentTermLower: 'prepaid' | 'collect' =
                     paymentTermUpper === 'COLLECT' ? 'collect' : 'prepaid';
+                const selectedCounterparty = parsePricingCounterparty(data.pricing_counterparty);
                 const triggerResult = await evaluateSpotTrigger({
                     origin_country: originCountry,
                     destination_country: destCountry,
@@ -282,6 +297,8 @@ export function useQuoteLogic({
                     has_valid_buy_rate: true,
                     service_scope: data.service_scope,
                     payment_term: paymentTermUpper,
+                    buy_currency: originCountry === 'PG' && destCountry === 'PG' ? 'PGK' : undefined,
+                    ...selectedCounterparty,
                 });
 
                 if (triggerResult.is_spot_required && triggerResult.trigger) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -393,6 +393,9 @@ export async function computeQuoteV3(
           ? payload.resolution_reason
           : null;
       const component = typeof payload.component === 'string' ? payload.component : null;
+      const missingDimensions = Array.isArray(payload.missing_dimensions)
+        ? payload.missing_dimensions.filter((item): item is string => typeof item === 'string')
+        : [];
 
       if (detail) {
         const contextBits: string[] = [];
@@ -400,6 +403,9 @@ export async function computeQuoteV3(
         if (resolutionReason) contextBits.push(resolutionReason);
         if (component) contextBits.push(`component ${component}`);
         message = contextBits.length > 0 ? `${detail} [${contextBits.join(' | ')}]` : detail;
+        if (missingDimensions.length > 0) {
+          message = `${message} Missing: ${missingDimensions.join(', ')}.`;
+        }
         if (remediation) {
           message = `${message} Suggested action: ${remediation}`;
         }

--- a/frontend/src/lib/api/quotes.ts
+++ b/frontend/src/lib/api/quotes.ts
@@ -31,6 +31,9 @@ function formatQuoteComputeError(
       ? payload.resolution_reason
       : null;
   const component = typeof payload.component === "string" ? payload.component : null;
+  const missingDimensions = Array.isArray(payload.missing_dimensions)
+    ? payload.missing_dimensions.filter((item): item is string => typeof item === "string")
+    : [];
 
   if (!detail) {
     return Object.keys(payload).length > 0 ? JSON.stringify(payload) : message;
@@ -45,6 +48,10 @@ function formatQuoteComputeError(
     message = `${detail} [${contextBits.join(" | ")}]`;
   } else {
     message = detail;
+  }
+
+  if (missingDimensions.length > 0) {
+    message = `${message} Missing: ${missingDimensions.join(", ")}.`;
   }
 
   if (remediation) {

--- a/frontend/src/lib/quote-workflow.ts
+++ b/frontend/src/lib/quote-workflow.ts
@@ -85,6 +85,16 @@ export const buildQuoteComputePayload = (
     output_currency: data.output_currency || undefined,
   };
 
+  const counterpartyMatch = data.pricing_counterparty?.match(/^(agent|carrier):(\d+)$/);
+  if (counterpartyMatch) {
+    const [, kind, id] = counterpartyMatch;
+    if (kind === "agent") {
+      payload.agent_id = Number(id);
+    } else {
+      payload.carrier_id = Number(id);
+    }
+  }
+
   if (!speOverrides) {
     return payload;
   }

--- a/frontend/src/lib/schemas/quoteSchema.ts
+++ b/frontend/src/lib/schemas/quoteSchema.ts
@@ -331,6 +331,10 @@ export const quoteFormSchemaV3 = z
 
     is_dangerous_goods: z.boolean().default(false),
     output_currency: z.string().length(3).optional(),
+    pricing_counterparty: z
+      .string()
+      .regex(/^(agent|carrier):\d+$/, 'Select a valid buy counterparty.')
+      .optional(),
 
     // --- Step 4: Dimensions (The Array) ---
     dimensions: z

--- a/frontend/src/lib/spot-finalization.ts
+++ b/frontend/src/lib/spot-finalization.ts
@@ -1,0 +1,47 @@
+import type { SpotPricingEnvelope } from "@/lib/spot-types";
+
+type FinalizeEnvelopeState = Pick<
+  SpotPricingEnvelope,
+  "acknowledgement" | "can_proceed" | "intake_safety" | "is_expired" | "missing_mandatory_fields" | "status"
+>;
+
+export function getSpotFinalizeDisabledReason({
+  spe,
+  unresolvedReviewIssueCount,
+}: {
+  spe: FinalizeEnvelopeState | null | undefined;
+  unresolvedReviewIssueCount: number;
+}): string | null {
+  if (!spe) {
+    return "SPOT envelope is still loading.";
+  }
+
+  if (spe.is_expired || spe.status === "expired") {
+    return "This SPOT envelope has expired. Create a new SPOT quote.";
+  }
+
+  if (spe.status === "rejected") {
+    return "This SPOT quote is no longer active.";
+  }
+
+  if (!spe.acknowledgement && spe.status === "ready") {
+    return "SPOT acknowledgement is required before creating quote.";
+  }
+
+  if (spe.status !== "draft" && !spe.can_proceed) {
+    const missing = spe.missing_mandatory_fields?.length
+      ? spe.missing_mandatory_fields.join(", ")
+      : "required rate fields";
+    return `Complete missing SPOT fields before creating quote: ${missing}.`;
+  }
+
+  if (unresolvedReviewIssueCount > 0) {
+    return `Resolve ${unresolvedReviewIssueCount} issue${unresolvedReviewIssueCount === 1 ? "" : "s"} before creating quote.`;
+  }
+
+  if (!spe.acknowledgement && spe.intake_safety && !spe.intake_safety.is_safe_to_quote) {
+    return spe.intake_safety.blocking_issues?.[0] || "Review imported SPOT source findings before creating quote.";
+  }
+
+  return null;
+}

--- a/frontend/src/lib/spot-types.ts
+++ b/frontend/src/lib/spot-types.ts
@@ -90,6 +90,9 @@ export interface TriggerEvaluateRequest {
     has_valid_sell?: boolean;
     is_multi_leg?: boolean;
     service_scope?: string;
+    agent_id?: number;
+    carrier_id?: number;
+    buy_currency?: string;
 }
 
 /** Trigger result from backend */
@@ -106,6 +109,15 @@ export interface TriggerResult {
 export interface TriggerEvaluateResponse {
     is_spot_required: boolean;
     trigger: TriggerResult | null;
+    selector_issue?: {
+        detail?: string;
+        component?: string;
+        selector_model?: string;
+        selector_context?: Record<string, unknown>;
+        missing_dimensions?: string[];
+        conflicting_rows?: Array<Record<string, unknown>>;
+        suggested_remediation?: string;
+    };
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Adds deterministic domestic buy-side selector handling for ambiguous COGS rows.
- Updates SPOT trigger evaluation to accept buy-side selectors and return `selector_issue` instead of false `MISSING_SCOPE_RATES` triggers when DB rates exist but selector dimensions are ambiguous.
- Retires overlapping legacy PX carrier COGS rows during launch domestic tariff seeding.
- Wires domestic counterparty hints and selector submission through the quote frontend.
- Keeps the customer-discount adapter refactor as a separate commit in this branch.

## Validation

- `python backend/manage.py test pricing_v4.tests.test_seed_launch_domestic_tariffs_command pricing_v4.tests.test_quote_counterparty_hints_api quotes.tests.test_quote_compute_selector_validation quotes.tests.test_spot_flow_api`
- `python backend/manage.py test pricing_v4.tests.test_customer_discount_api pricing_v4.tests.test_import_customer_discounts_command`
- `python -m compileall backend/pricing_v4/adapter.py`
- `npm --prefix frontend run build`
- `git diff --check origin/main..HEAD`

## Notes

Manual browser check still recommended before merge: create a domestic POM-LAE quote with two active COGS counterparties, confirm the buy counterparty selector appears, select one, and verify the quote avoids SPOT and computes successfully.