### PR TITLE
[codex] Lock domestic air service scopes

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "test:quote-store": "node --experimental-strip-types --experimental-specifier-resolution=node scripts/quote-store.test.mjs",
     "test:quote-workflow": "node scripts/quote-workflow-roundtrip.test.mjs",
     "test:crm-quote-prefill": "node scripts/crm-quote-prefill.test.mjs",
+    "test:domestic-service-scope": "node scripts/domestic-service-scope.test.mjs",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",

--- a/frontend/scripts/domestic-service-scope.test.mjs
+++ b/frontend/scripts/domestic-service-scope.test.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import ts from "typescript";
+
+const frontendRoot = path.resolve(process.cwd());
+const sourcePath = path.join(frontendRoot, "src", "lib", "domestic-service-scope.ts");
+
+async function loadModule() {
+  const source = await readFile(sourcePath, "utf8");
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName: sourcePath,
+  }).outputText;
+
+  const tempDir = await mkdtemp(path.join(tmpdir(), "domestic-service-scope-test-"));
+  const modulePath = path.join(tempDir, "domestic-service-scope.mjs");
+
+  try {
+    await writeFile(modulePath, transpiled, "utf8");
+    return await import(`file://${modulePath}`);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+const {
+  getDomesticServiceScopeError,
+  isDomesticServiceScopeAvailable,
+  resolveCountryCode,
+} = await loadModule();
+
+assert.equal(resolveCountryCode(null, "HGU"), "PG");
+assert.equal(resolveCountryCode({ code: "BNE", display_name: "Brisbane (BNE), AU" }, "BNE"), "AU");
+
+assert.match(
+  getDomesticServiceScopeError("D2D", "POM", "HGU", "PG", "PG"),
+  /Delivery is only available/,
+);
+assert.match(
+  getDomesticServiceScopeError("D2D", "POM", "HGU", "pg", "pg"),
+  /Delivery is only available/,
+);
+assert.equal(isDomesticServiceScopeAvailable("D2A", "POM", "HGU", "PG", "PG"), true);
+assert.equal(isDomesticServiceScopeAvailable("A2D", "HGU", "POM", "PG", "PG"), true);
+assert.match(
+  getDomesticServiceScopeError("D2A", "HGU", "POM", "PG", "PG"),
+  /Pickup is only available/,
+);
+assert.match(
+  getDomesticServiceScopeError("D2D", "POM", "WEW", "PG", "PG"),
+  /Delivery is only available/,
+);
+assert.equal(getDomesticServiceScopeError("A2D", "BNE", "HGU", "AU", "PG"), "");
+
+console.log("domestic service scope checks passed");

--- a/frontend/src/components/forms/quote-sections/QuoteRouteSection.tsx
+++ b/frontend/src/components/forms/quote-sections/QuoteRouteSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useFormContext } from "react-hook-form";
+import { useEffect, useMemo } from "react";
+import { useFormContext, useWatch } from "react-hook-form";
 
 import { Plane, Ship } from "lucide-react";
 
