### PR TITLE
[codex] Fix domestic scope selector render loop

### DIFF
--- a/frontend/scripts/domestic-service-scope.test.mjs
+++ b/frontend/scripts/domestic-service-scope.test.mjs
@@ -47,9 +47,14 @@ assert.match(
 );
 assert.equal(isDomesticServiceScopeAvailable("D2A", "POM", "HGU", "PG", "PG"), true);
 assert.equal(isDomesticServiceScopeAvailable("A2D", "HGU", "POM", "PG", "PG"), true);
+assert.equal(isDomesticServiceScopeAvailable("A2A", "HGU", "GKA", "PG", "PG"), true);
 assert.match(
   getDomesticServiceScopeError("D2A", "HGU", "POM", "PG", "PG"),
   /Pickup is only available/,
+);
+assert.match(
+  getDomesticServiceScopeError("A2D", "POM", "HGU", "PG", "PG"),
+  /Delivery is only available/,
 );
 assert.match(
   getDomesticServiceScopeError("D2D", "POM", "WEW", "PG", "PG"),

--- a/frontend/src/components/forms/quote-sections/QuoteRouteSection.tsx
+++ b/frontend/src/components/forms/quote-sections/QuoteRouteSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 
 import { Plane, Ship } from "lucide-react";
@@ -67,15 +67,6 @@ export default function QuoteRouteSection() {
         : "",
     [destinationCode, destinationCountry, mode, originCode, originCountry, selectedServiceScope],
   );
-
-  useEffect(() => {
-    if (serviceScopeError) {
-      form.setError("service_scope", { type: "validate", message: serviceScopeError });
-      return;
-    }
-
-    form.clearErrors("service_scope");
-  }, [form, serviceScopeError]);
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Summary

- Removes render-cycle form error writes from `QuoteRouteSection` that could trigger React's maximum update depth guard.
- Keeps domestic scope warnings derived in the UI and preserves submit-level validation in `useQuoteLogic`.
- Extends the domestic service-scope regression script with additional valid/invalid domestic combinations.

## Root Cause

`QuoteRouteSection` called `form.setError` / `form.clearErrors` from an effect keyed by derived route state. React Hook Form state updates fed back into the same render path, causing the selector to re-render repeatedly on the quote route step.

## Validation

- `npm --prefix frontend run test:domestic-service-scope`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run typecheck`
- `git diff --check`
- `npm --prefix frontend run build` after clearing stale `frontend/.next` cache

## Notes

The first local build attempt failed after compilation because the existing `.next` cache reported missing page modules across unrelated routes. Removing generated `frontend/.next` and rebuilding produced a clean production build.