### PR TITLE
Fix SPOT conditional acknowledgement deadlock

### DIFF
--- a/backend/quotes/tests/test_spot_compute_completeness.py
+++ b/backend/quotes/tests/test_spot_compute_completeness.py
@@ -661,3 +661,119 @@ def test_spot_create_quote_allows_acknowledged_conditional_matched_line(monkeypa
 
     assert response.status_code == 200
     assert response.json()["success"] is True
+
+
+def test_spot_conditional_acknowledgement_flow_can_create_can_to_pom_import_collect(monkeypatch):
+    pgk = Currency.objects.create(code="PGK", name="Papua New Guinea Kina")
+    cad = Currency.objects.create(code="CAD", name="Canadian Dollar")
+    pg = Country.objects.create(code="PG", name="Papua New Guinea", currency=pgk)
+    ca = Country.objects.create(code="CA", name="Canada", currency=cad)
+
+    origin = _create_location("CAN", ca)
+    destination = _create_location("POM", pg)
+    user = get_user_model().objects.create_user(username="spotconditionalflow", password="testpass")
+    ctx = {
+        "origin_country": "CA",
+        "destination_country": "PG",
+        "origin_code": origin.code,
+        "destination_code": destination.code,
+        "commodity": "GCR",
+        "total_weight_kg": 100.0,
+        "pieces": 1,
+        "service_scope": "d2d",
+        "payment_term": "COLLECT",
+    }
+    spe = SpotPricingEnvelopeDB.objects.create(
+        status=SpotPricingEnvelopeDB.Status.DRAFT,
+        shipment_context_json=ctx,
+        conditions_json={},
+        spot_trigger_reason_code=SpotTriggerReason.MISSING_SCOPE_RATES,
+        spot_trigger_reason_text="Missing required rate components",
+        created_by=user,
+        expires_at=timezone.now() + timedelta(hours=72),
+    )
+    source_batch = SPESourceBatchDB.objects.create(
+        envelope=spe,
+        source_kind=SPESourceBatchDB.SourceKind.AGENT,
+        source_type=SPESourceBatchDB.SourceType.TEXT,
+        target_bucket=SPESourceBatchDB.TargetBucket.MIXED,
+        label="Uploaded rates",
+        source_reference="Uploaded rates",
+        raw_text="Import Air Freight USD 6.80/kg. Origin fee applies subject to carrier confirmation.",
+        analysis_summary_json={
+            "can_proceed": True,
+            "ai_used": True,
+            "imported_charge_count": 2,
+            "conditional_charge_count": 1,
+        },
+        created_by=user,
+    )
+    SPEChargeLineDB.objects.create(
+        envelope=spe,
+        source_batch=source_batch,
+        code="IMP-FRT-AIR",
+        description="Import Air Freight",
+        amount=Decimal("6.80"),
+        currency="USD",
+        unit="per_kg",
+        bucket="airfreight",
+        is_primary_cost=True,
+        source_reference="Uploaded rates",
+        normalization_status=SPEChargeLineDB.NormalizationStatus.MATCHED,
+        normalization_method=SPEChargeLineDB.NormalizationMethod.EXACT_ALIAS,
+        entered_at=timezone.now(),
+    )
+    conditional_line = SPEChargeLineDB.objects.create(
+        envelope=spe,
+        source_batch=source_batch,
+        code="ORIGIN_LOCAL",
+        description="Pick-Up Fee (Origin)",
+        amount=Decimal("75.00"),
+        currency="USD",
+        unit="flat",
+        bucket="origin_charges",
+        conditional=True,
+        conditional_acknowledged=False,
+        source_reference="Uploaded rates",
+        normalization_status=SPEChargeLineDB.NormalizationStatus.MATCHED,
+        normalization_method=SPEChargeLineDB.NormalizationMethod.EXACT_ALIAS,
+        entered_at=timezone.now(),
+    )
+    monkeypatch.setattr(
+        PricingServiceV4Adapter,
+        "calculate_charges",
+        lambda self: _quote_charges_for_buckets(["airfreight", "origin_charges", "destination_charges"]),
+    )
+    customer = Company.objects.create(name="Seed Customer Pty Ltd", is_customer=True, company_type="CUSTOMER")
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    acknowledge_response = client.post(f"/api/v3/spot/envelopes/{spe.id}/acknowledge/", format="json")
+    assert acknowledge_response.status_code == 400
+    assert "conditional" in str(acknowledge_response.json()).lower()
+
+    conditional_response = client.patch(
+        f"/api/v3/spot/envelopes/{spe.id}/charges/{conditional_line.id}/conditional-resolution/",
+        {"action": "KEEP"},
+        format="json",
+    )
+    assert conditional_response.status_code == 200
+
+    source_review_response = client.post(
+        f"/api/v3/spot/envelopes/{spe.id}/sources/{source_batch.id}/review/",
+        {"reviewed_safe_to_quote": True},
+        format="json",
+    )
+    assert source_review_response.status_code == 200
+
+    acknowledge_response = client.post(f"/api/v3/spot/envelopes/{spe.id}/acknowledge/", format="json")
+    assert acknowledge_response.status_code == 200
+
+    response = client.post(
+        f"/api/v3/spot/envelopes/{spe.id}/create-quote/",
+        {"quote_request": {"service_scope": "D2D", "payment_term": "COLLECT", "customer_id": str(customer.id)}},
+        format="json",
+    )
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True

--- a/frontend/scripts/spot-finalization.test.mjs
+++ b/frontend/scripts/spot-finalization.test.mjs
@@ -94,8 +94,48 @@ assert.match(
     },
     unresolvedReviewIssueCount: 0,
   }) || "",
