### PR TITLE
Add draft quote calculation review

### DIFF
--- a/backend/pricing_v4/adapter.py
+++ b/backend/pricing_v4/adapter.py
@@ -288,6 +288,14 @@ class PricingServiceV4Adapter:
                 line.sell_fcy = discounted_sell
                 line.sell_fcy_incl_gst = discounted_sell + new_gst
 
+            line.calculation_notes = (
+                f"{line.calculation_notes} | " if line.calculation_notes else ""
+            ) + (
+                f"Customer discount applied: {discount.discount_type} "
+                f"{discount.discount_value} {discount.currency or '%'}"
+            )
+            line.rate_source = line.rate_source or 'DB_TARIFF'
+
             logger.debug(
                 f"Applied {discount.discount_type} discount to {line.service_component_code}: "
                 f"{original_sell} -> {discounted_sell}"

--- a/backend/quotes/buckets.py
+++ b/backend/quotes/buckets.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from decimal import Decimal
+
 
 BUCKET_TO_LEG = {
     "origin_charges": "ORIGIN",
@@ -30,3 +32,35 @@ def resolve_quote_line_leg(line) -> str:
     because it can be resynced independently of saved quote results.
     """
     return normalize_bucket(getattr(line, "bucket", None)) or normalize_leg(getattr(line, "leg", None)) or "MAIN"
+
+
+def resolve_quote_line_sell_value(line, quote_currency: str) -> Decimal:
+    """Return the customer-facing sell amount for the quote output currency."""
+    currency = str(quote_currency or "PGK").upper()
+    if currency != "PGK":
+        line_currency = str(getattr(line, "sell_fcy_currency", "") or "").upper()
+        if line_currency == currency and getattr(line, "sell_fcy", None) is not None:
+            return line.sell_fcy
+    return getattr(line, "sell_pgk", None) or Decimal("0")
+
+
+def should_display_quote_line(line, quote_currency: str) -> bool:
+    """Return whether a line should appear in the customer/public breakdown."""
+    if getattr(line, "is_informational", False):
+        return False
+    if getattr(line, "conditional", False):
+        return False
+    if getattr(line, "is_rate_missing", False):
+        return False
+    return resolve_quote_line_sell_value(line, quote_currency) > Decimal("0")
+
+
+def should_include_quote_line_in_subtotal(line, quote_currency: str) -> bool:
+    """Return whether a line contributes to customer-facing subtotals/totals."""
+    if getattr(line, "is_informational", False):
+        return False
+    if getattr(line, "conditional", False):
+        return False
+    if getattr(line, "is_rate_missing", False):
+        return False
+    return resolve_quote_line_sell_value(line, quote_currency) > Decimal("0")

--- a/backend/quotes/intake_safety.py
+++ b/backend/quotes/intake_safety.py
@@ -129,7 +129,11 @@ def normalize_source_analysis_summary(value: Any) -> dict[str, Any]:
         "pdf_fallback_used": bool(raw.get("pdf_fallback_used", False)),
     }
     risk_flags, blocking_reasons, risk_level, requires_review_note = _derive_blocking_reasons(summary)
-    review_required = bool(risk_flags)
+    # Only high-risk extraction findings require explicit source review before
+    # acknowledgement/final quote creation. Medium-risk audit signals such as
+    # low-confidence lines or scanned-PDF fallback stay visible as warnings, but
+    # they must not turn a proceedable SPOT envelope into a dead final button.
+    review_required = bool(requires_review_note)
     reviewed_safe_to_quote = bool(raw.get("reviewed_safe_to_quote", False)) if review_required else False
     raw_review_status = str(raw.get("review_status") or "").strip().upper()
     if review_required:

--- a/backend/quotes/pdf_service.py
+++ b/backend/quotes/pdf_service.py
@@ -19,7 +19,11 @@ from fpdf import FPDF
 
 from core.commodity import COMMODITY_CODE_DG, DEFAULT_COMMODITY_CODE, commodity_label
 from core.storage_utils import materialize_file_field
-from .buckets import resolve_quote_line_leg
+from .buckets import (
+    resolve_quote_line_leg,
+    resolve_quote_line_sell_value,
+    should_include_quote_line_in_subtotal,
+)
 from .branding import QuoteBrandingContext, get_quote_branding
 from .models import Quote, QuoteVersion, QuoteLine, QuoteTotal
 from .public_links import build_public_quote_url
@@ -144,8 +148,9 @@ def generate_quote_pdf(
         # Get data
         origin_code, origin_name = _extract_location_info(quote, 'origin')
         destination_code, destination_name = _extract_location_info(quote, 'destination')
-        charge_buckets = _get_charge_buckets(version)
-        totals = _get_totals(version)
+        quote_currency = quote.output_currency or "PGK"
+        charge_buckets = _get_charge_buckets(version, quote_currency)
+        totals = _get_totals(version, quote_currency)
         cargo_type = _get_cargo_type(quote, version)
         chargeable_weight = _get_chargeable_weight(quote, version)
         
@@ -655,7 +660,7 @@ def _build_terms_and_conditions(quote, valid_until_str: str, branding: Optional[
     return terms
 
 
-def _get_charge_buckets(version) -> list[dict]:
+def _get_charge_buckets(version, currency: str = "PGK") -> list[dict]:
     """Get charge summary grouped by the saved quote line bucket/leg."""
     buckets = {
         'Origin Charges': Decimal('0'),
@@ -664,6 +669,9 @@ def _get_charge_buckets(version) -> list[dict]:
     }
     
     for line in version.lines.select_related('service_component').all():
+        if not should_include_quote_line_in_subtotal(line, currency):
+            continue
+
         leg = resolve_quote_line_leg(line)
 
         if leg == 'ORIGIN':
@@ -675,7 +683,7 @@ def _get_charge_buckets(version) -> list[dict]:
         else:
             bucket_name = 'International Freight'
         
-        buckets[bucket_name] += line.sell_pgk or Decimal('0')
+        buckets[bucket_name] += resolve_quote_line_sell_value(line, currency)
     
     result = []
     for name in ['Origin Charges', 'International Freight', 'Destination Charges']:
@@ -685,13 +693,17 @@ def _get_charge_buckets(version) -> list[dict]:
     return result
 
 
-def _get_totals(version) -> dict:
+def _get_totals(version, currency: str = "PGK") -> dict:
     """Get totals for the version."""
     try:
         total = version.totals
         if total:
-            sell_excl = total.total_sell_pgk or Decimal('0')
-            sell_incl = total.total_sell_pgk_incl_gst or Decimal('0')
+            if str(currency or "PGK").upper() != "PGK" and total.total_sell_fcy:
+                sell_excl = total.total_sell_fcy or Decimal('0')
+                sell_incl = total.total_sell_fcy_incl_gst or Decimal('0')
+            else:
+                sell_excl = total.total_sell_pgk or Decimal('0')
+                sell_incl = total.total_sell_pgk_incl_gst or Decimal('0')
             gst = sell_incl - sell_excl
             return {
                 'sell_excl_gst': sell_excl,
@@ -701,7 +713,14 @@ def _get_totals(version) -> dict:
     except Exception:
         pass
     
-    sell_total = sum((line.sell_pgk or Decimal('0')) for line in version.lines.all())
+    sell_total = sum(
+        (
+            resolve_quote_line_sell_value(line, currency)
+            for line in version.lines.all()
+            if should_include_quote_line_in_subtotal(line, currency)
+        ),
+        Decimal('0'),
+    )
     gst = sell_total * Decimal('0.10')
     return {'sell_excl_gst': sell_total, 'gst': gst, 'sell_incl_gst': sell_total + gst}
 

--- a/backend/quotes/quote_result_contract.py
+++ b/backend/quotes/quote_result_contract.py
@@ -667,6 +667,16 @@ def line_item_from_quote_line(
     else:
         sell_amount = decimal_or_zero(getattr(line, "sell_fcy", None))
 
+    cost_amount_pgk = decimal_or_zero(getattr(line, "cost_pgk", None))
+    sell_amount_pgk = decimal_or_zero(getattr(line, "sell_pgk", None))
+    margin_amount_pgk = sell_amount_pgk - cost_amount_pgk
+    margin_percent = ZERO_DECIMAL
+    if sell_amount_pgk > ZERO_DECIMAL:
+        margin_percent = ((margin_amount_pgk / sell_amount_pgk) * Decimal("100")).quantize(
+            Decimal("0.01"),
+            rounding=ROUND_HALF_UP,
+        )
+
     tax_amount = display_tax_amount(line, customer_currency)
     notes = _dedupe(
         [
@@ -718,8 +728,10 @@ def line_item_from_quote_line(
             quantity=quantity,
             sell_amount=sell_amount,
         ),
-        "cost_amount": decimal_or_zero(getattr(line, "cost_pgk", None)),
+        "cost_amount": cost_amount_pgk,
         "sell_amount": sell_amount,
+        "margin_amount": margin_amount_pgk,
+        "margin_percent": margin_percent,
         "tax_code": getattr(line, "gst_category", None) or getattr(service_component, "tax_code", None) or "GST",
         "tax_amount": tax_amount,
         "included_in_total": included_in_total,

--- a/backend/quotes/serializers.py
+++ b/backend/quotes/serializers.py
@@ -153,7 +153,10 @@ class V3QuoteLineSerializer(serializers.ModelSerializer):
             'sell_pgk', 'sell_pgk_incl_gst', 'sell_fcy', 'sell_fcy_incl_gst',
             'sell_fcy_currency', 'exchange_rate', 'cost_source',
             'cost_source_description', 'is_rate_missing', 'leg', 'bucket',
-            'gst_category', 'gst_rate', 'gst_amount'
+            'basis', 'rule_family', 'service_family', 'unit_type', 'rate',
+            'rate_source', 'canonical_cost_source', 'is_spot_sourced',
+            'is_manual_override', 'calculation_notes', 'is_informational',
+            'conditional', 'gst_category', 'gst_rate', 'gst_amount'
         )
     
     def to_representation(self, instance):
@@ -290,6 +293,8 @@ class CanonicalQuoteLineItemSerializer(serializers.Serializer):
     rate = serializers.DecimalField(max_digits=18, decimal_places=6, allow_null=True)
     cost_amount = serializers.DecimalField(max_digits=18, decimal_places=2)
     sell_amount = serializers.DecimalField(max_digits=18, decimal_places=2)
+    margin_amount = serializers.DecimalField(max_digits=18, decimal_places=2)
+    margin_percent = serializers.DecimalField(max_digits=18, decimal_places=2)
     tax_code = serializers.CharField()
     tax_amount = serializers.DecimalField(max_digits=18, decimal_places=2)
     included_in_total = serializers.BooleanField()

--- a/backend/quotes/spot_views.py
+++ b/backend/quotes/spot_views.py
@@ -399,6 +399,10 @@ def _existing_line_source_semantic_signature(line: SPEChargeLineDB) -> tuple[str
 
 
 def _should_preserve_existing_line_audit(existing_line: SPEChargeLineDB, charge: dict) -> bool:
+    incoming_charge_line_id = str(charge.get("charge_line_id") or "").strip()
+    if incoming_charge_line_id and incoming_charge_line_id == str(existing_line.id):
+        return True
+
     incoming_source_label = _incoming_charge_source_label(charge)
     incoming_bucket = str(charge.get("bucket") or "").strip().lower()
     return (
@@ -438,7 +442,9 @@ def _build_spe_charge_line_field_values(
 
     return {
         "envelope": spe_db,
-        "source_batch": source_batch,
+        "source_batch": source_batch if source_batch is not None else (
+            existing_line.source_batch if existing_line is not None else None
+        ),
         "code": charge["code"],
         "description": charge["description"],
         "amount": charge["amount"],

--- a/backend/quotes/tests/test_pdf_export.py
+++ b/backend/quotes/tests/test_pdf_export.py
@@ -13,6 +13,7 @@ from quotes.pdf_service import (
     _get_charge_buckets,
     _get_chargeable_weight,
     _get_location_country_code,
+    _get_totals,
     generate_quote_pdf,
 )
 from services.models import ServiceComponent
@@ -278,3 +279,86 @@ class QuotePDFExportTest(TestCase):
                 {"name": "Destination Charges", "subtotal": Decimal("75.00")},
             ],
         )
+
+    def test_pdf_charge_buckets_exclude_unapplied_conditional_quote_lines(self):
+        quote = Quote.objects.create(
+            customer=self.customer,
+            organization=self.organization,
+            origin_location=self.origin,
+            destination_location=self.dest,
+            quote_number="QT-2026-0001",
+            status="SENT",
+            mode="AIR",
+            shipment_type="IMPORT",
+            output_currency="PGK",
+        )
+        version = QuoteVersion.objects.create(quote=quote, version_number=1)
+
+        QuoteLine.objects.create(
+            quote_version=version,
+            cost_source_description="Import Documentation Fee (Origin)",
+            sell_pgk=Decimal("159.02"),
+            leg="DESTINATION",
+            bucket="origin_charges",
+        )
+        QuoteLine.objects.create(
+            quote_version=version,
+            cost_source_description="Import Origin Customs Clearance",
+            sell_pgk=Decimal("159.02"),
+            leg="ORIGIN",
+            bucket="origin_charges",
+        )
+        QuoteLine.objects.create(
+            quote_version=version,
+            cost_source_description="Import Origin Permit / License",
+            sell_pgk=Decimal("265.04"),
+            leg="ORIGIN",
+            bucket="origin_charges",
+            conditional=True,
+            is_informational=True,
+        )
+        QuoteLine.objects.create(
+            quote_version=version,
+            cost_source_description="Pick-Up Fee (Origin)",
+            sell_pgk=Decimal("689.09"),
+            leg="DESTINATION",
+            bucket="origin_charges",
+        )
+        QuoteLine.objects.create(
+            quote_version=version,
+            cost_source_description="Import Air Freight",
+            sell_pgk=Decimal("3975.53"),
+            leg="MAIN",
+            bucket="airfreight",
+        )
+        QuoteLine.objects.create(
+            quote_version=version,
+            cost_source_description="Destination Charges",
+            sell_pgk=Decimal("1165.00"),
+            leg="DESTINATION",
+            bucket="destination_charges",
+        )
+        QuoteTotal.objects.create(
+            quote_version=version,
+            total_sell_pgk=Decimal("6147.66"),
+            total_sell_pgk_incl_gst=Decimal("6264.16"),
+        )
+
+        buckets = _get_charge_buckets(version)
+        totals = _get_totals(version)
+
+        self.assertEqual(
+            buckets,
+            [
+                {"name": "Origin Charges", "subtotal": Decimal("1007.13")},
+                {"name": "International Freight", "subtotal": Decimal("3975.53")},
+                {"name": "Destination Charges", "subtotal": Decimal("1165.00")},
+            ],
+        )
+        self.assertNotEqual(buckets[0]["subtotal"], Decimal("1272.17"))
+        self.assertEqual(totals["sell_excl_gst"], Decimal("6147.66"))
+        self.assertEqual(totals["gst"], Decimal("116.50"))
+        self.assertEqual(totals["sell_incl_gst"], Decimal("6264.16"))
+
+        pdf_bytes = generate_quote_pdf(str(quote.id))
+        self.assertTrue(pdf_bytes.startswith(b"%PDF"))

--- a/backend/quotes/tests/test_public_quote_api.py
+++ b/backend/quotes/tests/test_public_quote_api.py
@@ -249,6 +249,57 @@ class QuotePublicDetailAPITest(APITestCase):
         self.assertEqual(len(origin_lines), 1)
         self.assertEqual(origin_lines[0]["description"], "AWB Fee")
 
+    def test_public_quote_hides_unapplied_conditional_lines_from_charge_breakdown(self):
+        quote = self._create_quote(service_scope="D2D")
+        quote.quote_number = "QT-2026-0001"
+        quote.output_currency = "PGK"
+        quote.save(update_fields=["quote_number", "output_currency"])
+        version = quote.versions.get(version_number=1)
+
+        QuoteLine.objects.create(
+            quote_version=version,
+            cost_source_description="Import Documentation Fee (Origin)",
+            sell_pgk=Decimal("159.02"),
+            leg="DESTINATION",
+            bucket="origin_charges",
+        )
+        QuoteLine.objects.create(
+            quote_version=version,
+            cost_source_description="Import Origin Customs Clearance",
+            sell_pgk=Decimal("159.02"),
+            leg="ORIGIN",
+            bucket="origin_charges",
+        )
+        QuoteLine.objects.create(
+            quote_version=version,
+            cost_source_description="Import Origin Permit / License",
+            sell_pgk=Decimal("265.04"),
+            leg="ORIGIN",
+            bucket="origin_charges",
+            conditional=True,
+            is_informational=True,
+        )
+        QuoteLine.objects.create(
+            quote_version=version,
+            cost_source_description="Pick-Up Fee (Origin)",
+            sell_pgk=Decimal("689.09"),
+            leg="DESTINATION",
+            bucket="origin_charges",
+        )
+
+        token = build_public_quote_token(str(quote.id))
+        response = self.client.get(self.url, {"token": token})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        payload = response.json()
+        buckets = {bucket["name"]: bucket for bucket in payload["charge_buckets"]}
+        origin_bucket = buckets["Origin Charges"]
+        descriptions = [line["description"] for line in origin_bucket["lines"]]
+
+        self.assertEqual(origin_bucket["subtotal"], "1007.13")
+        self.assertNotIn("Import Origin Permit / License", descriptions)
+        self.assertNotIn("265.04", [line["sell"] for line in origin_bucket["lines"]])
+
     def test_public_quote_includes_branding_payload(self):
         quote = self._create_quote(service_scope="D2D")
         token = build_public_quote_token(str(quote.id))

--- a/backend/quotes/tests/test_spot_compute_completeness.py
+++ b/backend/quotes/tests/test_spot_compute_completeness.py
@@ -572,6 +572,69 @@ def test_spot_create_quote_blocks_risky_source_batch_until_reviewed(monkeypatch)
     assert response.json()["intake_safety"]["is_safe_to_quote"] is False
 
 
+def test_spot_create_quote_allows_low_confidence_source_warning(monkeypatch):
+    user, origin, destination = _setup_user_and_locations()
+    spe = _create_ready_spe(
+        user=user,
+        origin_code=origin.code,
+        dest_code=destination.code,
+        origin_country="AU",
+        dest_country="PG",
+        service_scope="A2D",
+    )
+    SPESourceBatchDB.objects.create(
+        envelope=spe,
+        source_kind=SPESourceBatchDB.SourceKind.AGENT,
+        source_type=SPESourceBatchDB.SourceType.TEXT,
+        target_bucket=SPESourceBatchDB.TargetBucket.DESTINATION_CHARGES,
+        label="Uploaded rates",
+        source_reference="Uploaded rates",
+        raw_text="Destination fee USD 75",
+        analysis_summary_json={
+            "can_proceed": True,
+            "ai_used": True,
+            "imported_charge_count": 1,
+            "low_confidence_line_count": 1,
+        },
+        created_by=user,
+    )
+    SPEChargeLineDB.objects.create(
+        envelope=spe,
+        code="DESTINATION_LOCAL",
+        description="Destination fee",
+        amount=Decimal("75.00"),
+        currency="USD",
+        unit="flat",
+        bucket="destination_charges",
+        source_reference="Uploaded rates",
+        normalization_status=SPEChargeLineDB.NormalizationStatus.MATCHED,
+        normalization_method=SPEChargeLineDB.NormalizationMethod.EXACT_ALIAS,
+        entered_at=timezone.now(),
+    )
+    monkeypatch.setattr(
+        PricingServiceV4Adapter,
+        "calculate_charges",
+        lambda self: _quote_charges_for_buckets(["destination_charges"]),
+    )
+    customer = Company.objects.create(name="Low Confidence Customer", is_customer=True, company_type="CUSTOMER")
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    detail_response = client.get(f"/api/v3/spot/envelopes/{spe.id}/")
+    assert detail_response.status_code == 200
+    assert detail_response.json()["intake_safety"]["is_safe_to_quote"] is True
+    assert detail_response.json()["sources"][0]["review_status"] == "NOT_REQUIRED"
+
+    response = client.post(
+        f"/api/v3/spot/envelopes/{spe.id}/create-quote/",
+        {"quote_request": {"service_scope": "A2D", "payment_term": "PREPAID", "customer_id": str(customer.id)}},
+        format="json",
+    )
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+
+
 def test_spot_create_quote_blocks_unacknowledged_conditional_matched_line(monkeypatch):
     user, origin, destination = _setup_user_and_locations()
     spe = _create_ready_spe(

--- a/backend/quotes/tests/test_spot_regression_create_quote.py
+++ b/backend/quotes/tests/test_spot_regression_create_quote.py
@@ -121,6 +121,94 @@ def test_manual_resolution_syncs_batch_analysis_summary():
     assert resp.json()["intake_safety"]["is_safe_to_quote"] is True
 
 
+def test_patch_preserves_imported_charge_audit_when_round_tripped_by_id():
+    user, origin, dest, pc = _setup_test_data()
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    spe = SpotPricingEnvelopeDB.objects.create(
+        created_by=user,
+        status="draft",
+        expires_at=timezone.now() + timedelta(days=7),
+        shipment_context_json={
+            "origin_country": "PG",
+            "destination_country": "AU",
+            "origin_code": origin.code,
+            "destination_code": dest.code,
+            "total_weight_kg": 100,
+            "pieces": 1,
+            "commodity": "GCR",
+            "service_scope": "D2D",
+        },
+        spot_trigger_reason_code=SpotTriggerReason.MISSING_SCOPE_RATES,
+        spot_trigger_reason_text="Missing required rate components",
+    )
+    batch = SPESourceBatchDB.objects.create(
+        envelope=spe,
+        source_kind="AGENT",
+        source_type="TEXT",
+        label="Agent reply",
+        analysis_summary_json={"can_proceed": True, "unmapped_line_count": 0, "risk_level": "LOW"},
+    )
+    line = SPEChargeLineDB.objects.create(
+        envelope=spe,
+        source_batch=batch,
+        code="FRT_SPOT",
+        description="Import Air Freight",
+        amount=Decimal("100.00"),
+        currency="USD",
+        unit="per_kg",
+        bucket="airfreight",
+        is_primary_cost=True,
+        source_label="A/F",
+        normalized_label="a f",
+        normalization_status=SPEChargeLineDB.NormalizationStatus.MATCHED,
+        normalization_method=SPEChargeLineDB.NormalizationMethod.EXACT_ALIAS,
+        resolved_product_code=pc,
+        source_reference="Agent email",
+        source_line_identity="agent:1",
+        entered_at=timezone.now(),
+        entered_by=user,
+    )
+
+    detail_url = reverse("quotes:spot-envelope-detail", kwargs={"envelope_id": spe.id})
+    response = client.patch(
+        detail_url,
+        {
+            "charges": [
+                {
+                    "charge_line_id": str(line.id),
+                    "code": line.code,
+                    "description": line.description,
+                    "amount": "125.00",
+                    "currency": line.currency,
+                    "unit": line.unit,
+                    "bucket": line.bucket,
+                    "is_primary_cost": line.is_primary_cost,
+                    "conditional": line.conditional,
+                    "source_reference": line.source_reference,
+                    "source_line_identity": line.source_line_identity,
+                }
+            ]
+        },
+        format="json",
+    )
+
+    assert response.status_code == 200
+    payload_line = response.json()["charges"][0]
+    assert payload_line["id"] == str(line.id)
+    assert payload_line["source_label"] == "A/F"
+    assert payload_line["normalization_status"] == "MATCHED"
+    assert payload_line["effective_resolved_product_code"]["id"] == pc.id
+
+    line.refresh_from_db()
+    assert line.amount == Decimal("125.00")
+    assert line.source_batch_id == batch.id
+    assert line.source_label == "A/F"
+    assert line.normalization_status == SPEChargeLineDB.NormalizationStatus.MATCHED
+    assert line.resolved_product_code_id == pc.id
+
+
 def test_a2a_service_scope_schema_support():
     """Verify that 'a2a' service scope is supported in the Pydantic schema."""
     context = SPEShipmentContext(

--- a/backend/quotes/views/public.py
+++ b/backend/quotes/views/public.py
@@ -9,7 +9,12 @@ from rest_framework.throttling import ScopedRateThrottle
 from rest_framework.views import APIView
 
 from quotes.branding import get_quote_branding
-from quotes.buckets import resolve_quote_line_leg
+from quotes.buckets import (
+    resolve_quote_line_leg,
+    resolve_quote_line_sell_value,
+    should_display_quote_line,
+    should_include_quote_line_in_subtotal,
+)
 from quotes.models import Quote, QuoteLine, QuoteTotal
 from quotes.public_links import get_public_quote_id_from_token
 
@@ -104,17 +109,11 @@ def _resolve_service_scope(quote: Quote, version) -> str | None:
 
 
 def _resolve_line_sell_value(line, quote_currency: str) -> Decimal:
-    if quote_currency != "PGK":
-        line_currency = str(getattr(line, "sell_fcy_currency", "") or "").upper()
-        if line_currency == quote_currency and getattr(line, "sell_fcy", None) is not None:
-            return line.sell_fcy
-    return line.sell_pgk or Decimal("0")
+    return resolve_quote_line_sell_value(line, quote_currency)
 
 
 def _should_include_public_line(line, quote_currency: str) -> bool:
-    if getattr(line, "is_informational", False):
-        return True
-    return _resolve_line_sell_value(line, quote_currency) > Decimal("0")
+    return should_display_quote_line(line, quote_currency)
 
 
 def _build_public_charge_buckets(lines, currency: str) -> list[dict]:
@@ -145,7 +144,7 @@ def _build_public_charge_buckets(lines, currency: str) -> list[dict]:
         }
 
         buckets[leg]['lines'].append(line_data)
-        if not line.is_informational:
+        if should_include_quote_line_in_subtotal(line, currency):
             buckets[leg]['subtotal'] += sell_value
 
     return [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "test:quote-workflow": "node scripts/quote-workflow-roundtrip.test.mjs",
     "test:crm-quote-prefill": "node scripts/crm-quote-prefill.test.mjs",
     "test:domestic-service-scope": "node scripts/domestic-service-scope.test.mjs",
+    "test:spot-finalization": "node scripts/spot-finalization.test.mjs",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",

--- a/frontend/scripts/spot-finalization.test.mjs
+++ b/frontend/scripts/spot-finalization.test.mjs
@@ -28,7 +28,10 @@ async function loadModule() {
   }
 }
 
-const { getSpotFinalizeDisabledReason } = await loadModule();
+const {
+  getSpotFinalizeDisabledReason,
+  getSpotFinalizeFormDisabledReason,
+} = await loadModule();
 
 const baseSpe = {
   acknowledgement: null,
@@ -66,9 +69,10 @@ assert.match(
   getSpotFinalizeDisabledReason({
     spe: baseSpe,
     unresolvedReviewIssueCount: 2,
+    unresolvedReviewIssueLabels: ["Import Air Freight", "Documentation Fee"],
   }) || "",
-  /Resolve 2 issues before creating quote/,
-  "unresolved charge blockers should expose a clear disabled reason",
+  /Resolve 2 issues before creating quote: Import Air Freight, Documentation Fee\./,
+  "unresolved charge blockers should name affected charges",
 );
 
 assert.equal(
@@ -140,4 +144,81 @@ assert.match(
   "unacknowledged source blockers should show the backend blocking issue",
 );
 
-console.log("spot finalization gating checks passed");
+assert.equal(
+  getSpotFinalizeDisabledReason({
+    spe: {
+      ...baseSpe,
+      intake_safety: {
+        is_safe_to_quote: false,
+        blocking_issues: ["Uploaded rates: 2 extracted charge line(s) were low-confidence."],
+        pending_source_batch_ids: ["source-1"],
+        pending_source_labels: ["Uploaded rates"],
+        review_note_required_batch_ids: [],
+      },
+    },
+    unresolvedReviewIssueCount: 0,
+  }),
+  null,
+  "low-confidence source warnings should stay visible but not disable final quote creation",
+);
+
+const readyAcknowledgedSpe = {
+  acknowledgement: { acknowledged_at: "2026-05-11T00:00:00Z" },
+  can_proceed: true,
+  intake_safety: { is_safe_to_quote: false, blocking_issues: ["AI audit flagged fallback extraction."] },
+  is_expired: false,
+  missing_mandatory_fields: [],
+  status: "ready",
+};
+
+assert.equal(
+  getSpotFinalizeDisabledReason({
+    spe: readyAcknowledgedSpe,
+    unresolvedReviewIssueCount: 0,
+  }),
+  null,
+  "acknowledged unsafe-audit fallback must not block when backend can proceed",
+);
+
+assert.equal(
+  getSpotFinalizeFormDisabledReason({
+    finalizeDisabledReason: null,
+    editableChargeCount: 0,
+    isFormValid: false,
+    allowEmptySubmit: true,
+  }),
+  null,
+  "ready SPEs with no editable manual rows must still be submittable",
+);
+
+assert.match(
+  getSpotFinalizeFormDisabledReason({
+    finalizeDisabledReason: null,
+    editableChargeCount: 0,
+    isFormValid: false,
+    allowEmptySubmit: false,
+  }),
+  /at least one SPOT charge line/,
+);
+
+assert.match(
+  getSpotFinalizeFormDisabledReason({
+    finalizeDisabledReason: null,
+    editableChargeCount: 2,
+    isFormValid: false,
+    allowEmptySubmit: true,
+  }),
+  /Complete the visible SPOT charge fields/,
+);
+
+assert.equal(
+  getSpotFinalizeFormDisabledReason({
+    finalizeDisabledReason: "Resolve 1 issue before creating quote.",
+    editableChargeCount: 0,
+    isFormValid: false,
+    allowEmptySubmit: true,
+  }),
+  "Resolve 1 issue before creating quote.",
+);
+
+console.log("spot finalization checks passed");

--- a/frontend/src/app/public/quote/PublicQuoteActions.tsx
+++ b/frontend/src/app/public/quote/PublicQuoteActions.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Download, Mail } from "lucide-react";
+
+type PublicQuoteActionsProps = {
+  quoteNumber: string;
+  supportEmail?: string | null;
+  brandPrimary: string;
+  brandAccent: string;
+};
+
+export function PublicQuoteActions({
+  quoteNumber,
+  supportEmail,
+  brandPrimary,
+  brandAccent,
+}: PublicQuoteActionsProps) {
+  const approvalHref = supportEmail
+    ? `mailto:${supportEmail}?subject=${encodeURIComponent(`Approval for ${quoteNumber}`)}`
+    : undefined;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <button
+        type="button"
+        onClick={() => window.print()}
+        className="inline-flex h-10 w-full items-center justify-center gap-2 whitespace-nowrap rounded-md border border-slate-300 bg-white px-4 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-slate-400 hover:bg-slate-50"
+      >
+        <Download className="h-4 w-4" aria-hidden="true" />
+        Print / Save PDF
+      </button>
+      {approvalHref ? (
+        <a
+          href={approvalHref}
+          className="inline-flex h-10 w-full items-center justify-center gap-2 whitespace-nowrap rounded-md px-4 text-sm font-semibold text-white shadow-sm transition hover:brightness-95"
+          style={{ backgroundColor: brandAccent || brandPrimary }}
+        >
+          <Mail className="h-4 w-4" aria-hidden="true" />
+          Approve by Email
+        </a>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/app/public/quote/page.tsx
+++ b/frontend/src/app/public/quote/page.tsx
@@ -1,6 +1,9 @@
 import { notFound } from "next/navigation";
+import type { ReactNode } from "react";
+import { ArrowRight, CalendarDays, Globe2, Mail, MapPin, Phone, Plane, ReceiptText, ShieldCheck } from "lucide-react";
 import { API_BASE_URL } from "@/lib/config";
 import { formatIncoterm, formatPaymentTerm, formatServiceScope } from "@/lib/display";
+import { PublicQuoteActions } from "./PublicQuoteActions";
 
 type PublicQuoteLine = {
   description: string;
@@ -74,6 +77,15 @@ const formatMoney = (currency: string, value: string | number | null) => {
   })}`;
 };
 
+const formatDate = (value: string | null) => {
+  if (!value) return "N/A";
+  return new Date(value).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+};
+
 const withAlpha = (hex: string, alphaHex: string) => {
   const value = (hex || "").trim();
   if (!/^#[0-9A-Fa-f]{6}$/.test(value)) {
@@ -81,6 +93,14 @@ const withAlpha = (hex: string, alphaHex: string) => {
   }
   return `${value}${alphaHex}`;
 };
+
+const statusLabel = (status: string) =>
+  status
+    .toLowerCase()
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+
+const bucketLabel = (name: string) => (name === "Freight" ? "International Freight" : name);
 
 type PublicQuoteSearchParams = {
   token?: string | string[];
@@ -91,6 +111,31 @@ type PublicQuoteSearchParams = {
 type PublicQuotePageProps = {
   searchParams?: Promise<PublicQuoteSearchParams>;
 };
+
+function DetailItem({ label, value }: { label: string; value: string | null | undefined }) {
+  return (
+    <div className="min-w-0">
+      <div className="text-xs font-semibold text-slate-500">{label}</div>
+      <div className="mt-1 truncate text-sm font-semibold text-slate-950">{value || "N/A"}</div>
+    </div>
+  );
+}
+
+function ContactItem({
+  icon,
+  value,
+}: {
+  icon: ReactNode;
+  value: string | null | undefined;
+}) {
+  if (!value) return null;
+  return (
+    <div className="inline-flex items-center gap-2 text-sm text-slate-600">
+      <span className="text-slate-400">{icon}</span>
+      <span>{value}</span>
+    </div>
+  );
+}
 
 export default async function PublicQuotePage({ searchParams }: PublicQuotePageProps) {
   const resolvedSearchParams = await searchParams;
@@ -128,11 +173,11 @@ export default async function PublicQuotePage({ searchParams }: PublicQuotePageP
         ? detail.detail
         : "This shared link is invalid or has expired.";
     return (
-      <main className="min-h-screen bg-slate-50">
+      <main className="min-h-screen bg-slate-100">
         <div className="mx-auto max-w-3xl px-4 py-12">
-          <div className="rounded-2xl border border-slate-200 bg-white p-8 shadow-sm">
-            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Quote Share</p>
-            <h1 className="mt-2 text-2xl font-semibold text-slate-900">Link unavailable</h1>
+          <div className="rounded-lg border border-slate-200 bg-white p-8 shadow-sm">
+            <p className="text-sm font-semibold text-slate-500">Quote Share</p>
+            <h1 className="mt-2 text-2xl font-semibold text-slate-950">Link unavailable</h1>
             <p className="mt-3 text-sm text-slate-600">{message}</p>
           </div>
         </div>
@@ -145,193 +190,237 @@ export default async function PublicQuotePage({ searchParams }: PublicQuotePageP
   const showAirportReferences = ["A2D", "D2A", "A2A", "P2P"].includes(normalizedScope);
   const brandPrimary = data.branding.primary_color || "#0F2A56";
   const brandAccent = data.branding.accent_color || "#D71920";
-  const mutedBrandBackground = withAlpha(brandPrimary, "12");
-  const accentBackground = withAlpha(brandAccent, "12");
+  const primarySoft = withAlpha(brandPrimary, "10") || "#eef2ff";
+  const primaryBorder = withAlpha(brandPrimary, "24") || "#cbd5e1";
+  const accentSoft = withAlpha(brandAccent, "12") || "#fff1f2";
+  const accentBorder = withAlpha(brandAccent, "33") || "#fecaca";
+  const statusText = statusLabel(data.status);
+  const chargeLineCount = data.charge_buckets.reduce((total, bucket) => total + bucket.lines.length, 0);
 
   return (
-    <main className="min-h-screen bg-slate-50">
-      <div className="mx-auto max-w-4xl px-4 py-10 space-y-6">
-        <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">Quote</p>
-              <div className="mt-2 flex items-center gap-3">
-                {data.branding.logo_url ? (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img
-                    src={data.branding.logo_url}
-                    alt={data.branding.display_name}
-                    className="h-10 w-auto object-contain"
-                  />
-                ) : (
-                  <div
-                    className="flex h-10 w-10 items-center justify-center rounded-xl text-sm font-bold text-white"
-                    style={{ backgroundColor: brandPrimary }}
-                  >
-                    {data.branding.display_name.slice(0, 1).toUpperCase()}
+    <main className="min-h-screen bg-[#f3f6fa] text-slate-950">
+      <div className="h-3" style={{ backgroundColor: brandPrimary }} />
+
+      <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
+        <section className="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
+          <div className="border-b border-slate-200 px-5 py-5 sm:px-8">
+            <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-4">
+                  {data.branding.logo_url ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={data.branding.logo_url}
+                      alt={data.branding.display_name}
+                      className="h-12 w-auto max-w-[220px] object-contain"
+                    />
+                  ) : (
+                    <div
+                      className="flex h-12 w-12 items-center justify-center rounded-md text-base font-bold text-white"
+                      style={{ backgroundColor: brandPrimary }}
+                    >
+                      {data.branding.display_name.slice(0, 1).toUpperCase()}
+                    </div>
+                  )}
+                  <div>
+                    <div className="text-base font-semibold text-slate-950">{data.branding.display_name}</div>
+                    {data.branding.public_quote_tagline ? (
+                      <div className="text-sm text-slate-500">{data.branding.public_quote_tagline}</div>
+                    ) : null}
                   </div>
-                )}
-                <div>
-                  <p className="text-sm font-semibold" style={{ color: brandPrimary }}>
-                    {data.branding.display_name}
-                  </p>
-                  <p className="text-xs text-slate-500">{data.branding.public_quote_tagline}</p>
                 </div>
-              </div>
-              <h1 className="mt-2 text-3xl font-semibold text-slate-900">{data.quote_number}</h1>
-              <p className="mt-2 text-sm text-slate-500">
-                Created {new Date(data.created_at).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" })}
-              </p>
-              <p className="text-sm text-slate-500">
-                Valid until {data.valid_until ? new Date(data.valid_until).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" }) : "N/A"}
-              </p>
-            </div>
-            <div
-              className="rounded-full border px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em]"
-              style={{
-                borderColor: withAlpha(brandAccent, "33") || "#fecaca",
-                backgroundColor: accentBackground || "#fff1f2",
-                color: brandAccent,
-              }}
-            >
-              {data.status}
-            </div>
-          </div>
-          <div
-            className="mt-6 grid gap-4 rounded-xl border p-4 md:grid-cols-2"
-            style={{
-              borderColor: withAlpha(brandPrimary, "1f") || "#e2e8f0",
-              backgroundColor: mutedBrandBackground || "#f8fafc",
-            }}
-          >
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Customer</p>
-              <p className="mt-1 text-base font-semibold text-slate-800">{data.customer.name}</p>
-              {data.customer.contact && (
-                <p className="text-sm text-slate-500">Contact: {data.customer.contact}</p>
-              )}
-            </div>
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Shipment</p>
-              <p className="mt-1 text-base font-semibold text-slate-800">
-                {[data.shipment.mode, data.shipment.direction].filter(Boolean).join(" • ")}
-              </p>
-              <p className="text-sm text-slate-500">
-                Payment: {formatPaymentTerm(data.shipment.payment_term)}
-              </p>
-              <p className="text-sm text-slate-500">
-                Service Scope: {formatServiceScope(data.shipment.service_scope)}
-              </p>
-              {data.shipment.incoterm && (
-                <p className="text-sm text-slate-500">Incoterm: {formatIncoterm(data.shipment.incoterm)}</p>
-              )}
-            </div>
-          </div>
-          <div className="mt-4 flex flex-wrap gap-4 text-sm text-slate-500">
-            {data.branding.support_email && <span>Email: {data.branding.support_email}</span>}
-            {data.branding.support_phone && <span>Phone: {data.branding.support_phone}</span>}
-            {data.branding.website_url && <span>{data.branding.website_url}</span>}
-          </div>
-          {data.branding.address_lines.length > 0 && (
-            <p className="mt-2 text-sm text-slate-500">{data.branding.address_lines.join(", ")}</p>
-          )}
-        </section>
 
-        <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Route</p>
-          <div className="mt-4 flex flex-col items-center gap-4 text-center md:flex-row md:justify-between">
-            <div>
-              <p className="text-3xl font-semibold text-slate-900">{data.route.origin_code}</p>
-              {showAirportReferences && (
-                <p className="text-sm text-slate-500">{data.route.origin_name}</p>
-              )}
-            </div>
-            <div className="text-sm font-semibold uppercase tracking-[0.3em] text-rose-500">to</div>
-            <div>
-              <p className="text-3xl font-semibold text-slate-900">{data.route.destination_code}</p>
-              {showAirportReferences && (
-                <p className="text-sm text-slate-500">{data.route.destination_name}</p>
-              )}
-            </div>
-          </div>
-        </section>
-
-        <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Totals</p>
-          <div className="mt-4 grid gap-3 md:grid-cols-3">
-            <div className="rounded-xl border border-slate-100 bg-slate-50 p-4">
-              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Excl. GST</p>
-              <p className="mt-2 text-lg font-semibold text-slate-900">
-                {formatMoney(data.currency, data.totals.sell_excl_gst)}
-              </p>
-            </div>
-            <div className="rounded-xl border border-slate-100 bg-slate-50 p-4">
-              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">GST (10%)</p>
-              <p className="mt-2 text-lg font-semibold text-slate-900">
-                {formatMoney(data.currency, data.totals.gst)}
-              </p>
-            </div>
-            <div className="rounded-xl border border-slate-100 bg-slate-50 p-4">
-              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Grand Total</p>
-              <p className="mt-2 text-lg font-semibold text-slate-900">
-                {formatMoney(data.currency, data.totals.sell_incl_gst)}
-              </p>
-            </div>
-          </div>
-          {data.totals.fcy && data.totals.fcy_currency && data.totals.fcy_amount && (
-            <p className="mt-3 text-sm text-slate-500">
-              Equivalent: {formatMoney(data.totals.fcy_currency, data.totals.fcy_amount)}
-            </p>
-          )}
-        </section>
-
-        <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-          <div className="flex items-center justify-between">
-            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
-              {summaryOnly ? "Pricing Summary" : "Charge Breakdown"}
-            </p>
-            <p className="text-xs text-slate-400">Link valid for 7 days</p>
-          </div>
-          <div className="mt-4 space-y-4">
-            {data.charge_buckets.map((bucket) => (
-              <div key={bucket.name} className="rounded-xl border border-slate-200 bg-slate-50 p-4">
-                <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
-                  <span className="text-sm font-semibold text-slate-900">{bucket.name}</span>
-                  <span className="text-sm font-semibold text-slate-700">
-                    {formatMoney(data.currency, bucket.subtotal)}
+                <div className="mt-6 flex flex-wrap items-center gap-3">
+                  <h1 className="text-3xl font-semibold text-slate-950 sm:text-4xl">{data.quote_number}</h1>
+                  <span
+                    className="inline-flex h-8 items-center rounded-full border px-3 text-xs font-semibold"
+                    style={{ borderColor: accentBorder, backgroundColor: accentSoft, color: brandAccent }}
+                  >
+                    {statusText}
                   </span>
                 </div>
-                {!summaryOnly && (
-                  <div className="overflow-x-auto">
-                    <table className="w-full text-left text-sm text-slate-600">
-                      <thead className="text-xs uppercase tracking-wide text-slate-400">
-                        <tr>
-                          <th className="pb-2">Description</th>
-                          <th className="pb-2 text-right">Amount ({data.currency})</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {bucket.lines.map((line, index) => (
-                          <tr key={`${bucket.name}-${index}`} className={line.is_informational ? "text-slate-400" : ""}>
-                            <td className="py-2 pr-4">{line.description}</td>
-                            <td className="py-2 text-right">{formatMoney(data.currency, line.sell)}</td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
-                )}
+
+                <div className="mt-3 flex flex-wrap gap-x-5 gap-y-2 text-sm text-slate-600">
+                  <span className="inline-flex items-center gap-2">
+                    <CalendarDays className="h-4 w-4 text-slate-400" aria-hidden="true" />
+                    Created {formatDate(data.created_at)}
+                  </span>
+                  <span className="inline-flex items-center gap-2">
+                    <ShieldCheck className="h-4 w-4 text-slate-400" aria-hidden="true" />
+                    Valid until {formatDate(data.valid_until)}
+                  </span>
+                </div>
               </div>
-            ))}
-            {data.charge_buckets.length === 0 && (
-              <p className="text-sm text-slate-500">No charge lines available.</p>
-            )}
+
+              <div className="w-full rounded-lg border border-slate-200 bg-slate-50 p-5 lg:w-[340px]">
+                <div className="text-sm font-semibold text-slate-600">Grand Total</div>
+                <div className="mt-2 text-3xl font-semibold text-slate-950">
+                  {formatMoney(data.currency, data.totals.sell_incl_gst)}
+                </div>
+                <div className="mt-2 text-sm text-slate-500">
+                  Includes GST of {formatMoney(data.currency, data.totals.gst)}
+                </div>
+                <div className="mt-5">
+                  <PublicQuoteActions
+                    quoteNumber={data.quote_number}
+                    supportEmail={data.branding.support_email}
+                    brandPrimary={brandPrimary}
+                    brandAccent={brandAccent}
+                  />
+                </div>
+              </div>
+            </div>
           </div>
+
+          <div className="grid border-b border-slate-200 lg:grid-cols-[1.15fr_0.85fr]">
+            <section className="border-b border-slate-200 px-5 py-6 sm:px-8 lg:border-b-0 lg:border-r">
+              <div className="flex items-center gap-2 text-sm font-semibold text-slate-700">
+                <MapPin className="h-4 w-4" style={{ color: brandAccent }} aria-hidden="true" />
+                Route
+              </div>
+              <div className="mt-5 grid grid-cols-[1fr_auto_1fr] items-center gap-4">
+                <div>
+                  <div className="text-4xl font-semibold text-slate-950 sm:text-5xl">{data.route.origin_code}</div>
+                  <div className="mt-2 text-sm text-slate-600">{showAirportReferences ? data.route.origin_name : "Origin"}</div>
+                </div>
+                <div className="flex items-center gap-3">
+                  <span className="hidden h-px w-16 bg-slate-300 sm:block" />
+                  <span
+                    className="flex h-10 w-10 items-center justify-center rounded-full border bg-white"
+                    style={{ borderColor: primaryBorder }}
+                  >
+                    <Plane className="h-4 w-4" style={{ color: brandPrimary }} aria-hidden="true" />
+                  </span>
+                  <ArrowRight className="hidden h-4 w-4 text-slate-400 sm:block" aria-hidden="true" />
+                </div>
+                <div className="text-right">
+                  <div className="text-4xl font-semibold text-slate-950 sm:text-5xl">{data.route.destination_code}</div>
+                  <div className="mt-2 text-sm text-slate-600">{showAirportReferences ? data.route.destination_name : "Destination"}</div>
+                </div>
+              </div>
+            </section>
+
+            <section className="px-5 py-6 sm:px-8">
+              <div className="flex items-center gap-2 text-sm font-semibold text-slate-700">
+                <ReceiptText className="h-4 w-4" style={{ color: brandAccent }} aria-hidden="true" />
+                Quote Details
+              </div>
+              <div className="mt-5 grid grid-cols-2 gap-5">
+                <DetailItem label="Customer" value={data.customer.name} />
+                <DetailItem label="Contact" value={data.customer.contact} />
+                <DetailItem label="Shipment" value={[data.shipment.mode, data.shipment.direction].filter(Boolean).join(" / ")} />
+                <DetailItem label="Payment" value={formatPaymentTerm(data.shipment.payment_term)} />
+                <DetailItem label="Service Scope" value={formatServiceScope(data.shipment.service_scope)} />
+                <DetailItem label="Incoterm" value={data.shipment.incoterm ? formatIncoterm(data.shipment.incoterm) : "N/A"} />
+              </div>
+            </section>
+          </div>
+
+          <section className="border-b border-slate-200 px-5 py-6 sm:px-8">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+              <div>
+                <h2 className="text-xl font-semibold text-slate-950">Totals</h2>
+                <p className="mt-1 text-sm text-slate-500">{chargeLineCount} charge lines across {data.charge_buckets.length} categories</p>
+              </div>
+              {data.totals.fcy && data.totals.fcy_currency && data.totals.fcy_amount ? (
+                <div className="text-sm text-slate-500">
+                  Equivalent: <span className="font-semibold text-slate-800">{formatMoney(data.totals.fcy_currency, data.totals.fcy_amount)}</span>
+                </div>
+              ) : null}
+            </div>
+            <div className="mt-5 grid gap-3 md:grid-cols-3">
+              <div className="rounded-lg border border-slate-200 bg-white p-4">
+                <div className="text-sm font-semibold text-slate-500">Total Excl. GST</div>
+                <div className="mt-2 text-xl font-semibold text-slate-950">{formatMoney(data.currency, data.totals.sell_excl_gst)}</div>
+              </div>
+              <div className="rounded-lg border border-slate-200 bg-white p-4">
+                <div className="text-sm font-semibold text-slate-500">GST</div>
+                <div className="mt-2 text-xl font-semibold text-slate-950">{formatMoney(data.currency, data.totals.gst)}</div>
+              </div>
+              <div className="rounded-lg border p-4" style={{ borderColor: primaryBorder, backgroundColor: primarySoft }}>
+                <div className="text-sm font-semibold" style={{ color: brandPrimary }}>Amount Payable</div>
+                <div className="mt-2 text-2xl font-semibold text-slate-950">{formatMoney(data.currency, data.totals.sell_incl_gst)}</div>
+              </div>
+            </div>
+          </section>
+
+          <section className="px-5 py-6 sm:px-8">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <h2 className="text-xl font-semibold text-slate-950">
+                  {summaryOnly ? "Pricing Summary" : "Charge Breakdown"}
+                </h2>
+                <p className="mt-1 text-sm text-slate-500">Amounts are shown in {data.currency}</p>
+              </div>
+              <div className="text-sm text-slate-500">Shared quote link valid for 7 days</div>
+            </div>
+
+            <div className="mt-5 overflow-hidden rounded-lg border border-slate-200">
+              {data.charge_buckets.map((bucket, bucketIndex) => (
+                <div key={bucket.name} className={bucketIndex > 0 ? "border-t border-slate-200" : ""}>
+                  <div className="flex flex-col gap-2 bg-slate-50 px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <div className="text-base font-semibold text-slate-950">{bucketLabel(bucket.name)}</div>
+                      <div className="text-sm text-slate-500">{bucket.lines.length} line{bucket.lines.length === 1 ? "" : "s"}</div>
+                    </div>
+                    <div className="text-right">
+                      <div className="text-xs font-semibold text-slate-500">Subtotal</div>
+                      <div className="text-lg font-semibold text-slate-950">{formatMoney(data.currency, bucket.subtotal)}</div>
+                    </div>
+                  </div>
+
+                  {!summaryOnly ? (
+                    <div className="overflow-x-auto">
+                      <table className="w-full min-w-[560px] text-left text-sm">
+                        <thead className="border-y border-slate-200 bg-white text-slate-500">
+                          <tr>
+                            <th className="px-4 py-3 font-semibold">Description</th>
+                            <th className="px-4 py-3 text-right font-semibold">Amount</th>
+                          </tr>
+                        </thead>
+                        <tbody className="divide-y divide-slate-100 bg-white">
+                          {bucket.lines.map((line, index) => (
+                            <tr key={`${bucket.name}-${index}`} className={line.is_informational ? "bg-slate-50 text-slate-500" : "text-slate-700"}>
+                              <td className="px-4 py-3">
+                                <div className="font-medium text-slate-800">{line.description}</div>
+                                {line.is_informational ? (
+                                  <div className="mt-1 inline-flex rounded-full border border-slate-200 bg-white px-2 py-0.5 text-xs font-semibold text-slate-500">
+                                    Not included in subtotal
+                                  </div>
+                                ) : null}
+                              </td>
+                              <td className="whitespace-nowrap px-4 py-3 text-right font-semibold">
+                                {formatMoney(data.currency, line.sell)}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  ) : null}
+                </div>
+              ))}
+              {data.charge_buckets.length === 0 ? (
+                <div className="bg-white px-4 py-8 text-center text-sm text-slate-500">No charge lines available.</div>
+              ) : null}
+            </div>
+          </section>
+
+          <footer className="border-t border-slate-200 bg-slate-50 px-5 py-5 sm:px-8">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+              <div className="flex flex-wrap gap-x-5 gap-y-2">
+                <ContactItem icon={<Mail className="h-4 w-4" aria-hidden="true" />} value={data.branding.support_email} />
+                <ContactItem icon={<Phone className="h-4 w-4" aria-hidden="true" />} value={data.branding.support_phone} />
+                <ContactItem icon={<Globe2 className="h-4 w-4" aria-hidden="true" />} value={data.branding.website_url} />
+              </div>
+              <div className="text-sm text-slate-500">
+                {data.branding.address_lines.length > 0 ? data.branding.address_lines.join(", ") : "Powered by RateEngine"}
+              </div>
+            </div>
+          </footer>
         </section>
 
-        <p className="text-center text-xs text-slate-400">
-          Powered by RateEngine
-        </p>
+        <div className="pb-4 text-center text-xs text-slate-500">Powered by RateEngine</div>
       </div>
     </main>
   );

--- a/frontend/src/app/quotes/[id]/page.tsx
+++ b/frontend/src/app/quotes/[id]/page.tsx
@@ -536,11 +536,7 @@ export default function QuoteDetailPage() {
         ) : (
           /* Full-width Layout for Finalized Quotes */
           <div className="space-y-6">
-            {computeResult ? (
-              <QuoteFinancialBreakdown result={computeResult} />
-            ) : (
-              <QuoteFinancialBreakdown result={quote} />
-            )}
+            <QuoteFinancialBreakdown result={quote} />
           </div>
         )}
       </div>

--- a/frontend/src/app/quotes/spot/[speId]/page.tsx
+++ b/frontend/src/app/quotes/spot/[speId]/page.tsx
@@ -896,6 +896,7 @@ export default function SpotRateEntryPage() {
     const quoteSubmitDisabledReason = getSpotFinalizeDisabledReason({
         spe: state.spe,
         unresolvedReviewIssueCount,
+        unresolvedReviewIssueLabels: reviewLines.affected.map((line) => line.label),
     });
     const quoteSubmitDisabled = Boolean(quoteSubmitDisabledReason);
     const hasReviewActions =
@@ -918,7 +919,7 @@ export default function SpotRateEntryPage() {
             setFinalizeError(null);
             let spe = state.spe;
 
-            if (spe.status === "draft") {
+            if (spe.status === "draft" && charges.length > 0) {
                 const updatedSpe = await actions.updateSPE(spe.id, {
                     charges,
                     conditions: {
@@ -1483,6 +1484,7 @@ export default function SpotRateEntryPage() {
                                             submitLabel="Create Quote"
                                             submitDisabled={quoteSubmitDisabled}
                                             submitDisabledReason={quoteSubmitDisabledReason}
+                                            allowEmptySubmit={Boolean(state.spe?.can_proceed)}
                                             onSaveDraft={handleSaveDraft}
                                             onManualResolveChargeLine={actions.manuallyResolveChargeLine}
                                             productCodeDomain={resolvedShipmentType}

--- a/frontend/src/components/QuoteFinancialBreakdown.tsx
+++ b/frontend/src/components/QuoteFinancialBreakdown.tsx
@@ -6,6 +6,7 @@ import {
     CanonicalQuoteResult,
     QuoteComputeResult,
     SellLine,
+    V3QuoteLine,
     V3QuoteComputeResponse,
 } from "@/lib/types";
 import {
@@ -23,7 +24,7 @@ import {
     TableRow,
 } from "@/components/ui/table";
 import { Separator } from "@/components/ui/separator";
-import { ChevronDown, ChevronRight, Package, MapPin, ReceiptText, Plane } from "lucide-react";
+import { AlertTriangle, Calculator, ChevronDown, ChevronRight, Package, MapPin, ReceiptText, Plane } from "lucide-react";
 
 interface QuoteFinancialBreakdownProps {
     result: QuoteComputeResult | V3QuoteComputeResponse;
@@ -32,6 +33,7 @@ interface QuoteFinancialBreakdownProps {
 type LooseRecord = Record<string, unknown>;
 type BreakdownLine = SellLine & { sell_fcy_currency?: string };
 type BreakdownDataShape = {
+    status?: string;
     quote_result?: CanonicalQuoteResult | null;
     latest_version?: {
         sell_lines?: BreakdownLine[];
@@ -42,6 +44,7 @@ type BreakdownDataShape = {
     lines?: BreakdownLine[];
     totals?: LooseRecord;
 };
+type RawQuoteLine = V3QuoteLine & BreakdownLine;
 
 function toMoneyString(value: number): string {
     return value.toFixed(2);
@@ -154,6 +157,61 @@ function getDisplaySellAmount(line: BreakdownLine, isShowingFCY: boolean): numbe
     return parseFloat(String(rawValue || "0"));
 }
 
+function normalizeStatus(result: QuoteComputeResult | V3QuoteComputeResponse): string {
+    const maybeStatus = readStringField(result, "status") || readStringField((result as BreakdownDataShape).quote_result, "status");
+    return (maybeStatus || "").toUpperCase();
+}
+
+function isAvailable(value: unknown): boolean {
+    return value !== null && value !== undefined && value !== "";
+}
+
+function displayValue(value: unknown): string {
+    return isAvailable(value) ? String(value) : "Not available";
+}
+
+function displayMoney(value: unknown, currency: string): string {
+    if (!isAvailable(value)) return "Not available";
+    return formatAmount(String(value), currency);
+}
+
+function displayPercent(value: unknown): string {
+    if (!isAvailable(value)) return "Not available";
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) return String(value);
+    return `${parsed.toFixed(2)}%`;
+}
+
+function findRawLine(rawLines: RawQuoteLine[], canonicalLine: CanonicalQuoteLineItem): RawQuoteLine | undefined {
+    if (canonicalLine.line_id) {
+        const byId = rawLines.find((line) => line.id === canonicalLine.line_id);
+        if (byId) return byId;
+    }
+    return rawLines.find((line) => {
+        const code = line.product_code || line.component || line.service_component?.code;
+        return code === canonicalLine.product_code && line.description === canonicalLine.description;
+    });
+}
+
+function lineWarnings(line: CanonicalQuoteLineItem, rawLine?: RawQuoteLine): string[] {
+    const warnings: string[] = [];
+    if (rawLine?.is_rate_missing) warnings.push("Missing buy rate");
+    if (line.is_manual_override || rawLine?.is_manual_override) warnings.push("Manual override");
+    if (line.rate_source === "FALLBACK_RULE") warnings.push("FX or rate fallback");
+    if (!line.calculation_notes && !rawLine?.calculation_notes) warnings.push("Missing calculation metadata");
+    return warnings;
+}
+
+function sourceLabel(line: CanonicalQuoteLineItem, rawLine?: RawQuoteLine): string {
+    if (line.is_spot_sourced || rawLine?.is_spot_sourced) return "SPOT";
+    if (line.is_manual_override || rawLine?.is_manual_override) return "Manual entry";
+    if (line.rate_source === "MANUAL_OVERRIDE") return "Manual entry";
+    if (line.rate_source === "PARTNER_SPOT") return "SPOT";
+    if (line.rate_source === "DB_TARIFF") return "V4 rate card";
+    if (line.rate_source === "FALLBACK_RULE") return "Fallback rule";
+    return displayValue(line.rate_source);
+}
+
 
 export default function QuoteFinancialBreakdown({ result }: QuoteFinancialBreakdownProps) {
     const normalizedResult = result as unknown as BreakdownDataShape;
@@ -166,7 +224,10 @@ export default function QuoteFinancialBreakdown({ result }: QuoteFinancialBreakd
     const sell_lines = canonicalLines.length > 0
         ? canonicalLines
         : (((data.sell_lines || data.lines || []) as unknown[]) as BreakdownLine[]);
+    const rawQuoteLines = ((((data.lines || []) as unknown[]) as RawQuoteLine[]) || []);
     const totals = canonicalResult ? buildCanonicalTotals(canonicalResult) : data.totals;
+    const quoteStatus = normalizeStatus(result);
+    const showCalculationReview = Boolean(canonicalResult && ["DRAFT", "INCOMPLETE"].includes(quoteStatus));
 
     // Detect display currency and logic flags
     const firstLineCurrency = sell_lines[0]?.sell_fcy_currency || sell_lines[0]?.sell_currency || 'PGK';
@@ -283,6 +344,14 @@ export default function QuoteFinancialBreakdown({ result }: QuoteFinancialBreakd
                     </div>
                 </div>
 
+                {showCalculationReview && canonicalResult && (
+                    <CalculationReviewPanel
+                        quoteResult={canonicalResult}
+                        rawLines={rawQuoteLines}
+                        displayCurrency={displayCurrency}
+                    />
+                )}
+
                 {/* Conditional Charges Footnotes */}
                 {informationalLines.length > 0 && (
                     <div className="p-4 bg-amber-50/50 border-t border-amber-200">
@@ -301,6 +370,196 @@ export default function QuoteFinancialBreakdown({ result }: QuoteFinancialBreakd
                 )}
             </CardContent>
         </Card>
+    );
+}
+
+function CalculationReviewPanel({
+    quoteResult,
+    rawLines,
+    displayCurrency,
+}: {
+    quoteResult: CanonicalQuoteResult;
+    rawLines: RawQuoteLine[];
+    displayCurrency: string;
+}) {
+    const [isOpen, setIsOpen] = useState(false);
+    const taxTotal = quoteResult.tax_breakdown?.gst_amount || "0.00";
+    const grandTotal = quoteResult.sell_total || "0.00";
+    const fx = quoteResult.fx_applied;
+    const warnings = [
+        ...(quoteResult.warnings || []),
+        ...quoteResult.line_items.flatMap((line) => lineWarnings(line, findRawLine(rawLines, line))),
+    ].filter((item, index, items) => item && items.indexOf(item) === index);
+
+    return (
+        <div className="border-t border-slate-200 bg-white">
+            <button
+                type="button"
+                onClick={() => setIsOpen(!isOpen)}
+                className="flex w-full items-center justify-between gap-4 px-6 py-5 text-left hover:bg-slate-50"
+            >
+                <div className="flex items-start gap-3">
+                    <div className="mt-0.5 rounded-md bg-slate-100 p-2 text-slate-600">
+                        <Calculator className="h-4 w-4" />
+                    </div>
+                    <div>
+                        <div className="flex flex-wrap items-center gap-2">
+                            <h3 className="text-base font-semibold text-slate-900">Pricing Breakdown</h3>
+                            <span className="rounded border border-slate-200 px-2 py-0.5 text-[10px] font-semibold uppercase text-slate-500">
+                                Internal only
+                            </span>
+                        </div>
+                        <p className="mt-1 text-sm text-slate-500">
+                            Review calculation inputs, source flags, margins, FX, CAF, and metadata gaps before finalizing.
+                        </p>
+                    </div>
+                </div>
+                {isOpen ? (
+                    <ChevronDown className="h-5 w-5 shrink-0 text-slate-400" />
+                ) : (
+                    <ChevronRight className="h-5 w-5 shrink-0 text-slate-400" />
+                )}
+            </button>
+
+            {isOpen && (
+                <div className="space-y-5 border-t border-slate-100 px-6 py-5">
+                    <div className="grid gap-3 md:grid-cols-3">
+                        <ReviewMetric label="Total buy cost" value={displayMoney(quoteResult.total_cost_pgk, "PGK")} />
+                        <ReviewMetric label="Total sell amount" value={displayMoney(quoteResult.total_sell_pgk, "PGK")} />
+                        <ReviewMetric label="Gross margin" value={`${displayMoney(quoteResult.margin_amount, "PGK")} (${displayPercent(quoteResult.margin_percent)})`} />
+                        <ReviewMetric label="GST/tax total" value={displayMoney(taxTotal, displayCurrency)} />
+                        <ReviewMetric label="Grand total" value={displayMoney(grandTotal, displayCurrency)} />
+                        <ReviewMetric
+                            label="Currency conversion"
+                            value={
+                                fx?.applied
+                                    ? `${displayValue(fx.currency)} -> PGK at ${displayValue(fx.rate)}`
+                                    : "No FCY conversion recorded"
+                            }
+                        />
+                    </div>
+
+                    {warnings.length > 0 && (
+                        <div className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3">
+                            <div className="flex items-center gap-2 text-sm font-semibold text-amber-900">
+                                <AlertTriangle className="h-4 w-4" />
+                                Warnings and exceptions
+                            </div>
+                            <ul className="mt-2 space-y-1 text-sm text-amber-900">
+                                {warnings.map((warning) => (
+                                    <li key={warning}>{warning}</li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+
+                    <div className="space-y-3">
+                        {quoteResult.line_items.map((line) => (
+                            <CalculationLineDetails
+                                key={line.line_id || `${line.product_code}-${line.sort_order}`}
+                                line={line}
+                                rawLine={findRawLine(rawLines, line)}
+                                displayCurrency={displayCurrency}
+                                fx={fx}
+                            />
+                        ))}
+                    </div>
+
+                    <div className="rounded-md border border-slate-200 bg-slate-50 px-4 py-3 text-xs text-slate-600">
+                        Unavailable in this version: explicit buy-rate basis, FX direction, effective FX after CAF,
+                        minimum margin rule, and customer override/discount detail unless it has been written into
+                        calculation notes. These fields need structured persistence from the V4 engines/adapter for
+                        full audit traceability.
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}
+
+function ReviewMetric({ label, value }: { label: string; value: string }) {
+    return (
+        <div className="rounded-md border border-slate-200 bg-slate-50 px-4 py-3">
+            <div className="text-[11px] font-semibold uppercase text-slate-500">{label}</div>
+            <div className="mt-1 text-sm font-semibold text-slate-900">{value}</div>
+        </div>
+    );
+}
+
+function CalculationLineDetails({
+    line,
+    rawLine,
+    displayCurrency,
+    fx,
+}: {
+    line: CanonicalQuoteLineItem;
+    rawLine?: RawQuoteLine;
+    displayCurrency: string;
+    fx: CanonicalQuoteResult["fx_applied"];
+}) {
+    const warnings = lineWarnings(line, rawLine);
+    const buyCurrency = rawLine?.cost_fcy_currency || line.cost_currency || "PGK";
+    const buyAmount = rawLine?.cost_fcy_currency ? rawLine.cost_fcy : line.cost_amount;
+    const sellCurrency = line.sell_currency || displayCurrency;
+    const gstTreatment = `${displayValue(line.tax_code)} at ${displayPercent(rawLine?.gst_rate ? Number(rawLine.gst_rate) * 100 : undefined)}`;
+
+    return (
+        <details className="rounded-md border border-slate-200 bg-white">
+            <summary className="cursor-pointer list-none px-4 py-3 hover:bg-slate-50">
+                <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                    <div>
+                        <div className="font-medium text-slate-900">{line.description}</div>
+                        <div className="mt-1 text-xs text-slate-500">
+                            {displayValue(line.product_code)} | {sourceLabel(line, rawLine)} | {line.is_manual_override || rawLine?.is_manual_override ? "Manual" : "System-calculated"}
+                        </div>
+                    </div>
+                    <div className="text-sm font-semibold text-slate-900">
+                        {displayMoney(line.sell_amount, sellCurrency)}
+                    </div>
+                </div>
+                {warnings.length > 0 && (
+                    <div className="mt-2 flex flex-wrap gap-2">
+                        {warnings.map((warning) => (
+                            <span key={warning} className="rounded border border-amber-200 bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-800">
+                                {warning}
+                            </span>
+                        ))}
+                    </div>
+                )}
+            </summary>
+            <div className="grid gap-x-5 gap-y-3 border-t border-slate-100 px-4 py-4 text-sm md:grid-cols-2 lg:grid-cols-3">
+                <ReviewField label="Charge description" value={line.description} />
+                <ReviewField label="Product code" value={line.product_code} />
+                <ReviewField label="Buy amount" value={displayMoney(buyAmount, buyCurrency)} />
+                <ReviewField label="Buy currency" value={buyCurrency} />
+                <ReviewField label="Sell amount" value={displayMoney(line.sell_amount, sellCurrency)} />
+                <ReviewField label="Sell currency" value={sellCurrency} />
+                <ReviewField label="Quantity" value={displayValue(line.quantity)} />
+                <ReviewField label="Unit / basis" value={`${displayValue(line.unit_type)} / ${displayValue(line.basis)}`} />
+                <ReviewField label="Buy rate used" value="Not available" />
+                <ReviewField label="FX rate used" value={displayValue(rawLine?.exchange_rate || fx?.rate)} />
+                <ReviewField label="FX direction" value="Not available" />
+                <ReviewField label="CAF applied" value={fx?.caf_percent ? displayPercent(fx.caf_percent) : "Not available"} />
+                <ReviewField label="Effective FX after CAF" value="Not available" />
+                <ReviewField label="Margin used" value={`${displayMoney(line.margin_amount, "PGK")} (${displayPercent(line.margin_percent)})`} />
+                <ReviewField label="Minimum margin rule" value="Not available" />
+                <ReviewField label="Customer override/discount" value={line.calculation_notes?.includes("discount") ? line.calculation_notes : "Not available"} />
+                <ReviewField label="GST/tax treatment" value={gstTreatment} />
+                <ReviewField label="Final calculated sell" value={displayMoney(Number(line.sell_amount || 0) + Number(line.tax_amount || 0), sellCurrency)} />
+                <ReviewField label="Pricing source" value={sourceLabel(line, rawLine)} />
+                <ReviewField label="Entry mode" value={line.is_manual_override || rawLine?.is_manual_override ? "Manually entered" : "System-calculated"} />
+                <ReviewField label="Calculation notes" value={line.calculation_notes || rawLine?.calculation_notes || "Not available"} />
+            </div>
+        </details>
+    );
+}
+
+function ReviewField({ label, value }: { label: string; value: string }) {
+    return (
+        <div>
+            <div className="text-[11px] font-semibold uppercase text-slate-500">{label}</div>
+            <div className="mt-1 break-words text-slate-900">{value}</div>
+        </div>
     );
 }
 

--- a/frontend/src/components/spot/SpotRateEntryForm.tsx
+++ b/frontend/src/components/spot/SpotRateEntryForm.tsx
@@ -16,6 +16,7 @@ import { Form } from "@/components/ui/form";
 
 import type { SPEChargeLine, SPEChargeBucket, SPEChargeUnit, ExtractedAssertion } from "@/lib/spot-types";
 import { spotFormSchema, type SpotFormInputValues, type SpotFormSubmitValues } from "@/lib/schemas/spotSchema";
+import { getSpotFinalizeFormDisabledReason } from "@/lib/spot-finalization";
 import { ChargeBucketSection } from "./ChargeBucketSection";
 import { SpotChargeLineManualReviewSheet } from "./SpotChargeLineManualReviewSheet";
 import { getSpotChargeDisplayLabel } from "@/lib/spot-charge-display";
@@ -37,6 +38,7 @@ interface SpotRateEntryFormProps {
     submitLabel?: string;
     submitDisabled?: boolean;
     submitDisabledReason?: string | null;
+    allowEmptySubmit?: boolean;
     onSaveDraft?: (charges: Array<Omit<SPEChargeLine, 'id'> & { charge_line_id?: string }>) => Promise<void>;
     onManualResolveChargeLine?: (
         chargeLineId: string,
@@ -120,6 +122,7 @@ export function SpotRateEntryForm({
     submitLabel,
     submitDisabled = false,
     submitDisabledReason = null,
+    allowEmptySubmit = false,
     onSaveDraft,
     onManualResolveChargeLine,
     productCodeDomain,
@@ -360,6 +363,20 @@ export function SpotRateEntryForm({
             conditional_acknowledged_by: line.conditional_acknowledged_by,
             conditional_acknowledged_at: line.conditional_acknowledged_at,
             source_reference: normalizeSourceReference(line.source_reference),
+            source_label: line.source_label,
+            normalized_label: line.normalized_label,
+            normalization_status: line.normalization_status,
+            normalization_method: line.normalization_method,
+            matched_alias_id: line.matched_alias_id,
+            resolved_product_code: line.resolved_product_code,
+            effective_resolved_product_code: line.effective_resolved_product_code,
+            effective_resolution_status: line.effective_resolution_status,
+            requires_review: line.requires_review,
+            manual_resolution_status: line.manual_resolution_status,
+            manual_resolved_product_code: line.manual_resolved_product_code,
+            manual_resolution_by_user_id: line.manual_resolution_by_user_id,
+            manual_resolution_by_username: line.manual_resolution_by_username,
+            manual_resolution_at: line.manual_resolution_at,
             source_excerpt: line.source_excerpt,
             source_line_number: line.source_line_number,
             source_line_identity: line.source_line_identity,
@@ -383,6 +400,20 @@ export function SpotRateEntryForm({
         conditional_acknowledged_by: charge.conditional_acknowledged_by,
         conditional_acknowledged_at: charge.conditional_acknowledged_at,
         source_reference: normalizeSourceReference(charge.source_reference),
+        source_label: charge.source_label,
+        normalized_label: charge.normalized_label,
+        normalization_status: charge.normalization_status,
+        normalization_method: charge.normalization_method,
+        matched_alias_id: charge.matched_alias_id,
+        resolved_product_code: charge.resolved_product_code,
+        effective_resolved_product_code: charge.effective_resolved_product_code,
+        effective_resolution_status: charge.effective_resolution_status,
+        requires_review: charge.requires_review,
+        manual_resolution_status: charge.manual_resolution_status,
+        manual_resolved_product_code: charge.manual_resolved_product_code,
+        manual_resolution_by_user_id: charge.manual_resolution_by_user_id,
+        manual_resolution_by_username: charge.manual_resolution_by_username,
+        manual_resolution_at: charge.manual_resolution_at,
         source_excerpt: charge.source_excerpt,
         source_line_number: charge.source_line_number,
         source_line_identity: charge.source_line_identity,
@@ -430,20 +461,40 @@ export function SpotRateEntryForm({
         }
     };
 
+    const isSubmitBusy = Boolean(isLoading || form.formState.isSubmitting || isSavingDraft);
+    const editableChargeCount = fields.length;
+    const effectiveSubmitDisabledReason = getSpotFinalizeFormDisabledReason({
+        finalizeDisabledReason: submitDisabledReason || (submitDisabled ? "Resolve SPOT blockers before creating quote." : null),
+        editableChargeCount,
+        isFormValid: form.formState.isValid,
+        allowEmptySubmit,
+    });
+    const canSubmitEmpty = editableChargeCount === 0 && allowEmptySubmit && !submitDisabled;
+    const canSubmit = !isSubmitBusy && !effectiveSubmitDisabledReason;
+
+    const handleEmptySubmitClick = () => {
+        if (!canSubmitEmpty || !canSubmit || submitLockRef.current) return;
+        void handleFormSubmit({ charges: [] });
+    };
+
     // Keyboard Shortcuts
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
             // Ctrl/Cmd + Enter to submit
             if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
-                if (form.formState.isSubmitting || isLoading || isSavingDraft) return;
+                if (!canSubmit) return;
                 e.preventDefault();
+                if (canSubmitEmpty) {
+                    void handleFormSubmitRef.current({ charges: [] });
+                    return;
+                }
                 form.handleSubmit((data) => handleFormSubmitRef.current(data))();
             }
         };
 
         window.addEventListener('keydown', handleKeyDown);
         return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [form, isLoading, isSavingDraft]);
+    }, [canSubmit, canSubmitEmpty, form]);
 
     const addLine = (bucket: SPEChargeBucket) => {
         append({
@@ -567,9 +618,6 @@ export function SpotRateEntryForm({
     const getFieldsByBucket = (bucket: SPEChargeBucket) =>
         fields.map((field, index) => ({ field, index })).filter(item => item.field.bucket === bucket);
 
-    const isSubmitBusy = Boolean(isLoading || form.formState.isSubmitting || isSavingDraft);
-    const canSubmit = form.formState.isValid && !isSubmitBusy && !submitDisabled;
-
     return (
         <Form {...form}>
             <form onSubmit={form.handleSubmit(handleFormSubmit)} className="space-y-8">
@@ -579,9 +627,9 @@ export function SpotRateEntryForm({
                     </Alert>
                 )}
 
-                {submitDisabledReason && (
+                {effectiveSubmitDisabledReason && (
                     <Alert>
-                        <AlertDescription>{submitDisabledReason}</AlertDescription>
+                        <AlertDescription>{effectiveSubmitDisabledReason}</AlertDescription>
                     </Alert>
                 )}
 
@@ -618,7 +666,8 @@ export function SpotRateEntryForm({
                         </Button>
                     )}
                     <Button
-                        type="submit"
+                        type={canSubmitEmpty ? "button" : "submit"}
+                        onClick={canSubmitEmpty ? handleEmptySubmitClick : undefined}
                         disabled={!canSubmit}
                         size="lg"
                         loading={Boolean(isLoading || form.formState.isSubmitting)}

--- a/frontend/src/lib/spot-finalization.ts
+++ b/frontend/src/lib/spot-finalization.ts
@@ -5,12 +5,28 @@ type FinalizeEnvelopeState = Pick<
   "acknowledgement" | "can_proceed" | "intake_safety" | "is_expired" | "missing_mandatory_fields" | "status"
 >;
 
+const NON_BLOCKING_INTAKE_ISSUE_PATTERNS = [
+  /low-confidence/i,
+  /scanned-pdf fallback/i,
+  /fallback extraction/i,
+];
+
+function hasOnlyNonBlockingIntakeIssues(issues: string[] | undefined): boolean {
+  const cleaned = (issues || []).map((issue) => issue.trim()).filter(Boolean);
+  if (cleaned.length === 0) return false;
+  return cleaned.every((issue) =>
+    NON_BLOCKING_INTAKE_ISSUE_PATTERNS.some((pattern) => pattern.test(issue))
+  );
+}
+
 export function getSpotFinalizeDisabledReason({
   spe,
   unresolvedReviewIssueCount,
+  unresolvedReviewIssueLabels = [],
 }: {
   spe: FinalizeEnvelopeState | null | undefined;
   unresolvedReviewIssueCount: number;
+  unresolvedReviewIssueLabels?: string[];
 }): string | null {
   if (!spe) {
     return "SPOT envelope is still loading.";
@@ -36,12 +52,54 @@ export function getSpotFinalizeDisabledReason({
   }
 
   if (unresolvedReviewIssueCount > 0) {
+    const labels = unresolvedReviewIssueLabels.map((label) => label.trim()).filter(Boolean);
+    if (labels.length > 0) {
+      const shownLabels = labels.slice(0, 3).join(", ");
+      const remainingCount = Math.max(unresolvedReviewIssueCount - 3, 0);
+      const suffix = remainingCount > 0 ? `, and ${remainingCount} more` : "";
+      return `Resolve ${unresolvedReviewIssueCount} issue${unresolvedReviewIssueCount === 1 ? "" : "s"} before creating quote: ${shownLabels}${suffix}.`;
+    }
     return `Resolve ${unresolvedReviewIssueCount} issue${unresolvedReviewIssueCount === 1 ? "" : "s"} before creating quote.`;
   }
 
-  if (!spe.acknowledgement && spe.intake_safety && !spe.intake_safety.is_safe_to_quote) {
+  if (
+    !spe.acknowledgement &&
+    spe.intake_safety &&
+    !spe.intake_safety.is_safe_to_quote &&
+    !hasOnlyNonBlockingIntakeIssues(spe.intake_safety.blocking_issues)
+  ) {
     return spe.intake_safety.blocking_issues?.[0] || "Review imported SPOT source findings before creating quote.";
   }
 
   return null;
+}
+
+export function getSpotFinalizeFormDisabledReason({
+  finalizeDisabledReason,
+  editableChargeCount,
+  isFormValid,
+  allowEmptySubmit,
+}: {
+  finalizeDisabledReason?: string | null;
+  editableChargeCount: number;
+  isFormValid: boolean;
+  allowEmptySubmit: boolean;
+}): string | null {
+  if (finalizeDisabledReason) {
+    return finalizeDisabledReason;
+  }
+
+  if (isFormValid) {
+    return null;
+  }
+
+  if (editableChargeCount === 0 && allowEmptySubmit) {
+    return null;
+  }
+
+  if (editableChargeCount === 0) {
+    return "Add at least one SPOT charge line before creating quote.";
+  }
+
+  return "Complete the visible SPOT charge fields before creating quote.";
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -352,6 +352,7 @@ export interface V3QuoteLine {
   product_code?: string | null;
   description?: string | null;
   leg?: string;
+  bucket?: string | null;
   cost_pgk: string;
   cost_fcy?: string | null;
   cost_fcy_currency?: string | null;
@@ -363,6 +364,21 @@ export interface V3QuoteLine {
   exchange_rate?: string | null;
   cost_source?: string | null;
   cost_source_description?: string | null;
+  basis?: string | null;
+  rule_family?: string | null;
+  service_family?: string | null;
+  unit_type?: string | null;
+  rate?: string | null;
+  rate_source?: string | null;
+  canonical_cost_source?: string | null;
+  is_spot_sourced?: boolean | null;
+  is_manual_override?: boolean | null;
+  calculation_notes?: string | null;
+  is_informational?: boolean;
+  conditional?: boolean;
+  gst_category?: string | null;
+  gst_rate?: string | null;
+  gst_amount?: string | null;
   is_rate_missing: boolean;
 }
 
@@ -445,6 +461,8 @@ export interface CanonicalQuoteLineItem {
   rate: string | null;
   cost_amount: string;
   sell_amount: string;
+  margin_amount: string;
+  margin_percent: string;
   tax_code: string;
   tax_amount: string;
   included_in_total: boolean;


### PR DESCRIPTION
## Summary
- Adds an internal-only Pricing Breakdown panel for draft/incomplete quote detail views.
- Surfaces persisted calculation metadata, source flags, line warnings, totals, margin, GST, and FX/CAF summary where available.
- Labels non-persisted audit fields as Not available and records customer discount notes when V4 discount logic changes sell amounts.

## Checks
- npm --prefix frontend run lint
- npm --prefix frontend run build
- python backend\manage.py test pricing_v4.tests.test_customer_discount_api quotes.tests.test_public_quote_api
- git diff --check
- git diff --cached --check

## Notes
- Existing unrelated dirty files were present before this branch and were not staged or committed.