### PR TITLE
Fix PR22 verification blockers

### DIFF
--- a/backend/quotes/spot_views.py
+++ b/backend/quotes/spot_views.py
@@ -120,12 +120,12 @@ def _sync_batch_analysis_summary(batch: SPESourceBatchDB):
         if l.normalization_status == SPEChargeLineDB.NormalizationStatus.UNMAPPED
         and l.manual_resolution_status != SPEChargeLineDB.ManualResolutionStatus.RESOLVED
     )
-    
+
     # We don't currently store normalization_confidence on the charge line model,
     # so we preserve the original AI-detected count for now.
     summary = normalize_source_analysis_summary(batch.analysis_summary_json)
     low_conf = summary.get("low_confidence_line_count", 0)
-    
+
     conditional = sum(1 for l in lines if l.conditional and not l.conditional_acknowledged)
 
     batch.analysis_summary_json = sync_source_analysis_summary_counts(
@@ -1045,7 +1045,31 @@ class SpotTriggerEvaluateAPIView(APIView):
         }
     """
     permission_classes = [IsAuthenticated]
-    
+
+    @staticmethod
+    def _optional_int(value):
+        if value in (None, ""):
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _selector_issue_from_outcomes(
+        *,
+        component_outcomes: dict,
+        direction: str,
+        service_scope: str,
+    ) -> Optional[dict]:
+        from quotes.completeness import required_components
+
+        for component in sorted(required_components(direction, service_scope)):
+            outcome = component_outcomes.get(component) or {}
+            if outcome.get("status") in {"missing_dimension", "ambiguous"}:
+                return outcome
+        return None
+
     def post(self, request):
         # Calculate direction
         origin_airport = request.data.get('origin_airport', '')
@@ -1074,9 +1098,24 @@ class SpotTriggerEvaluateAPIView(APIView):
             direction=direction,
             service_scope=service_scope,
             payment_term=payment_term,
+            agent_id=self._optional_int(request.data.get("agent_id")),
+            carrier_id=self._optional_int(request.data.get("carrier_id")),
+            buy_currency=request.data.get("buy_currency"),
+            quote_currency=request.data.get("quote_currency"),
+        )
+        selector_issue = self._selector_issue_from_outcomes(
+            component_outcomes=component_outcomes,
+            direction=direction,
+            service_scope=service_scope,
         )
         component_availability = {
-            component: outcome.get('status') in {'covered_exact', 'covered_fallback'}
+            component: (
+                outcome.get('status') in {'covered_exact', 'covered_fallback'}
+                or (
+                    selector_issue is outcome
+                    and outcome.get('status') in {'missing_dimension', 'ambiguous'}
+                )
+            )
             for component, outcome in component_outcomes.items()
         }
         commodity = str(request.data.get('commodity') or 'GCR').upper()
@@ -1119,7 +1158,7 @@ class SpotTriggerEvaluateAPIView(APIView):
             is_spot,
         )
         
-        return Response({
+        response_payload = {
             'is_spot_required': is_spot,
             'trigger': {
                 'code': trigger.code,
@@ -1130,7 +1169,11 @@ class SpotTriggerEvaluateAPIView(APIView):
                 'manual_required_product_codes': trigger.manual_required_product_codes,
             } if trigger else None,
             'component_outcomes': component_outcomes,
-        })
+        }
+        if selector_issue is not None:
+            response_payload['selector_issue'] = selector_issue
+
+        return Response(response_payload)
 
 
 # =============================================================================

--- a/backend/quotes/tests/test_spot_regression_create_quote.py
+++ b/backend/quotes/tests/test_spot_regression_create_quote.py
@@ -18,17 +18,18 @@ from quotes.spot_schemas import SpotPricingEnvelope, SPEShipmentContext, SPEStat
 
 pytestmark = pytest.mark.django_db
 
+
 def _setup_test_data():
     User = get_user_model()
     user = User.objects.create_user(username="testuser", password="testpass")
-    
+
     currency = Currency.objects.create(code="PGK", name="Papua New Guinea Kina")
     pg = Country.objects.create(code="PG", name="Papua New Guinea", currency=currency)
     au = Country.objects.create(code="AU", name="Australia", currency=currency)
-    
+
     origin = create_location(code="POM", name="Port Moresby", country=pg)
     dest = create_location(code="SYD", name="Sydney", country=au)
-    
+
     product_code = ProductCode.objects.create(
         id=5001,
         code="EXP-FRT-TEST",
@@ -41,14 +42,15 @@ def _setup_test_data():
         gl_revenue_code="4100",
         gl_cost_code="5100",
     )
-    
+
     return user, origin, dest, product_code
+
 
 def test_manual_resolution_syncs_batch_analysis_summary():
     user, origin, dest, pc = _setup_test_data()
     client = APIClient()
     client.force_authenticate(user=user)
-    
+
     # 1. Create SPE with an unsafe batch (unmapped line)
     spe = SpotPricingEnvelopeDB.objects.create(
         created_by=user,
@@ -67,7 +69,7 @@ def test_manual_resolution_syncs_batch_analysis_summary():
         spot_trigger_reason_code=SpotTriggerReason.MISSING_SCOPE_RATES,
         spot_trigger_reason_text="Missing required rate components",
     )
-    
+
     batch = SPESourceBatchDB.objects.create(
         envelope=spe,
         source_kind='AGENT',
@@ -81,7 +83,7 @@ def test_manual_resolution_syncs_batch_analysis_summary():
             'is_safe_to_quote': False
         }
     )
-    
+
     cl = SPEChargeLineDB.objects.create(
         envelope=spe,
         source_batch=batch,
@@ -96,12 +98,12 @@ def test_manual_resolution_syncs_batch_analysis_summary():
         entered_by=user,
         source_reference='Test'
     )
-    
+
     # Verify initial state is unsafe
     detail_url = reverse("quotes:spot-envelope-detail", kwargs={"envelope_id": spe.id})
     resp = client.get(detail_url)
     assert resp.json()["intake_safety"]["is_safe_to_quote"] is False
-    
+
     # 2. Resolve the line via API
     resolution_url = reverse(
         "quotes:spot-charge-line-manual-resolution",
@@ -109,14 +111,15 @@ def test_manual_resolution_syncs_batch_analysis_summary():
     )
     resp = client.patch(resolution_url, {"manual_resolved_product_code_id": pc.id}, format="json")
     assert resp.status_code == 200
-    
+
     # 3. Verify batch summary is synced and SPE is now safe
     batch.refresh_from_db()
     assert batch.analysis_summary_json["unmapped_line_count"] == 0
     assert batch.analysis_summary_json["risk_level"] == "LOW"
-    
+
     resp = client.get(detail_url)
     assert resp.json()["intake_safety"]["is_safe_to_quote"] is True
+
 
 def test_a2a_service_scope_schema_support():
     """Verify that 'a2a' service scope is supported in the Pydantic schema."""
@@ -131,7 +134,7 @@ def test_a2a_service_scope_schema_support():
         service_scope="a2a", # This should not raise ValidationError now
     )
     assert context.service_scope == "a2a"
-    
+
     spe = SpotPricingEnvelope(
         id=str(uuid.uuid4()),
         status=SPEStatus.DRAFT,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
+    "typecheck": "tsc --noEmit",
     "lint": "eslint",
     "test:quote-store": "node --experimental-strip-types --experimental-specifier-resolution=node scripts/quote-store.test.mjs",
     "test:quote-workflow": "node scripts/quote-workflow-roundtrip.test.mjs",

--- a/frontend/src/app/public/quote/page.tsx
+++ b/frontend/src/app/public/quote/page.tsx
@@ -82,20 +82,23 @@ const withAlpha = (hex: string, alphaHex: string) => {
   return `${value}${alphaHex}`;
 };
 
+type PublicQuoteSearchParams = {
+  token?: string | string[];
+  version?: string | string[];
+  summary?: string | string[];
+};
+
 type PublicQuotePageProps = {
-  searchParams?: {
-    token?: string | string[];
-    version?: string | string[];
-    summary?: string | string[];
-  };
+  searchParams?: Promise<PublicQuoteSearchParams>;
 };
 
 export default async function PublicQuotePage({ searchParams }: PublicQuotePageProps) {
-  const tokenParam = searchParams?.token;
+  const resolvedSearchParams = await searchParams;
+  const tokenParam = resolvedSearchParams?.token;
   const token = Array.isArray(tokenParam) ? tokenParam[0] : tokenParam;
-  const versionParam = searchParams?.version;
+  const versionParam = resolvedSearchParams?.version;
   const version = Array.isArray(versionParam) ? versionParam[0] : versionParam;
-  const summaryParam = searchParams?.summary;
+  const summaryParam = resolvedSearchParams?.summary;
   const summaryValue = Array.isArray(summaryParam) ? summaryParam[0] : summaryParam;
   const summaryOnly = summaryValue ? ["1", "true", "yes"].includes(summaryValue.toLowerCase()) : false;
   if (!token) {


### PR DESCRIPTION
## Summary

- Pass buy-side selector fields through SPOT trigger evaluation and report selector ambiguity separately from SPOT missing-rate triggers.
- Fix the public quote route to use the Next 15 async `searchParams` page contract.
- Add a frontend `typecheck` script and clean trailing whitespace in the new SPOT regression test path.

## Root Cause

- The frontend and `RateAvailabilityService` supported `agent_id`, `carrier_id`, and `buy_currency`, but `SpotTriggerEvaluateAPIView` was not forwarding those fields. Domestic lanes with valid COGS rows were therefore still evaluated as ambiguous/missing and incorrectly surfaced as SPOT-required.
- Selector ambiguity also needed to be returned as `selector_issue` rather than counted as missing scope-rate coverage.
- Next 15 generated route types expect `searchParams` to be awaited; the public quote page was typed as a plain object.

## Validation

- `python manage.py test quotes.tests.test_spot_flow_api` - passed, 25 tests.
- `python manage.py test quotes.tests.test_spot_regression_create_quote` - ran 0 tests because the file is pytest-style.
- `pytest quotes/tests/test_spot_regression_create_quote.py -q` - passed, 2 tests.
- `python manage.py test quotes.tests.test_quote_compute_selector_validation` - passed, 8 tests.
- `python manage.py test quotes.tests.test_public_quote_api quotes.tests.test_pdf_export` - passed, 17 tests.
- `npm --prefix frontend run lint` - passed.
- `npm --prefix frontend run typecheck` - passed.
- `git diff --check origin/main` - passed.

## Notes

- This PR is stacked on PR #22 because PR #22 is still open and these fixes depend on that branch.