-  /acknowledgement is required/,
-  "ready envelopes without acknowledgement should expose the invalid acknowledgement state first",
+  /currency/,
+  "real missing rate fields should block before acknowledgement flow",
+);
+
+assert.match(
+  getSpotFinalizeDisabledReason({
+    spe: {
+      ...baseSpe,
+      intake_safety: {
+        is_safe_to_quote: false,
+        blocking_issues: ["Uploaded rates: 1 extracted charge line(s) are conditional."],
+        pending_source_batch_ids: ["source-1"],
+        pending_source_labels: ["Uploaded rates"],
+        review_note_required_batch_ids: [],
+      },
+    },
+    unresolvedReviewIssueCount: 1,
+    conditionalAcknowledgementRequired: true,
+    conditionalAcknowledgementAccepted: false,
+  }) || "",
+  /Acknowledge the conditional SPOT rates/,
+  "conditional acknowledgement should expose a clear action blocker",
+);
+
+assert.equal(
+  getSpotFinalizeDisabledReason({
+    spe: {
+      ...baseSpe,
+      intake_safety: {
+        is_safe_to_quote: false,
+        blocking_issues: ["Uploaded rates: 1 extracted charge line(s) are conditional."],
+        pending_source_batch_ids: ["source-1"],
+        pending_source_labels: ["Uploaded rates"],
+        review_note_required_batch_ids: [],
+      },
+    },
+    unresolvedReviewIssueCount: 0,
+    conditionalAcknowledgementRequired: true,
+    conditionalAcknowledgementAccepted: true,
+  }),
+  null,
+  "accepted conditional-only blockers should allow submit so the UI can record acknowledgement then create quote",
 );
 
 assert.equal(

--- a/frontend/src/app/quotes/spot/[speId]/page.tsx
+++ b/frontend/src/app/quotes/spot/[speId]/page.tsx
@@ -14,6 +14,7 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
     Sheet,
     SheetContent,
@@ -892,10 +893,41 @@ export default function SpotRateEntryPage() {
     const [activeIssueDetails, setActiveIssueDetails] = useState<ImportedReviewLine | null>(null);
     const [sourceComparisonOpen, setSourceComparisonOpen] = useState(false);
     const [selectedSourceChargeKey, setSelectedSourceChargeKey] = useState<string | null>(null);
+    const pendingConditionalReviewLines = useMemo(
+        () => reviewLines.affected.filter((line) => line.canResolveConditional),
+        [reviewLines.affected]
+    );
+    const conditionalIntakeSafetyBlocker = useMemo(() => {
+        const intakeSafety = state.spe?.intake_safety;
+        const blockingIssues = intakeSafety?.blocking_issues || [];
+        return (
+            !state.spe?.acknowledgement &&
+            blockingIssues.length > 0 &&
+            blockingIssues.every((issue) => issue.toLowerCase().includes("conditional")) &&
+            (intakeSafety?.review_note_required_batch_ids || []).length === 0
+        );
+    }, [state.spe?.acknowledgement, state.spe?.intake_safety]);
+    const conditionalAcknowledgementRequired =
+        pendingConditionalReviewLines.length > 0 || conditionalIntakeSafetyBlocker;
+    const [conditionalAcknowledgementAccepted, setConditionalAcknowledgementAccepted] = useState(false);
+    useEffect(() => {
+        if (!conditionalAcknowledgementRequired && conditionalAcknowledgementAccepted) {
+            setConditionalAcknowledgementAccepted(false);
+        }
+    }, [conditionalAcknowledgementAccepted, conditionalAcknowledgementRequired]);
+    const unresolvedBlockingReviewIssueCount = useMemo(
+        () =>
+            reviewLines.affected.filter(
+                (line) => !(line.canResolveConditional && conditionalAcknowledgementAccepted)
+            ).length,
+        [conditionalAcknowledgementAccepted, reviewLines.affected]
+    );
     const unresolvedReviewIssueCount = reviewLines.affected.length;
     const quoteSubmitDisabledReason = getSpotFinalizeDisabledReason({
         spe: state.spe,
-        unresolvedReviewIssueCount,
+        unresolvedReviewIssueCount: unresolvedBlockingReviewIssueCount,
+        conditionalAcknowledgementRequired,
+        conditionalAcknowledgementAccepted,
     });
     const quoteSubmitDisabled = Boolean(quoteSubmitDisabledReason);
     const hasReviewActions =
@@ -934,7 +966,31 @@ export default function SpotRateEntryPage() {
                 spe = updatedSpe;
             }
 
-            if (!spe.acknowledgement && spe.status !== "ready") {
+            if (conditionalAcknowledgementAccepted) {
+                for (const line of pendingConditionalReviewLines) {
+                    if (!line.chargeLineId) continue;
+                    const updatedSpe = await actions.resolveConditionalChargeLine(line.chargeLineId, "KEEP");
+                    if (!updatedSpe) {
+                        return;
+                    }
+                    spe = updatedSpe;
+                }
+
+                if (conditionalIntakeSafetyBlocker) {
+                    const sourceBatchIds = spe.intake_safety?.pending_source_batch_ids || [];
+                    for (const sourceBatchId of sourceBatchIds) {
+                        const updatedSpe = await actions.reviewSourceBatch(sourceBatchId, {
+                            reviewed_safe_to_quote: true,
+                        });
+                        if (!updatedSpe) {
+                            return;
+                        }
+                        spe = updatedSpe;
+                    }
+                }
+            }
+
+            if (!spe.acknowledgement) {
                 const success = await actions.submitAcknowledgement();
                 if (!success) {
                     return;
@@ -1488,6 +1544,25 @@ export default function SpotRateEntryPage() {
                                             productCodeDomain={resolvedShipmentType}
                                             reviewRequest={activeReviewRequest}
                                         />
+
+                                        {conditionalAcknowledgementRequired && (
+                                            <Card className="border-amber-200 bg-amber-50/70">
+                                                <CardContent className="flex gap-3 pt-4">
+                                                    <Checkbox
+                                                        id="spot-conditional-acknowledgement"
+                                                        checked={conditionalAcknowledgementAccepted}
+                                                        onCheckedChange={(checked) => setConditionalAcknowledgementAccepted(checked === true)}
+                                                        className="mt-0.5"
+                                                    />
+                                                    <label
+                                                        htmlFor="spot-conditional-acknowledgement"
+                                                        className="text-sm font-medium leading-6 text-amber-950"
+                                                    >
+                                                        I acknowledge these SPOT rates are conditional until carrier and space are confirmed.
+                                                    </label>
+                                                </CardContent>
+                                            </Card>
+                                        )}
 
                                         {importWideChecks.length > 0 ? (
                                             <details className="rounded-xl border border-slate-200 bg-slate-50/70 px-5 py-4">

--- a/frontend/src/components/spot/SpotRateEntryForm.tsx
+++ b/frontend/src/components/spot/SpotRateEntryForm.tsx
@@ -626,6 +626,11 @@ export function SpotRateEntryForm({
                     >
                         {submitLabel || "Save & Proceed"}
                     </Button>
+                    {submitDisabledReason && (
+                        <div className="max-w-sm text-sm font-medium text-amber-800">
+                            {submitDisabledReason}
+                        </div>
+                    )}
                 </PageActionBar>
             </form>
             <SpotChargeLineManualReviewSheet

--- a/frontend/src/lib/spot-finalization.ts
+++ b/frontend/src/lib/spot-finalization.ts
@@ -8,9 +8,13 @@ type FinalizeEnvelopeState = Pick<
 export function getSpotFinalizeDisabledReason({
   spe,
   unresolvedReviewIssueCount,
+  conditionalAcknowledgementRequired = false,
+  conditionalAcknowledgementAccepted = false,
 }: {
   spe: FinalizeEnvelopeState | null | undefined;
   unresolvedReviewIssueCount: number;
+  conditionalAcknowledgementRequired?: boolean;
+  conditionalAcknowledgementAccepted?: boolean;
 }): string | null {
   if (!spe) {
     return "SPOT envelope is still loading.";
@@ -24,10 +28,6 @@ export function getSpotFinalizeDisabledReason({
     return "This SPOT quote is no longer active.";
   }
 
-  if (!spe.acknowledgement && spe.status === "ready") {
-    return "SPOT acknowledgement is required before creating quote.";
-  }
-
   if (spe.status !== "draft" && !spe.can_proceed) {
     const missing = spe.missing_mandatory_fields?.length
       ? spe.missing_mandatory_fields.join(", ")
@@ -35,11 +35,23 @@ export function getSpotFinalizeDisabledReason({
     return `Complete missing SPOT fields before creating quote: ${missing}.`;
   }
 
+  if (conditionalAcknowledgementRequired && !conditionalAcknowledgementAccepted) {
+    return "Acknowledge the conditional SPOT rates before creating quote.";
+  }
+
   if (unresolvedReviewIssueCount > 0) {
     return `Resolve ${unresolvedReviewIssueCount} issue${unresolvedReviewIssueCount === 1 ? "" : "s"} before creating quote.`;
   }
 
   if (!spe.acknowledgement && spe.intake_safety && !spe.intake_safety.is_safe_to_quote) {
+    const blockingIssues = spe.intake_safety.blocking_issues || [];
+    const onlyConditionalBlockers =
+      conditionalAcknowledgementAccepted &&
+      blockingIssues.length > 0 &&
+      blockingIssues.every((issue) => issue.toLowerCase().includes("conditional"));
+    if (onlyConditionalBlockers) {
+      return null;
+    }
     return spe.intake_safety.blocking_issues?.[0] || "Review imported SPOT source findings before creating quote.";
   }
 


### PR DESCRIPTION
## Summary
- Adds an explicit final-review acknowledgement control for conditional SPOT rates.
- Allows conditional-only blockers to submit after acknowledgement, then records conditional line/source acknowledgement before SPE acknowledgement and quote creation.
- Keeps missing rate fields, unresolved unmapped/ambiguous lines, and non-conditional source blockers as hard blockers with visible reasons.

## Validation
- `node scripts/spot-finalization.test.mjs`
- `node scripts/quote-workflow-roundtrip.test.mjs`
- `node scripts/quote-store.test.mjs`
- `npm run typecheck`
- `npm run lint`
- `npm run build` (rerun with network approval for Google Fonts)
- `pytest backend/quotes/tests/test_spot_compute_completeness.py -q`
- Manual browser flow on local CAN -> POM SPOT fixture: disabled reason visible, acknowledgement checkbox enables Create Quote, `/conditional-resolution/`, `/acknowledge/`, and `/create-quote/` sent, backend returned `success: true` with quote `602445ad-beee-4cdb-a97d-964eaf4ce7e4`.