@@ -27,6 +28,11 @@ import {
 import {
   V3_LOCATION_TYPES,
 } from "@/lib/schemas/quoteSchema";
+import {
+  getDomesticServiceScopeError,
+  isDomesticPngRoute,
+  resolveCountryCode,
+} from "@/lib/domestic-service-scope";
 import { SERVICE_SCOPE_OPTIONS } from "@/lib/display";
 import { useQuoteStore } from "@/store/useQuoteStore";
 
@@ -36,6 +42,40 @@ export default function QuoteRouteSection() {
   const destinationLocation = useQuoteStore((state) => state.destinationLocation);
   const setOriginLocation = useQuoteStore((state) => state.setOriginLocation);
   const setDestinationLocation = useQuoteStore((state) => state.setDestinationLocation);
+  const mode = useWatch({ control: form.control, name: "mode" });
+  const selectedServiceScope = useWatch({ control: form.control, name: "service_scope" });
+  const originAirport = useWatch({ control: form.control, name: "origin_airport" });
+  const destinationAirport = useWatch({ control: form.control, name: "destination_airport" });
+
+  const originCode = (originAirport || originLocation?.code || "").trim().toUpperCase();
+  const destinationCode = (destinationAirport || destinationLocation?.code || "").trim().toUpperCase();
+  const originCountry = resolveCountryCode(originLocation, originCode);
+  const destinationCountry = resolveCountryCode(destinationLocation, destinationCode);
+  const isDomesticAirRoute =
+    mode === "AIR" &&
+    isDomesticPngRoute(originCountry, destinationCountry, originCode, destinationCode);
+  const serviceScopeError = useMemo(
+    () =>
+      mode === "AIR"
+        ? getDomesticServiceScopeError(
+            selectedServiceScope,
+            originCode,
+            destinationCode,
+            originCountry,
+            destinationCountry,
+          )
+        : "",
+    [destinationCode, destinationCountry, mode, originCode, originCountry, selectedServiceScope],
+  );
+
+  useEffect(() => {
+    if (serviceScopeError) {
+      form.setError("service_scope", { type: "validate", message: serviceScopeError });
+      return;
+    }
+
+    form.clearErrors("service_scope");
+  }, [form, serviceScopeError]);
 
   return (
     <div className="space-y-6">
@@ -85,13 +125,40 @@ export default function QuoteRouteSection() {
                   </SelectTrigger>
                 </FormControl>
                 <SelectContent>
-                  {SERVICE_SCOPE_OPTIONS.map((option) => (
-                    <SelectItem key={option.value} value={option.value}>
-                      {option.label}
-                    </SelectItem>
-                  ))}
+                  {SERVICE_SCOPE_OPTIONS.map((option) => {
+                    const disabledReason =
+                      isDomesticAirRoute
+                        ? getDomesticServiceScopeError(
+                            option.value,
+                            originCode,
+                            destinationCode,
+                            originCountry,
+                            destinationCountry,
+                          )
+                        : "";
+
+                    return (
+                      <SelectItem
+                        key={option.value}
+                        value={option.value}
+                        disabled={Boolean(disabledReason)}
+                      >
+                        <span className="flex w-full items-center justify-between gap-3">
+                          <span>{option.label}</span>
+                          {disabledReason ? (
+                            <span className="text-xs text-muted-foreground">Unavailable</span>
+                          ) : null}
+                        </span>
+                      </SelectItem>
+                    );
+                  })}
                 </SelectContent>
               </Select>
+              {serviceScopeError ? (
+                <FormDescription className="text-destructive">
+                  {serviceScopeError}
+                </FormDescription>
+              ) : null}
               <FormMessage />
             </FormItem>
           )}

--- a/frontend/src/hooks/useQuoteLogic.ts
+++ b/frontend/src/hooks/useQuoteLogic.ts
@@ -17,6 +17,10 @@ import {
     getValidIncoterms,
     getDefaultIncoterm,
 } from "@/lib/schemas/quoteSchema";
+import {
+    getDomesticServiceScopeError,
+    resolveCountryCode,
+} from "@/lib/domestic-service-scope";
 import { Contact, CompanySearchResult, LocationSearchResult, User } from "@/lib/types";
 import { SPECommodity } from "@/lib/spot-types";
 import { useQuoteStore } from "@/store/useQuoteStore";
@@ -34,36 +38,6 @@ const mapCargoToSPECommodity = (cargoType: string): SPECommodity => {
         case 'General Cargo':
         default: return 'GCR';
     }
-};
-
-const AIRPORT_COUNTRY_MAP: Record<string, string> = {
-    POM: "PG",
-    LAE: "PG",
-    SIN: "SG",
-    HKG: "HK",
-    BNE: "AU",
-    SYD: "AU",
-    CNS: "AU",
-    NAN: "FJ",
-    HIR: "SB",
-    VLI: "VU",
-};
-
-const resolveCountryCode = (
-    location: LocationSearchResult | null,
-    airportCode?: string,
-): string => {
-    const explicit = (location?.country_code || "").trim().toUpperCase();
-    if (explicit) return explicit;
-
-    const displayName = location?.display_name || "";
-    const displayMatch = displayName.match(/,\s*([A-Z]{2})\s*$/i);
-    if (displayMatch?.[1]) {
-        return displayMatch[1].toUpperCase();
-    }
-
-    const code = (airportCode || location?.code || "").trim().toUpperCase();
-    return AIRPORT_COUNTRY_MAP[code] || "OTHER";
 };
 
 const parsePricingCounterparty = (
@@ -266,6 +240,22 @@ export function useQuoteLogic({
             const destinationCode = (data.destination_airport || destinationLocation?.code || '').toUpperCase();
             const originCountry = resolveCountryCode(originLocation, originCode);
             const destCountry = resolveCountryCode(destinationLocation, destinationCode);
+            const domesticServiceScopeError =
+                data.mode === "AIR"
+                    ? getDomesticServiceScopeError(
+                        data.service_scope,
+                        originCode,
+                        destinationCode,
+                        originCountry,
+                        destCountry,
+                    )
+                    : "";
+
+            if (domesticServiceScopeError) {
+                form.setError("service_scope", { type: "validate", message: domesticServiceScopeError });
+                setInternalError(domesticServiceScopeError);
+                return;
+            }
 
             try {
                 // 1. Validate Scope

--- a/frontend/src/lib/domestic-service-scope.ts
+++ b/frontend/src/lib/domestic-service-scope.ts
@@ -1,0 +1,108 @@
+import type { LocationSearchResult } from "@/lib/types";
+
+const DOOR_PORTS = new Set(["POM", "LAE"]);
+const PNG_AIRPORT_CODES = new Set([
+  "POM",
+  "LAE",
+  "HGU",
+  "GKA",
+  "RAB",
+  "WWK",
+  "KVG",
+  "MAG",
+  "GUR",
+  "TBG",
+  "HKN",
+  "KIE",
+]);
+
+const AIRPORT_COUNTRY_MAP: Record<string, string> = {
+  ...Object.fromEntries(Array.from(PNG_AIRPORT_CODES).map((code) => [code, "PG"])),
+  SIN: "SG",
+  HKG: "HK",
+  BNE: "AU",
+  SYD: "AU",
+  CNS: "AU",
+  NAN: "FJ",
+  HIR: "SB",
+  VLI: "VU",
+};
+
+export const DOMESTIC_DOOR_PORT_LABEL = "POM or LAE";
+
+export const resolveCountryCode = (
+  location: LocationSearchResult | null,
+  airportCode?: string,
+): string => {
+  const explicit = (location?.country_code || "").trim().toUpperCase();
+  if (explicit) return explicit;
+
+  const displayName = location?.display_name || "";
+  const displayMatch = displayName.match(/,\s*([A-Z]{2})\s*$/i);
+  if (displayMatch?.[1]) {
+    return displayMatch[1].toUpperCase();
+  }
+
+  const code = (airportCode || location?.code || "").trim().toUpperCase();
+  return AIRPORT_COUNTRY_MAP[code] || "OTHER";
+};
+
+export const isDomesticPngRoute = (
+  originCountry: string,
+  destinationCountry: string,
+  originCode?: string,
+  destinationCode?: string,
+) => {
+  const normalizedOriginCountry = (originCountry || "").trim().toUpperCase();
+  const normalizedDestinationCountry = (destinationCountry || "").trim().toUpperCase();
+  const origin = (originCode || "").trim().toUpperCase();
+  const destination = (destinationCode || "").trim().toUpperCase();
+
+  return (
+    normalizedOriginCountry === "PG" &&
+    normalizedDestinationCountry === "PG" &&
+    Boolean(origin) &&
+    Boolean(destination)
+  );
+};
+
+export const getDomesticServiceScopeError = (
+  serviceScope: string | undefined,
+  originCode: string | undefined,
+  destinationCode: string | undefined,
+  originCountry: string,
+  destinationCountry: string,
+) => {
+  const scope = (serviceScope || "").trim().toUpperCase();
+  const origin = (originCode || "").trim().toUpperCase();
+  const destination = (destinationCode || "").trim().toUpperCase();
+
+  if (!isDomesticPngRoute(originCountry, destinationCountry, origin, destination)) {
+    return "";
+  }
+
+  if ((scope === "D2D" || scope === "D2A") && !DOOR_PORTS.has(origin)) {
+    return `Pickup is only available from ${DOMESTIC_DOOR_PORT_LABEL} for domestic routes.`;
+  }
+
+  if ((scope === "D2D" || scope === "A2D") && !DOOR_PORTS.has(destination)) {
+    return `Delivery is only available to ${DOMESTIC_DOOR_PORT_LABEL} for domestic routes.`;
+  }
+
+  return "";
+};
+
+export const isDomesticServiceScopeAvailable = (
+  serviceScope: string,
+  originCode: string | undefined,
+  destinationCode: string | undefined,
+  originCountry: string,
+  destinationCountry: string,
+) =>
+  !getDomesticServiceScopeError(
+    serviceScope,
+    originCode,
+    destinationCode,
+    originCountry,
+    destinationCountry,
+  );


### PR DESCRIPTION
## Summary

- Adds a shared frontend helper for PNG domestic AIR door-service scope validation.
- Disables invalid domestic door scope options in the quote route selector when pickup or delivery is unavailable for the selected domestic route.
- Adds submit-time validation so stale invalid domestic scope values cannot reach SPOT or quote creation preflight.
- Registers the domestic scope helper regression script in `frontend/package.json`.

## Behavior

Before: users could select domestic AIR D2D/D2A/A2D combinations for routes where the backend domestic engine rejects pickup or delivery outside POM/LAE.

After: invalid domestic AIR door scopes are disabled in the frontend selector and blocked again at submit. International routes and non-AIR modes continue using the existing scope options without domestic restrictions.

## Validation

- `node scripts/domestic-service-scope.test.mjs`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run typecheck`
- `npm --prefix frontend run test:domestic-service-scope`
- `git diff --check`