### PR TITLE
Fix financial breakdown regression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,8 @@ backend/shipments/efm/
 
 # Codex temporary workspace snapshots
 .codex-temp-*/
+
+# Tool-specific metadata
+.agents/
+.codex/
+graphify-out/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,13 @@ LEGACY SPOT-RATE CRUD IS DEPRECATED. ALL NEW WORK MUST USE THE SPE ENVELOPE AND 
 
 - The live AI intake pipeline is `Raw -> Normalized -> Audit -> Quote Input`.
 - AI extraction supports Spot intake, but final quote pricing still belongs to the deterministic V4 engine.
+
+## graphify
+
+This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
+
+Rules:
+- ALWAYS read graphify-out/GRAPH_REPORT.md before reading any source files, running grep/glob searches, or answering codebase questions. The graph is your primary map of the codebase.
+- IF graphify-out/wiki/index.md EXISTS, navigate it instead of reading raw files
+- For cross-module "how does X relate to Y" questions, prefer `graphify query "<question>"`, `graphify path "<A>" "<B>"`, or `graphify explain "<concept>"` over grep — these traverse the graph's EXTRACTED + INFERRED edges instead of scanning files
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/backend/pricing_v4/adapter.py
+++ b/backend/pricing_v4/adapter.py
@@ -288,6 +288,14 @@ class PricingServiceV4Adapter:
                 line.sell_fcy = discounted_sell
                 line.sell_fcy_incl_gst = discounted_sell + new_gst
 
+            line.calculation_notes = (
+                f"{line.calculation_notes} | " if line.calculation_notes else ""
+            ) + (
+                f"Customer discount applied: {discount.discount_type} "
+                f"{discount.discount_value} {discount.currency or '%'}"
+            )
+            line.rate_source = line.rate_source or 'DB_TARIFF'
+
             logger.debug(
                 f"Applied {discount.discount_type} discount to {line.service_component_code}: "
                 f"{original_sell} -> {discounted_sell}"

--- a/backend/pricing_v4/adapter.py
+++ b/backend/pricing_v4/adapter.py
@@ -150,6 +150,56 @@ class PricingServiceV4Adapter:
                 }
             )
 
+    def _capture_fx_audit(
+        self,
+        *,
+        applied: bool,
+        from_currency: Optional[str],
+        to_currency: Optional[str],
+        base_rate_type: Optional[str],
+        base_rate: Optional[Decimal],
+        caf_percent: Optional[Decimal],
+        caf_operation: Optional[str],
+        effective_rate_after_caf: Optional[Decimal],
+        defaults_used: Optional[list[dict[str, str]]] = None,
+        notes: Optional[str] = None,
+    ) -> None:
+        """
+        Persist a minimal, auditable FX/CAF record for the Pricing Breakdown.
+
+        This is intentionally quote-level metadata: it records the base rate and CAF
+        that the adapter supplied to the V4 engines (or used in SPOT overlay math),
+        plus the effective rate after CAF. Line-level FX can vary; this is the
+        canonical "engine inputs" view for internal audit.
+        """
+        fx_snapshot = getattr(self, "fx_snapshot", None)
+        payload: dict[str, object] = {
+            "applied": bool(applied),
+            "from_currency": (str(from_currency or "").upper() or None),
+            "to_currency": (str(to_currency or "").upper() or None),
+            "direction": (
+                f"{str(from_currency or '').upper()} -> {str(to_currency or '').upper()}"
+                if from_currency and to_currency
+                else None
+            ),
+            "base_rate_type": (str(base_rate_type or "").upper() or None),
+            "base_rate": (str(base_rate) if base_rate is not None else None),
+            "caf_percent": (str(caf_percent) if caf_percent is not None else None),
+            "caf_operation": (str(caf_operation or "").upper() or None),
+            "effective_rate_after_caf": (
+                str(effective_rate_after_caf) if effective_rate_after_caf is not None else None
+            ),
+            "fx_snapshot_source": getattr(fx_snapshot, "source", None),
+            "fx_snapshot_timestamp": (
+                getattr(fx_snapshot, "as_of_timestamp", None).isoformat()
+                if getattr(fx_snapshot, "as_of_timestamp", None)
+                else None
+            ),
+            "defaults_used": defaults_used or [],
+            "notes": notes,
+        }
+        self._audit_metadata["fx_audit"] = payload
+
     def get_fx_snapshot(self):
         return self.fx_snapshot
 
@@ -436,8 +486,10 @@ class PricingServiceV4Adapter:
             
             # Get TT rates for the quote currency
             fx_info = fx_rates.get(quote_currency, {})
-            tt_buy = Decimal(str(fx_info.get('tt_buy', '2.50'))) if fx_info else Decimal('2.50')
-            tt_sell = Decimal(str(fx_info.get('tt_sell', '2.78'))) if fx_info else Decimal('2.78')
+            tt_buy_from_snapshot = bool(fx_info and fx_info.get('tt_buy') is not None)
+            tt_sell_from_snapshot = bool(fx_info and fx_info.get('tt_sell') is not None)
+            tt_buy = Decimal(str(fx_info.get('tt_buy'))) if tt_buy_from_snapshot else Decimal('2.50')
+            tt_sell = Decimal(str(fx_info.get('tt_sell'))) if tt_sell_from_snapshot else Decimal('2.78')
             
             # Get CAF and margin from policy or use defaults
             caf_rate = None
@@ -447,6 +499,29 @@ class PricingServiceV4Adapter:
                     caf_rate = Decimal(str(self.policy.caf_export_pct))
                 if self.policy.margin_pct is not None:
                     margin_rate = Decimal(str(self.policy.margin_pct))
+
+            caf_used = caf_rate if caf_rate is not None else ExportPricingEngine.DEFAULT_CAF
+            fx_applied = (str(quote_currency or '').upper() != 'PGK') and (export_payment_term == ExportPaymentTerm.PREPAID)
+            defaults_used: list[dict[str, str]] = []
+            if not tt_buy_from_snapshot:
+                defaults_used.append({"field": "tt_buy", "currency": str(quote_currency or "").upper() or "UNKNOWN", "default": str(tt_buy)})
+            if not tt_sell_from_snapshot:
+                defaults_used.append({"field": "tt_sell", "currency": str(quote_currency or "").upper() or "UNKNOWN", "default": str(tt_sell)})
+            if caf_rate is None:
+                defaults_used.append({"field": "caf_percent", "scope": "export", "default": str(caf_used)})
+
+            self._capture_fx_audit(
+                applied=fx_applied,
+                from_currency=(quote_currency if fx_applied else None),
+                to_currency=("PGK" if fx_applied else None),
+                base_rate_type=("TT_SELL" if fx_applied else None),
+                base_rate=(tt_sell if fx_applied else None),
+                caf_percent=(caf_used if fx_applied else None),
+                caf_operation=("ADDED" if fx_applied else None),
+                effective_rate_after_caf=(tt_sell * (Decimal("1") + caf_used) if fx_applied else None),
+                defaults_used=defaults_used,
+                notes=("Export PREPAID: CAF added to TT_SELL; conversion recorded for FCY -> PGK audit." if fx_applied else None),
+            )
             
             engine = ExportPricingEngine(
                 quote_date=self.quote_input.quote_date,
@@ -477,8 +552,10 @@ class PricingServiceV4Adapter:
             
             fx_info = fx_rates.get(quote_currency, {})
             # Use defaults if missing (same as Export)
-            tt_buy = Decimal(str(fx_info.get('tt_buy', '0.35'))) if fx_info else Decimal('0.35')
-            tt_sell = Decimal(str(fx_info.get('tt_sell', '0.36'))) if fx_info else Decimal('0.36')
+            tt_buy_from_snapshot = bool(fx_info and fx_info.get('tt_buy') is not None)
+            tt_sell_from_snapshot = bool(fx_info and fx_info.get('tt_sell') is not None)
+            tt_buy = Decimal(str(fx_info.get('tt_buy'))) if tt_buy_from_snapshot else Decimal('0.35')
+            tt_sell = Decimal(str(fx_info.get('tt_sell'))) if tt_sell_from_snapshot else Decimal('0.36')
             
             # Get specific policy overrides if any (reuse Export policy fields or define Import ones?)
             # Assuming shared policy margin/caf for now or defaults in engine
@@ -489,6 +566,40 @@ class PricingServiceV4Adapter:
                      caf_rate = Decimal(str(self.policy.caf_import_pct))
                 if self.policy.margin_pct is not None:
                      margin_rate = Decimal(str(self.policy.margin_pct))
+
+            caf_used = caf_rate if caf_rate is not None else ImportPricingEngine.DEFAULT_CAF
+            normalized_quote_currency = str(quote_currency or "").upper() or "PGK"
+            normalized_buy_currency = str(getattr(self.quote_input, "buy_currency", None) or "").upper() or None
+            fx_applied = (normalized_quote_currency != "PGK") or (normalized_buy_currency not in (None, "", "PGK"))
+            defaults_used = []
+            if not tt_buy_from_snapshot:
+                defaults_used.append({"field": "tt_buy", "currency": normalized_quote_currency, "default": str(tt_buy)})
+            if not tt_sell_from_snapshot:
+                defaults_used.append({"field": "tt_sell", "currency": normalized_quote_currency, "default": str(tt_sell)})
+            if caf_rate is None:
+                defaults_used.append({"field": "caf_percent", "scope": "import", "default": str(caf_used)})
+
+            if fx_applied:
+                if normalized_quote_currency != "PGK":
+                    from_currency = normalized_quote_currency
+                    base_rate_type = "TT_SELL"
+                    base_rate = tt_sell
+                else:
+                    from_currency = normalized_buy_currency or "UNKNOWN"
+                    base_rate_type = "TT_BUY"
+                    base_rate = tt_buy
+                self._capture_fx_audit(
+                    applied=True,
+                    from_currency=from_currency,
+                    to_currency="PGK",
+                    base_rate_type=base_rate_type,
+                    base_rate=base_rate,
+                    caf_percent=caf_used,
+                    caf_operation="DEDUCTED",
+                    effective_rate_after_caf=(base_rate * (Decimal("1") - caf_used)) if base_rate is not None else None,
+                    defaults_used=defaults_used,
+                    notes="Import: CAF deducted from base TT rate; conversion recorded for audit.",
+                )
 
             engine = ImportPricingEngine(
                 quote_date=self.quote_input.quote_date,
@@ -777,6 +888,7 @@ class PricingServiceV4Adapter:
                     sell_fcy_currency=currency,
                     cost_fcy=cost_fcy,
                     cost_fcy_currency=cost_currency,
+                    exchange_rate=fx_sell_rate,
                     bucket=data.get('bucket', 'origin_charges'),
                     product_code=data.get('product_code') or code,
                     component=data.get('component'),
@@ -821,6 +933,7 @@ class PricingServiceV4Adapter:
                     sell_fcy_currency='PGK',
                     cost_fcy=cost_fcy,
                     cost_fcy_currency=cost_fcy_currency,
+                    exchange_rate=fx_buy_rate if cost_fcy_currency else None,
                     bucket=data.get('bucket', 'origin_charges'),
                     product_code=data.get('product_code') or code,
                     component=data.get('component'),
@@ -1271,6 +1384,41 @@ class PricingServiceV4Adapter:
                 elif shipment_type == 'EXPORT':
                     caf_pct = Decimal(str(self.policy.caf_export_pct))
 
+            # Capture quote-level FX audit for SPOT overlay conversion when the
+            # output currency is FCY (rare) or when FCY buy costs exist.
+            if "fx_audit" not in self._audit_metadata:
+                normalized_output_currency = str(output_currency or "").upper() or "PGK"
+                normalized_charge_currency = str(getattr(charge, "currency", None) or "").upper() or "PGK"
+                fx_applied = (normalized_output_currency != "PGK") or (normalized_charge_currency != "PGK")
+                if fx_applied:
+                    if normalized_output_currency != "PGK":
+                        from_currency = normalized_output_currency
+                        base_rate_type = "TT_SELL"
+                        base_rate = output_fx_sell
+                        caf_operation = "ADDED" if getattr(self.quote_input.shipment, "shipment_type", None) == "EXPORT" else "DEDUCTED"
+                        effective_rate = (
+                            output_fx_sell * (Decimal("1") + caf_pct)
+                            if caf_operation == "ADDED"
+                            else output_fx_sell * (Decimal("1") - caf_pct)
+                        )
+                    else:
+                        from_currency = normalized_charge_currency
+                        base_rate_type = "TT_BUY"
+                        base_rate = self._get_fx_buy_rate(normalized_charge_currency, fx_rates)
+                        caf_operation = "DEDUCTED"
+                        effective_rate = base_rate * (Decimal("1") - caf_pct) if base_rate is not None else None
+                    self._capture_fx_audit(
+                        applied=True,
+                        from_currency=from_currency,
+                        to_currency="PGK",
+                        base_rate_type=base_rate_type,
+                        base_rate=base_rate,
+                        caf_percent=caf_pct,
+                        caf_operation=caf_operation,
+                        effective_rate_after_caf=effective_rate,
+                        notes="SPOT overlay: adapter FX/CAF conversion captured for audit.",
+                    )
+
             fx_buy = self._get_fx_buy_rate(charge.currency, fx_rates)
             
             # Canonical rule evaluator (supports FLAT, PER_UNIT, MIN_OR_PER_UNIT, PERCENT_OF, etc.)
@@ -1416,6 +1564,7 @@ class PricingServiceV4Adapter:
                 cost_fcy=cost_fcy,
                 cost_fcy_currency=charge.currency,
                 sell_fcy_currency=output_currency,
+                exchange_rate=(output_fx_sell if str(output_currency or '').upper() != 'PGK' else (fx_buy if str(getattr(charge, 'currency', None) or '').upper() != 'PGK' else None)),
                 bucket=charge.bucket, # Ensure bucket is passed
                 product_code=charge.code,
                 component=canonical_component,

--- a/backend/quotes/buckets.py
+++ b/backend/quotes/buckets.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from decimal import Decimal
+import re
 
 
 BUCKET_TO_LEG = {
@@ -8,6 +9,99 @@ BUCKET_TO_LEG = {
     "airfreight": "MAIN",
     "destination_charges": "DESTINATION",
 }
+
+PUBLIC_CHARGE_SUBCATEGORY_ORDER = [
+    "Customs / Regulatory",
+    "Documentation",
+    "Pickup / Delivery / Cartage",
+    "Handling / Terminal",
+    "Freight / Carrier Charges",
+    "Carrier Surcharges",
+    "Service / Agency Fees",
+    "Other Charges",
+]
+
+_CATEGORY_TO_PUBLIC_SUBCATEGORY = {
+    "CUSTOMS": "Customs / Regulatory",
+    "STATUTORY": "Customs / Regulatory",
+    "DOCUMENTATION": "Documentation",
+    "LOCAL": "Pickup / Delivery / Cartage",
+    "HANDLING": "Handling / Terminal",
+    "TRANSPORT": "Freight / Carrier Charges",
+}
+
+_CUSTOMS_TERMS = (
+    "customs",
+    "clearance",
+    "brokerage",
+    "naqia",
+    "quarantine",
+    "permit",
+    "licence",
+    "license",
+    "inspection",
+    "duty",
+    "tax",
+    "compliance",
+)
+
+_DOCUMENTATION_TERMS = (
+    "documentation",
+    "document",
+    "docs",
+    "awb",
+    "bill of lading",
+    "manifest",
+)
+
+_PICKUP_DELIVERY_TERMS = (
+    "pickup",
+    "pick-up",
+    "pick up",
+    "delivery",
+    "cartage",
+    "transport",
+    "trucking",
+    "haulage",
+)
+
+_HANDLING_TERMS = (
+    "handling",
+    "terminal",
+    "thc",
+    "loading",
+    "unloading",
+    "forklift",
+    "depot",
+    "warehouse",
+)
+
+_FREIGHT_TERMS = (
+    "air freight",
+    "ocean freight",
+    "sea freight",
+    "base freight",
+    "carrier freight",
+)
+
+_SURCHARGE_TERMS = (
+    "fuel surcharge",
+    "security surcharge",
+    "baf",
+    "caf",
+    "pss",
+    "gri",
+    "emergency surcharge",
+    "container surcharge",
+)
+
+_SERVICE_AGENCY_TERMS = (
+    "service fee",
+    "admin fee",
+    "processing fee",
+    "coordination fee",
+    "agency fee",
+)
 
 
 def normalize_bucket(raw_bucket) -> str | None:
@@ -64,3 +158,71 @@ def should_include_quote_line_in_subtotal(line, quote_currency: str) -> bool:
     if getattr(line, "is_rate_missing", False):
         return False
     return resolve_quote_line_sell_value(line, quote_currency) > Decimal("0")
+
+
+def _contains_term(value: str, terms: tuple[str, ...]) -> bool:
+    return any(re.search(rf"(?<![a-z0-9]){re.escape(term)}(?![a-z0-9])", value) for term in terms)
+
+
+def _line_text_value(line) -> str:
+    component = getattr(line, "service_component", None)
+    values = [
+        getattr(line, "cost_source_description", None),
+        getattr(line, "description", None),
+        getattr(component, "description", None),
+    ]
+    return " ".join(str(value or "") for value in values).strip().lower()
+
+
+def _line_metadata_value(line) -> str:
+    component = getattr(line, "service_component", None)
+    values = [
+        getattr(line, "product_code", None),
+        getattr(line, "component", None),
+        getattr(line, "basis", None),
+        getattr(line, "rule_family", None),
+        getattr(line, "service_family", None),
+        getattr(component, "code", None),
+        getattr(component, "category", None),
+    ]
+    return " ".join(str(value or "") for value in values).replace("_", " ").replace("-", " ").strip().lower()
+
+
+def classify_quote_line_public_subcategory(line) -> str:
+    """Return the customer-facing sub-category for a public quote line."""
+    text = _line_text_value(line)
+    metadata = _line_metadata_value(line)
+    searchable = f"{metadata} {text}".strip()
+    leg = resolve_quote_line_leg(line)
+
+    # EFM local cartage fuel must stay with cartage, not carrier surcharges.
+    if "cartage" in searchable and "fuel surcharge" in searchable and leg in {"ORIGIN", "DESTINATION"}:
+        return "Pickup / Delivery / Cartage"
+
+    # EFM destination agency fee is part of destination customs handling.
+    if "agency fee" in searchable and ("dest" in searchable or leg == "DESTINATION"):
+        return "Customs / Regulatory"
+
+    component = getattr(line, "service_component", None)
+    category = str(getattr(component, "category", "") or "").upper()
+    if category in _CATEGORY_TO_PUBLIC_SUBCATEGORY:
+        if category == "TRANSPORT" and leg in {"ORIGIN", "DESTINATION"}:
+            return "Pickup / Delivery / Cartage"
+        return _CATEGORY_TO_PUBLIC_SUBCATEGORY[category]
+
+    if _contains_term(searchable, _CUSTOMS_TERMS):
+        return "Customs / Regulatory"
+    if _contains_term(searchable, _DOCUMENTATION_TERMS):
+        return "Documentation"
+    if _contains_term(searchable, _PICKUP_DELIVERY_TERMS):
+        return "Pickup / Delivery / Cartage"
+    if _contains_term(searchable, _HANDLING_TERMS):
+        return "Handling / Terminal"
+    if _contains_term(searchable, _FREIGHT_TERMS):
+        return "Freight / Carrier Charges"
+    if _contains_term(searchable, _SURCHARGE_TERMS):
+        return "Carrier Surcharges"
+    if _contains_term(searchable, _SERVICE_AGENCY_TERMS):
+        return "Service / Agency Fees"
+
+    return "Other Charges"

--- a/backend/quotes/buckets.py
+++ b/backend/quotes/buckets.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from decimal import Decimal
+
 
 BUCKET_TO_LEG = {
     "origin_charges": "ORIGIN",
@@ -30,3 +32,35 @@ def resolve_quote_line_leg(line) -> str:
     because it can be resynced independently of saved quote results.
     """
     return normalize_bucket(getattr(line, "bucket", None)) or normalize_leg(getattr(line, "leg", None)) or "MAIN"
+
+
+def resolve_quote_line_sell_value(line, quote_currency: str) -> Decimal:
+    """Return the customer-facing sell amount for the quote output currency."""
+    currency = str(quote_currency or "PGK").upper()
+    if currency != "PGK":
+        line_currency = str(getattr(line, "sell_fcy_currency", "") or "").upper()
+        if line_currency == currency and getattr(line, "sell_fcy", None) is not None:
+            return line.sell_fcy
+    return getattr(line, "sell_pgk", None) or Decimal("0")
+
+
+def should_display_quote_line(line, quote_currency: str) -> bool:
+    """Return whether a line should appear in the customer/public breakdown."""
+    if getattr(line, "is_informational", False):
+        return False
+    if getattr(line, "conditional", False):
+        return False
+    if getattr(line, "is_rate_missing", False):
+        return False
+    return resolve_quote_line_sell_value(line, quote_currency) > Decimal("0")
+
+
+def should_include_quote_line_in_subtotal(line, quote_currency: str) -> bool:
+    """Return whether a line contributes to customer-facing subtotals/totals."""
+    if getattr(line, "is_informational", False):
+        return False
+    if getattr(line, "conditional", False):
+        return False
+    if getattr(line, "is_rate_missing", False):
+        return False
+    return resolve_quote_line_sell_value(line, quote_currency) > Decimal("0")

--- a/backend/quotes/buckets.py
+++ b/backend/quotes/buckets.py
@@ -13,9 +13,9 @@ BUCKET_TO_LEG = {
 PUBLIC_CHARGE_SUBCATEGORY_ORDER = [
     "Customs / Regulatory",
     "Documentation",
-    "Pickup / Delivery / Cartage",
+    "Local Transport / Cartage",
     "Handling / Terminal",
-    "Freight / Carrier Charges",
+    "Freight / Carrier",
     "Carrier Surcharges",
     "Service / Agency Fees",
     "Other Charges",
@@ -25,9 +25,9 @@ _CATEGORY_TO_PUBLIC_SUBCATEGORY = {
     "CUSTOMS": "Customs / Regulatory",
     "STATUTORY": "Customs / Regulatory",
     "DOCUMENTATION": "Documentation",
-    "LOCAL": "Pickup / Delivery / Cartage",
+    "LOCAL": "Local Transport / Cartage",
     "HANDLING": "Handling / Terminal",
-    "TRANSPORT": "Freight / Carrier Charges",
+    "TRANSPORT": "Freight / Carrier",
 }
 
 _CUSTOMS_TERMS = (
@@ -197,7 +197,7 @@ def classify_quote_line_public_subcategory(line) -> str:
 
     # EFM local cartage fuel must stay with cartage, not carrier surcharges.
     if "cartage" in searchable and "fuel surcharge" in searchable and leg in {"ORIGIN", "DESTINATION"}:
-        return "Pickup / Delivery / Cartage"
+        return "Local Transport / Cartage"
 
     # EFM destination agency fee is part of destination customs handling.
     if "agency fee" in searchable and ("dest" in searchable or leg == "DESTINATION"):
@@ -207,7 +207,7 @@ def classify_quote_line_public_subcategory(line) -> str:
     category = str(getattr(component, "category", "") or "").upper()
     if category in _CATEGORY_TO_PUBLIC_SUBCATEGORY:
         if category == "TRANSPORT" and leg in {"ORIGIN", "DESTINATION"}:
-            return "Pickup / Delivery / Cartage"
+            return "Local Transport / Cartage"
         return _CATEGORY_TO_PUBLIC_SUBCATEGORY[category]
 
     if _contains_term(searchable, _CUSTOMS_TERMS):
@@ -215,11 +215,11 @@ def classify_quote_line_public_subcategory(line) -> str:
     if _contains_term(searchable, _DOCUMENTATION_TERMS):
         return "Documentation"
     if _contains_term(searchable, _PICKUP_DELIVERY_TERMS):
-        return "Pickup / Delivery / Cartage"
+        return "Local Transport / Cartage"
     if _contains_term(searchable, _HANDLING_TERMS):
         return "Handling / Terminal"
     if _contains_term(searchable, _FREIGHT_TERMS):
-        return "Freight / Carrier Charges"
+        return "Freight / Carrier"
     if _contains_term(searchable, _SURCHARGE_TERMS):
         return "Carrier Surcharges"
     if _contains_term(searchable, _SERVICE_AGENCY_TERMS):

--- a/backend/quotes/intake_safety.py
+++ b/backend/quotes/intake_safety.py
@@ -129,7 +129,11 @@ def normalize_source_analysis_summary(value: Any) -> dict[str, Any]:
         "pdf_fallback_used": bool(raw.get("pdf_fallback_used", False)),
     }
     risk_flags, blocking_reasons, risk_level, requires_review_note = _derive_blocking_reasons(summary)
-    review_required = bool(risk_flags)
+    # Only high-risk extraction findings require explicit source review before
+    # acknowledgement/final quote creation. Medium-risk audit signals such as
+    # low-confidence lines or scanned-PDF fallback stay visible as warnings, but
+    # they must not turn a proceedable SPOT envelope into a dead final button.
+    review_required = bool(requires_review_note)
     reviewed_safe_to_quote = bool(raw.get("reviewed_safe_to_quote", False)) if review_required else False
     raw_review_status = str(raw.get("review_status") or "").strip().upper()
     if review_required:

--- a/backend/quotes/pdf_service.py
+++ b/backend/quotes/pdf_service.py
@@ -19,7 +19,11 @@ from fpdf import FPDF
 
 from core.commodity import COMMODITY_CODE_DG, DEFAULT_COMMODITY_CODE, commodity_label
 from core.storage_utils import materialize_file_field
-from .buckets import resolve_quote_line_leg
+from .buckets import (
+    resolve_quote_line_leg,
+    resolve_quote_line_sell_value,
+    should_include_quote_line_in_subtotal,
+)
 from .branding import QuoteBrandingContext, get_quote_branding
 from .models import Quote, QuoteVersion, QuoteLine, QuoteTotal
 from .public_links import build_public_quote_url
@@ -144,8 +148,9 @@ def generate_quote_pdf(
         # Get data
         origin_code, origin_name = _extract_location_info(quote, 'origin')
         destination_code, destination_name = _extract_location_info(quote, 'destination')
-        charge_buckets = _get_charge_buckets(version)
-        totals = _get_totals(version)
+        quote_currency = quote.output_currency or "PGK"
+        charge_buckets = _get_charge_buckets(version, quote_currency)
+        totals = _get_totals(version, quote_currency)
         cargo_type = _get_cargo_type(quote, version)
         chargeable_weight = _get_chargeable_weight(quote, version)
         
@@ -655,7 +660,7 @@ def _build_terms_and_conditions(quote, valid_until_str: str, branding: Optional[
     return terms
 
 
-def _get_charge_buckets(version) -> list[dict]:
+def _get_charge_buckets(version, currency: str = "PGK") -> list[dict]:
     """Get charge summary grouped by the saved quote line bucket/leg."""
     buckets = {
         'Origin Charges': Decimal('0'),
@@ -664,6 +669,9 @@ def _get_charge_buckets(version) -> list[dict]:
     }
     
     for line in version.lines.select_related('service_component').all():
+        if not should_include_quote_line_in_subtotal(line, currency):
+            continue
+
         leg = resolve_quote_line_leg(line)
 
         if leg == 'ORIGIN':
@@ -675,7 +683,7 @@ def _get_charge_buckets(version) -> list[dict]:
         else:
             bucket_name = 'International Freight'
         
-        buckets[bucket_name] += line.sell_pgk or Decimal('0')
+        buckets[bucket_name] += resolve_quote_line_sell_value(line, currency)
     
     result = []
     for name in ['Origin Charges', 'International Freight', 'Destination Charges']:
@@ -685,13 +693,17 @@ def _get_charge_buckets(version) -> list[dict]:
     return result
 
 
-def _get_totals(version) -> dict:
+def _get_totals(version, currency: str = "PGK") -> dict:
     """Get totals for the version."""
     try:
         total = version.totals
         if total:
-            sell_excl = total.total_sell_pgk or Decimal('0')
-            sell_incl = total.total_sell_pgk_incl_gst or Decimal('0')
+            if str(currency or "PGK").upper() != "PGK" and total.total_sell_fcy:
+                sell_excl = total.total_sell_fcy or Decimal('0')
+                sell_incl = total.total_sell_fcy_incl_gst or Decimal('0')
+            else:
+                sell_excl = total.total_sell_pgk or Decimal('0')
+                sell_incl = total.total_sell_pgk_incl_gst or Decimal('0')
             gst = sell_incl - sell_excl
             return {
                 'sell_excl_gst': sell_excl,
@@ -701,7 +713,14 @@ def _get_totals(version) -> dict:
     except Exception:
         pass
     
-    sell_total = sum((line.sell_pgk or Decimal('0')) for line in version.lines.all())
+    sell_total = sum(
+        (
+            resolve_quote_line_sell_value(line, currency)
+            for line in version.lines.all()
+            if should_include_quote_line_in_subtotal(line, currency)
+        ),
+        Decimal('0'),
+    )
     gst = sell_total * Decimal('0.10')
     return {'sell_excl_gst': sell_total, 'gst': gst, 'sell_incl_gst': sell_total + gst}
 

--- a/backend/quotes/quote_result_contract.py
+++ b/backend/quotes/quote_result_contract.py
@@ -15,7 +15,10 @@ from core.charge_rules import (
     CALCULATION_TIERED_BREAK,
 )
 from core.commodity import DEFAULT_COMMODITY_CODE, commodity_label
-from quotes.buckets import resolve_quote_line_leg
+from quotes.buckets import (
+    classify_quote_line_public_subcategory,
+    resolve_quote_line_leg,
+)
 from quotes.completeness import (
     COMPONENT_DESTINATION_LOCAL,
     COMPONENT_FREIGHT,
@@ -922,6 +925,7 @@ def line_item_from_quote_line(
         "is_spot_sourced": is_spot_sourced,
         "is_manual_override": is_manual_override,
         "fx_applied": fx_applied,
+        "subcategory": classify_quote_line_public_subcategory(line),
         "sort_order": sort_order,
     }
 

--- a/backend/quotes/quote_result_contract.py
+++ b/backend/quotes/quote_result_contract.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from decimal import Decimal, ROUND_HALF_UP
 from typing import Any, Iterable, Optional
 
@@ -598,23 +600,199 @@ def build_tax_breakdown_payload(lines: Iterable[Any], totals: Any, display_curre
     }
 
 
-def build_fx_applied_payload(version: Any, lines: Iterable[Any], display_currency: str) -> dict[str, Any]:
+def build_fx_applied_payload(
+    version: Any,
+    lines: Iterable[Any],
+    display_currency: str,
+    totals: Any = None,
+) -> dict[str, Any]:
     line_list = list(lines or [])
     fx_rate = None
+    fx_currency = None
     for line in line_list:
         exchange_rate = decimal_or_none(getattr(line, "exchange_rate", None))
-        line_currency = str(getattr(line, "sell_fcy_currency", None) or getattr(line, "cost_fcy_currency", None) or "").upper()
-        if exchange_rate is not None and line_currency and line_currency != "PGK":
+        sell_currency = str(getattr(line, "sell_fcy_currency", None) or "").upper()
+        cost_currency = str(getattr(line, "cost_fcy_currency", None) or "").upper()
+        # FX can be required even when the SELL currency is PGK (e.g. FCY buy cost -> PGK sell).
+        # Prefer the non-PGK currency involved in the conversion when present.
+        non_pgk_currency = None
+        for candidate in (cost_currency, sell_currency):
+            if candidate and candidate != "PGK":
+                non_pgk_currency = candidate
+                break
+        if exchange_rate is not None and non_pgk_currency:
             fx_rate = exchange_rate
+            fx_currency = non_pgk_currency
             break
 
     fx_snapshot = getattr(version, "fx_snapshot", None)
+    persisted_audit = getattr(totals, "audit_metadata_json", {}) if totals else {}
+    fx_audit = persisted_audit.get("fx_audit") if isinstance(persisted_audit, dict) else None
+
+    # Prefer calculation-time persisted FX audit metadata (adapter/engine inputs).
+    base_rate = None
+    base_rate_type = None
+    direction = None
+    from_currency = None
+    to_currency = None
+    caf_operation = None
+    effective_fx_after_caf = None
+    defaults_used = []
+    if isinstance(fx_audit, dict):
+        base_rate = decimal_or_none(fx_audit.get("base_rate"))
+        base_rate_type = fx_audit.get("base_rate_type")
+        direction = fx_audit.get("direction")
+        from_currency = fx_audit.get("from_currency")
+        to_currency = fx_audit.get("to_currency")
+        caf_operation = fx_audit.get("caf_operation")
+        effective_fx_after_caf = decimal_or_none(fx_audit.get("effective_rate_after_caf"))
+        defaults_used = fx_audit.get("defaults_used") if isinstance(fx_audit.get("defaults_used"), list) else []
+
+    # Legacy fallback: derive FX/CAF from stored Policy + FxSnapshot.
+    derived_caf_percent = None
+    policy = getattr(version, "policy", None)
+    shipment_type = str(getattr(getattr(version, "quote", None), "shipment_type", "") or "").upper()
+    payment_term = str(getattr(getattr(version, "quote", None), "payment_term", "") or "").upper()
+    if policy is not None:
+        if shipment_type == "EXPORT":
+            derived_caf_percent = decimal_or_none(getattr(policy, "caf_export_pct", None))
+        elif shipment_type == "IMPORT":
+            derived_caf_percent = decimal_or_none(getattr(policy, "caf_import_pct", None))
+
+    caf_percent_value = None
+    if isinstance(fx_audit, dict):
+        caf_percent_value = decimal_or_none(fx_audit.get("caf_percent"))
+    if caf_percent_value is None:
+        caf_percent_value = derived_caf_percent
+    if caf_percent_value is None:
+        caf_percent_value = decimal_or_none(getattr(fx_snapshot, "caf_percent", None))
+
+    derived_from_currency = None
+    derived_base_rate_type = None
+    derived_base_rate = None
+    derived_caf_operation = None
+    derived_effective_rate = None
+
+    if base_rate is None and fx_snapshot is not None:
+        # Choose the non-PGK currency involved in conversion-to-PGK audit.
+        if str(display_currency or "").upper() != "PGK":
+            derived_from_currency = str(display_currency or "").upper()
+        else:
+            # Prefer any persisted line-level FCY currency when present (covers legacy quotes
+            # where request payload did not include buy_currency).
+            if not derived_from_currency:
+                for line in line_list:
+                    for candidate in (
+                        getattr(line, "cost_fcy_currency", None),
+                        getattr(line, "sell_fcy_currency", None),
+                    ):
+                        curr = str(candidate or "").upper()
+                        if curr and curr != "PGK":
+                            derived_from_currency = curr
+                            break
+                    if derived_from_currency:
+                        break
+
+            payload_json = getattr(version, "payload_json", {}) or {}
+            if isinstance(payload_json, dict):
+                derived_from_currency = str(payload_json.get("buy_currency") or "").upper() or None
+
+        rates = getattr(fx_snapshot, "rates", None) or {}
+        if isinstance(rates, str):
+            try:
+                rates = json.loads(rates)
+            except Exception:
+                rates = {}
+        if derived_from_currency and derived_from_currency != "PGK" and isinstance(rates, dict):
+            info = rates.get(derived_from_currency, {}) or {}
+            if shipment_type == "IMPORT" and (payment_term == "COLLECT" or str(display_currency or "").upper() == "PGK"):
+                derived_base_rate_type = "TT_BUY"
+                derived_base_rate = decimal_or_none(info.get("tt_buy"))
+                derived_caf_operation = "DEDUCTED"
+                if derived_base_rate is not None and derived_caf_percent is not None:
+                    derived_effective_rate = derived_base_rate * (Decimal("1") - derived_caf_percent)
+            else:
+                derived_base_rate_type = "TT_SELL"
+                derived_base_rate = decimal_or_none(info.get("tt_sell"))
+                if shipment_type == "EXPORT":
+                    derived_caf_operation = "ADDED"
+                    if derived_base_rate is not None and derived_caf_percent is not None:
+                        derived_effective_rate = derived_base_rate * (Decimal("1") + derived_caf_percent)
+                else:
+                    derived_caf_operation = "DEDUCTED"
+                    if derived_base_rate is not None and derived_caf_percent is not None:
+                        derived_effective_rate = derived_base_rate * (Decimal("1") - derived_caf_percent)
+
+        if direction is None and derived_from_currency and derived_from_currency != "PGK":
+            direction = f"{derived_from_currency} -> PGK"
+        if from_currency is None:
+            from_currency = derived_from_currency
+        if to_currency is None and derived_from_currency:
+            to_currency = "PGK"
+        if base_rate_type is None:
+            base_rate_type = derived_base_rate_type
+        if base_rate is None:
+            base_rate = derived_base_rate
+        if caf_operation is None:
+            caf_operation = derived_caf_operation
+        if effective_fx_after_caf is None:
+            effective_fx_after_caf = derived_effective_rate
+
+    # If we detected a line-level FX rate but don't have a richer record yet, fill the gaps
+    # from the stored quote context so legacy/older versions remain traceable.
+    if fx_rate is not None:
+        shipment_type = str(getattr(getattr(version, "quote", None), "shipment_type", "") or "").upper()
+        payment_term = str(getattr(getattr(version, "quote", None), "payment_term", "") or "").upper()
+        if base_rate is None:
+            base_rate = fx_rate
+        if from_currency is None and fx_currency:
+            from_currency = fx_currency
+        if to_currency is None and fx_currency:
+            to_currency = "PGK"
+        if direction is None and from_currency and to_currency:
+            direction = f"{from_currency} -> {to_currency}"
+        if base_rate_type is None:
+            if shipment_type == "IMPORT":
+                base_rate_type = "TT_BUY" if payment_term == "COLLECT" else "TT_SELL"
+            elif shipment_type == "EXPORT":
+                base_rate_type = "TT_SELL"
+        if caf_operation is None:
+            if shipment_type == "EXPORT":
+                caf_operation = "ADDED"
+            elif shipment_type == "IMPORT":
+                caf_operation = "DEDUCTED"
+        if effective_fx_after_caf is None and base_rate is not None and caf_percent_value is not None:
+            if str(caf_operation or "").upper() == "ADDED":
+                effective_fx_after_caf = base_rate * (Decimal("1") + caf_percent_value)
+            elif str(caf_operation or "").upper() == "DEDUCTED":
+                effective_fx_after_caf = base_rate * (Decimal("1") - caf_percent_value)
+
+    fx_fallbacks = persisted_audit.get("fx_fallbacks") if isinstance(persisted_audit, dict) else None
+    applied_flag = fx_rate is not None
+    if isinstance(fx_audit, dict) and bool(fx_audit.get("applied")):
+        applied_flag = True
+    if not applied_flag and (base_rate is not None and (direction or (from_currency and to_currency))):
+        applied_flag = True
+
+    rate_value = fx_rate
+    if rate_value is None:
+        rate_value = base_rate
+
     return {
-        "applied": fx_rate is not None,
-        "rate": fx_rate,
+        "applied": applied_flag,
+        "rate": rate_value,
+        "base_rate": base_rate,
+        "base_rate_type": base_rate_type,
+        "direction": direction,
+        "from_currency": from_currency,
+        "to_currency": to_currency,
+        "caf_operation": caf_operation,
+        "effective_fx_after_caf": effective_fx_after_caf,
+        "fx_fallbacks": fx_fallbacks if isinstance(fx_fallbacks, list) else [],
+        "fx_defaults_used": defaults_used,
         "source": getattr(fx_snapshot, "source", None),
         "snapshot_date": getattr(fx_snapshot, "as_of_timestamp", None),
-        "caf_percent": decimal_or_none(getattr(fx_snapshot, "caf_percent", None)),
+        "caf_percent": caf_percent_value,
         "currency": display_currency,
     }
 
@@ -666,6 +844,9 @@ def line_item_from_quote_line(
         sell_amount = decimal_or_zero(getattr(line, "sell_pgk", None))
     else:
         sell_amount = decimal_or_zero(getattr(line, "sell_fcy", None))
+
+    buy_currency = str(getattr(line, "cost_fcy_currency", None) or "PGK").upper()
+    fx_applied = buy_currency != "PGK" or customer_currency != "PGK"
 
     cost_amount_pgk = decimal_or_zero(getattr(line, "cost_pgk", None))
     sell_amount_pgk = decimal_or_zero(getattr(line, "sell_pgk", None))
@@ -740,6 +921,7 @@ def line_item_from_quote_line(
         "calculation_notes": calculation_notes,
         "is_spot_sourced": is_spot_sourced,
         "is_manual_override": is_manual_override,
+        "fx_applied": fx_applied,
         "sort_order": sort_order,
     }
 
@@ -821,7 +1003,7 @@ def build_quote_result_from_quote(quote: Any, version: Any = None) -> dict[str, 
         "total_sell_pgk": decimal_or_zero(getattr(totals, "total_sell_pgk", None)),
         "margin_amount": decimal_or_zero(getattr(totals, "gross_profit", None)),
         "margin_percent": decimal_or_zero(getattr(totals, "margin_percent", None)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP),
-        "fx_applied": build_fx_applied_payload(active_version, lines, display_currency),
+        "fx_applied": build_fx_applied_payload(active_version, lines, display_currency, totals),
         "tax_breakdown": build_tax_breakdown_payload(lines, totals, display_currency),
         "warnings": _dedupe(warnings),
         "missing_components": coverage.missing_required,

--- a/backend/quotes/quote_result_contract.py
+++ b/backend/quotes/quote_result_contract.py
@@ -667,6 +667,16 @@ def line_item_from_quote_line(
     else:
         sell_amount = decimal_or_zero(getattr(line, "sell_fcy", None))
 
+    cost_amount_pgk = decimal_or_zero(getattr(line, "cost_pgk", None))
+    sell_amount_pgk = decimal_or_zero(getattr(line, "sell_pgk", None))
+    margin_amount_pgk = sell_amount_pgk - cost_amount_pgk
+    margin_percent = ZERO_DECIMAL
+    if sell_amount_pgk > ZERO_DECIMAL:
+        margin_percent = ((margin_amount_pgk / sell_amount_pgk) * Decimal("100")).quantize(
+            Decimal("0.01"),
+            rounding=ROUND_HALF_UP,
+        )
+
     tax_amount = display_tax_amount(line, customer_currency)
     notes = _dedupe(
         [
@@ -718,8 +728,10 @@ def line_item_from_quote_line(
             quantity=quantity,
             sell_amount=sell_amount,
         ),
-        "cost_amount": decimal_or_zero(getattr(line, "cost_pgk", None)),
+        "cost_amount": cost_amount_pgk,
         "sell_amount": sell_amount,
+        "margin_amount": margin_amount_pgk,
+        "margin_percent": margin_percent,
         "tax_code": getattr(line, "gst_category", None) or getattr(service_component, "tax_code", None) or "GST",
         "tax_amount": tax_amount,
         "included_in_total": included_in_total,

--- a/backend/quotes/serializers.py
+++ b/backend/quotes/serializers.py
@@ -264,9 +264,18 @@ class QuoteBrandingSerializer(serializers.Serializer):
 class CanonicalFxAppliedSerializer(serializers.Serializer):
     applied = serializers.BooleanField()
     rate = serializers.DecimalField(max_digits=18, decimal_places=6, allow_null=True)
+    base_rate = serializers.DecimalField(max_digits=18, decimal_places=6, allow_null=True, required=False)
+    base_rate_type = serializers.CharField(allow_null=True, allow_blank=True, required=False)
+    direction = serializers.CharField(allow_null=True, allow_blank=True, required=False)
+    from_currency = serializers.CharField(allow_null=True, allow_blank=True, required=False)
+    to_currency = serializers.CharField(allow_null=True, allow_blank=True, required=False)
     source = serializers.CharField(allow_null=True, allow_blank=True)
     snapshot_date = serializers.DateTimeField(allow_null=True)
     caf_percent = serializers.DecimalField(max_digits=10, decimal_places=4, allow_null=True)
+    caf_operation = serializers.CharField(allow_null=True, allow_blank=True, required=False)
+    effective_fx_after_caf = serializers.DecimalField(max_digits=18, decimal_places=6, allow_null=True, required=False)
+    fx_fallbacks = serializers.ListField(child=serializers.DictField(), required=False, allow_empty=True)
+    fx_defaults_used = serializers.ListField(child=serializers.DictField(), required=False, allow_empty=True)
     currency = serializers.CharField(allow_null=True, allow_blank=True)
 
 
@@ -303,6 +312,7 @@ class CanonicalQuoteLineItemSerializer(serializers.Serializer):
     calculation_notes = serializers.CharField(allow_null=True, allow_blank=True)
     is_spot_sourced = serializers.BooleanField()
     is_manual_override = serializers.BooleanField()
+    fx_applied = serializers.BooleanField(required=False)
     sort_order = serializers.IntegerField()
 
 

--- a/backend/quotes/serializers.py
+++ b/backend/quotes/serializers.py
@@ -153,7 +153,10 @@ class V3QuoteLineSerializer(serializers.ModelSerializer):
             'sell_pgk', 'sell_pgk_incl_gst', 'sell_fcy', 'sell_fcy_incl_gst',
             'sell_fcy_currency', 'exchange_rate', 'cost_source',
             'cost_source_description', 'is_rate_missing', 'leg', 'bucket',
-            'gst_category', 'gst_rate', 'gst_amount'
+            'basis', 'rule_family', 'service_family', 'unit_type', 'rate',
+            'rate_source', 'canonical_cost_source', 'is_spot_sourced',
+            'is_manual_override', 'calculation_notes', 'is_informational',
+            'conditional', 'gst_category', 'gst_rate', 'gst_amount'
         )
     
     def to_representation(self, instance):
@@ -290,6 +293,8 @@ class CanonicalQuoteLineItemSerializer(serializers.Serializer):
     rate = serializers.DecimalField(max_digits=18, decimal_places=6, allow_null=True)
     cost_amount = serializers.DecimalField(max_digits=18, decimal_places=2)
     sell_amount = serializers.DecimalField(max_digits=18, decimal_places=2)
+    margin_amount = serializers.DecimalField(max_digits=18, decimal_places=2)
+    margin_percent = serializers.DecimalField(max_digits=18, decimal_places=2)
     tax_code = serializers.CharField()
     tax_amount = serializers.DecimalField(max_digits=18, decimal_places=2)
     included_in_total = serializers.BooleanField()

--- a/backend/quotes/serializers.py
+++ b/backend/quotes/serializers.py
@@ -313,6 +313,7 @@ class CanonicalQuoteLineItemSerializer(serializers.Serializer):
     is_spot_sourced = serializers.BooleanField()
     is_manual_override = serializers.BooleanField()
     fx_applied = serializers.BooleanField(required=False)
+    subcategory = serializers.CharField(required=False, allow_null=True, allow_blank=True)
     sort_order = serializers.IntegerField()
 
 

--- a/backend/quotes/spot_views.py
+++ b/backend/quotes/spot_views.py
@@ -2359,6 +2359,10 @@ class SpotEnvelopeCreateQuoteAPIView(APIView):
         # Ensure customer/contact logic
         cust_id = None
         cont_id = None
+        requested_contact_id = (
+            request.data.get('contact_id')
+            or quote_data.get('contact_id')
+        )
         
         if spe_db.quote:
             cust_id = spe_db.quote.customer_id
@@ -2395,6 +2399,26 @@ class SpotEnvelopeCreateQuoteAPIView(APIView):
                 status=status.HTTP_400_BAD_REQUEST
             )
 
+        if cont_id and not Contact.objects.filter(id=cont_id, company_id=cust_id).exists():
+            cont_id = None
+
+        if requested_contact_id:
+            try:
+                candidate_contact_id = UUID(str(requested_contact_id))
+            except (TypeError, ValueError):
+                return Response(
+                    {'error': f'Invalid contact_id: {requested_contact_id}'},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            if not Contact.objects.filter(id=candidate_contact_id, company_id=cust_id).exists():
+                return Response(
+                    {'error': 'Selected contact does not belong to the selected customer.'},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            cont_id = candidate_contact_id
+
         # Create QuoteInput
         # Note: If QuoteInput enforces contact_id is not None, we might need to fake it if cont_id is None.
         # But generally, for Spot, we just need basic input.
@@ -2409,6 +2433,11 @@ class SpotEnvelopeCreateQuoteAPIView(APIView):
             quote_date=date.today(),
             output_currency=resolved_output_currency,
         )
+        quote_request_payload = quote_input.model_dump(mode='json')
+        quote_request_payload['contact_id'] = str(cont_id) if cont_id else None
+        quote_request_payload['incoterm'] = shipment.incoterm
+        quote_request_payload['payment_term'] = shipment.payment_term
+        quote_request_payload['service_scope'] = shipment.service_scope
         
         adapter = PricingServiceV4Adapter(quote_input=quote_input, spot_envelope_id=UUID(str(spe_db.id)))
         
@@ -2469,6 +2498,7 @@ class SpotEnvelopeCreateQuoteAPIView(APIView):
         if spe_db.quote:
             quote = spe_db.quote
             quote.status = Quote.Status.DRAFT
+            quote.contact_id = cont_id
             quote.output_currency = quote_input.output_currency
             quote.incoterm = shipment.incoterm
             quote.payment_term = shipment.payment_term
@@ -2477,9 +2507,10 @@ class SpotEnvelopeCreateQuoteAPIView(APIView):
             quote.opportunity = opportunity
             quote.origin_location = origin_loc
             quote.destination_location = dest_loc
-            quote.request_details_json = quote_input.model_dump(mode='json')
+            quote.request_details_json = quote_request_payload
             quote.save(update_fields=[
                 'status',
+                'contact_id',
                 'output_currency',
                 'incoterm',
                 'payment_term',
@@ -2507,7 +2538,7 @@ class SpotEnvelopeCreateQuoteAPIView(APIView):
                 created_by=request.user,
                 organization=getattr(request.user, 'organization', None),
                 status=Quote.Status.DRAFT,
-                request_details_json=quote_input.model_dump(mode='json'),
+                request_details_json=quote_request_payload,
             )
             spe_db.quote = quote
             spe_db.save()
@@ -2525,7 +2556,7 @@ class SpotEnvelopeCreateQuoteAPIView(APIView):
             version_number=new_v_num,
             status=Quote.Status.DRAFT,
             created_by=request.user,
-            payload_json=quote_input.model_dump(mode='json'),
+            payload_json=quote_request_payload,
             reason="Created from SPOT Envelope"
         )
         

--- a/backend/quotes/spot_views.py
+++ b/backend/quotes/spot_views.py
@@ -399,6 +399,10 @@ def _existing_line_source_semantic_signature(line: SPEChargeLineDB) -> tuple[str
 
 
 def _should_preserve_existing_line_audit(existing_line: SPEChargeLineDB, charge: dict) -> bool:
+    incoming_charge_line_id = str(charge.get("charge_line_id") or "").strip()
+    if incoming_charge_line_id and incoming_charge_line_id == str(existing_line.id):
+        return True
+
     incoming_source_label = _incoming_charge_source_label(charge)
     incoming_bucket = str(charge.get("bucket") or "").strip().lower()
     return (
@@ -438,7 +442,9 @@ def _build_spe_charge_line_field_values(
 
     return {
         "envelope": spe_db,
-        "source_batch": source_batch,
+        "source_batch": source_batch if source_batch is not None else (
+            existing_line.source_batch if existing_line is not None else None
+        ),
         "code": charge["code"],
         "description": charge["description"],
         "amount": charge["amount"],

--- a/backend/quotes/tests/test_api_v3.py
+++ b/backend/quotes/tests/test_api_v3.py
@@ -457,6 +457,37 @@ class QuoteCanonicalResultContractAPITest(APITestCase):
             calculation_notes="Stored fallback audit note",
         )
 
+        QuoteLine.objects.create(
+            quote_version=version,
+            service_component=freight_component,
+            cost_pgk=Decimal("0.00"),
+            sell_pgk=Decimal("0.00"),
+            sell_pgk_incl_gst=Decimal("0.00"),
+            sell_fcy=Decimal("0.00"),
+            sell_fcy_incl_gst=Decimal("0.00"),
+            sell_fcy_currency="PGK",
+            bucket="destination_charges",
+            leg="DESTINATION",
+            cost_source="SYSTEM",
+            cost_source_description="Local PGK destination charge",
+            gst_category="GST",
+            gst_rate=Decimal("0.1000"),
+            gst_amount=Decimal("0.00"),
+            is_rate_missing=False,
+            product_code=freight_component.code,
+            component="DESTINATION_LOCAL",
+            basis="Per Shipment",
+            rule_family="FLAT",
+            service_family="PASSTHROUGH",
+            unit_type="SHIPMENT",
+            rate=None,
+            rate_source="DB_TARIFF",
+            canonical_cost_source="DB_TARIFF",
+            is_spot_sourced=False,
+            is_manual_override=False,
+            calculation_notes=None,
+        )
+
         QuoteTotal.objects.create(
             quote_version=version,
             total_cost_pgk=Decimal("120.00"),
@@ -502,7 +533,7 @@ class QuoteCanonicalResultContractAPITest(APITestCase):
         self.assertTrue(detail_quote_result["spot_required"])
         self.assertCountEqual(
             detail_quote_result["missing_components"],
-            ["ORIGIN_LOCAL", "DESTINATION_LOCAL"],
+            ["ORIGIN_LOCAL"],
         )
 
     def test_canonical_line_items_include_required_audit_fields_and_safe_defaults(self):
@@ -510,10 +541,11 @@ class QuoteCanonicalResultContractAPITest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         line_items = response.json()["quote_result"]["line_items"]
-        self.assertEqual(len(line_items), 2)
+        self.assertEqual(len(line_items), 3)
 
-        freight_line = next(line for line in line_items if line["product_code"])
+        freight_line = next(line for line in line_items if line["component"] == "FREIGHT")
         fallback_line = next(line for line in line_items if not line["product_code"])
+        pgk_local_line = next(line for line in line_items if line["component"] == "DESTINATION_LOCAL")
 
         self.assertEqual(freight_line["component"], "FREIGHT")
         self.assertEqual(freight_line["unit_type"], "KG")
@@ -535,6 +567,8 @@ class QuoteCanonicalResultContractAPITest(APITestCase):
         self.assertEqual(fallback_line["calculation_notes"], "Stored fallback audit note")
         self.assertEqual(fallback_line["included_in_total"], False)
         self.assertEqual(fallback_line["quantity"], "1.00")
+        self.assertEqual(fallback_line["fx_applied"], True)
+        self.assertEqual(pgk_local_line["fx_applied"], False)
 
     def test_canonical_rule_family_uses_only_calculation_family_vocabulary(self):
         response = self.client.get(self.detail_url)

--- a/backend/quotes/tests/test_api_v3.py
+++ b/backend/quotes/tests/test_api_v3.py
@@ -399,6 +399,16 @@ class QuoteCanonicalResultContractAPITest(APITestCase):
             service_code=freight_service_code,
         )
 
+        self.origin_component = ServiceComponent.objects.create(
+            code=f"PKP-{uuid4().hex[:6].upper()}",
+            description="Pickup",
+            mode="AIR",
+            leg="ORIGIN",
+            category="LOCAL",
+            unit="SHIPMENT",
+            service_code=freight_service_code,
+        )
+
         QuoteLine.objects.create(
             quote_version=version,
             service_component=freight_component,
@@ -616,3 +626,28 @@ class QuoteCanonicalResultContractAPITest(APITestCase):
         )
         self.assertIn("Stored quote warning", quote_result["warnings"])
         self.assertIn("FX SELL rate missing for AUD; used 1.0 fallback.", quote_result["warnings"])
+
+    def test_quote_result_subcategory_classification(self):
+        """Verify that line items in quote_result have correct subcategories."""
+        quote = self.quote
+        # Create a line with a known component that should map to a subcategory
+        QuoteLine.objects.create(
+            quote_version=quote.latest_version,
+            service_component=self.origin_component,
+            description="Test Pickup",
+            bucket="origin_charges",
+            cost_pgk=Decimal("100"),
+            sell_pgk=Decimal("150"),
+        )
+        
+        url = reverse('quotes:quote-v3-compute-v3', kwargs={'pk': quote.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        quote_result = response.data['quote_result']
+        line_items = quote_result['line_items']
+        
+        # Find the pickup line
+        pickup_line = next((l for l in line_items if l['description'] == "Test Pickup"), None)
+        self.assertIsNotNone(pickup_line)
+        self.assertEqual(pickup_line['subcategory'], "Local Transport / Cartage")

--- a/backend/quotes/tests/test_pdf_export.py
+++ b/backend/quotes/tests/test_pdf_export.py
@@ -13,6 +13,7 @@ from quotes.pdf_service import (
     _get_charge_buckets,
     _get_chargeable_weight,
     _get_location_country_code,
+    _get_totals,
     generate_quote_pdf,
 )
 from services.models import ServiceComponent
@@ -278,3 +279,86 @@ class QuotePDFExportTest(TestCase):
                 {"name": "Destination Charges", "subtotal": Decimal("75.00")},
             ],
         )
+
+    def test_pdf_charge_buckets_exclude_unapplied_conditional_quote_lines(self):
+        quote = Quote.objects.create(
+            customer=self.customer,
+            organization=self.organization,
+            origin_location=self.origin,
+            destination_location=self.dest,
+            quote_number="QT-2026-0001",
+            status="SENT",
+            mode="AIR",
+            shipment_type="IMPORT",
+            output_currency="PGK",
+        )
+        version = QuoteVersion.objects.create(quote=quote, version_number=1)
+
+        QuoteLine.objects.create(
+            quote_version=version,
+            cost_source_description="Import Documentation Fee (Origin)",
+            sell_pgk=Decimal("159.02"),
+            leg="DESTINATION",
+            bucket="origin_charges",
+        )
+        QuoteLine.objects.create(
+            quote_version=version,
+            cost_source_description="Import Origin Customs Clearance",
+            sell_pgk=Decimal("159.02"),
+            leg="ORIGIN",
+            bucket="origin_charges",
+        )
+        QuoteLine.objects.create(
+            quote_version=version,
+            cost_source_description="Import Origin Permit / License",
+            sell_pgk=Decimal("265.04"),
+            leg="ORIGIN",
+            bucket="origin_charges",
+            conditional=True,
+            is_informational=True,
+        )
+        QuoteLine.objects.create(
+            quote_version=version,
+            cost_source_description="Pick-Up Fee (Origin)",
+            sell_pgk=Decimal("689.09"),
+            leg="DESTINATION",
+            bucket="origin_charges",
+        )
+        QuoteLine.objects.create(
+            quote_version=version,
+            cost_source_description="Import Air Freight",
+            sell_pgk=Decimal("3975.53"),
+            leg="MAIN",
+            bucket="airfreight",
+        )
+        QuoteLine.objects.create(
+            quote_version=version,
+            cost_source_description="Destination Charges",
+            sell_pgk=Decimal("1165.00"),
+            leg="DESTINATION",
+            bucket="destination_charges",
+        )
+        QuoteTotal.objects.create(
+            quote_version=version,
+            total_sell_pgk=Decimal("6147.66"),
+            total_sell_pgk_incl_gst=Decimal("6264.16"),
+        )
+
+        buckets = _get_charge_buckets(version)
+        totals = _get_totals(version)
+
+        self.assertEqual(
+            buckets,
+            [
+                {"name": "Origin Charges", "subtotal": Decimal("1007.13")},
+                {"name": "International Freight", "subtotal": Decimal("3975.53")},
+                {"name": "Destination Charges", "subtotal": Decimal("1165.00")},
+            ],
+        )
+        self.assertNotEqual(buckets[0]["subtotal"], Decimal("1272.17"))
+        self.assertEqual(totals["sell_excl_gst"], Decimal("6147.66"))
+        self.assertEqual(totals["gst"], Decimal("116.50"))
+        self.assertEqual(totals["sell_incl_gst"], Decimal("6264.16"))
+
+        pdf_bytes = generate_quote_pdf(str(quote.id))
+        self.assertTrue(pdf_bytes.startswith(b"%PDF"))

--- a/backend/quotes/tests/test_public_quote_api.py
+++ b/backend/quotes/tests/test_public_quote_api.py
@@ -249,6 +249,57 @@ class QuotePublicDetailAPITest(APITestCase):
         self.assertEqual(len(origin_lines), 1)
         self.assertEqual(origin_lines[0]["description"], "AWB Fee")
 
+    def test_public_quote_hides_unapplied_conditional_lines_from_charge_breakdown(self):
+        quote = self._create_quote(service_scope="D2D")
+        quote.quote_number = "QT-2026-0001"
+        quote.output_currency = "PGK"
+        quote.save(update_fields=["quote_number", "output_currency"])
+        version = quote.versions.get(version_number=1)
+
+        QuoteLine.objects.create(
+            quote_version=version,
+            cost_source_description="Import Documentation Fee (Origin)",
+            sell_pgk=Decimal("159.02"),
+            leg="DESTINATION",
+            bucket="origin_charges",
+        )
+        QuoteLine.objects.create(
+            quote_version=version,
+            cost_source_description="Import Origin Customs Clearance",
+            sell_pgk=Decimal("159.02"),
+            leg="ORIGIN",
+            bucket="origin_charges",
+        )
+        QuoteLine.objects.create(
+            quote_version=version,
+            cost_source_description="Import Origin Permit / License",
+            sell_pgk=Decimal("265.04"),
+            leg="ORIGIN",
+            bucket="origin_charges",
+            conditional=True,
+            is_informational=True,
+        )
+        QuoteLine.objects.create(
+            quote_version=version,
+            cost_source_description="Pick-Up Fee (Origin)",
+            sell_pgk=Decimal("689.09"),
+            leg="DESTINATION",
+            bucket="origin_charges",
+        )
+
+        token = build_public_quote_token(str(quote.id))
+        response = self.client.get(self.url, {"token": token})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        payload = response.json()
+        buckets = {bucket["name"]: bucket for bucket in payload["charge_buckets"]}
+        origin_bucket = buckets["Origin Charges"]
+        descriptions = [line["description"] for line in origin_bucket["lines"]]
+
+        self.assertEqual(origin_bucket["subtotal"], "1007.13")
+        self.assertNotIn("Import Origin Permit / License", descriptions)
+        self.assertNotIn("265.04", [line["sell"] for line in origin_bucket["lines"]])
+
     def test_public_quote_includes_branding_payload(self):
         quote = self._create_quote(service_scope="D2D")
         token = build_public_quote_token(str(quote.id))

--- a/backend/quotes/tests/test_public_quote_api.py
+++ b/backend/quotes/tests/test_public_quote_api.py
@@ -8,7 +8,7 @@ from rest_framework.test import APITestCase
 
 from core.models import Location
 from core.tests.helpers import create_location
-from parties.models import Company, Organization, OrganizationBranding
+from parties.models import Company, Contact, Organization, OrganizationBranding
 from quotes.models import Quote, QuoteLine, QuoteTotal, QuoteVersion
 from quotes.public_links import build_public_quote_token
 from services.models import ServiceComponent
@@ -46,16 +46,22 @@ class QuotePublicDetailAPITest(APITestCase):
         self,
         *,
         service_scope=None,
+        contact=None,
+        incoterm="DAP",
+        payment_term=Quote.PaymentTerm.PREPAID,
+        shipment_type=Quote.ShipmentType.EXPORT,
         payload_json=None,
         request_details_json=None,
     ) -> Quote:
         quote = Quote.objects.create(
             customer=self.customer,
+            contact=contact,
             organization=self.organization,
             mode="AIR",
-            shipment_type=Quote.ShipmentType.EXPORT,
-            payment_term=Quote.PaymentTerm.PREPAID,
+            shipment_type=shipment_type,
+            payment_term=payment_term,
             service_scope=service_scope,
+            incoterm=incoterm,
             output_currency="USD",
             origin_location=self.origin,
             destination_location=self.destination,
@@ -81,6 +87,66 @@ class QuotePublicDetailAPITest(APITestCase):
             total_sell_fcy_currency="USD",
         )
         return quote
+
+    def test_public_quote_returns_persisted_customer_and_shipment_details(self):
+        contact = Contact.objects.create(
+            company=self.customer,
+            first_name="Chris",
+            last_name="Im",
+            email="chris@example.com",
+        )
+        quote = self._create_quote(
+            service_scope="D2D",
+            contact=contact,
+            incoterm="EXW",
+            payment_term=Quote.PaymentTerm.COLLECT,
+            shipment_type=Quote.ShipmentType.IMPORT,
+            payload_json={
+                "shipment": {
+                    "pieces": [
+                        {
+                            "pieces": 1,
+                            "length_cm": 0,
+                            "width_cm": 0,
+                            "height_cm": 0,
+                            "gross_weight_kg": 100,
+                        }
+                    ]
+                }
+            },
+        )
+        token = build_public_quote_token(str(quote.id))
+
+        response = self.client.get(self.url, {"token": token})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        payload = response.json()
+        self.assertEqual(payload["customer"]["name"], "Seed Customer")
+        self.assertEqual(payload["customer"]["contact"], "Chris Im")
+        self.assertEqual(payload["customer"]["contact_id"], str(contact.id))
+        self.assertEqual(payload["shipment"]["incoterm"], "EXW")
+        self.assertEqual(payload["shipment"]["payment_term"], "COLLECT")
+        self.assertEqual(payload["shipment"]["service_scope"], "D2D")
+        self.assertEqual(payload["shipment"]["direction"], "IMPORT")
+        self.assertEqual(payload["shipment"]["chargeable_weight_kg"], "100.00")
+        self.assertEqual(payload["route"]["origin_code"], "POM")
+        self.assertEqual(payload["route"]["destination_code"], "HKG")
+        self.assertEqual(payload["totals"]["sell_excl_gst"], "50.00")
+        self.assertEqual(payload["totals"]["gst"], "5.00")
+
+    def test_public_quote_does_not_treat_customer_id_as_missing_contact_fallback(self):
+        quote = self._create_quote(
+            service_scope="D2D",
+            request_details_json={"contact_id": str(self.customer.id)},
+        )
+        token = build_public_quote_token(str(quote.id))
+
+        response = self.client.get(self.url, {"token": token})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        payload = response.json()
+        self.assertIsNone(payload["customer"]["contact"])
+        self.assertIsNone(payload["customer"]["contact_id"])
 
     def test_public_quote_returns_scope_from_quote_field(self):
         quote = self._create_quote(service_scope="A2D")
@@ -299,6 +365,134 @@ class QuotePublicDetailAPITest(APITestCase):
         self.assertEqual(origin_bucket["subtotal"], "1007.13")
         self.assertNotIn("Import Origin Permit / License", descriptions)
         self.assertNotIn("265.04", [line["sell"] for line in origin_bucket["lines"]])
+
+    def test_public_quote_groups_charge_lines_into_customer_facing_subcategories(self):
+        quote = self._create_quote(service_scope="D2D")
+        quote.output_currency = "PGK"
+        quote.save(update_fields=["output_currency"])
+        version = quote.versions.get(version_number=1)
+
+        customs_component = ServiceComponent.objects.create(
+            code="DST-CUST",
+            description="Customs Clearance (Dest)",
+            mode="AIR",
+            leg="DESTINATION",
+            category="CUSTOMS",
+        )
+        agency_component = ServiceComponent.objects.create(
+            code="DST-AGENCY",
+            description="Agency Fee (Dest)",
+            mode="AIR",
+            leg="DESTINATION",
+            category="ACCESSORIAL",
+        )
+        cartage_component = ServiceComponent.objects.create(
+            code="DST-CARTAGE",
+            description="Cartage & Delivery (Dest)",
+            mode="AIR",
+            leg="DESTINATION",
+            category="LOCAL",
+        )
+        cartage_fuel_component = ServiceComponent.objects.create(
+            code="DST-CART-FUEL",
+            description="Cartage Fuel Surcharge (V4)",
+            mode="AIR",
+            leg="DESTINATION",
+            category="ACCESSORIAL",
+        )
+        handling_component = ServiceComponent.objects.create(
+            code="DST-HANDLE",
+            description="Loading Fee / Forklift (Dest)",
+            mode="AIR",
+            leg="DESTINATION",
+            category="HANDLING",
+        )
+        doc_component = ServiceComponent.objects.create(
+            code="DST-DOCS",
+            description="Documentation Fee (Dest)",
+            mode="AIR",
+            leg="DESTINATION",
+            category="DOCUMENTATION",
+        )
+        freight_component = ServiceComponent.objects.create(
+            code="FRT-AIR",
+            description="Import Air Freight",
+            mode="AIR",
+            leg="MAIN",
+            category="TRANSPORT",
+        )
+        surcharge_component = ServiceComponent.objects.create(
+            code="FRT-SEC",
+            description="Security Surcharge",
+            mode="AIR",
+            leg="MAIN",
+            category="ACCESSORIAL",
+        )
+        service_component = ServiceComponent.objects.create(
+            code="DST-PROC",
+            description="Processing Fee",
+            mode="AIR",
+            leg="DESTINATION",
+            category="ACCESSORIAL",
+        )
+        other_component = ServiceComponent.objects.create(
+            code="DST-MISC",
+            description="Miscellaneous Charge",
+            mode="AIR",
+            leg="DESTINATION",
+            category="ACCESSORIAL",
+        )
+
+        line_specs = [
+            (customs_component, "Customs Clearance (Dest)", "300.00", "destination_charges"),
+            (agency_component, "Agency Fee (Dest)", "250.00", "destination_charges"),
+            (cartage_component, "Cartage & Delivery (Dest)", "150.00", "destination_charges"),
+            (cartage_fuel_component, "Cartage Fuel Surcharge (V4)", "15.00", "destination_charges"),
+            (handling_component, "Loading Fee / Forklift (Dest)", "150.00", "destination_charges"),
+            (doc_component, "Documentation Fee (Dest)", "150.00", "destination_charges"),
+            (service_component, "Processing Fee", "40.00", "destination_charges"),
+            (other_component, "Miscellaneous Charge", "10.00", "destination_charges"),
+            (freight_component, "Import Air Freight", "3975.53", "airfreight"),
+            (surcharge_component, "Security Surcharge", "25.00", "airfreight"),
+        ]
+        for component, description, amount, bucket in line_specs:
+            QuoteLine.objects.create(
+                quote_version=version,
+                service_component=component,
+                cost_source_description=description,
+                sell_pgk=Decimal(amount),
+                leg=component.leg,
+                bucket=bucket,
+            )
+
+        token = build_public_quote_token(str(quote.id))
+        response = self.client.get(self.url, {"token": token})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        payload = response.json()
+        buckets = {bucket["name"]: bucket for bucket in payload["charge_buckets"]}
+        destination_groups = {group["name"]: group for group in buckets["Destination Charges"]["groups"]}
+        freight_groups = {group["name"]: group for group in buckets["Freight"]["groups"]}
+
+        self.assertEqual(buckets["Destination Charges"]["subtotal"], "1065.00")
+        self.assertEqual(destination_groups["Customs / Regulatory"]["subtotal"], "550.00")
+        self.assertEqual(
+            [line["description"] for line in destination_groups["Customs / Regulatory"]["lines"]],
+            ["Customs Clearance (Dest)", "Agency Fee (Dest)"],
+        )
+        self.assertEqual(destination_groups["Pickup / Delivery / Cartage"]["subtotal"], "165.00")
+        self.assertEqual(
+            [line["description"] for line in destination_groups["Pickup / Delivery / Cartage"]["lines"]],
+            ["Cartage & Delivery (Dest)", "Cartage Fuel Surcharge (V4)"],
+        )
+        self.assertEqual(destination_groups["Documentation"]["subtotal"], "150.00")
+        self.assertEqual(destination_groups["Handling / Terminal"]["subtotal"], "150.00")
+        self.assertEqual(destination_groups["Service / Agency Fees"]["subtotal"], "40.00")
+        self.assertEqual(destination_groups["Other Charges"]["subtotal"], "10.00")
+
+        self.assertEqual(buckets["Freight"]["subtotal"], "4000.53")
+        self.assertEqual(freight_groups["Freight / Carrier Charges"]["subtotal"], "3975.53")
+        self.assertEqual(freight_groups["Carrier Surcharges"]["subtotal"], "25.00")
 
     def test_public_quote_includes_branding_payload(self):
         quote = self._create_quote(service_scope="D2D")

--- a/backend/quotes/tests/test_spot_compute_completeness.py
+++ b/backend/quotes/tests/test_spot_compute_completeness.py
@@ -11,7 +11,7 @@ from core.dataclasses import CalculatedChargeLine, CalculatedTotals, QuoteCharge
 from core.models import Currency, Country, Location
 from core.tests.helpers import create_location
 from crm.models import Interaction, Opportunity
-from parties.models import Company
+from parties.models import Company, Contact
 from pricing_v4.adapter import PricingServiceV4Adapter, PricingMode
 from quotes.models import Quote
 from quotes.spot_models import SpotPricingEnvelopeDB, SPEAcknowledgementDB, SPEChargeLineDB, SPESourceBatchDB
@@ -291,6 +291,109 @@ def test_spot_create_quote_uses_export_prepaid_pgk_output_currency(monkeypatch):
     quote = Quote.objects.get(id=payload["quote_id"])
     assert captured.get("output_currency") == "PGK"
     assert quote.output_currency == "PGK"
+
+
+def test_spot_create_quote_persists_selected_contact_and_incoterm(monkeypatch):
+    user, origin, destination = _setup_user_and_locations()
+    spe = _create_ready_spe(
+        user=user,
+        origin_code=origin.code,
+        dest_code=destination.code,
+        origin_country="AU",
+        dest_country="PG",
+        service_scope="D2D",
+    )
+
+    def fake_calculate(self):
+        self.pricing_mode = PricingMode.SPOT
+        return _quote_charges_for_buckets(["origin_charges", "airfreight", "destination_charges"])
+
+    monkeypatch.setattr(PricingServiceV4Adapter, "calculate_charges", fake_calculate)
+
+    customer = Company.objects.create(
+        name="Spot Detail Customer",
+        is_customer=True,
+        company_type="CUSTOMER",
+    )
+    contact = Contact.objects.create(
+        company=customer,
+        first_name="Chris",
+        last_name="Im",
+        email="chris@example.com",
+    )
+
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.post(
+        f"/api/v3/spot/envelopes/{spe.id}/create-quote/",
+        {
+            "quote_request": {
+                "service_scope": "D2D",
+                "payment_term": "COLLECT",
+                "output_currency": "PGK",
+                "customer_id": str(customer.id),
+                "contact_id": str(contact.id),
+                "incoterm": "EXW",
+            }
+        },
+        format="json",
+    )
+
+    assert response.status_code == 200
+    quote = Quote.objects.get(id=response.json()["quote_id"])
+    version = quote.versions.get(version_number=1)
+
+    assert quote.customer_id == customer.id
+    assert quote.contact_id == contact.id
+    assert quote.incoterm == "EXW"
+    assert quote.payment_term == "COLLECT"
+    assert quote.service_scope == "D2D"
+    assert quote.request_details_json["contact_id"] == str(contact.id)
+    assert quote.request_details_json["incoterm"] == "EXW"
+    assert version.payload_json["contact_id"] == str(contact.id)
+    assert version.payload_json["incoterm"] == "EXW"
+
+
+def test_spot_create_quote_rejects_contact_from_another_customer(monkeypatch):
+    user, origin, destination = _setup_user_and_locations()
+    spe = _create_ready_spe(
+        user=user,
+        origin_code=origin.code,
+        dest_code=destination.code,
+        origin_country="AU",
+        dest_country="PG",
+        service_scope="D2D",
+    )
+    monkeypatch.setattr(
+        PricingServiceV4Adapter,
+        "calculate_charges",
+        lambda self: _quote_charges_for_buckets(["origin_charges", "airfreight", "destination_charges"]),
+    )
+
+    customer = Company.objects.create(name="Spot Customer", is_customer=True, company_type="CUSTOMER")
+    other_customer = Company.objects.create(name="Other Customer", is_customer=True, company_type="CUSTOMER")
+    other_contact = Contact.objects.create(company=other_customer, first_name="Wrong", last_name="Contact")
+
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.post(
+        f"/api/v3/spot/envelopes/{spe.id}/create-quote/",
+        {
+            "quote_request": {
+                "service_scope": "D2D",
+                "payment_term": "COLLECT",
+                "customer_id": str(customer.id),
+                "contact_id": str(other_contact.id),
+                "incoterm": "EXW",
+            }
+        },
+        format="json",
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"] == "Selected contact does not belong to the selected customer."
 
 
 def test_spot_create_quote_auto_creates_and_links_opportunity(monkeypatch):

--- a/backend/quotes/tests/test_spot_compute_completeness.py
+++ b/backend/quotes/tests/test_spot_compute_completeness.py
@@ -572,6 +572,69 @@ def test_spot_create_quote_blocks_risky_source_batch_until_reviewed(monkeypatch)
     assert response.json()["intake_safety"]["is_safe_to_quote"] is False
 
 
+def test_spot_create_quote_allows_low_confidence_source_warning(monkeypatch):
+    user, origin, destination = _setup_user_and_locations()
+    spe = _create_ready_spe(
+        user=user,
+        origin_code=origin.code,
+        dest_code=destination.code,
+        origin_country="AU",
+        dest_country="PG",
+        service_scope="A2D",
+    )
+    SPESourceBatchDB.objects.create(
+        envelope=spe,
+        source_kind=SPESourceBatchDB.SourceKind.AGENT,
+        source_type=SPESourceBatchDB.SourceType.TEXT,
+        target_bucket=SPESourceBatchDB.TargetBucket.DESTINATION_CHARGES,
+        label="Uploaded rates",
+        source_reference="Uploaded rates",
+        raw_text="Destination fee USD 75",
+        analysis_summary_json={
+            "can_proceed": True,
+            "ai_used": True,
+            "imported_charge_count": 1,
+            "low_confidence_line_count": 1,
+        },
+        created_by=user,
+    )
+    SPEChargeLineDB.objects.create(
+        envelope=spe,
+        code="DESTINATION_LOCAL",
+        description="Destination fee",
+        amount=Decimal("75.00"),
+        currency="USD",
+        unit="flat",
+        bucket="destination_charges",
+        source_reference="Uploaded rates",
+        normalization_status=SPEChargeLineDB.NormalizationStatus.MATCHED,
+        normalization_method=SPEChargeLineDB.NormalizationMethod.EXACT_ALIAS,
+        entered_at=timezone.now(),
+    )
+    monkeypatch.setattr(
+        PricingServiceV4Adapter,
+        "calculate_charges",
+        lambda self: _quote_charges_for_buckets(["destination_charges"]),
+    )
+    customer = Company.objects.create(name="Low Confidence Customer", is_customer=True, company_type="CUSTOMER")
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    detail_response = client.get(f"/api/v3/spot/envelopes/{spe.id}/")
+    assert detail_response.status_code == 200
+    assert detail_response.json()["intake_safety"]["is_safe_to_quote"] is True
+    assert detail_response.json()["sources"][0]["review_status"] == "NOT_REQUIRED"
+
+    response = client.post(
+        f"/api/v3/spot/envelopes/{spe.id}/create-quote/",
+        {"quote_request": {"service_scope": "A2D", "payment_term": "PREPAID", "customer_id": str(customer.id)}},
+        format="json",
+    )
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+
+
 def test_spot_create_quote_blocks_unacknowledged_conditional_matched_line(monkeypatch):
     user, origin, destination = _setup_user_and_locations()
     spe = _create_ready_spe(

--- a/backend/quotes/tests/test_spot_regression_create_quote.py
+++ b/backend/quotes/tests/test_spot_regression_create_quote.py
@@ -121,6 +121,94 @@ def test_manual_resolution_syncs_batch_analysis_summary():
     assert resp.json()["intake_safety"]["is_safe_to_quote"] is True
 
 
+def test_patch_preserves_imported_charge_audit_when_round_tripped_by_id():
+    user, origin, dest, pc = _setup_test_data()
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    spe = SpotPricingEnvelopeDB.objects.create(
+        created_by=user,
+        status="draft",
+        expires_at=timezone.now() + timedelta(days=7),
+        shipment_context_json={
+            "origin_country": "PG",
+            "destination_country": "AU",
+            "origin_code": origin.code,
+            "destination_code": dest.code,
+            "total_weight_kg": 100,
+            "pieces": 1,
+            "commodity": "GCR",
+            "service_scope": "D2D",
+        },
+        spot_trigger_reason_code=SpotTriggerReason.MISSING_SCOPE_RATES,
+        spot_trigger_reason_text="Missing required rate components",
+    )
+    batch = SPESourceBatchDB.objects.create(
+        envelope=spe,
+        source_kind="AGENT",
+        source_type="TEXT",
+        label="Agent reply",
+        analysis_summary_json={"can_proceed": True, "unmapped_line_count": 0, "risk_level": "LOW"},
+    )
+    line = SPEChargeLineDB.objects.create(
+        envelope=spe,
+        source_batch=batch,
+        code="FRT_SPOT",
+        description="Import Air Freight",
+        amount=Decimal("100.00"),
+        currency="USD",
+        unit="per_kg",
+        bucket="airfreight",
+        is_primary_cost=True,
+        source_label="A/F",
+        normalized_label="a f",
+        normalization_status=SPEChargeLineDB.NormalizationStatus.MATCHED,
+        normalization_method=SPEChargeLineDB.NormalizationMethod.EXACT_ALIAS,
+        resolved_product_code=pc,
+        source_reference="Agent email",
+        source_line_identity="agent:1",
+        entered_at=timezone.now(),
+        entered_by=user,
+    )
+
+    detail_url = reverse("quotes:spot-envelope-detail", kwargs={"envelope_id": spe.id})
+    response = client.patch(
+        detail_url,
+        {
+            "charges": [
+                {
+                    "charge_line_id": str(line.id),
+                    "code": line.code,
+                    "description": line.description,
+                    "amount": "125.00",
+                    "currency": line.currency,
+                    "unit": line.unit,
+                    "bucket": line.bucket,
+                    "is_primary_cost": line.is_primary_cost,
+                    "conditional": line.conditional,
+                    "source_reference": line.source_reference,
+                    "source_line_identity": line.source_line_identity,
+                }
+            ]
+        },
+        format="json",
+    )
+
+    assert response.status_code == 200
+    payload_line = response.json()["charges"][0]
+    assert payload_line["id"] == str(line.id)
+    assert payload_line["source_label"] == "A/F"
+    assert payload_line["normalization_status"] == "MATCHED"
+    assert payload_line["effective_resolved_product_code"]["id"] == pc.id
+
+    line.refresh_from_db()
+    assert line.amount == Decimal("125.00")
+    assert line.source_batch_id == batch.id
+    assert line.source_label == "A/F"
+    assert line.normalization_status == SPEChargeLineDB.NormalizationStatus.MATCHED
+    assert line.resolved_product_code_id == pc.id
+
+
 def test_a2a_service_scope_schema_support():
     """Verify that 'a2a' service scope is supported in the Pydantic schema."""
     context = SPEShipmentContext(

--- a/backend/quotes/views/public.py
+++ b/backend/quotes/views/public.py
@@ -9,7 +9,12 @@ from rest_framework.throttling import ScopedRateThrottle
 from rest_framework.views import APIView
 
 from quotes.branding import get_quote_branding
-from quotes.buckets import resolve_quote_line_leg
+from quotes.buckets import (
+    resolve_quote_line_leg,
+    resolve_quote_line_sell_value,
+    should_display_quote_line,
+    should_include_quote_line_in_subtotal,
+)
 from quotes.models import Quote, QuoteLine, QuoteTotal
 from quotes.public_links import get_public_quote_id_from_token
 
@@ -104,17 +109,11 @@ def _resolve_service_scope(quote: Quote, version) -> str | None:
 
 
 def _resolve_line_sell_value(line, quote_currency: str) -> Decimal:
-    if quote_currency != "PGK":
-        line_currency = str(getattr(line, "sell_fcy_currency", "") or "").upper()
-        if line_currency == quote_currency and getattr(line, "sell_fcy", None) is not None:
-            return line.sell_fcy
-    return line.sell_pgk or Decimal("0")
+    return resolve_quote_line_sell_value(line, quote_currency)
 
 
 def _should_include_public_line(line, quote_currency: str) -> bool:
-    if getattr(line, "is_informational", False):
-        return True
-    return _resolve_line_sell_value(line, quote_currency) > Decimal("0")
+    return should_display_quote_line(line, quote_currency)
 
 
 def _build_public_charge_buckets(lines, currency: str) -> list[dict]:
@@ -145,7 +144,7 @@ def _build_public_charge_buckets(lines, currency: str) -> list[dict]:
         }
 
         buckets[leg]['lines'].append(line_data)
-        if not line.is_informational:
+        if should_include_quote_line_in_subtotal(line, currency):
             buckets[leg]['subtotal'] += sell_value
 
     return [

--- a/backend/quotes/views/public.py
+++ b/backend/quotes/views/public.py
@@ -1,5 +1,6 @@
 import re
 from decimal import Decimal
+from uuid import UUID
 
 from django.shortcuts import get_object_or_404
 from rest_framework import status
@@ -10,11 +11,14 @@ from rest_framework.views import APIView
 
 from quotes.branding import get_quote_branding
 from quotes.buckets import (
+    PUBLIC_CHARGE_SUBCATEGORY_ORDER,
+    classify_quote_line_public_subcategory,
     resolve_quote_line_leg,
     resolve_quote_line_sell_value,
     should_display_quote_line,
     should_include_quote_line_in_subtotal,
 )
+from parties.models import Contact
 from quotes.models import Quote, QuoteLine, QuoteTotal
 from quotes.public_links import get_public_quote_id_from_token
 
@@ -108,6 +112,152 @@ def _resolve_service_scope(quote: Quote, version) -> str | None:
     )
 
 
+def _iter_payloads(quote: Quote, version):
+    for payload in (getattr(version, "payload_json", None), quote.request_details_json):
+        if isinstance(payload, dict):
+            yield payload
+
+
+def _coerce_uuid(value) -> UUID | None:
+    if not value:
+        return None
+    try:
+        return UUID(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _payload_get(payload: dict, *path):
+    current = payload
+    for key in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+def _extract_payload_contact_id(payload: dict) -> UUID | None:
+    for candidate in (
+        payload.get("contact_id"),
+        _payload_get(payload, "quote_request", "contact_id"),
+        _payload_get(payload, "customer", "contact_id"),
+    ):
+        contact_id = _coerce_uuid(candidate)
+        if contact_id:
+            return contact_id
+    return None
+
+
+def _resolve_public_contact(quote: Quote, version) -> Contact | None:
+    if quote.contact_id:
+        return quote.contact
+
+    for payload in _iter_payloads(quote, version):
+        contact_id = _extract_payload_contact_id(payload)
+        if not contact_id:
+            continue
+        contact = Contact.objects.filter(id=contact_id, company_id=quote.customer_id).first()
+        if contact:
+            return contact
+
+    return None
+
+
+def _format_contact_name(contact: Contact | None) -> str | None:
+    if not contact:
+        return None
+    name = f"{contact.first_name or ''} {contact.last_name or ''}".strip()
+    return name or contact.email or None
+
+
+def _to_decimal(value) -> Decimal | None:
+    if value in (None, ""):
+        return None
+    try:
+        return Decimal(str(value))
+    except Exception:
+        return None
+
+
+def _extract_piece_list(payload: dict) -> list[dict]:
+    candidates = (
+        _payload_get(payload, "shipment", "pieces"),
+        payload.get("pieces"),
+        payload.get("dimensions"),
+        _payload_get(payload, "cargo", "pieces"),
+    )
+    for candidate in candidates:
+        if isinstance(candidate, list):
+            return [piece for piece in candidate if isinstance(piece, dict)]
+    return []
+
+
+def _piece_value(piece: dict, *keys) -> Decimal | None:
+    for key in keys:
+        value = _to_decimal(piece.get(key))
+        if value is not None:
+            return value
+    return None
+
+
+def _calculate_chargeable_weight_from_pieces(pieces: list[dict]) -> Decimal | None:
+    if not pieces:
+        return None
+
+    gross_total = Decimal("0")
+    volumetric_total = Decimal("0")
+    has_weight = False
+    has_dimensions = False
+
+    for piece in pieces:
+        count = _piece_value(piece, "pieces", "quantity", "qty") or Decimal("1")
+        gross = _piece_value(piece, "gross_weight_kg", "weight_kg", "weight")
+        if gross is not None:
+            gross_total += gross * count
+            has_weight = True
+
+        length = _piece_value(piece, "length_cm", "length")
+        width = _piece_value(piece, "width_cm", "width")
+        height = _piece_value(piece, "height_cm", "height")
+        if length is not None and width is not None and height is not None and length > 0 and width > 0 and height > 0:
+            volumetric_total += (length * width * height * count) / Decimal("6000")
+            has_dimensions = True
+
+    if has_weight or has_dimensions:
+        return max(gross_total, volumetric_total)
+    return None
+
+
+def _resolve_chargeable_weight(quote: Quote, version) -> Decimal | None:
+    chargeable_paths = (
+        ("chargeable_weight_kg",),
+        ("chargeable_weight",),
+        ("total_chargeable_weight_kg",),
+        ("shipment", "chargeable_weight_kg"),
+        ("shipment", "chargeable_weight"),
+    )
+    gross_weight_fallback_paths = (
+        ("total_weight_kg",),
+        ("shipment", "total_weight_kg"),
+        ("shipment_context", "total_weight_kg"),
+    )
+
+    for payload in _iter_payloads(quote, version):
+        for path in chargeable_paths:
+            value = _to_decimal(_payload_get(payload, *path))
+            if value is not None:
+                return value
+        piece_weight = _calculate_chargeable_weight_from_pieces(_extract_piece_list(payload))
+        if piece_weight is not None:
+            return piece_weight
+        for path in gross_weight_fallback_paths:
+            value = _to_decimal(_payload_get(payload, *path))
+            if value is not None:
+                return value
+
+    return None
+
+
 def _resolve_line_sell_value(line, quote_currency: str) -> Decimal:
     return resolve_quote_line_sell_value(line, quote_currency)
 
@@ -116,11 +266,31 @@ def _should_include_public_line(line, quote_currency: str) -> bool:
     return should_display_quote_line(line, quote_currency)
 
 
+def _public_group_line_sort_key(group_name: str, line_data: dict) -> tuple[int, str]:
+    description = str(line_data.get("description") or "").lower()
+    priority = 10
+
+    if group_name == "Customs / Regulatory":
+        if "customs" in description or "clearance" in description:
+            priority = 0
+        elif "agency fee" in description:
+            priority = 1
+    elif group_name == "Pickup / Delivery / Cartage":
+        if "cartage fuel surcharge" in description:
+            priority = 1
+        elif "fuel surcharge" in description:
+            priority = 2
+        else:
+            priority = 0
+
+    return priority, description
+
+
 def _build_public_charge_buckets(lines, currency: str) -> list[dict]:
     buckets = {
-        'ORIGIN': {'name': 'Origin Charges', 'lines': [], 'subtotal': Decimal('0')},
-        'MAIN': {'name': 'Freight', 'lines': [], 'subtotal': Decimal('0')},
-        'DESTINATION': {'name': 'Destination Charges', 'lines': [], 'subtotal': Decimal('0')},
+        'ORIGIN': {'name': 'Origin Charges', 'lines': [], 'groups': {}, 'subtotal': Decimal('0')},
+        'MAIN': {'name': 'Freight', 'lines': [], 'groups': {}, 'subtotal': Decimal('0')},
+        'DESTINATION': {'name': 'Destination Charges', 'lines': [], 'groups': {}, 'subtotal': Decimal('0')},
     }
 
     for line in lines:
@@ -142,19 +312,56 @@ def _build_public_charge_buckets(lines, currency: str) -> list[dict]:
             'sell': _format_decimal(sell_value),
             'is_informational': line.is_informational,
         }
+        subcategory = classify_quote_line_public_subcategory(line)
+        line_data['subcategory'] = subcategory
 
         buckets[leg]['lines'].append(line_data)
         if should_include_quote_line_in_subtotal(line, currency):
             buckets[leg]['subtotal'] += sell_value
+            group = buckets[leg]['groups'].setdefault(
+                subcategory,
+                {'name': subcategory, 'lines': [], 'subtotal': Decimal('0')},
+            )
+            group['subtotal'] += sell_value
+            group['lines'].append(line_data)
+        else:
+            group = buckets[leg]['groups'].setdefault(
+                subcategory,
+                {'name': subcategory, 'lines': [], 'subtotal': Decimal('0')},
+            )
+            group['lines'].append(line_data)
 
-    return [
-        {
-            'name': bucket['name'],
-            'lines': bucket['lines'],
-            'subtotal': _format_decimal(bucket['subtotal']),
-        }
-        for bucket in buckets.values() if bucket['lines']
-    ]
+    response_buckets = []
+    for bucket in buckets.values():
+        if not bucket['lines']:
+            continue
+
+        groups = []
+        bucket_lines = []
+        for group_name in PUBLIC_CHARGE_SUBCATEGORY_ORDER:
+            group = bucket['groups'].get(group_name)
+            if not group:
+                continue
+            sorted_lines = sorted(group['lines'], key=lambda line: _public_group_line_sort_key(group_name, line))
+            bucket_lines.extend(sorted_lines)
+            groups.append(
+                {
+                    'name': group['name'],
+                    'lines': sorted_lines,
+                    'subtotal': _format_decimal(group['subtotal']),
+                }
+            )
+
+        response_buckets.append(
+            {
+                'name': bucket['name'],
+                'lines': bucket_lines,
+                'groups': groups,
+                'subtotal': _format_decimal(bucket['subtotal']),
+            }
+        )
+
+    return response_buckets
 
 
 def _calculate_public_totals(totals: QuoteTotal | None, currency: str) -> dict:
@@ -236,13 +443,15 @@ class QuotePublicDetailAPIView(APIView):
 
         lines = QuoteLine.objects.select_related('service_component').filter(
             quote_version=version
-        ).order_by('service_component__category', 'id')
+        ).order_by('id')
 
         totals = QuoteTotal.objects.filter(quote_version=version).first()
         currency = quote.output_currency or 'PGK'
         origin_code, origin_name = _parse_location_label(quote.origin_location)
         destination_code, destination_name = _parse_location_label(quote.destination_location)
         resolved_service_scope = _resolve_service_scope(quote, version)
+        selected_contact = _resolve_public_contact(quote, version)
+        chargeable_weight = _resolve_chargeable_weight(quote, version)
         branding = get_quote_branding(quote, request=request)
 
         response_data = {
@@ -252,7 +461,8 @@ class QuotePublicDetailAPIView(APIView):
             'valid_until': quote.valid_until.isoformat() if quote.valid_until else None,
             'customer': {
                 'name': quote.customer.name if quote.customer else 'Customer',
-                'contact': f"{quote.contact.first_name} {quote.contact.last_name}".strip() if quote.contact else None,
+                'contact': _format_contact_name(selected_contact),
+                'contact_id': str(selected_contact.id) if selected_contact else None,
             },
             'shipment': {
                 'mode': quote.mode,
@@ -260,6 +470,7 @@ class QuotePublicDetailAPIView(APIView):
                 'service_scope': resolved_service_scope,
                 'incoterm': quote.incoterm,
                 'payment_term': quote.payment_term,
+                'chargeable_weight_kg': _format_decimal(chargeable_weight) if chargeable_weight is not None else None,
             },
             'route': {
                 'origin_code': origin_code,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "test:quote-workflow": "node scripts/quote-workflow-roundtrip.test.mjs",
     "test:crm-quote-prefill": "node scripts/crm-quote-prefill.test.mjs",
     "test:domestic-service-scope": "node scripts/domestic-service-scope.test.mjs",
+    "test:spot-finalization": "node scripts/spot-finalization.test.mjs",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",

--- a/frontend/scripts/spot-finalization.test.mjs
+++ b/frontend/scripts/spot-finalization.test.mjs
@@ -28,7 +28,10 @@ async function loadModule() {
   }
 }
 
-const { getSpotFinalizeDisabledReason } = await loadModule();
+const {
+  getSpotFinalizeDisabledReason,
+  getSpotFinalizeFormDisabledReason,
+} = await loadModule();
 
 const baseSpe = {
   acknowledgement: null,
@@ -66,9 +69,10 @@ assert.match(
   getSpotFinalizeDisabledReason({
     spe: baseSpe,
     unresolvedReviewIssueCount: 2,
+    unresolvedReviewIssueLabels: ["Import Air Freight", "Documentation Fee"],
   }) || "",
-  /Resolve 2 issues before creating quote/,
-  "unresolved charge blockers should expose a clear disabled reason",
+  /Resolve 2 issues before creating quote: Import Air Freight, Documentation Fee\./,
+  "unresolved charge blockers should name affected charges",
 );
 
 assert.equal(
@@ -140,4 +144,81 @@ assert.match(
   "unacknowledged source blockers should show the backend blocking issue",
 );
 
-console.log("spot finalization gating checks passed");
+assert.equal(
+  getSpotFinalizeDisabledReason({
+    spe: {
+      ...baseSpe,
+      intake_safety: {
+        is_safe_to_quote: false,
+        blocking_issues: ["Uploaded rates: 2 extracted charge line(s) were low-confidence."],
+        pending_source_batch_ids: ["source-1"],
+        pending_source_labels: ["Uploaded rates"],
+        review_note_required_batch_ids: [],
+      },
+    },
+    unresolvedReviewIssueCount: 0,
+  }),
+  null,
+  "low-confidence source warnings should stay visible but not disable final quote creation",
+);
+
+const readyAcknowledgedSpe = {
+  acknowledgement: { acknowledged_at: "2026-05-11T00:00:00Z" },
+  can_proceed: true,
+  intake_safety: { is_safe_to_quote: false, blocking_issues: ["AI audit flagged fallback extraction."] },
+  is_expired: false,
+  missing_mandatory_fields: [],
+  status: "ready",
+};
+
+assert.equal(
+  getSpotFinalizeDisabledReason({
+    spe: readyAcknowledgedSpe,
+    unresolvedReviewIssueCount: 0,
+  }),
+  null,
+  "acknowledged unsafe-audit fallback must not block when backend can proceed",
+);
+
+assert.equal(
+  getSpotFinalizeFormDisabledReason({
+    finalizeDisabledReason: null,
+    editableChargeCount: 0,
+    isFormValid: false,
+    allowEmptySubmit: true,
+  }),
+  null,
+  "ready SPEs with no editable manual rows must still be submittable",
+);
+
+assert.match(
+  getSpotFinalizeFormDisabledReason({
+    finalizeDisabledReason: null,
+    editableChargeCount: 0,
+    isFormValid: false,
+    allowEmptySubmit: false,
+  }),
+  /at least one SPOT charge line/,
+);
+
+assert.match(
+  getSpotFinalizeFormDisabledReason({
+    finalizeDisabledReason: null,
+    editableChargeCount: 2,
+    isFormValid: false,
+    allowEmptySubmit: true,
+  }),
+  /Complete the visible SPOT charge fields/,
+);
+
+assert.equal(
+  getSpotFinalizeFormDisabledReason({
+    finalizeDisabledReason: "Resolve 1 issue before creating quote.",
+    editableChargeCount: 0,
+    isFormValid: false,
+    allowEmptySubmit: true,
+  }),
+  "Resolve 1 issue before creating quote.",
+);
+
+console.log("spot finalization checks passed");

--- a/frontend/src/app/crm/activities/page.tsx
+++ b/frontend/src/app/crm/activities/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { CrmSubNav } from '@/components/crm/CrmSubNav';
+import { InteractionLogSheet } from '@/components/crm/InteractionLogSheet';
 import { TaskDialog } from '@/components/crm/TaskDialog';
 import { PageHeader, StandardPageContainer } from '@/components/layout/standard-page';
 import ProtectedRoute from '@/components/protected-route';
@@ -115,6 +116,7 @@ export default function CrmActivitiesPage() {
   const [interactions, setInteractions] = useState<Interaction[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [quickLogOpen, setQuickLogOpen] = useState(false);
   const [taskDialogOpen, setTaskDialogOpen] = useState(false);
   const [editingTask, setEditingTask] = useState<Task | null>(null);
   const [completingTaskIds, setCompletingTaskIds] = useState<Set<string>>(() => new Set());
@@ -277,9 +279,14 @@ export default function CrmActivitiesPage() {
           title="Activities"
           description="Manage CRM follow-up tasks and recent customer activity."
           actions={
-            <Button type="button" onClick={openCreateDialog}>
-              Create Task
-            </Button>
+            <>
+              <Button type="button" variant="outline" onClick={() => setQuickLogOpen(true)}>
+                Log Activity
+              </Button>
+              <Button type="button" onClick={openCreateDialog}>
+                Create Task
+              </Button>
+            </>
           }
         />
 
@@ -529,6 +536,15 @@ export default function CrmActivitiesPage() {
           }}
           onSaved={() => {
             void loadData();
+          }}
+        />
+        <InteractionLogSheet
+          open={quickLogOpen}
+          onOpenChange={(nextOpen) => {
+            setQuickLogOpen(nextOpen);
+            if (!nextOpen) {
+              void loadData();
+            }
           }}
         />
       </StandardPageContainer>

--- a/frontend/src/app/public/quote/PublicQuoteActions.tsx
+++ b/frontend/src/app/public/quote/PublicQuoteActions.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Download, Mail } from "lucide-react";
+
+type PublicQuoteActionsProps = {
+  quoteNumber: string;
+  supportEmail?: string | null;
+  brandPrimary: string;
+  brandAccent: string;
+};
+
+export function PublicQuoteActions({
+  quoteNumber,
+  supportEmail,
+  brandPrimary,
+  brandAccent,
+}: PublicQuoteActionsProps) {
+  const approvalHref = supportEmail
+    ? `mailto:${supportEmail}?subject=${encodeURIComponent(`Approval for ${quoteNumber}`)}`
+    : undefined;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <button
+        type="button"
+        onClick={() => window.print()}
+        className="inline-flex h-10 w-full items-center justify-center gap-2 whitespace-nowrap rounded-md border border-slate-300 bg-white px-4 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-slate-400 hover:bg-slate-50"
+      >
+        <Download className="h-4 w-4" aria-hidden="true" />
+        Print / Save PDF
+      </button>
+      {approvalHref ? (
+        <a
+          href={approvalHref}
+          className="inline-flex h-10 w-full items-center justify-center gap-2 whitespace-nowrap rounded-md px-4 text-sm font-semibold text-white shadow-sm transition hover:brightness-95"
+          style={{ backgroundColor: brandAccent || brandPrimary }}
+        >
+          <Mail className="h-4 w-4" aria-hidden="true" />
+          Approve by Email
+        </a>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/app/public/quote/page.tsx
+++ b/frontend/src/app/public/quote/page.tsx
@@ -10,12 +10,20 @@ type PublicQuoteLine = {
   source: string;
   sell: string;
   is_informational: boolean;
+  subcategory?: string;
+};
+
+type PublicQuoteGroup = {
+  name: string;
+  subtotal: string;
+  lines: PublicQuoteLine[];
 };
 
 type PublicQuoteBucket = {
   name: string;
   subtotal: string;
   lines: PublicQuoteLine[];
+  groups?: PublicQuoteGroup[];
 };
 
 type PublicQuoteResponse = {
@@ -37,6 +45,7 @@ type PublicQuoteResponse = {
   customer: {
     name: string;
     contact: string | null;
+    contact_id?: string | null;
   };
   shipment: {
     mode: string;
@@ -44,6 +53,7 @@ type PublicQuoteResponse = {
     service_scope: string | null;
     incoterm: string | null;
     payment_term: string | null;
+    chargeable_weight_kg?: string | null;
   };
   route: {
     origin_code: string;
@@ -84,6 +94,20 @@ const formatDate = (value: string | null) => {
     month: "short",
     day: "numeric",
   });
+};
+
+const formatWeight = (value: string | number | null | undefined) => {
+  if (value === null || value === undefined || value === "") {
+    return "N/A";
+  }
+  const amount = typeof value === "number" ? value : Number(value);
+  if (Number.isNaN(amount)) {
+    return `${value} kg`;
+  }
+  return `${amount.toLocaleString("en-US", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  })} kg`;
 };
 
 const withAlpha = (hex: string, alphaHex: string) => {
@@ -308,7 +332,9 @@ export default async function PublicQuotePage({ searchParams }: PublicQuotePageP
               <div className="mt-5 grid grid-cols-2 gap-5">
                 <DetailItem label="Customer" value={data.customer.name} />
                 <DetailItem label="Contact" value={data.customer.contact} />
-                <DetailItem label="Shipment" value={[data.shipment.mode, data.shipment.direction].filter(Boolean).join(" / ")} />
+                <DetailItem label="Mode" value={data.shipment.mode} />
+                <DetailItem label="Direction" value={data.shipment.direction} />
+                <DetailItem label="Charge Weight" value={formatWeight(data.shipment.chargeable_weight_kg)} />
                 <DetailItem label="Payment" value={formatPaymentTerm(data.shipment.payment_term)} />
                 <DetailItem label="Service Scope" value={formatServiceScope(data.shipment.service_scope)} />
                 <DetailItem label="Incoterm" value={data.shipment.incoterm ? formatIncoterm(data.shipment.incoterm) : "N/A"} />
@@ -355,53 +381,109 @@ export default async function PublicQuotePage({ searchParams }: PublicQuotePageP
               <div className="text-sm text-slate-500">Shared quote link valid for 7 days</div>
             </div>
 
-            <div className="mt-5 overflow-hidden rounded-lg border border-slate-200">
-              {data.charge_buckets.map((bucket, bucketIndex) => (
-                <div key={bucket.name} className={bucketIndex > 0 ? "border-t border-slate-200" : ""}>
-                  <div className="flex flex-col gap-2 bg-slate-50 px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
-                    <div>
-                      <div className="text-base font-semibold text-slate-950">{bucketLabel(bucket.name)}</div>
-                      <div className="text-sm text-slate-500">{bucket.lines.length} line{bucket.lines.length === 1 ? "" : "s"}</div>
-                    </div>
-                    <div className="text-right">
-                      <div className="text-xs font-semibold text-slate-500">Subtotal</div>
-                      <div className="text-lg font-semibold text-slate-950">{formatMoney(data.currency, bucket.subtotal)}</div>
-                    </div>
-                  </div>
+            <div className="mt-5 space-y-4">
+              {data.charge_buckets.map((bucket) => {
+                const groups = bucket.groups && bucket.groups.length > 0
+                  ? bucket.groups
+                  : [{ name: "Other Charges", subtotal: bucket.subtotal, lines: bucket.lines }];
 
-                  {!summaryOnly ? (
-                    <div className="overflow-x-auto">
-                      <table className="w-full min-w-[560px] text-left text-sm">
-                        <thead className="border-y border-slate-200 bg-white text-slate-500">
-                          <tr>
-                            <th className="px-4 py-3 font-semibold">Description</th>
-                            <th className="px-4 py-3 text-right font-semibold">Amount</th>
-                          </tr>
-                        </thead>
-                        <tbody className="divide-y divide-slate-100 bg-white">
-                          {bucket.lines.map((line, index) => (
-                            <tr key={`${bucket.name}-${index}`} className={line.is_informational ? "bg-slate-50 text-slate-500" : "text-slate-700"}>
-                              <td className="px-4 py-3">
-                                <div className="font-medium text-slate-800">{line.description}</div>
-                                {line.is_informational ? (
-                                  <div className="mt-1 inline-flex rounded-full border border-slate-200 bg-white px-2 py-0.5 text-xs font-semibold text-slate-500">
-                                    Not included in subtotal
-                                  </div>
-                                ) : null}
-                              </td>
-                              <td className="whitespace-nowrap px-4 py-3 text-right font-semibold">
-                                {formatMoney(data.currency, line.sell)}
-                              </td>
-                            </tr>
-                          ))}
-                        </tbody>
-                      </table>
+                return (
+                  <div
+                    key={bucket.name}
+                    className="overflow-hidden rounded-lg border border-slate-200 bg-white"
+                  >
+                    {/* ── Level 1: Main Bucket Header ── */}
+                    <div
+                      className="flex flex-col gap-2 border-l-4 px-5 py-4 sm:flex-row sm:items-center sm:justify-between"
+                      style={{ borderLeftColor: brandPrimary, backgroundColor: withAlpha(brandPrimary, "08") || "#f8fafc" }}
+                    >
+                      <div>
+                        <h3 className="text-base font-bold tracking-tight text-slate-950">
+                          {bucketLabel(bucket.name)}
+                        </h3>
+                        <p className="mt-0.5 text-xs text-slate-500">
+                          {bucket.lines.length} line{bucket.lines.length === 1 ? "" : "s"}
+                        </p>
+                      </div>
+                      <div className="text-right">
+                        <div className="text-[11px] font-semibold uppercase tracking-wider text-slate-400">
+                          Subtotal
+                        </div>
+                        <div className="mt-0.5 text-xl font-bold text-slate-950">
+                          {formatMoney(data.currency, bucket.subtotal)}
+                        </div>
+                      </div>
                     </div>
-                  ) : null}
-                </div>
-              ))}
+
+                    {!summaryOnly ? (
+                      <div>
+                        {/* Single table header per bucket */}
+                        <div className="flex items-center justify-between border-b border-slate-100 bg-slate-50/60 px-5 py-2 text-[11px] font-semibold uppercase tracking-wider text-slate-400">
+                          <span className="pl-4">Description</span>
+                          <span>Amount</span>
+                        </div>
+
+                        {groups.map((group, groupIndex) => (
+                          <div
+                            key={`${bucket.name}-${group.name}`}
+                            className={groupIndex > 0 ? "mt-0" : ""}
+                          >
+                            {/* ── Level 2: Sub-Category Header ── */}
+                            <div
+                              className={`flex items-center justify-between border-l-2 border-slate-300 px-5 py-2.5 ${groupIndex > 0 ? "border-t border-t-slate-100" : ""}`}
+                              style={{ backgroundColor: "#f8fafc" }}
+                            >
+                              <div className="flex items-center gap-2">
+                                <span className="text-[13px] font-semibold text-slate-700">
+                                  {group.name}
+                                </span>
+                                <span className="text-[11px] text-slate-400">
+                                  ({group.lines.length})
+                                </span>
+                              </div>
+                              <span className="text-[13px] font-semibold text-slate-700">
+                                {formatMoney(data.currency, group.subtotal)}
+                              </span>
+                            </div>
+
+                            {/* ── Level 3: Charge Lines ── */}
+                            <div className="overflow-x-auto">
+                              <table className="w-full min-w-[560px] text-left text-sm">
+                                <tbody>
+                                  {group.lines.map((line, index) => (
+                                    <tr
+                                      key={`${bucket.name}-${group.name}-${index}`}
+                                      className={`border-b border-slate-50 last:border-b-0 ${line.is_informational ? "bg-slate-50/50 text-slate-400" : "text-slate-600"}`}
+                                    >
+                                      <td className="py-2.5 pl-9 pr-4">
+                                        <span className={`text-[13px] ${line.is_informational ? "text-slate-400" : "font-medium text-slate-700"}`}>
+                                          {line.description}
+                                        </span>
+                                        {line.is_informational ? (
+                                          <span className="ml-2 inline-flex rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[10px] font-semibold text-slate-400">
+                                            Not included in subtotal
+                                          </span>
+                                        ) : null}
+                                      </td>
+                                      <td className="whitespace-nowrap px-5 py-2.5 text-right text-[13px] font-medium text-slate-600">
+                                        {formatMoney(data.currency, line.sell)}
+                                      </td>
+                                    </tr>
+                                  ))}
+                                </tbody>
+                              </table>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    ) : null}
+                  </div>
+                );
+              })}
               {data.charge_buckets.length === 0 ? (
-                <div className="bg-white px-4 py-8 text-center text-sm text-slate-500">No charge lines available.</div>
+                <div className="rounded-lg border border-slate-200 bg-white px-4 py-8 text-center text-sm text-slate-500">
+                  No charge lines available.
+                </div>
               ) : null}
             </div>
           </section>

--- a/frontend/src/app/public/quote/page.tsx
+++ b/frontend/src/app/public/quote/page.tsx
@@ -1,6 +1,9 @@
 import { notFound } from "next/navigation";
+import type { ReactNode } from "react";
+import { ArrowRight, CalendarDays, Globe2, Mail, MapPin, Phone, Plane, ReceiptText, ShieldCheck } from "lucide-react";
 import { API_BASE_URL } from "@/lib/config";
 import { formatIncoterm, formatPaymentTerm, formatServiceScope } from "@/lib/display";
+import { PublicQuoteActions } from "./PublicQuoteActions";
 
 type PublicQuoteLine = {
   description: string;
@@ -74,6 +77,15 @@ const formatMoney = (currency: string, value: string | number | null) => {
   })}`;
 };
 
+const formatDate = (value: string | null) => {
+  if (!value) return "N/A";
+  return new Date(value).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+};
+
 const withAlpha = (hex: string, alphaHex: string) => {
   const value = (hex || "").trim();
   if (!/^#[0-9A-Fa-f]{6}$/.test(value)) {
@@ -81,6 +93,14 @@ const withAlpha = (hex: string, alphaHex: string) => {
   }
   return `${value}${alphaHex}`;
 };
+
+const statusLabel = (status: string) =>
+  status
+    .toLowerCase()
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+
+const bucketLabel = (name: string) => (name === "Freight" ? "International Freight" : name);
 
 type PublicQuoteSearchParams = {
   token?: string | string[];
@@ -91,6 +111,31 @@ type PublicQuoteSearchParams = {
 type PublicQuotePageProps = {
   searchParams?: Promise<PublicQuoteSearchParams>;
 };
+
+function DetailItem({ label, value }: { label: string; value: string | null | undefined }) {
+  return (
+    <div className="min-w-0">
+      <div className="text-xs font-semibold text-slate-500">{label}</div>
+      <div className="mt-1 truncate text-sm font-semibold text-slate-950">{value || "N/A"}</div>
+    </div>
+  );
+}
+
+function ContactItem({
+  icon,
+  value,
+}: {
+  icon: ReactNode;
+  value: string | null | undefined;
+}) {
+  if (!value) return null;
+  return (
+    <div className="inline-flex items-center gap-2 text-sm text-slate-600">
+      <span className="text-slate-400">{icon}</span>
+      <span>{value}</span>
+    </div>
+  );
+}
 
 export default async function PublicQuotePage({ searchParams }: PublicQuotePageProps) {
   const resolvedSearchParams = await searchParams;
@@ -128,11 +173,11 @@ export default async function PublicQuotePage({ searchParams }: PublicQuotePageP
         ? detail.detail
         : "This shared link is invalid or has expired.";
     return (
-      <main className="min-h-screen bg-slate-50">
+      <main className="min-h-screen bg-slate-100">
         <div className="mx-auto max-w-3xl px-4 py-12">
-          <div className="rounded-2xl border border-slate-200 bg-white p-8 shadow-sm">
-            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Quote Share</p>
-            <h1 className="mt-2 text-2xl font-semibold text-slate-900">Link unavailable</h1>
+          <div className="rounded-lg border border-slate-200 bg-white p-8 shadow-sm">
+            <p className="text-sm font-semibold text-slate-500">Quote Share</p>
+            <h1 className="mt-2 text-2xl font-semibold text-slate-950">Link unavailable</h1>
             <p className="mt-3 text-sm text-slate-600">{message}</p>
           </div>
         </div>
@@ -145,193 +190,237 @@ export default async function PublicQuotePage({ searchParams }: PublicQuotePageP
   const showAirportReferences = ["A2D", "D2A", "A2A", "P2P"].includes(normalizedScope);
   const brandPrimary = data.branding.primary_color || "#0F2A56";
   const brandAccent = data.branding.accent_color || "#D71920";
-  const mutedBrandBackground = withAlpha(brandPrimary, "12");
-  const accentBackground = withAlpha(brandAccent, "12");
+  const primarySoft = withAlpha(brandPrimary, "10") || "#eef2ff";
+  const primaryBorder = withAlpha(brandPrimary, "24") || "#cbd5e1";
+  const accentSoft = withAlpha(brandAccent, "12") || "#fff1f2";
+  const accentBorder = withAlpha(brandAccent, "33") || "#fecaca";
+  const statusText = statusLabel(data.status);
+  const chargeLineCount = data.charge_buckets.reduce((total, bucket) => total + bucket.lines.length, 0);
 
   return (
-    <main className="min-h-screen bg-slate-50">
-      <div className="mx-auto max-w-4xl px-4 py-10 space-y-6">
-        <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">Quote</p>
-              <div className="mt-2 flex items-center gap-3">
-                {data.branding.logo_url ? (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img
-                    src={data.branding.logo_url}
-                    alt={data.branding.display_name}
-                    className="h-10 w-auto object-contain"
-                  />
-                ) : (
-                  <div
-                    className="flex h-10 w-10 items-center justify-center rounded-xl text-sm font-bold text-white"
-                    style={{ backgroundColor: brandPrimary }}
-                  >
-                    {data.branding.display_name.slice(0, 1).toUpperCase()}
+    <main className="min-h-screen bg-[#f3f6fa] text-slate-950">
+      <div className="h-3" style={{ backgroundColor: brandPrimary }} />
+
+      <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
+        <section className="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
+          <div className="border-b border-slate-200 px-5 py-5 sm:px-8">
+            <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-4">
+                  {data.branding.logo_url ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={data.branding.logo_url}
+                      alt={data.branding.display_name}
+                      className="h-12 w-auto max-w-[220px] object-contain"
+                    />
+                  ) : (
+                    <div
+                      className="flex h-12 w-12 items-center justify-center rounded-md text-base font-bold text-white"
+                      style={{ backgroundColor: brandPrimary }}
+                    >
+                      {data.branding.display_name.slice(0, 1).toUpperCase()}
+                    </div>
+                  )}
+                  <div>
+                    <div className="text-base font-semibold text-slate-950">{data.branding.display_name}</div>
+                    {data.branding.public_quote_tagline ? (
+                      <div className="text-sm text-slate-500">{data.branding.public_quote_tagline}</div>
+                    ) : null}
                   </div>
-                )}
-                <div>
-                  <p className="text-sm font-semibold" style={{ color: brandPrimary }}>
-                    {data.branding.display_name}
-                  </p>
-                  <p className="text-xs text-slate-500">{data.branding.public_quote_tagline}</p>
                 </div>
-              </div>
-              <h1 className="mt-2 text-3xl font-semibold text-slate-900">{data.quote_number}</h1>
-              <p className="mt-2 text-sm text-slate-500">
-                Created {new Date(data.created_at).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" })}
-              </p>
-              <p className="text-sm text-slate-500">
-                Valid until {data.valid_until ? new Date(data.valid_until).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" }) : "N/A"}
-              </p>
-            </div>
-            <div
-              className="rounded-full border px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em]"
-              style={{
-                borderColor: withAlpha(brandAccent, "33") || "#fecaca",
-                backgroundColor: accentBackground || "#fff1f2",
-                color: brandAccent,
-              }}
-            >
-              {data.status}
-            </div>
-          </div>
-          <div
-            className="mt-6 grid gap-4 rounded-xl border p-4 md:grid-cols-2"
-            style={{
-              borderColor: withAlpha(brandPrimary, "1f") || "#e2e8f0",
-              backgroundColor: mutedBrandBackground || "#f8fafc",
-            }}
-          >
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Customer</p>
-              <p className="mt-1 text-base font-semibold text-slate-800">{data.customer.name}</p>
-              {data.customer.contact && (
-                <p className="text-sm text-slate-500">Contact: {data.customer.contact}</p>
-              )}
-            </div>
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Shipment</p>
-              <p className="mt-1 text-base font-semibold text-slate-800">
-                {[data.shipment.mode, data.shipment.direction].filter(Boolean).join(" • ")}
-              </p>
-              <p className="text-sm text-slate-500">
-                Payment: {formatPaymentTerm(data.shipment.payment_term)}
-              </p>
-              <p className="text-sm text-slate-500">
-                Service Scope: {formatServiceScope(data.shipment.service_scope)}
-              </p>
-              {data.shipment.incoterm && (
-                <p className="text-sm text-slate-500">Incoterm: {formatIncoterm(data.shipment.incoterm)}</p>
-              )}
-            </div>
-          </div>
-          <div className="mt-4 flex flex-wrap gap-4 text-sm text-slate-500">
-            {data.branding.support_email && <span>Email: {data.branding.support_email}</span>}
-            {data.branding.support_phone && <span>Phone: {data.branding.support_phone}</span>}
-            {data.branding.website_url && <span>{data.branding.website_url}</span>}
-          </div>
-          {data.branding.address_lines.length > 0 && (
-            <p className="mt-2 text-sm text-slate-500">{data.branding.address_lines.join(", ")}</p>
-          )}
-        </section>
 
-        <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Route</p>
-          <div className="mt-4 flex flex-col items-center gap-4 text-center md:flex-row md:justify-between">
-            <div>
-              <p className="text-3xl font-semibold text-slate-900">{data.route.origin_code}</p>
-              {showAirportReferences && (
-                <p className="text-sm text-slate-500">{data.route.origin_name}</p>
-              )}
-            </div>
-            <div className="text-sm font-semibold uppercase tracking-[0.3em] text-rose-500">to</div>
-            <div>
-              <p className="text-3xl font-semibold text-slate-900">{data.route.destination_code}</p>
-              {showAirportReferences && (
-                <p className="text-sm text-slate-500">{data.route.destination_name}</p>
-              )}
-            </div>
-          </div>
-        </section>
-
-        <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Totals</p>
-          <div className="mt-4 grid gap-3 md:grid-cols-3">
-            <div className="rounded-xl border border-slate-100 bg-slate-50 p-4">
-              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Excl. GST</p>
-              <p className="mt-2 text-lg font-semibold text-slate-900">
-                {formatMoney(data.currency, data.totals.sell_excl_gst)}
-              </p>
-            </div>
-            <div className="rounded-xl border border-slate-100 bg-slate-50 p-4">
-              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">GST (10%)</p>
-              <p className="mt-2 text-lg font-semibold text-slate-900">
-                {formatMoney(data.currency, data.totals.gst)}
-              </p>
-            </div>
-            <div className="rounded-xl border border-slate-100 bg-slate-50 p-4">
-              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Grand Total</p>
-              <p className="mt-2 text-lg font-semibold text-slate-900">
-                {formatMoney(data.currency, data.totals.sell_incl_gst)}
-              </p>
-            </div>
-          </div>
-          {data.totals.fcy && data.totals.fcy_currency && data.totals.fcy_amount && (
-            <p className="mt-3 text-sm text-slate-500">
-              Equivalent: {formatMoney(data.totals.fcy_currency, data.totals.fcy_amount)}
-            </p>
-          )}
-        </section>
-
-        <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-          <div className="flex items-center justify-between">
-            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
-              {summaryOnly ? "Pricing Summary" : "Charge Breakdown"}
-            </p>
-            <p className="text-xs text-slate-400">Link valid for 7 days</p>
-          </div>
-          <div className="mt-4 space-y-4">
-            {data.charge_buckets.map((bucket) => (
-              <div key={bucket.name} className="rounded-xl border border-slate-200 bg-slate-50 p-4">
-                <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
-                  <span className="text-sm font-semibold text-slate-900">{bucket.name}</span>
-                  <span className="text-sm font-semibold text-slate-700">
-                    {formatMoney(data.currency, bucket.subtotal)}
+                <div className="mt-6 flex flex-wrap items-center gap-3">
+                  <h1 className="text-3xl font-semibold text-slate-950 sm:text-4xl">{data.quote_number}</h1>
+                  <span
+                    className="inline-flex h-8 items-center rounded-full border px-3 text-xs font-semibold"
+                    style={{ borderColor: accentBorder, backgroundColor: accentSoft, color: brandAccent }}
+                  >
+                    {statusText}
                   </span>
                 </div>
-                {!summaryOnly && (
-                  <div className="overflow-x-auto">
-                    <table className="w-full text-left text-sm text-slate-600">
-                      <thead className="text-xs uppercase tracking-wide text-slate-400">
-                        <tr>
-                          <th className="pb-2">Description</th>
-                          <th className="pb-2 text-right">Amount ({data.currency})</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {bucket.lines.map((line, index) => (
-                          <tr key={`${bucket.name}-${index}`} className={line.is_informational ? "text-slate-400" : ""}>
-                            <td className="py-2 pr-4">{line.description}</td>
-                            <td className="py-2 text-right">{formatMoney(data.currency, line.sell)}</td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
-                )}
+
+                <div className="mt-3 flex flex-wrap gap-x-5 gap-y-2 text-sm text-slate-600">
+                  <span className="inline-flex items-center gap-2">
+                    <CalendarDays className="h-4 w-4 text-slate-400" aria-hidden="true" />
+                    Created {formatDate(data.created_at)}
+                  </span>
+                  <span className="inline-flex items-center gap-2">
+                    <ShieldCheck className="h-4 w-4 text-slate-400" aria-hidden="true" />
+                    Valid until {formatDate(data.valid_until)}
+                  </span>
+                </div>
               </div>
-            ))}
-            {data.charge_buckets.length === 0 && (
-              <p className="text-sm text-slate-500">No charge lines available.</p>
-            )}
+
+              <div className="w-full rounded-lg border border-slate-200 bg-slate-50 p-5 lg:w-[340px]">
+                <div className="text-sm font-semibold text-slate-600">Grand Total</div>
+                <div className="mt-2 text-3xl font-semibold text-slate-950">
+                  {formatMoney(data.currency, data.totals.sell_incl_gst)}
+                </div>
+                <div className="mt-2 text-sm text-slate-500">
+                  Includes GST of {formatMoney(data.currency, data.totals.gst)}
+                </div>
+                <div className="mt-5">
+                  <PublicQuoteActions
+                    quoteNumber={data.quote_number}
+                    supportEmail={data.branding.support_email}
+                    brandPrimary={brandPrimary}
+                    brandAccent={brandAccent}
+                  />
+                </div>
+              </div>
+            </div>
           </div>
+
+          <div className="grid border-b border-slate-200 lg:grid-cols-[1.15fr_0.85fr]">
+            <section className="border-b border-slate-200 px-5 py-6 sm:px-8 lg:border-b-0 lg:border-r">
+              <div className="flex items-center gap-2 text-sm font-semibold text-slate-700">
+                <MapPin className="h-4 w-4" style={{ color: brandAccent }} aria-hidden="true" />
+                Route
+              </div>
+              <div className="mt-5 grid grid-cols-[1fr_auto_1fr] items-center gap-4">
+                <div>
+                  <div className="text-4xl font-semibold text-slate-950 sm:text-5xl">{data.route.origin_code}</div>
+                  <div className="mt-2 text-sm text-slate-600">{showAirportReferences ? data.route.origin_name : "Origin"}</div>
+                </div>
+                <div className="flex items-center gap-3">
+                  <span className="hidden h-px w-16 bg-slate-300 sm:block" />
+                  <span
+                    className="flex h-10 w-10 items-center justify-center rounded-full border bg-white"
+                    style={{ borderColor: primaryBorder }}
+                  >
+                    <Plane className="h-4 w-4" style={{ color: brandPrimary }} aria-hidden="true" />
+                  </span>
+                  <ArrowRight className="hidden h-4 w-4 text-slate-400 sm:block" aria-hidden="true" />
+                </div>
+                <div className="text-right">
+                  <div className="text-4xl font-semibold text-slate-950 sm:text-5xl">{data.route.destination_code}</div>
+                  <div className="mt-2 text-sm text-slate-600">{showAirportReferences ? data.route.destination_name : "Destination"}</div>
+                </div>
+              </div>
+            </section>
+
+            <section className="px-5 py-6 sm:px-8">
+              <div className="flex items-center gap-2 text-sm font-semibold text-slate-700">
+                <ReceiptText className="h-4 w-4" style={{ color: brandAccent }} aria-hidden="true" />
+                Quote Details
+              </div>
+              <div className="mt-5 grid grid-cols-2 gap-5">
+                <DetailItem label="Customer" value={data.customer.name} />
+                <DetailItem label="Contact" value={data.customer.contact} />
+                <DetailItem label="Shipment" value={[data.shipment.mode, data.shipment.direction].filter(Boolean).join(" / ")} />
+                <DetailItem label="Payment" value={formatPaymentTerm(data.shipment.payment_term)} />
+                <DetailItem label="Service Scope" value={formatServiceScope(data.shipment.service_scope)} />
+                <DetailItem label="Incoterm" value={data.shipment.incoterm ? formatIncoterm(data.shipment.incoterm) : "N/A"} />
+              </div>
+            </section>
+          </div>
+
+          <section className="border-b border-slate-200 px-5 py-6 sm:px-8">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+              <div>
+                <h2 className="text-xl font-semibold text-slate-950">Totals</h2>
+                <p className="mt-1 text-sm text-slate-500">{chargeLineCount} charge lines across {data.charge_buckets.length} categories</p>
+              </div>
+              {data.totals.fcy && data.totals.fcy_currency && data.totals.fcy_amount ? (
+                <div className="text-sm text-slate-500">
+                  Equivalent: <span className="font-semibold text-slate-800">{formatMoney(data.totals.fcy_currency, data.totals.fcy_amount)}</span>
+                </div>
+              ) : null}
+            </div>
+            <div className="mt-5 grid gap-3 md:grid-cols-3">
+              <div className="rounded-lg border border-slate-200 bg-white p-4">
+                <div className="text-sm font-semibold text-slate-500">Total Excl. GST</div>
+                <div className="mt-2 text-xl font-semibold text-slate-950">{formatMoney(data.currency, data.totals.sell_excl_gst)}</div>
+              </div>
+              <div className="rounded-lg border border-slate-200 bg-white p-4">
+                <div className="text-sm font-semibold text-slate-500">GST</div>
+                <div className="mt-2 text-xl font-semibold text-slate-950">{formatMoney(data.currency, data.totals.gst)}</div>
+              </div>
+              <div className="rounded-lg border p-4" style={{ borderColor: primaryBorder, backgroundColor: primarySoft }}>
+                <div className="text-sm font-semibold" style={{ color: brandPrimary }}>Amount Payable</div>
+                <div className="mt-2 text-2xl font-semibold text-slate-950">{formatMoney(data.currency, data.totals.sell_incl_gst)}</div>
+              </div>
+            </div>
+          </section>
+
+          <section className="px-5 py-6 sm:px-8">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <h2 className="text-xl font-semibold text-slate-950">
+                  {summaryOnly ? "Pricing Summary" : "Charge Breakdown"}
+                </h2>
+                <p className="mt-1 text-sm text-slate-500">Amounts are shown in {data.currency}</p>
+              </div>
+              <div className="text-sm text-slate-500">Shared quote link valid for 7 days</div>
+            </div>
+
+            <div className="mt-5 overflow-hidden rounded-lg border border-slate-200">
+              {data.charge_buckets.map((bucket, bucketIndex) => (
+                <div key={bucket.name} className={bucketIndex > 0 ? "border-t border-slate-200" : ""}>
+                  <div className="flex flex-col gap-2 bg-slate-50 px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <div className="text-base font-semibold text-slate-950">{bucketLabel(bucket.name)}</div>
+                      <div className="text-sm text-slate-500">{bucket.lines.length} line{bucket.lines.length === 1 ? "" : "s"}</div>
+                    </div>
+                    <div className="text-right">
+                      <div className="text-xs font-semibold text-slate-500">Subtotal</div>
+                      <div className="text-lg font-semibold text-slate-950">{formatMoney(data.currency, bucket.subtotal)}</div>
+                    </div>
+                  </div>
+
+                  {!summaryOnly ? (
+                    <div className="overflow-x-auto">
+                      <table className="w-full min-w-[560px] text-left text-sm">
+                        <thead className="border-y border-slate-200 bg-white text-slate-500">
+                          <tr>
+                            <th className="px-4 py-3 font-semibold">Description</th>
+                            <th className="px-4 py-3 text-right font-semibold">Amount</th>
+                          </tr>
+                        </thead>
+                        <tbody className="divide-y divide-slate-100 bg-white">
+                          {bucket.lines.map((line, index) => (
+                            <tr key={`${bucket.name}-${index}`} className={line.is_informational ? "bg-slate-50 text-slate-500" : "text-slate-700"}>
+                              <td className="px-4 py-3">
+                                <div className="font-medium text-slate-800">{line.description}</div>
+                                {line.is_informational ? (
+                                  <div className="mt-1 inline-flex rounded-full border border-slate-200 bg-white px-2 py-0.5 text-xs font-semibold text-slate-500">
+                                    Not included in subtotal
+                                  </div>
+                                ) : null}
+                              </td>
+                              <td className="whitespace-nowrap px-4 py-3 text-right font-semibold">
+                                {formatMoney(data.currency, line.sell)}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  ) : null}
+                </div>
+              ))}
+              {data.charge_buckets.length === 0 ? (
+                <div className="bg-white px-4 py-8 text-center text-sm text-slate-500">No charge lines available.</div>
+              ) : null}
+            </div>
+          </section>
+
+          <footer className="border-t border-slate-200 bg-slate-50 px-5 py-5 sm:px-8">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+              <div className="flex flex-wrap gap-x-5 gap-y-2">
+                <ContactItem icon={<Mail className="h-4 w-4" aria-hidden="true" />} value={data.branding.support_email} />
+                <ContactItem icon={<Phone className="h-4 w-4" aria-hidden="true" />} value={data.branding.support_phone} />
+                <ContactItem icon={<Globe2 className="h-4 w-4" aria-hidden="true" />} value={data.branding.website_url} />
+              </div>
+              <div className="text-sm text-slate-500">
+                {data.branding.address_lines.length > 0 ? data.branding.address_lines.join(", ") : "Powered by RateEngine"}
+              </div>
+            </div>
+          </footer>
         </section>
 
-        <p className="text-center text-xs text-slate-400">
-          Powered by RateEngine
-        </p>
+        <div className="pb-4 text-center text-xs text-slate-500">Powered by RateEngine</div>
       </div>
     </main>
   );

--- a/frontend/src/app/quotes/[id]/page.tsx
+++ b/frontend/src/app/quotes/[id]/page.tsx
@@ -536,11 +536,7 @@ export default function QuoteDetailPage() {
         ) : (
           /* Full-width Layout for Finalized Quotes */
           <div className="space-y-6">
-            {computeResult ? (
-              <QuoteFinancialBreakdown result={computeResult} />
-            ) : (
-              <QuoteFinancialBreakdown result={quote} />
-            )}
+            <QuoteFinancialBreakdown result={quote} />
           </div>
         )}
       </div>

--- a/frontend/src/app/quotes/[id]/page.tsx
+++ b/frontend/src/app/quotes/[id]/page.tsx
@@ -428,10 +428,10 @@ export default function QuoteDetailPage() {
                 <div>
                   <p className="text-xs font-semibold text-slate-500 uppercase">FX Rate</p>
                   <div className="font-medium text-slate-900 text-xs">
-                    {fxEntries.length > 0 ? (
-                      fxEntries.map(([currency, rate]) => (
-                        <div key={currency}>{currency}: {String(rate)}</div>
-                      ))
+                    {fxEntries.length > 1 ? (
+                      <span className="text-slate-600">Multiple FX rates used</span>
+                    ) : fxEntries.length === 1 ? (
+                      <div>{fxEntries[0][0]}: {String(fxEntries[0][1])}</div>
                     ) : (
                       <span className="text-slate-400 italic">Base (PGK)</span>
                     )}
@@ -1092,7 +1092,6 @@ function buildFxEntries(
   }
 
   const sorted = visible.sort((a, b) => a[0].localeCompare(b[0]));
-  if (sorted.length > 0) return sorted;
-  return [["PGK/PGK", "1.000000"]];
+  return sorted;
 }
 

--- a/frontend/src/app/quotes/spot/[speId]/page.tsx
+++ b/frontend/src/app/quotes/spot/[speId]/page.tsx
@@ -354,6 +354,8 @@ export default function SpotRateEntryPage() {
     const customerIdParam = searchParams.get("customer_id") || "";
     const customerNameParam = searchParams.get("customer_name") || "";
     const outputCurrency = searchParams.get("output_currency") || "PGK";
+    const contactIdParam = searchParams.get("contact_id") || "";
+    const incotermParam = searchParams.get("incoterm") || "";
     const shipmentTypeParam = searchParams.get("shipment_type") as "EXPORT" | "IMPORT" | "DOMESTIC" | null;
     const returnTo = searchParams.get("returnTo");
 
@@ -951,6 +953,8 @@ export default function SpotRateEntryPage() {
                 service_scope: resolvedScope,
                 output_currency: resolvedOutputCurrency,
                 customer_id: customerIdParam || undefined,
+                contact_id: contactIdParam || undefined,
+                incoterm: incotermParam || undefined,
             });
 
             if (result?.success && result.quote_id) {

--- a/frontend/src/app/quotes/spot/[speId]/page.tsx
+++ b/frontend/src/app/quotes/spot/[speId]/page.tsx
@@ -896,6 +896,7 @@ export default function SpotRateEntryPage() {
     const quoteSubmitDisabledReason = getSpotFinalizeDisabledReason({
         spe: state.spe,
         unresolvedReviewIssueCount,
+        unresolvedReviewIssueLabels: reviewLines.affected.map((line) => line.label),
     });
     const quoteSubmitDisabled = Boolean(quoteSubmitDisabledReason);
     const hasReviewActions =
@@ -918,7 +919,7 @@ export default function SpotRateEntryPage() {
             setFinalizeError(null);
             let spe = state.spe;
 
-            if (spe.status === "draft") {
+            if (spe.status === "draft" && charges.length > 0) {
                 const updatedSpe = await actions.updateSPE(spe.id, {
                     charges,
                     conditions: {
@@ -1483,6 +1484,7 @@ export default function SpotRateEntryPage() {
                                             submitLabel="Create Quote"
                                             submitDisabled={quoteSubmitDisabled}
                                             submitDisabledReason={quoteSubmitDisabledReason}
+                                            allowEmptySubmit={Boolean(state.spe?.can_proceed)}
                                             onSaveDraft={handleSaveDraft}
                                             onManualResolveChargeLine={actions.manuallyResolveChargeLine}
                                             productCodeDomain={resolvedShipmentType}

--- a/frontend/src/app/quotes/spot/[speId]/page.tsx
+++ b/frontend/src/app/quotes/spot/[speId]/page.tsx
@@ -937,7 +937,7 @@ export default function SpotRateEntryPage() {
                 spe = updatedSpe;
             }
 
-            if (!spe.acknowledgement && spe.status !== "ready") {
+            if (!spe.acknowledgement) {
                 const success = await actions.submitAcknowledgement();
                 if (!success) {
                     return;
@@ -1253,6 +1253,10 @@ export default function SpotRateEntryPage() {
                     sourceLabel="Uploaded rates"
                     onAnalysisComplete={(result) => handleAnalysisComplete(result, "mixed")}
                     onDirtyChange={handleMixedIntakeDirtyChange}
+                    onSkipToManual={() => {
+                        userAdvancedToReviewRef.current = true;
+                        setCurrentStep("review");
+                    }}
                 />
             )}
 

--- a/frontend/src/components/QuoteFinancialBreakdown.tsx
+++ b/frontend/src/components/QuoteFinancialBreakdown.tsx
@@ -6,6 +6,7 @@ import {
     CanonicalQuoteResult,
     QuoteComputeResult,
     SellLine,
+    V3QuoteLine,
     V3QuoteComputeResponse,
 } from "@/lib/types";
 import {
@@ -23,7 +24,7 @@ import {
     TableRow,
 } from "@/components/ui/table";
 import { Separator } from "@/components/ui/separator";
-import { ChevronDown, ChevronRight, Package, MapPin, ReceiptText, Plane } from "lucide-react";
+import { AlertTriangle, Calculator, ChevronDown, ChevronRight, Package, MapPin, ReceiptText, Plane } from "lucide-react";
 
 interface QuoteFinancialBreakdownProps {
     result: QuoteComputeResult | V3QuoteComputeResponse;
@@ -32,6 +33,7 @@ interface QuoteFinancialBreakdownProps {
 type LooseRecord = Record<string, unknown>;
 type BreakdownLine = SellLine & { sell_fcy_currency?: string };
 type BreakdownDataShape = {
+    status?: string;
     quote_result?: CanonicalQuoteResult | null;
     latest_version?: {
         sell_lines?: BreakdownLine[];
@@ -42,6 +44,7 @@ type BreakdownDataShape = {
     lines?: BreakdownLine[];
     totals?: LooseRecord;
 };
+type RawQuoteLine = V3QuoteLine & BreakdownLine;
 
 function toMoneyString(value: number): string {
     return value.toFixed(2);
@@ -154,6 +157,61 @@ function getDisplaySellAmount(line: BreakdownLine, isShowingFCY: boolean): numbe
     return parseFloat(String(rawValue || "0"));
 }
 
+function normalizeStatus(result: QuoteComputeResult | V3QuoteComputeResponse): string {
+    const maybeStatus = readStringField(result, "status") || readStringField((result as BreakdownDataShape).quote_result, "status");
+    return (maybeStatus || "").toUpperCase();
+}
+
+function isAvailable(value: unknown): boolean {
+    return value !== null && value !== undefined && value !== "";
+}
+
+function displayValue(value: unknown): string {
+    return isAvailable(value) ? String(value) : "Not available";
+}
+
+function displayMoney(value: unknown, currency: string): string {
+    if (!isAvailable(value)) return "Not available";
+    return formatAmount(String(value), currency);
+}
+
+function displayPercent(value: unknown): string {
+    if (!isAvailable(value)) return "Not available";
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) return String(value);
+    return `${parsed.toFixed(2)}%`;
+}
+
+function findRawLine(rawLines: RawQuoteLine[], canonicalLine: CanonicalQuoteLineItem): RawQuoteLine | undefined {
+    if (canonicalLine.line_id) {
+        const byId = rawLines.find((line) => line.id === canonicalLine.line_id);
+        if (byId) return byId;
+    }
+    return rawLines.find((line) => {
+        const code = line.product_code || line.component || line.service_component?.code;
+        return code === canonicalLine.product_code && line.description === canonicalLine.description;
+    });
+}
+
+function lineWarnings(line: CanonicalQuoteLineItem, rawLine?: RawQuoteLine): string[] {
+    const warnings: string[] = [];
+    if (rawLine?.is_rate_missing) warnings.push("Missing buy rate");
+    if (line.is_manual_override || rawLine?.is_manual_override) warnings.push("Manual override");
+    if (line.rate_source === "FALLBACK_RULE") warnings.push("FX or rate fallback");
+    if (!line.calculation_notes && !rawLine?.calculation_notes) warnings.push("Missing calculation metadata");
+    return warnings;
+}
+
+function sourceLabel(line: CanonicalQuoteLineItem, rawLine?: RawQuoteLine): string {
+    if (line.is_spot_sourced || rawLine?.is_spot_sourced) return "SPOT";
+    if (line.is_manual_override || rawLine?.is_manual_override) return "Manual entry";
+    if (line.rate_source === "MANUAL_OVERRIDE") return "Manual entry";
+    if (line.rate_source === "PARTNER_SPOT") return "SPOT";
+    if (line.rate_source === "DB_TARIFF") return "V4 rate card";
+    if (line.rate_source === "FALLBACK_RULE") return "Fallback rule";
+    return displayValue(line.rate_source);
+}
+
 
 export default function QuoteFinancialBreakdown({ result }: QuoteFinancialBreakdownProps) {
     const normalizedResult = result as unknown as BreakdownDataShape;
@@ -166,7 +224,10 @@ export default function QuoteFinancialBreakdown({ result }: QuoteFinancialBreakd
     const sell_lines = canonicalLines.length > 0
         ? canonicalLines
         : (((data.sell_lines || data.lines || []) as unknown[]) as BreakdownLine[]);
+    const rawQuoteLines = ((((data.lines || []) as unknown[]) as RawQuoteLine[]) || []);
     const totals = canonicalResult ? buildCanonicalTotals(canonicalResult) : data.totals;
+    const quoteStatus = normalizeStatus(result);
+    const showCalculationReview = Boolean(canonicalResult && ["DRAFT", "INCOMPLETE"].includes(quoteStatus));
 
     // Detect display currency and logic flags
     const firstLineCurrency = sell_lines[0]?.sell_fcy_currency || sell_lines[0]?.sell_currency || 'PGK';
@@ -283,6 +344,14 @@ export default function QuoteFinancialBreakdown({ result }: QuoteFinancialBreakd
                     </div>
                 </div>
 
+                {showCalculationReview && canonicalResult && (
+                    <CalculationReviewPanel
+                        quoteResult={canonicalResult}
+                        rawLines={rawQuoteLines}
+                        displayCurrency={displayCurrency}
+                    />
+                )}
+
                 {/* Conditional Charges Footnotes */}
                 {informationalLines.length > 0 && (
                     <div className="p-4 bg-amber-50/50 border-t border-amber-200">
@@ -301,6 +370,196 @@ export default function QuoteFinancialBreakdown({ result }: QuoteFinancialBreakd
                 )}
             </CardContent>
         </Card>
+    );
+}
+
+function CalculationReviewPanel({
+    quoteResult,
+    rawLines,
+    displayCurrency,
+}: {
+    quoteResult: CanonicalQuoteResult;
+    rawLines: RawQuoteLine[];
+    displayCurrency: string;
+}) {
+    const [isOpen, setIsOpen] = useState(false);
+    const taxTotal = quoteResult.tax_breakdown?.gst_amount || "0.00";
+    const grandTotal = quoteResult.sell_total || "0.00";
+    const fx = quoteResult.fx_applied;
+    const warnings = [
+        ...(quoteResult.warnings || []),
+        ...quoteResult.line_items.flatMap((line) => lineWarnings(line, findRawLine(rawLines, line))),
+    ].filter((item, index, items) => item && items.indexOf(item) === index);
+
+    return (
+        <div className="border-t border-slate-200 bg-white">
+            <button
+                type="button"
+                onClick={() => setIsOpen(!isOpen)}
+                className="flex w-full items-center justify-between gap-4 px-6 py-5 text-left hover:bg-slate-50"
+            >
+                <div className="flex items-start gap-3">
+                    <div className="mt-0.5 rounded-md bg-slate-100 p-2 text-slate-600">
+                        <Calculator className="h-4 w-4" />
+                    </div>
+                    <div>
+                        <div className="flex flex-wrap items-center gap-2">
+                            <h3 className="text-base font-semibold text-slate-900">Pricing Breakdown</h3>
+                            <span className="rounded border border-slate-200 px-2 py-0.5 text-[10px] font-semibold uppercase text-slate-500">
+                                Internal only
+                            </span>
+                        </div>
+                        <p className="mt-1 text-sm text-slate-500">
+                            Review calculation inputs, source flags, margins, FX, CAF, and metadata gaps before finalizing.
+                        </p>
+                    </div>
+                </div>
+                {isOpen ? (
+                    <ChevronDown className="h-5 w-5 shrink-0 text-slate-400" />
+                ) : (
+                    <ChevronRight className="h-5 w-5 shrink-0 text-slate-400" />
+                )}
+            </button>
+
+            {isOpen && (
+                <div className="space-y-5 border-t border-slate-100 px-6 py-5">
+                    <div className="grid gap-3 md:grid-cols-3">
+                        <ReviewMetric label="Total buy cost" value={displayMoney(quoteResult.total_cost_pgk, "PGK")} />
+                        <ReviewMetric label="Total sell amount" value={displayMoney(quoteResult.total_sell_pgk, "PGK")} />
+                        <ReviewMetric label="Gross margin" value={`${displayMoney(quoteResult.margin_amount, "PGK")} (${displayPercent(quoteResult.margin_percent)})`} />
+                        <ReviewMetric label="GST/tax total" value={displayMoney(taxTotal, displayCurrency)} />
+                        <ReviewMetric label="Grand total" value={displayMoney(grandTotal, displayCurrency)} />
+                        <ReviewMetric
+                            label="Currency conversion"
+                            value={
+                                fx?.applied
+                                    ? `${displayValue(fx.currency)} -> PGK at ${displayValue(fx.rate)}`
+                                    : "No FCY conversion recorded"
+                            }
+                        />
+                    </div>
+
+                    {warnings.length > 0 && (
+                        <div className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3">
+                            <div className="flex items-center gap-2 text-sm font-semibold text-amber-900">
+                                <AlertTriangle className="h-4 w-4" />
+                                Warnings and exceptions
+                            </div>
+                            <ul className="mt-2 space-y-1 text-sm text-amber-900">
+                                {warnings.map((warning) => (
+                                    <li key={warning}>{warning}</li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+
+                    <div className="space-y-3">
+                        {quoteResult.line_items.map((line) => (
+                            <CalculationLineDetails
+                                key={line.line_id || `${line.product_code}-${line.sort_order}`}
+                                line={line}
+                                rawLine={findRawLine(rawLines, line)}
+                                displayCurrency={displayCurrency}
+                                fx={fx}
+                            />
+                        ))}
+                    </div>
+
+                    <div className="rounded-md border border-slate-200 bg-slate-50 px-4 py-3 text-xs text-slate-600">
+                        Unavailable in this version: explicit buy-rate basis, FX direction, effective FX after CAF,
+                        minimum margin rule, and customer override/discount detail unless it has been written into
+                        calculation notes. These fields need structured persistence from the V4 engines/adapter for
+                        full audit traceability.
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}
+
+function ReviewMetric({ label, value }: { label: string; value: string }) {
+    return (
+        <div className="rounded-md border border-slate-200 bg-slate-50 px-4 py-3">
+            <div className="text-[11px] font-semibold uppercase text-slate-500">{label}</div>
+            <div className="mt-1 text-sm font-semibold text-slate-900">{value}</div>
+        </div>
+    );
+}
+
+function CalculationLineDetails({
+    line,
+    rawLine,
+    displayCurrency,
+    fx,
+}: {
+    line: CanonicalQuoteLineItem;
+    rawLine?: RawQuoteLine;
+    displayCurrency: string;
+    fx: CanonicalQuoteResult["fx_applied"];
+}) {
+    const warnings = lineWarnings(line, rawLine);
+    const buyCurrency = rawLine?.cost_fcy_currency || line.cost_currency || "PGK";
+    const buyAmount = rawLine?.cost_fcy_currency ? rawLine.cost_fcy : line.cost_amount;
+    const sellCurrency = line.sell_currency || displayCurrency;
+    const gstTreatment = `${displayValue(line.tax_code)} at ${displayPercent(rawLine?.gst_rate ? Number(rawLine.gst_rate) * 100 : undefined)}`;
+
+    return (
+        <details className="rounded-md border border-slate-200 bg-white">
+            <summary className="cursor-pointer list-none px-4 py-3 hover:bg-slate-50">
+                <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                    <div>
+                        <div className="font-medium text-slate-900">{line.description}</div>
+                        <div className="mt-1 text-xs text-slate-500">
+                            {displayValue(line.product_code)} | {sourceLabel(line, rawLine)} | {line.is_manual_override || rawLine?.is_manual_override ? "Manual" : "System-calculated"}
+                        </div>
+                    </div>
+                    <div className="text-sm font-semibold text-slate-900">
+                        {displayMoney(line.sell_amount, sellCurrency)}
+                    </div>
+                </div>
+                {warnings.length > 0 && (
+                    <div className="mt-2 flex flex-wrap gap-2">
+                        {warnings.map((warning) => (
+                            <span key={warning} className="rounded border border-amber-200 bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-800">
+                                {warning}
+                            </span>
+                        ))}
+                    </div>
+                )}
+            </summary>
+            <div className="grid gap-x-5 gap-y-3 border-t border-slate-100 px-4 py-4 text-sm md:grid-cols-2 lg:grid-cols-3">
+                <ReviewField label="Charge description" value={line.description} />
+                <ReviewField label="Product code" value={line.product_code} />
+                <ReviewField label="Buy amount" value={displayMoney(buyAmount, buyCurrency)} />
+                <ReviewField label="Buy currency" value={buyCurrency} />
+                <ReviewField label="Sell amount" value={displayMoney(line.sell_amount, sellCurrency)} />
+                <ReviewField label="Sell currency" value={sellCurrency} />
+                <ReviewField label="Quantity" value={displayValue(line.quantity)} />
+                <ReviewField label="Unit / basis" value={`${displayValue(line.unit_type)} / ${displayValue(line.basis)}`} />
+                <ReviewField label="Buy rate used" value="Not available" />
+                <ReviewField label="FX rate used" value={displayValue(rawLine?.exchange_rate || fx?.rate)} />
+                <ReviewField label="FX direction" value="Not available" />
+                <ReviewField label="CAF applied" value={fx?.caf_percent ? displayPercent(fx.caf_percent) : "Not available"} />
+                <ReviewField label="Effective FX after CAF" value="Not available" />
+                <ReviewField label="Margin used" value={`${displayMoney(line.margin_amount, "PGK")} (${displayPercent(line.margin_percent)})`} />
+                <ReviewField label="Minimum margin rule" value="Not available" />
+                <ReviewField label="Customer override/discount" value={line.calculation_notes?.includes("discount") ? line.calculation_notes : "Not available"} />
+                <ReviewField label="GST/tax treatment" value={gstTreatment} />
+                <ReviewField label="Final calculated sell" value={displayMoney(Number(line.sell_amount || 0) + Number(line.tax_amount || 0), sellCurrency)} />
+                <ReviewField label="Pricing source" value={sourceLabel(line, rawLine)} />
+                <ReviewField label="Entry mode" value={line.is_manual_override || rawLine?.is_manual_override ? "Manually entered" : "System-calculated"} />
+                <ReviewField label="Calculation notes" value={line.calculation_notes || rawLine?.calculation_notes || "Not available"} />
+            </div>
+        </details>
+    );
+}
+
+function ReviewField({ label, value }: { label: string; value: string }) {
+    return (
+        <div>
+            <div className="text-[11px] font-semibold uppercase text-slate-500">{label}</div>
+            <div className="mt-1 break-words text-slate-900">{value}</div>
+        </div>
     );
 }
 

--- a/frontend/src/components/QuoteFinancialBreakdown.tsx
+++ b/frontend/src/components/QuoteFinancialBreakdown.tsx
@@ -22,11 +22,19 @@ interface QuoteFinancialBreakdownProps {
 }
 
 type LooseRecord = Record<string, unknown>;
+
+type RawQuoteLine = V3QuoteLine & Partial<SellLine> & {
+    margin_amount?: string | null;
+};
+
 type BreakdownLine = SellLine & { 
     sell_fcy_currency?: string;
     canonical_item?: CanonicalQuoteLineItem;
     raw_line?: RawQuoteLine;
+    subcategory?: string;
+    margin_amount?: string | null;
 };
+
 type BreakdownDataShape = {
     status?: string;
     quote_result?: CanonicalQuoteResult | null;
@@ -39,7 +47,6 @@ type BreakdownDataShape = {
     lines?: BreakdownLine[];
     totals?: LooseRecord;
 };
-type RawQuoteLine = V3QuoteLine & BreakdownLine;
 
 function toMoneyString(value: number): string {
     return value.toFixed(2);
@@ -85,6 +92,7 @@ function mapCanonicalLineItemToBreakdownLine(
         subcategory: item.subcategory,
         source: item.cost_source,
         is_informational: !item.included_in_total,
+        margin_amount: item.margin_amount,
         canonical_item: item,
         raw_line: rawLine,
     };
@@ -190,7 +198,7 @@ function findRawLine(rawLines: RawQuoteLine[], canonicalLine: CanonicalQuoteLine
 
 type WarningDetails = { text: string; level: 'critical' | 'info' };
 
-function lineWarnings(line: CanonicalQuoteLineItem, rawLine?: RawQuoteLine): WarningDetails[] {
+function lineWarnings(line: CanonicalQuoteLineItem, rawLine?: Partial<V3QuoteLine>): WarningDetails[] {
     const warnings: WarningDetails[] = [];
     if (rawLine?.is_rate_missing) warnings.push({ text: "Missing buy rate", level: 'critical' });
     if (line.is_manual_override || rawLine?.is_manual_override) warnings.push({ text: "Manual override", level: 'info' });
@@ -198,7 +206,7 @@ function lineWarnings(line: CanonicalQuoteLineItem, rawLine?: RawQuoteLine): War
     return warnings;
 }
 
-function sourceLabel(line: CanonicalQuoteLineItem, rawLine?: RawQuoteLine): string {
+function sourceLabel(line: CanonicalQuoteLineItem, rawLine?: Partial<V3QuoteLine>): string {
     if (line.is_spot_sourced || rawLine?.is_spot_sourced) return "SPOT";
     if (line.is_manual_override || rawLine?.is_manual_override) return "Manual entry";
     if (line.rate_source === "MANUAL_OVERRIDE") return "Manual entry";
@@ -395,7 +403,7 @@ function BucketSection({
     // Grouping logic within the bucket
     const groups: Record<string, BreakdownLine[]> = {};
     lines.forEach(line => {
-        const sub = line.canonical_item?.subcategory || (line as any).subcategory || 'Other Charges';
+        const sub = line.canonical_item?.subcategory || line.subcategory || 'Other Charges';
         if (!groups[sub]) groups[sub] = [];
         groups[sub].push(line);
     });
@@ -496,8 +504,6 @@ function ChargeCard({
     const desc = line.description;
     const code = canonicalItem?.product_code || line.component || "MISC";
     const status = canonicalItem ? sourceLabel(canonicalItem, rawLine) : "Unknown";
-    const marginAmount = canonicalItem?.margin_amount;
-    const marginPercent = canonicalItem?.margin_percent;
     const warnings = canonicalItem ? lineWarnings(canonicalItem, rawLine) : [];
     
     const hasWarnings = warnings.length > 0;
@@ -506,8 +512,8 @@ function ChargeCard({
     const buyAmountNum = Number(buyAmount || 0);
     const sellExGstNum = Number(sellExGst || 0);
     
-    let finalMarginAmount = canonicalItem?.margin_amount ?? rawLine?.margin_amount;
-    let finalMarginPercent = canonicalItem?.margin_percent ?? rawLine?.margin_percent;
+    let finalMarginAmount = line.margin_amount || rawLine?.margin_amount;
+    let finalMarginPercent = line.margin_percent || rawLine?.margin_percent;
     
     if (finalMarginAmount === undefined || finalMarginAmount === null) {
         finalMarginAmount = String(sellExGstNum - buyAmountNum);

--- a/frontend/src/components/QuoteFinancialBreakdown.tsx
+++ b/frontend/src/components/QuoteFinancialBreakdown.tsx
@@ -80,8 +80,9 @@ function mapCanonicalLineItemToBreakdownLine(
         sell_fcy_incl_gst: currency !== "PGK" ? toMoneyString(sellInclTax) : toMoneyString(sellInclTax),
         sell_currency: currency,
         sell_fcy_currency: currency !== "PGK" ? currency : undefined,
-        margin_percent: "0",
-        exchange_rate: "0",
+        margin_percent: item.margin_percent,
+        exchange_rate: item.rate || "0",
+        subcategory: item.subcategory,
         source: item.cost_source,
         is_informational: !item.included_in_total,
         canonical_item: item,
@@ -358,6 +359,17 @@ function getSectionStyle() {
     };
 }
 
+const SUBCATEGORY_ORDER = [
+    "Customs / Regulatory",
+    "Documentation",
+    "Local Transport / Cartage",
+    "Handling / Terminal",
+    "Freight / Carrier",
+    "Carrier Surcharges",
+    "Service / Agency Fees",
+    "Other Charges",
+];
+
 function BucketSection({
     title,
     lines,
@@ -379,6 +391,22 @@ function BucketSection({
     const bucketTotal = isShowingFCY
         ? calculateBucketTotal(lines, 'sell_fcy')
         : calculateBucketTotal(lines, 'sell_pgk');
+
+    // Grouping logic within the bucket
+    const groups: Record<string, BreakdownLine[]> = {};
+    lines.forEach(line => {
+        const sub = line.canonical_item?.subcategory || (line as any).subcategory || 'Other Charges';
+        if (!groups[sub]) groups[sub] = [];
+        groups[sub].push(line);
+    });
+
+    const sortedGroups = Object.keys(groups).sort((a, b) => {
+        const orderA = SUBCATEGORY_ORDER.indexOf(a);
+        const orderB = SUBCATEGORY_ORDER.indexOf(b);
+        const finalA = orderA === -1 ? 999 : orderA;
+        const finalB = orderB === -1 ? 999 : orderB;
+        return finalA - finalB;
+    });
 
     return (
         <div className={styles.wrapper}>
@@ -418,15 +446,24 @@ function BucketSection({
             </button>
 
             {isExpanded && (
-                <div className="p-4 bg-slate-50/30 flex flex-col gap-2">
-                    {lines.map((line, index) => (
-                        <ChargeCard
-                            key={index}
-                            line={line}
-                            displayCurrency={displayCurrency}
-                            isShowingFCY={isShowingFCY}
-                            globalFx={globalFx}
-                        />
+                <div className="p-4 bg-slate-50/30 flex flex-col gap-6">
+                    {sortedGroups.map(groupName => (
+                        <div key={groupName} className="space-y-3">
+                            <h4 className="text-[10px] font-bold text-slate-400 uppercase tracking-widest pl-1">
+                                {groupName}
+                            </h4>
+                            <div className="flex flex-col gap-2">
+                                {groups[groupName].map((line, index) => (
+                                    <ChargeCard
+                                        key={index}
+                                        line={line}
+                                        displayCurrency={displayCurrency}
+                                        isShowingFCY={isShowingFCY}
+                                        globalFx={globalFx}
+                                    />
+                                ))}
+                            </div>
+                        </div>
                     ))}
                 </div>
             )}

--- a/frontend/src/components/QuoteFinancialBreakdown.tsx
+++ b/frontend/src/components/QuoteFinancialBreakdown.tsx
@@ -15,23 +15,18 @@ import {
     CardHeader,
     CardTitle,
 } from "@/components/ui/card";
-import {
-    Table,
-    TableBody,
-    TableCell,
-    TableHead,
-    TableHeader,
-    TableRow,
-} from "@/components/ui/table";
-import { Separator } from "@/components/ui/separator";
-import { AlertTriangle, Calculator, ChevronDown, ChevronRight, Package, MapPin, ReceiptText, Plane } from "lucide-react";
+import { AlertTriangle, ChevronDown, ChevronRight, Package, MapPin, ReceiptText, Plane } from "lucide-react";
 
 interface QuoteFinancialBreakdownProps {
     result: QuoteComputeResult | V3QuoteComputeResponse;
 }
 
 type LooseRecord = Record<string, unknown>;
-type BreakdownLine = SellLine & { sell_fcy_currency?: string };
+type BreakdownLine = SellLine & { 
+    sell_fcy_currency?: string;
+    canonical_item?: CanonicalQuoteLineItem;
+    raw_line?: RawQuoteLine;
+};
 type BreakdownDataShape = {
     status?: string;
     quote_result?: CanonicalQuoteResult | null;
@@ -66,6 +61,7 @@ function mapCanonicalComponentToLeg(component: string): SellLine["leg"] {
 function mapCanonicalLineItemToBreakdownLine(
     item: CanonicalQuoteLineItem,
     currency: string,
+    rawLine?: RawQuoteLine
 ): BreakdownLine {
     const sellAmount = parseFloat(item.sell_amount || "0");
     const taxAmount = parseFloat(item.tax_amount || "0");
@@ -88,6 +84,8 @@ function mapCanonicalLineItemToBreakdownLine(
         exchange_rate: "0",
         source: item.cost_source,
         is_informational: !item.included_in_total,
+        canonical_item: item,
+        raw_line: rawLine,
     };
 }
 
@@ -111,7 +109,6 @@ function buildCanonicalTotals(result: CanonicalQuoteResult): LooseRecord {
     };
 }
 
-// Simplified currency display without symbol (for cleaner table display)
 const formatAmount = (amountStr: string | number | undefined, currency: string) => {
     const amount = typeof amountStr === 'number' ? amountStr : parseFloat(amountStr || "0");
     const formatted = new Intl.NumberFormat("en-US", {
@@ -121,17 +118,14 @@ const formatAmount = (amountStr: string | number | undefined, currency: string) 
     return `${currency} ${formatted}`;
 };
 
-
 type BucketType = 'ORIGIN' | 'FREIGHT' | 'DESTINATION';
 
-// Get bucket for a line
 function getBucket(line: SellLine): BucketType {
     if (line.leg === 'MAIN' || line.leg === 'FREIGHT') return 'FREIGHT';
     if (line.leg === 'ORIGIN') return 'ORIGIN';
     return 'DESTINATION';
 }
 
-// Calculate bucket subtotal
 function calculateBucketTotal(lines: BreakdownLine[], field: string): number {
     return lines.reduce((sum, line) => {
         const rawValue = ((line as unknown) as Record<string, unknown>)[field];
@@ -157,17 +151,17 @@ function getDisplaySellAmount(line: BreakdownLine, isShowingFCY: boolean): numbe
     return parseFloat(String(rawValue || "0"));
 }
 
-function normalizeStatus(result: QuoteComputeResult | V3QuoteComputeResponse): string {
-    const maybeStatus = readStringField(result, "status") || readStringField((result as BreakdownDataShape).quote_result, "status");
-    return (maybeStatus || "").toUpperCase();
-}
-
 function isAvailable(value: unknown): boolean {
     return value !== null && value !== undefined && value !== "";
 }
 
 function displayValue(value: unknown): string {
     return isAvailable(value) ? String(value) : "Not available";
+}
+
+function displayApplicable(value: unknown, applicable: boolean): string {
+    if (!applicable) return "Not applicable";
+    return displayValue(value);
 }
 
 function displayMoney(value: unknown, currency: string): string {
@@ -193,12 +187,13 @@ function findRawLine(rawLines: RawQuoteLine[], canonicalLine: CanonicalQuoteLine
     });
 }
 
-function lineWarnings(line: CanonicalQuoteLineItem, rawLine?: RawQuoteLine): string[] {
-    const warnings: string[] = [];
-    if (rawLine?.is_rate_missing) warnings.push("Missing buy rate");
-    if (line.is_manual_override || rawLine?.is_manual_override) warnings.push("Manual override");
-    if (line.rate_source === "FALLBACK_RULE") warnings.push("FX or rate fallback");
-    if (!line.calculation_notes && !rawLine?.calculation_notes) warnings.push("Missing calculation metadata");
+type WarningDetails = { text: string; level: 'critical' | 'info' };
+
+function lineWarnings(line: CanonicalQuoteLineItem, rawLine?: RawQuoteLine): WarningDetails[] {
+    const warnings: WarningDetails[] = [];
+    if (rawLine?.is_rate_missing) warnings.push({ text: "Missing buy rate", level: 'critical' });
+    if (line.is_manual_override || rawLine?.is_manual_override) warnings.push({ text: "Manual override", level: 'info' });
+    if (line.rate_source === "FALLBACK_RULE") warnings.push({ text: "FX or rate fallback applied", level: 'info' });
     return warnings;
 }
 
@@ -212,35 +207,33 @@ function sourceLabel(line: CanonicalQuoteLineItem, rawLine?: RawQuoteLine): stri
     return displayValue(line.rate_source);
 }
 
-
 export default function QuoteFinancialBreakdown({ result }: QuoteFinancialBreakdownProps) {
     const normalizedResult = result as unknown as BreakdownDataShape;
     const canonicalResult = normalizedResult.quote_result ?? null;
     const data = normalizedResult.latest_version ?? normalizedResult;
     const canonicalCurrency = (canonicalResult?.currency || "PGK").toUpperCase();
+    
+    const rawQuoteLines = ((((data.lines || []) as unknown[]) as RawQuoteLine[]) || []);
+    
     const canonicalLines = canonicalResult?.line_items?.length
-        ? canonicalResult.line_items.map((item) => mapCanonicalLineItemToBreakdownLine(item, canonicalCurrency))
+        ? canonicalResult.line_items.map((item) => mapCanonicalLineItemToBreakdownLine(item, canonicalCurrency, findRawLine(rawQuoteLines, item)))
         : [];
+        
     const sell_lines = canonicalLines.length > 0
         ? canonicalLines
         : (((data.sell_lines || data.lines || []) as unknown[]) as BreakdownLine[]);
-    const rawQuoteLines = ((((data.lines || []) as unknown[]) as RawQuoteLine[]) || []);
+        
     const totals = canonicalResult ? buildCanonicalTotals(canonicalResult) : data.totals;
-    const quoteStatus = normalizeStatus(result);
-    const showCalculationReview = Boolean(canonicalResult && ["DRAFT", "INCOMPLETE"].includes(quoteStatus));
 
-    // Detect display currency and logic flags
     const firstLineCurrency = sell_lines[0]?.sell_fcy_currency || sell_lines[0]?.sell_currency || 'PGK';
     const displayCurrency = readStringField(totals, 'currency') || readStringField(totals, 'total_sell_fcy_currency') || firstLineCurrency;
     const isShowingFCY = displayCurrency !== 'PGK';
 
-    // Separate informational (conditional) charges from priced lines
     const pricedLines = sell_lines.filter(
         (line) => !line.is_informational && getDisplaySellAmount(line, isShowingFCY) > 0
     );
     const informationalLines = sell_lines.filter((line) => line.is_informational);
 
-    // Group PRICED lines by bucket (not informational ones)
     const buckets: Record<BucketType, BreakdownLine[]> = {
         ORIGIN: [],
         FREIGHT: [],
@@ -252,22 +245,9 @@ export default function QuoteFinancialBreakdown({ result }: QuoteFinancialBreakd
         buckets[bucket].push(line);
     });
 
-    // 3. Robust Total Mapping - Exhaustive check of all possible backend field names
-    const totalExGst = isShowingFCY
-        ? parseFloat(String(readField(totals, 'total_sell_ex_gst') ?? readField(totals, 'total_sell_fcy') ?? readField(totals, 'sell_fcy') ?? '0'))
-        : parseFloat(String(readField(totals, 'total_sell_pgk') ?? readField(totals, 'sell_pgk') ?? '0'));
-        
-    const totalGst = parseFloat(String(readField(totals, 'gst_amount') ?? readField(totals, 'total_gst') ?? readField(totals, 'gst_pgk') ?? '0'));
-    
-    const totalIncGst = isShowingFCY
-        ? parseFloat(String(readField(totals, 'total_quote_amount') ?? readField(totals, 'total_sell_fcy_incl_gst') ?? readField(totals, 'sell_fcy_incl_gst') ?? readField(totals, 'total_sell_fcy') ?? '0'))
-        : parseFloat(String(readField(totals, 'total_sell_pgk_incl_gst') ?? readField(totals, 'sell_pgk_incl_gst') ?? readField(totals, 'sell_pgk') ?? '0'));
-
-
-
     return (
-        <Card className="overflow-hidden border-slate-200">
-            <CardHeader className="pb-4 border-b border-slate-100">
+        <Card className="overflow-hidden border-slate-200 shadow-sm">
+            <CardHeader className="pb-4 border-b border-slate-100 bg-white">
                 <div className="flex items-center justify-between">
                     <CardTitle className="text-lg font-semibold flex items-center gap-2">
                         <ReceiptText className="w-5 h-5 text-slate-400" />
@@ -278,79 +258,74 @@ export default function QuoteFinancialBreakdown({ result }: QuoteFinancialBreakd
                     </span>
                 </div>
             </CardHeader>
-            <CardContent className="p-0">
-                {/* ORIGIN CHARGES */}
-                {buckets.ORIGIN.length > 0 && (
-                    <BucketSection
-                        title="Origin Charges"
-                        lines={buckets.ORIGIN}
-                        displayCurrency={displayCurrency}
-                        isShowingFCY={isShowingFCY}
-                        icon={<Package className="w-4 h-4 text-blue-600" />}
-                        colorClass="blue"
-                    />
-                )}
-                {/* FREIGHT CHARGES */}
-                {buckets.FREIGHT.length > 0 && (
-                    <BucketSection
-                        title="Freight Charges"
-                        lines={buckets.FREIGHT}
-                        displayCurrency={displayCurrency}
-                        isShowingFCY={isShowingFCY}
-                        icon={<Plane className="w-4 h-4 text-blue-600" />}
-                        colorClass="blue"
-                    />
-                )}
-
-                {/* DESTINATION CHARGES */}
-                {buckets.DESTINATION.length > 0 && (
-                    <BucketSection
-                        title="Destination Charges"
-                        lines={buckets.DESTINATION}
-                        displayCurrency={displayCurrency}
-                        isShowingFCY={isShowingFCY}
-                        icon={<MapPin className="w-4 h-4 text-blue-600" />}
-                        colorClass="blue"
-                    />
-                )}
-
-                {/* Totals Section */}
-                <div className="p-6 bg-slate-50 border-t border-slate-200">
-                    <div className="flex flex-col items-end space-y-2">
-                        <div className="flex justify-between w-full max-w-xs text-sm">
-                            <span className="text-slate-500">Total Sell (Ex GST)</span>
-                            <span className="font-mono font-medium">
-                                {formatAmount(totalExGst, displayCurrency)}
-                            </span>
+            <CardContent className="p-0 bg-slate-50/50">
+                
+                {/* Top Financial Summary */}
+                {canonicalResult && (
+                    <div className="px-6 py-5 border-b border-slate-200 bg-white grid grid-cols-2 md:grid-cols-5 gap-4">
+                        <div className="flex flex-col justify-center">
+                            <span className="text-[11px] font-semibold uppercase tracking-wider text-slate-500 mb-1">Total Buy Cost</span>
+                            <span className="text-base font-medium text-slate-800">{displayMoney(canonicalResult.total_cost_pgk, "PGK")}</span>
                         </div>
-                        <div className="flex justify-between w-full max-w-xs text-sm">
-                            <span className="text-slate-500">Total GST (10%)</span>
-                            <span className="font-mono">
-                                {formatAmount(totalGst, displayCurrency)}
-                            </span>
+                        <div className="flex flex-col justify-center">
+                            <span className="text-[11px] font-semibold uppercase tracking-wider text-slate-500 mb-1">Total Sell Amount</span>
+                            <span className="text-base font-medium text-slate-800">{displayMoney(canonicalResult.total_sell_pgk, "PGK")}</span>
                         </div>
-                        <Separator className="w-full max-w-xs my-2" />
-                        <div className="flex justify-between w-full max-w-xs items-end">
-                            <span className="text-sm font-medium text-slate-700">Total Quote Amount</span>
-                            <div className="text-right">
-                                <span className="block text-2xl font-bold text-blue-600">
-                                    {displayCurrency} {totalIncGst.toLocaleString('en-US', { minimumFractionDigits: 2 })}
-                                </span>
-                                <span className="text-[10px] text-slate-400 uppercase">
-                                    {displayCurrency} (INC GST)
-                                </span>
+                        <div className="flex flex-col justify-center">
+                            <span className="text-[11px] font-semibold uppercase tracking-wider text-slate-500 mb-1">GST / Tax Total</span>
+                            <span className="text-base font-medium text-slate-800">{displayMoney(canonicalResult.tax_breakdown?.gst_amount, displayCurrency)}</span>
+                        </div>
+                        <div className="flex flex-col justify-center md:border-l md:border-slate-200 md:pl-6">
+                            <span className="text-[11px] font-bold uppercase tracking-wider text-emerald-600 mb-1">Gross Margin</span>
+                            <div className="flex items-baseline gap-1.5">
+                                <span className="text-xl font-bold text-slate-900">{displayMoney(canonicalResult.margin_amount, "PGK")}</span>
+                                <span className="text-sm font-medium text-emerald-600">({displayPercent(canonicalResult.margin_percent)})</span>
                             </div>
                         </div>
+                        <div className="flex flex-col justify-center md:border-l md:border-slate-200 md:pl-6">
+                            <span className="text-[11px] font-bold uppercase tracking-wider text-blue-600 mb-1">Grand Total</span>
+                            <span className="text-2xl font-black text-slate-900">{displayMoney(canonicalResult.sell_total, displayCurrency)}</span>
+                        </div>
                     </div>
-                </div>
-
-                {showCalculationReview && canonicalResult && (
-                    <CalculationReviewPanel
-                        quoteResult={canonicalResult}
-                        rawLines={rawQuoteLines}
-                        displayCurrency={displayCurrency}
-                    />
                 )}
+
+                <div className="p-6 space-y-6">
+                    {/* ORIGIN CHARGES */}
+                    {buckets.ORIGIN.length > 0 && (
+                        <BucketSection
+                            title="Origin Charges"
+                            lines={buckets.ORIGIN}
+                            displayCurrency={displayCurrency}
+                            isShowingFCY={isShowingFCY}
+                            globalFx={canonicalResult?.fx_applied}
+                            icon={<Package className="w-4 h-4 text-blue-600" />}
+                        />
+                    )}
+                    
+                    {/* FREIGHT CHARGES */}
+                    {buckets.FREIGHT.length > 0 && (
+                        <BucketSection
+                            title="Freight Charges"
+                            lines={buckets.FREIGHT}
+                            displayCurrency={displayCurrency}
+                            isShowingFCY={isShowingFCY}
+                            globalFx={canonicalResult?.fx_applied}
+                            icon={<Plane className="w-4 h-4 text-blue-600" />}
+                        />
+                    )}
+
+                    {/* DESTINATION CHARGES */}
+                    {buckets.DESTINATION.length > 0 && (
+                        <BucketSection
+                            title="Destination Charges"
+                            lines={buckets.DESTINATION}
+                            displayCurrency={displayCurrency}
+                            isShowingFCY={isShowingFCY}
+                            globalFx={canonicalResult?.fx_applied}
+                            icon={<MapPin className="w-4 h-4 text-blue-600" />}
+                        />
+                    )}
+                </div>
 
                 {/* Conditional Charges Footnotes */}
                 {informationalLines.length > 0 && (
@@ -373,229 +348,34 @@ export default function QuoteFinancialBreakdown({ result }: QuoteFinancialBreakd
     );
 }
 
-function CalculationReviewPanel({
-    quoteResult,
-    rawLines,
-    displayCurrency,
-}: {
-    quoteResult: CanonicalQuoteResult;
-    rawLines: RawQuoteLine[];
-    displayCurrency: string;
-}) {
-    const [isOpen, setIsOpen] = useState(false);
-    const taxTotal = quoteResult.tax_breakdown?.gst_amount || "0.00";
-    const grandTotal = quoteResult.sell_total || "0.00";
-    const fx = quoteResult.fx_applied;
-    const warnings = [
-        ...(quoteResult.warnings || []),
-        ...quoteResult.line_items.flatMap((line) => lineWarnings(line, findRawLine(rawLines, line))),
-    ].filter((item, index, items) => item && items.indexOf(item) === index);
-
-    return (
-        <div className="border-t border-slate-200 bg-white">
-            <button
-                type="button"
-                onClick={() => setIsOpen(!isOpen)}
-                className="flex w-full items-center justify-between gap-4 px-6 py-5 text-left hover:bg-slate-50"
-            >
-                <div className="flex items-start gap-3">
-                    <div className="mt-0.5 rounded-md bg-slate-100 p-2 text-slate-600">
-                        <Calculator className="h-4 w-4" />
-                    </div>
-                    <div>
-                        <div className="flex flex-wrap items-center gap-2">
-                            <h3 className="text-base font-semibold text-slate-900">Pricing Breakdown</h3>
-                            <span className="rounded border border-slate-200 px-2 py-0.5 text-[10px] font-semibold uppercase text-slate-500">
-                                Internal only
-                            </span>
-                        </div>
-                        <p className="mt-1 text-sm text-slate-500">
-                            Review calculation inputs, source flags, margins, FX, CAF, and metadata gaps before finalizing.
-                        </p>
-                    </div>
-                </div>
-                {isOpen ? (
-                    <ChevronDown className="h-5 w-5 shrink-0 text-slate-400" />
-                ) : (
-                    <ChevronRight className="h-5 w-5 shrink-0 text-slate-400" />
-                )}
-            </button>
-
-            {isOpen && (
-                <div className="space-y-5 border-t border-slate-100 px-6 py-5">
-                    <div className="grid gap-3 md:grid-cols-3">
-                        <ReviewMetric label="Total buy cost" value={displayMoney(quoteResult.total_cost_pgk, "PGK")} />
-                        <ReviewMetric label="Total sell amount" value={displayMoney(quoteResult.total_sell_pgk, "PGK")} />
-                        <ReviewMetric label="Gross margin" value={`${displayMoney(quoteResult.margin_amount, "PGK")} (${displayPercent(quoteResult.margin_percent)})`} />
-                        <ReviewMetric label="GST/tax total" value={displayMoney(taxTotal, displayCurrency)} />
-                        <ReviewMetric label="Grand total" value={displayMoney(grandTotal, displayCurrency)} />
-                        <ReviewMetric
-                            label="Currency conversion"
-                            value={
-                                fx?.applied
-                                    ? `${displayValue(fx.currency)} -> PGK at ${displayValue(fx.rate)}`
-                                    : "No FCY conversion recorded"
-                            }
-                        />
-                    </div>
-
-                    {warnings.length > 0 && (
-                        <div className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3">
-                            <div className="flex items-center gap-2 text-sm font-semibold text-amber-900">
-                                <AlertTriangle className="h-4 w-4" />
-                                Warnings and exceptions
-                            </div>
-                            <ul className="mt-2 space-y-1 text-sm text-amber-900">
-                                {warnings.map((warning) => (
-                                    <li key={warning}>{warning}</li>
-                                ))}
-                            </ul>
-                        </div>
-                    )}
-
-                    <div className="space-y-3">
-                        {quoteResult.line_items.map((line) => (
-                            <CalculationLineDetails
-                                key={line.line_id || `${line.product_code}-${line.sort_order}`}
-                                line={line}
-                                rawLine={findRawLine(rawLines, line)}
-                                displayCurrency={displayCurrency}
-                                fx={fx}
-                            />
-                        ))}
-                    </div>
-
-                    <div className="rounded-md border border-slate-200 bg-slate-50 px-4 py-3 text-xs text-slate-600">
-                        Unavailable in this version: explicit buy-rate basis, FX direction, effective FX after CAF,
-                        minimum margin rule, and customer override/discount detail unless it has been written into
-                        calculation notes. These fields need structured persistence from the V4 engines/adapter for
-                        full audit traceability.
-                    </div>
-                </div>
-            )}
-        </div>
-    );
-}
-
-function ReviewMetric({ label, value }: { label: string; value: string }) {
-    return (
-        <div className="rounded-md border border-slate-200 bg-slate-50 px-4 py-3">
-            <div className="text-[11px] font-semibold uppercase text-slate-500">{label}</div>
-            <div className="mt-1 text-sm font-semibold text-slate-900">{value}</div>
-        </div>
-    );
-}
-
-function CalculationLineDetails({
-    line,
-    rawLine,
-    displayCurrency,
-    fx,
-}: {
-    line: CanonicalQuoteLineItem;
-    rawLine?: RawQuoteLine;
-    displayCurrency: string;
-    fx: CanonicalQuoteResult["fx_applied"];
-}) {
-    const warnings = lineWarnings(line, rawLine);
-    const buyCurrency = rawLine?.cost_fcy_currency || line.cost_currency || "PGK";
-    const buyAmount = rawLine?.cost_fcy_currency ? rawLine.cost_fcy : line.cost_amount;
-    const sellCurrency = line.sell_currency || displayCurrency;
-    const gstTreatment = `${displayValue(line.tax_code)} at ${displayPercent(rawLine?.gst_rate ? Number(rawLine.gst_rate) * 100 : undefined)}`;
-
-    return (
-        <details className="rounded-md border border-slate-200 bg-white">
-            <summary className="cursor-pointer list-none px-4 py-3 hover:bg-slate-50">
-                <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-                    <div>
-                        <div className="font-medium text-slate-900">{line.description}</div>
-                        <div className="mt-1 text-xs text-slate-500">
-                            {displayValue(line.product_code)} | {sourceLabel(line, rawLine)} | {line.is_manual_override || rawLine?.is_manual_override ? "Manual" : "System-calculated"}
-                        </div>
-                    </div>
-                    <div className="text-sm font-semibold text-slate-900">
-                        {displayMoney(line.sell_amount, sellCurrency)}
-                    </div>
-                </div>
-                {warnings.length > 0 && (
-                    <div className="mt-2 flex flex-wrap gap-2">
-                        {warnings.map((warning) => (
-                            <span key={warning} className="rounded border border-amber-200 bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-800">
-                                {warning}
-                            </span>
-                        ))}
-                    </div>
-                )}
-            </summary>
-            <div className="grid gap-x-5 gap-y-3 border-t border-slate-100 px-4 py-4 text-sm md:grid-cols-2 lg:grid-cols-3">
-                <ReviewField label="Charge description" value={line.description} />
-                <ReviewField label="Product code" value={line.product_code} />
-                <ReviewField label="Buy amount" value={displayMoney(buyAmount, buyCurrency)} />
-                <ReviewField label="Buy currency" value={buyCurrency} />
-                <ReviewField label="Sell amount" value={displayMoney(line.sell_amount, sellCurrency)} />
-                <ReviewField label="Sell currency" value={sellCurrency} />
-                <ReviewField label="Quantity" value={displayValue(line.quantity)} />
-                <ReviewField label="Unit / basis" value={`${displayValue(line.unit_type)} / ${displayValue(line.basis)}`} />
-                <ReviewField label="Buy rate used" value="Not available" />
-                <ReviewField label="FX rate used" value={displayValue(rawLine?.exchange_rate || fx?.rate)} />
-                <ReviewField label="FX direction" value="Not available" />
-                <ReviewField label="CAF applied" value={fx?.caf_percent ? displayPercent(fx.caf_percent) : "Not available"} />
-                <ReviewField label="Effective FX after CAF" value="Not available" />
-                <ReviewField label="Margin used" value={`${displayMoney(line.margin_amount, "PGK")} (${displayPercent(line.margin_percent)})`} />
-                <ReviewField label="Minimum margin rule" value="Not available" />
-                <ReviewField label="Customer override/discount" value={line.calculation_notes?.includes("discount") ? line.calculation_notes : "Not available"} />
-                <ReviewField label="GST/tax treatment" value={gstTreatment} />
-                <ReviewField label="Final calculated sell" value={displayMoney(Number(line.sell_amount || 0) + Number(line.tax_amount || 0), sellCurrency)} />
-                <ReviewField label="Pricing source" value={sourceLabel(line, rawLine)} />
-                <ReviewField label="Entry mode" value={line.is_manual_override || rawLine?.is_manual_override ? "Manually entered" : "System-calculated"} />
-                <ReviewField label="Calculation notes" value={line.calculation_notes || rawLine?.calculation_notes || "Not available"} />
-            </div>
-        </details>
-    );
-}
-
-function ReviewField({ label, value }: { label: string; value: string }) {
-    return (
-        <div>
-            <div className="text-[11px] font-semibold uppercase text-slate-500">{label}</div>
-            <div className="mt-1 break-words text-slate-900">{value}</div>
-        </div>
-    );
-}
-
-// Helper for section styling - Refined for visual hierarchy & lighter feel
 function getSectionStyle() {
     return {
-        wrapper: "mb-6 rounded-lg border border-slate-200 overflow-hidden bg-white shadow-sm", // Clean card style
-        header: "bg-white hover:bg-slate-50 border-b border-slate-100 transition-colors", // Lighter header
-        title: "text-slate-900", // Stronger title contrast
-        iconBg: "bg-blue-50 text-blue-600", // Subtler icon background
-        borderLeft: "border-l-[4px] border-l-blue-500" // Consistent accent
+        wrapper: "rounded-xl border border-slate-200 bg-white shadow-sm overflow-hidden",
+        header: "bg-white hover:bg-slate-50 border-b border-slate-100 transition-colors cursor-pointer",
+        title: "text-slate-900",
+        iconBg: "bg-blue-50 text-blue-600",
+        borderLeft: "border-l-[4px] border-l-blue-500"
     };
 }
 
-// Bucket Section Component
 function BucketSection({
     title,
     lines,
     displayCurrency,
     isShowingFCY,
+    globalFx,
     icon,
-    // colorClass prop is present in parent but ignored here to enforce standardized Blue theme
 }: {
     title: string;
     lines: BreakdownLine[];
     displayCurrency: string;
     isShowingFCY: boolean;
+    globalFx?: CanonicalQuoteResult["fx_applied"];
     icon: React.ReactNode;
-    colorClass?: string;
 }) {
-    // Default to collapsed for Freight/Dest, maybe Expanded for Origin? 
-    // User requested default collapsed previously.
-    const [isExpanded, setIsExpanded] = useState(false);
+    const [isExpanded, setIsExpanded] = useState(true);
     const styles = getSectionStyle();
 
-    // Calculate subtotal for this bucket
     const bucketTotal = isShowingFCY
         ? calculateBucketTotal(lines, 'sell_fcy')
         : calculateBucketTotal(lines, 'sell_pgk');
@@ -603,6 +383,7 @@ function BucketSection({
     return (
         <div className={styles.wrapper}>
             <button
+                type="button"
                 onClick={() => setIsExpanded(!isExpanded)}
                 className={`w-full flex items-center justify-between p-5 ${styles.header} ${styles.borderLeft}`}
             >
@@ -615,11 +396,9 @@ function BucketSection({
                             <h3 className={`text-base font-bold tracking-tight ${styles.title}`}>
                                 {title}
                             </h3>
-                            {!isExpanded && (
-                                <span className="flex items-center justify-center bg-slate-100 text-slate-500 text-[11px] font-semibold h-6 px-2 rounded-full">
-                                    {lines.length}
-                                </span>
-                            )}
+                            <span className="flex items-center justify-center bg-slate-100 text-slate-500 text-[11px] font-semibold h-6 px-2 rounded-full">
+                                {lines.length} {lines.length === 1 ? 'charge' : 'charges'}
+                            </span>
                         </div>
                     </div>
                 </div>
@@ -639,28 +418,146 @@ function BucketSection({
             </button>
 
             {isExpanded && (
-                <div className="p-6 pt-2 bg-slate-50/30">
-                    <div className="bg-white rounded-lg border border-slate-200 shadow-sm overflow-hidden">
-                        <Table>
-                            <TableHeader className="bg-slate-50/80">
-                                <TableRow className="hover:bg-transparent border-b border-slate-100">
-                                    <TableHead className="w-[50%] h-10 text-[11px] font-bold uppercase tracking-wider text-slate-500 pl-6">Description</TableHead>
-                                    <TableHead className="text-right h-10 text-[11px] font-bold uppercase tracking-wider text-slate-500">Sell (Ex GST)</TableHead>
-                                    <TableHead className="text-center h-10 text-[11px] font-bold uppercase tracking-wider text-slate-500 w-[120px]">GST</TableHead>
-                                    <TableHead className="text-right h-10 text-[11px] font-bold uppercase tracking-wider text-slate-500 pr-6">Total</TableHead>
-                                </TableRow>
-                            </TableHeader>
-                            <TableBody>
-                                {lines.map((line, index: number) => (
-                                    <ChargeRow
-                                        key={index}
-                                        line={line}
-                                        displayCurrency={displayCurrency}
-                                        isShowingFCY={isShowingFCY}
-                                    />
+                <div className="p-4 bg-slate-50/30 flex flex-col gap-2">
+                    {lines.map((line, index) => (
+                        <ChargeCard
+                            key={index}
+                            line={line}
+                            displayCurrency={displayCurrency}
+                            isShowingFCY={isShowingFCY}
+                            globalFx={globalFx}
+                        />
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}
+
+function ChargeCard({
+    line,
+    displayCurrency,
+    isShowingFCY,
+    globalFx,
+}: {
+    line: BreakdownLine;
+    displayCurrency: string;
+    isShowingFCY: boolean;
+    globalFx?: CanonicalQuoteResult["fx_applied"];
+}) {
+    const [isExpanded, setIsExpanded] = useState(false);
+    const canonicalItem = line.canonical_item;
+    const rawLine = line.raw_line;
+
+    const sellExGst = isShowingFCY 
+        ? (line.sell_fcy || line.sell_pgk) 
+        : (line.sell_pgk || line.sell_fcy);
+    
+    const buyCurrency = rawLine?.cost_fcy_currency || canonicalItem?.cost_currency || "PGK";
+    const buyAmount = rawLine?.cost_fcy_currency ? rawLine.cost_fcy : canonicalItem?.cost_amount;
+    
+    const desc = line.description;
+    const code = canonicalItem?.product_code || line.component || "MISC";
+    const status = canonicalItem ? sourceLabel(canonicalItem, rawLine) : "Unknown";
+    const marginAmount = canonicalItem?.margin_amount;
+    const marginPercent = canonicalItem?.margin_percent;
+    const warnings = canonicalItem ? lineWarnings(canonicalItem, rawLine) : [];
+    
+    const hasWarnings = warnings.length > 0;
+    const isCriticalWarning = warnings.some(w => w.level === 'critical');
+
+    return (
+        <div className={`rounded-lg border ${isExpanded ? 'border-blue-200 shadow-sm' : 'border-slate-200'} bg-white overflow-hidden transition-all`}>
+            <div 
+                className={`flex flex-col xl:flex-row xl:items-center gap-4 p-4 cursor-pointer hover:bg-slate-50 ${hasWarnings ? (isCriticalWarning ? 'bg-red-50/20' : 'bg-amber-50/20') : ''}`}
+                onClick={() => setIsExpanded(!isExpanded)}
+            >
+                <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                        <span className="font-semibold text-slate-800 text-sm truncate">{desc}</span>
+                        {canonicalItem?.is_manual_override && (
+                            <span className="px-1.5 py-0.5 rounded bg-slate-100 text-slate-600 text-[10px] font-medium uppercase tracking-wide">Manual</span>
+                        )}
+                    </div>
+                    <div className="flex items-center gap-3 mt-1.5">
+                        <span className="text-[11px] font-mono text-slate-500 bg-slate-100 px-1.5 py-0.5 rounded border border-slate-200">{code}</span>
+                        <span className="text-[11px] font-medium text-slate-500">{status}</span>
+                        {hasWarnings && (
+                            <span className={`text-[11px] font-medium flex items-center gap-1 ${isCriticalWarning ? 'text-red-600' : 'text-amber-600'}`}>
+                                <AlertTriangle className="w-3 h-3" />
+                                {warnings.length} note{warnings.length !== 1 ? 's' : ''}
+                            </span>
+                        )}
+                    </div>
+                </div>
+
+                <div className="flex flex-wrap items-center gap-4 md:gap-8 justify-between xl:justify-end">
+                    <div className="flex flex-col xl:items-end min-w-[80px]">
+                        <span className="text-[10px] uppercase tracking-wider text-slate-400 font-semibold mb-0.5">Buy</span>
+                        <span className="text-sm font-medium text-slate-600">{canonicalItem ? displayMoney(buyAmount, buyCurrency) : "—"}</span>
+                    </div>
+                    <div className="flex flex-col xl:items-end min-w-[100px]">
+                        <span className="text-[10px] uppercase tracking-wider text-slate-400 font-semibold mb-0.5">Margin</span>
+                        <div className="flex items-center gap-1 text-sm">
+                            <span className="font-medium text-emerald-600">{canonicalItem ? displayMoney(marginAmount, "PGK") : "—"}</span>
+                            {canonicalItem && <span className="text-[11px] font-medium text-emerald-600/70">({displayPercent(marginPercent)})</span>}
+                        </div>
+                    </div>
+                    <div className="flex flex-col xl:items-end min-w-[100px]">
+                        <span className="text-[10px] uppercase tracking-wider text-slate-400 font-semibold mb-0.5">Sell (Ex GST)</span>
+                        <span className="text-sm font-bold text-slate-900">{formatAmount(sellExGst, displayCurrency)}</span>
+                    </div>
+                    <div className="text-slate-400 self-center hidden md:block">
+                        {isExpanded ? <ChevronDown className="w-5 h-5" /> : <ChevronRight className="w-5 h-5" />}
+                    </div>
+                </div>
+            </div>
+
+            {isExpanded && canonicalItem && (
+                <div className="border-t border-slate-100 bg-slate-50/50 p-5">
+                    <div className="flex items-center justify-between mb-4">
+                        <h4 className="text-[11px] font-bold text-slate-500 uppercase tracking-wider">Calculation Details</h4>
+                    </div>
+
+                    {hasWarnings && (
+                        <div className={`mb-5 rounded-md border p-3 ${isCriticalWarning ? 'border-red-200 bg-red-50 text-red-800' : 'border-amber-200 bg-amber-50 text-amber-800'}`}>
+                            <div className="flex items-center gap-2 text-xs font-semibold mb-1.5">
+                                <AlertTriangle className="h-4 w-4" />
+                                {isCriticalWarning ? 'Pricing Risks' : 'Informational Notes'}
+                            </div>
+                            <ul className="space-y-1 text-xs">
+                                {warnings.map((w, i) => (
+                                    <li key={i} className="flex gap-2 items-start"><span className="opacity-50">•</span>{w.text}</li>
                                 ))}
-                            </TableBody>
-                        </Table>
+                            </ul>
+                        </div>
+                    )}
+
+                    <div className="grid grid-cols-2 md:grid-cols-4 gap-y-5 gap-x-6 text-sm">
+                        <DetailField label="Quantity" value={displayValue(canonicalItem.quantity)} />
+                        <DetailField label="Unit / Basis" value={`${displayValue(canonicalItem.unit_type)} / ${displayValue(canonicalItem.basis)}`} />
+                        <DetailField label="GST Treatment" value={`${displayValue(canonicalItem.tax_code)} at ${displayPercent(rawLine?.gst_rate ? Number(rawLine.gst_rate) * 100 : undefined)}`} />
+                        <DetailField label="Final Total (Inc GST)" value={displayMoney(Number(canonicalItem.sell_amount || 0) + Number(canonicalItem.tax_amount || 0), canonicalItem.sell_currency || displayCurrency)} />
+                        
+                        {(() => {
+                            const sellCurrency = canonicalItem.sell_currency || displayCurrency;
+                            const fxApplies = typeof canonicalItem.fx_applied === "boolean"
+                                ? canonicalItem.fx_applied
+                                : String(buyCurrency || "PGK").toUpperCase() !== "PGK" || String(sellCurrency || "PGK").toUpperCase() !== "PGK";
+
+                            if (!fxApplies) return <DetailField label="FX & CAF" value="Not applicable" />;
+                            
+                            return (
+                                <>
+                                    <DetailField label="FX Base Rate" value={displayApplicable(globalFx?.base_rate || rawLine?.exchange_rate || globalFx?.rate, true)} />
+                                    <DetailField label="CAF Applied" value={globalFx?.caf_percent ? displayPercent(Number(globalFx.caf_percent) * 100) : "Not available"} />
+                                    <DetailField label="Effective FX" value={displayApplicable(globalFx?.effective_fx_after_caf, true)} />
+                                    <DetailField label="FX Direction" value={displayApplicable(globalFx?.direction, true)} />
+                                </>
+                            );
+                        })()}
+                        
+                        <DetailField label="Notes" value={canonicalItem.calculation_notes || rawLine?.calculation_notes || "None"} colSpan={2} />
                     </div>
                 </div>
             )}
@@ -668,59 +565,11 @@ function BucketSection({
     );
 }
 
-// Individual Charge Row
-function ChargeRow({
-    line,
-    displayCurrency,
-    isShowingFCY
-}: {
-    line: BreakdownLine;
-    displayCurrency: string;
-    isShowingFCY: boolean;
-}) {
-    // Robust line mapping
-    const sellExGst = isShowingFCY 
-        ? (line.sell_fcy || line.sell_pgk) 
-        : (line.sell_pgk || line.sell_fcy);
-        
-    const gstAmountVal = parseFloat(line.gst_amount || '0');
-
-    // Determine GST display text
-    let gstDisplay: React.ReactNode = '—';
-    if (gstAmountVal > 0) {
-        gstDisplay = formatAmount(gstAmountVal, displayCurrency);
-    } else {
-        // Updated to non-interactive muted text
-        gstDisplay = <span className="text-[10px] font-medium text-slate-400 uppercase tracking-wide">Exempt</span>;
-    }
-
-    const total = isShowingFCY
-        ? (line.sell_fcy_incl_gst || line.sell_fcy)
-        : (line.sell_pgk_incl_gst || line.sell_pgk || line.sell_fcy_incl_gst);
-
+function DetailField({ label, value, colSpan = 1 }: { label: string; value: React.ReactNode; colSpan?: number }) {
     return (
-        <TableRow className="hover:bg-blue-50/30 border-b border-slate-50 last:border-0 transition-colors">
-            <TableCell className="py-4 pl-6">
-                <div className="font-medium text-slate-700 text-sm">
-                    {line.description}
-                </div>
-                {/* Reduced emphasis on line codes - secondary info */}
-                <div className="text-[10px] text-slate-400 uppercase tracking-wider mt-1 font-mono opacity-80">
-                    {line.component || 'MISC'}
-                </div>
-            </TableCell>
-            <TableCell className="text-right font-mono text-sm text-slate-600 py-4">
-                {formatAmount(sellExGst, displayCurrency)}
-            </TableCell>
-            <TableCell className="text-center py-4">
-                {/* GST Column centered and clean */}
-                <div className="flex items-center justify-center">
-                    {gstDisplay}
-                </div>
-            </TableCell>
-            <TableCell className="text-right font-mono text-sm font-bold text-slate-800 py-4 pr-6">
-                {formatAmount(total, displayCurrency)}
-            </TableCell>
-        </TableRow>
+        <div className={colSpan > 1 ? `md:col-span-${colSpan}` : ''}>
+            <div className="text-[10px] font-semibold uppercase tracking-wider text-slate-500 mb-1">{label}</div>
+            <div className="text-slate-800 break-words font-medium">{value}</div>
+        </div>
     );
 }

--- a/frontend/src/components/QuoteFinancialBreakdown.tsx
+++ b/frontend/src/components/QuoteFinancialBreakdown.tsx
@@ -466,6 +466,26 @@ function ChargeCard({
     const hasWarnings = warnings.length > 0;
     const isCriticalWarning = warnings.some(w => w.level === 'critical');
 
+    const buyAmountNum = Number(buyAmount || 0);
+    const sellExGstNum = Number(sellExGst || 0);
+    
+    let finalMarginAmount = canonicalItem?.margin_amount ?? rawLine?.margin_amount;
+    let finalMarginPercent = canonicalItem?.margin_percent ?? rawLine?.margin_percent;
+    
+    if (finalMarginAmount === undefined || finalMarginAmount === null) {
+        finalMarginAmount = String(sellExGstNum - buyAmountNum);
+    }
+    
+    if (finalMarginPercent === undefined || finalMarginPercent === null || finalMarginPercent === "0" || finalMarginPercent === "0.00") {
+        if (buyAmountNum > 0) {
+            finalMarginPercent = String(((sellExGstNum - buyAmountNum) / buyAmountNum) * 100);
+        } else if (sellExGstNum > 0) {
+            finalMarginPercent = "100.00";
+        } else {
+            finalMarginPercent = "0.00";
+        }
+    }
+
     return (
         <div className={`rounded-lg border ${isExpanded ? 'border-blue-200 shadow-sm' : 'border-slate-200'} bg-white overflow-hidden transition-all`}>
             <div 
@@ -494,13 +514,13 @@ function ChargeCard({
                 <div className="flex flex-wrap items-center gap-4 md:gap-8 justify-between xl:justify-end">
                     <div className="flex flex-col xl:items-end min-w-[80px]">
                         <span className="text-[10px] uppercase tracking-wider text-slate-400 font-semibold mb-0.5">Buy</span>
-                        <span className="text-sm font-medium text-slate-600">{canonicalItem ? displayMoney(buyAmount, buyCurrency) : "—"}</span>
+                        <span className="text-sm font-medium text-slate-600">{canonicalItem || rawLine ? displayMoney(buyAmount, buyCurrency) : "—"}</span>
                     </div>
                     <div className="flex flex-col xl:items-end min-w-[100px]">
                         <span className="text-[10px] uppercase tracking-wider text-slate-400 font-semibold mb-0.5">Margin</span>
                         <div className="flex items-center gap-1 text-sm">
-                            <span className="font-medium text-emerald-600">{canonicalItem ? displayMoney(marginAmount, "PGK") : "—"}</span>
-                            {canonicalItem && <span className="text-[11px] font-medium text-emerald-600/70">({displayPercent(marginPercent)})</span>}
+                            <span className="font-medium text-emerald-600">{canonicalItem || rawLine ? displayMoney(finalMarginAmount, "PGK") : "—"}</span>
+                            {(canonicalItem || rawLine) && <span className="text-[11px] font-medium text-emerald-600/70">({displayPercent(finalMarginPercent)})</span>}
                         </div>
                     </div>
                     <div className="flex flex-col xl:items-end min-w-[100px]">
@@ -536,7 +556,22 @@ function ChargeCard({
                     <div className="grid grid-cols-2 md:grid-cols-4 gap-y-5 gap-x-6 text-sm">
                         <DetailField label="Quantity" value={displayValue(canonicalItem.quantity)} />
                         <DetailField label="Unit / Basis" value={`${displayValue(canonicalItem.unit_type)} / ${displayValue(canonicalItem.basis)}`} />
-                        <DetailField label="GST Treatment" value={`${displayValue(canonicalItem.tax_code)} at ${displayPercent(rawLine?.gst_rate ? Number(rawLine.gst_rate) * 100 : undefined)}`} />
+                        <DetailField label="GST Treatment" value={(() => {
+                            let computedGstRate = rawLine?.gst_rate ? Number(rawLine.gst_rate) * 100 : 0;
+                            const taxAmtNum = Number(canonicalItem.tax_amount || 0);
+                            const sellAmtNum = Number(canonicalItem.sell_amount || 0);
+                            
+                            // If explicit rate missing but tax amount exists, compute it
+                            if (computedGstRate === 0 && taxAmtNum > 0 && sellAmtNum > 0) {
+                                computedGstRate = (taxAmtNum / sellAmtNum) * 100;
+                            }
+                            
+                            const rateDisplay = displayPercent(computedGstRate);
+                            if (taxAmtNum > 0) {
+                                return `${displayValue(canonicalItem.tax_code)} at ${rateDisplay} (${displayMoney(taxAmtNum, canonicalItem.sell_currency || displayCurrency)})`;
+                            }
+                            return `${displayValue(canonicalItem.tax_code)} at ${rateDisplay}`;
+                        })()} />
                         <DetailField label="Final Total (Inc GST)" value={displayMoney(Number(canonicalItem.sell_amount || 0) + Number(canonicalItem.tax_amount || 0), canonicalItem.sell_currency || displayCurrency)} />
                         
                         {(() => {

--- a/frontend/src/components/app-header.tsx
+++ b/frontend/src/components/app-header.tsx
@@ -25,11 +25,7 @@ import {
 } from "@/components/ui/sheet";
 import { useState } from 'react';
 
-type AppHeaderProps = {
-  onLogActivity?: () => void;
-};
-
-export default function AppHeader({ onLogActivity }: AppHeaderProps) {
+export default function AppHeader() {
   const pathname = usePathname();
   const router = useRouter();
   const { user, logout } = useAuth();
@@ -137,21 +133,7 @@ export default function AppHeader({ onLogActivity }: AppHeaderProps) {
                     </Link>
                   )
                 })}
-                {(onLogActivity || moreItems.length > 0) && <div className="border-t my-2" />}
-                {onLogActivity ? (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    className="mx-3 justify-start"
-                    onClick={() => {
-                      onLogActivity();
-                      setOpen(false);
-                    }}
-                  >
-                    Log Activity
-                  </Button>
-                ) : null}
-                {onLogActivity && moreItems.length > 0 && <div className="border-t my-2" />}
+                {moreItems.length > 0 && <div className="border-t my-2" />}
                 {moreItems.map((item) => {
                   const Icon = item.icon;
                   const isActive = pathname.startsWith(item.href);
@@ -247,21 +229,11 @@ export default function AppHeader({ onLogActivity }: AppHeaderProps) {
         </nav>
 
         {/* New Quote Action Button - Hide for Finance (they can't edit quotes) */}
-        {onLogActivity ? (
-          <Button
-            type="button"
-            variant="outline"
-            onClick={onLogActivity}
-            className="hidden md:flex ml-auto"
-          >
-            Log Activity
-          </Button>
-        ) : null}
         {canEditQuotes && (
           <Button
             variant="success"
             onClick={() => router.push('/quotes/new')}
-            className={`hidden md:flex ${onLogActivity ? '' : 'ml-auto'}`}
+            className="hidden md:flex ml-auto"
           >
             <Plus className="w-4 h-4 mr-2" />
             New Quote

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -1,39 +1,11 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
-import { useEffect, useState } from 'react';
 import AppHeader from '@/components/app-header';
-import { InteractionLogSheet } from '@/components/crm/InteractionLogSheet';
-
-function isTypingTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) {
-    return false;
-  }
-  const tagName = target.tagName.toLowerCase();
-  return tagName === 'input' || tagName === 'textarea' || tagName === 'select' || target.isContentEditable;
-}
 
 export default function AppShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname() || '';
-  const [quickLogOpen, setQuickLogOpen] = useState(false);
   const hideInternalChrome = pathname === '/login' || pathname.startsWith('/public');
-
-  useEffect(() => {
-    if (hideInternalChrome) return;
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey && event.key.toLowerCase() === 'l') {
-        if (isTypingTarget(event.target)) {
-          return;
-        }
-        event.preventDefault();
-        setQuickLogOpen(true);
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [hideInternalChrome]);
 
   if (hideInternalChrome) {
     return <main className="min-h-screen">{children}</main>;
@@ -41,9 +13,8 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
 
   return (
     <div className="flex flex-col h-screen overflow-hidden">
-      <AppHeader onLogActivity={() => setQuickLogOpen(true)} />
+      <AppHeader />
       <main className="flex-1 overflow-y-auto p-6">{children}</main>
-      <InteractionLogSheet open={quickLogOpen} onOpenChange={setQuickLogOpen} />
     </div>
   );
 }

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -5,7 +5,6 @@ import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/context/auth-context';
-import { InteractionLogSheet } from '@/components/crm/InteractionLogSheet';
 import {
     LayoutDashboard,
     FileText,
@@ -22,7 +21,6 @@ export function AppSidebar() {
     const pathname = usePathname();
     const { user, logout } = useAuth();
     const [collapsed, setCollapsed] = useState(false);
-    const [quickLogOpen, setQuickLogOpen] = useState(false);
     const brandName = user?.organization?.branding?.display_name || user?.organization?.name || 'RateEngine';
     const brandLogoUrl = user?.organization?.branding?.logo_url || null;
 
@@ -113,14 +111,6 @@ export function AppSidebar() {
             </div>
 
             <div className="space-y-1 px-3 flex-1">
-                <Button
-                    type="button"
-                    variant="outline"
-                    className={cn("mb-3 w-full", collapsed && "px-2")}
-                    onClick={() => setQuickLogOpen(true)}
-                >
-                    {collapsed ? "Log" : "Log Activity"}
-                </Button>
                 {routes.map((route) => {
                     if (route.role && (!user || !route.role.includes(user.role))) return null;
                     const isActive = route.href === "/"
@@ -161,7 +151,6 @@ export function AppSidebar() {
                     </Button>
                 </div>
             </div>
-            <InteractionLogSheet open={quickLogOpen} onOpenChange={setQuickLogOpen} />
         </div>
     );
 }

--- a/frontend/src/components/spot/ReplyPasteCard.tsx
+++ b/frontend/src/components/spot/ReplyPasteCard.tsx
@@ -33,6 +33,7 @@ interface ReplyPasteCardProps {
     sourceReference?: string;
     hideMissingMessage?: boolean;
     onDirtyChange?: (isDirty: boolean) => void;
+    onSkipToManual?: () => void;
     submitLabel?: string;
 }
 
@@ -50,6 +51,7 @@ export function ReplyPasteCard({
     sourceReference,
     hideMissingMessage = false,
     onDirtyChange,
+    onSkipToManual,
     submitLabel = "Analyze Intake",
 }: ReplyPasteCardProps) {
     const [text, setText] = useState("");
@@ -302,17 +304,28 @@ Agent Name`}
                                 : "No text pasted or file selected"}
                     </div>
 
-                    <Button
-                        onClick={handleSubmit}
-                        disabled={isLoading || (!text.trim() && !selectedFile)}
-                    >
-                        {isLoading ? "Analyzing..." : (
-                            <>
-                                {submitLabel}
-                                <ArrowRight className="h-4 w-4 ml-2" />
-                            </>
+                    <div className="flex items-center gap-3">
+                        {onSkipToManual && !text.trim() && !selectedFile && (
+                            <Button
+                                variant="outline"
+                                onClick={onSkipToManual}
+                                disabled={isLoading}
+                            >
+                                Enter rates manually
+                            </Button>
                         )}
-                    </Button>
+                        <Button
+                            onClick={handleSubmit}
+                            disabled={isLoading || (!text.trim() && !selectedFile)}
+                        >
+                            {isLoading ? "Analyzing..." : (
+                                <>
+                                    {submitLabel}
+                                    <ArrowRight className="h-4 w-4 ml-2" />
+                                </>
+                            )}
+                        </Button>
+                    </div>
                 </div>
 
                 {isLoading && (

--- a/frontend/src/components/spot/SpotRateEntryForm.tsx
+++ b/frontend/src/components/spot/SpotRateEntryForm.tsx
@@ -16,6 +16,7 @@ import { Form } from "@/components/ui/form";
 
 import type { SPEChargeLine, SPEChargeBucket, SPEChargeUnit, ExtractedAssertion } from "@/lib/spot-types";
 import { spotFormSchema, type SpotFormInputValues, type SpotFormSubmitValues } from "@/lib/schemas/spotSchema";
+import { getSpotFinalizeFormDisabledReason } from "@/lib/spot-finalization";
 import { ChargeBucketSection } from "./ChargeBucketSection";
 import { SpotChargeLineManualReviewSheet } from "./SpotChargeLineManualReviewSheet";
 import { getSpotChargeDisplayLabel } from "@/lib/spot-charge-display";
@@ -37,6 +38,7 @@ interface SpotRateEntryFormProps {
     submitLabel?: string;
     submitDisabled?: boolean;
     submitDisabledReason?: string | null;
+    allowEmptySubmit?: boolean;
     onSaveDraft?: (charges: Array<Omit<SPEChargeLine, 'id'> & { charge_line_id?: string }>) => Promise<void>;
     onManualResolveChargeLine?: (
         chargeLineId: string,
@@ -120,6 +122,7 @@ export function SpotRateEntryForm({
     submitLabel,
     submitDisabled = false,
     submitDisabledReason = null,
+    allowEmptySubmit = false,
     onSaveDraft,
     onManualResolveChargeLine,
     productCodeDomain,
@@ -360,6 +363,20 @@ export function SpotRateEntryForm({
             conditional_acknowledged_by: line.conditional_acknowledged_by,
             conditional_acknowledged_at: line.conditional_acknowledged_at,
             source_reference: normalizeSourceReference(line.source_reference),
+            source_label: line.source_label,
+            normalized_label: line.normalized_label,
+            normalization_status: line.normalization_status,
+            normalization_method: line.normalization_method,
+            matched_alias_id: line.matched_alias_id,
+            resolved_product_code: line.resolved_product_code,
+            effective_resolved_product_code: line.effective_resolved_product_code,
+            effective_resolution_status: line.effective_resolution_status,
+            requires_review: line.requires_review,
+            manual_resolution_status: line.manual_resolution_status,
+            manual_resolved_product_code: line.manual_resolved_product_code,
+            manual_resolution_by_user_id: line.manual_resolution_by_user_id,
+            manual_resolution_by_username: line.manual_resolution_by_username,
+            manual_resolution_at: line.manual_resolution_at,
             source_excerpt: line.source_excerpt,
             source_line_number: line.source_line_number,
             source_line_identity: line.source_line_identity,
@@ -383,6 +400,20 @@ export function SpotRateEntryForm({
         conditional_acknowledged_by: charge.conditional_acknowledged_by,
         conditional_acknowledged_at: charge.conditional_acknowledged_at,
         source_reference: normalizeSourceReference(charge.source_reference),
+        source_label: charge.source_label,
+        normalized_label: charge.normalized_label,
+        normalization_status: charge.normalization_status,
+        normalization_method: charge.normalization_method,
+        matched_alias_id: charge.matched_alias_id,
+        resolved_product_code: charge.resolved_product_code,
+        effective_resolved_product_code: charge.effective_resolved_product_code,
+        effective_resolution_status: charge.effective_resolution_status,
+        requires_review: charge.requires_review,
+        manual_resolution_status: charge.manual_resolution_status,
+        manual_resolved_product_code: charge.manual_resolved_product_code,
+        manual_resolution_by_user_id: charge.manual_resolution_by_user_id,
+        manual_resolution_by_username: charge.manual_resolution_by_username,
+        manual_resolution_at: charge.manual_resolution_at,
         source_excerpt: charge.source_excerpt,
         source_line_number: charge.source_line_number,
         source_line_identity: charge.source_line_identity,
@@ -430,20 +461,40 @@ export function SpotRateEntryForm({
         }
     };
 
+    const isSubmitBusy = Boolean(isLoading || form.formState.isSubmitting || isSavingDraft);
+    const editableChargeCount = fields.length;
+    const effectiveSubmitDisabledReason = getSpotFinalizeFormDisabledReason({
+        finalizeDisabledReason: submitDisabledReason || (submitDisabled ? "Resolve SPOT blockers before creating quote." : null),
+        editableChargeCount,
+        isFormValid: form.formState.isValid,
+        allowEmptySubmit,
+    });
+    const canSubmitEmpty = editableChargeCount === 0 && allowEmptySubmit && !submitDisabled;
+    const canSubmit = !isSubmitBusy && !effectiveSubmitDisabledReason;
+
+    const handleEmptySubmitClick = () => {
+        if (!canSubmitEmpty || !canSubmit || submitLockRef.current) return;
+        void handleFormSubmit({ charges: [] });
+    };
+
     // Keyboard Shortcuts
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
             // Ctrl/Cmd + Enter to submit
             if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
-                if (form.formState.isSubmitting || isLoading || isSavingDraft) return;
+                if (!canSubmit) return;
                 e.preventDefault();
+                if (canSubmitEmpty) {
+                    void handleFormSubmitRef.current({ charges: [] });
+                    return;
+                }
                 form.handleSubmit((data) => handleFormSubmitRef.current(data))();
             }
         };
 
         window.addEventListener('keydown', handleKeyDown);
         return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [form, isLoading, isSavingDraft]);
+    }, [canSubmit, canSubmitEmpty, form]);
 
     const addLine = (bucket: SPEChargeBucket) => {
         append({
@@ -567,9 +618,6 @@ export function SpotRateEntryForm({
     const getFieldsByBucket = (bucket: SPEChargeBucket) =>
         fields.map((field, index) => ({ field, index })).filter(item => item.field.bucket === bucket);
 
-    const isSubmitBusy = Boolean(isLoading || form.formState.isSubmitting || isSavingDraft);
-    const canSubmit = form.formState.isValid && !isSubmitBusy && !submitDisabled;
-
     return (
         <Form {...form}>
             <form onSubmit={form.handleSubmit(handleFormSubmit)} className="space-y-8">
@@ -579,9 +627,9 @@ export function SpotRateEntryForm({
                     </Alert>
                 )}
 
-                {submitDisabledReason && (
+                {effectiveSubmitDisabledReason && (
                     <Alert>
-                        <AlertDescription>{submitDisabledReason}</AlertDescription>
+                        <AlertDescription>{effectiveSubmitDisabledReason}</AlertDescription>
                     </Alert>
                 )}
 
@@ -618,7 +666,8 @@ export function SpotRateEntryForm({
                         </Button>
                     )}
                     <Button
-                        type="submit"
+                        type={canSubmitEmpty ? "button" : "submit"}
+                        onClick={canSubmitEmpty ? handleEmptySubmitClick : undefined}
                         disabled={!canSubmit}
                         size="lg"
                         loading={Boolean(isLoading || form.formState.isSubmitting)}

--- a/frontend/src/components/spot/SpotRateEntryForm.tsx
+++ b/frontend/src/components/spot/SpotRateEntryForm.tsx
@@ -16,7 +16,6 @@ import { Form } from "@/components/ui/form";
 
 import type { SPEChargeLine, SPEChargeBucket, SPEChargeUnit, ExtractedAssertion } from "@/lib/spot-types";
 import { spotFormSchema, type SpotFormInputValues, type SpotFormSubmitValues } from "@/lib/schemas/spotSchema";
-import { getSpotFinalizeFormDisabledReason } from "@/lib/spot-finalization";
 import { ChargeBucketSection } from "./ChargeBucketSection";
 import { SpotChargeLineManualReviewSheet } from "./SpotChargeLineManualReviewSheet";
 import { getSpotChargeDisplayLabel } from "@/lib/spot-charge-display";
@@ -470,6 +469,16 @@ export function SpotRateEntryForm({
         }
     };
 
+    const isSubmitBusy = Boolean(isLoading || form.formState.isSubmitting || isSavingDraft);
+    const formDisabledReason = getSpotChargeFormDisabledReason({
+        charges: watchedFormCharges,
+        isFormValid: form.formState.isValid,
+    });
+    const effectiveSubmitDisabledReason = submitDisabledReason || formDisabledReason;
+    const editableChargeCount = fields.length;
+    const canSubmitEmpty = editableChargeCount === 0 && allowEmptySubmit && !submitDisabled;
+    const canSubmit = !effectiveSubmitDisabledReason && !isSubmitBusy && !submitDisabled;
+
     const handleEmptySubmitClick = () => {
         if (!canSubmitEmpty || !canSubmit || submitLockRef.current) return;
         void handleFormSubmit({ charges: [] });
@@ -616,15 +625,6 @@ export function SpotRateEntryForm({
     const getFieldsByBucket = (bucket: SPEChargeBucket) =>
         fields.map((field, index) => ({ field, index })).filter(item => item.field.bucket === bucket);
 
-    const isSubmitBusy = Boolean(isLoading || form.formState.isSubmitting || isSavingDraft);
-    const formDisabledReason = getSpotChargeFormDisabledReason({
-        charges: watchedFormCharges,
-        isFormValid: form.formState.isValid,
-    });
-    const effectiveSubmitDisabledReason = submitDisabledReason || formDisabledReason;
-    const editableChargeCount = fields.length;
-    const canSubmitEmpty = editableChargeCount === 0 && allowEmptySubmit && !submitDisabled;
-    const canSubmit = !effectiveSubmitDisabledReason && !isSubmitBusy && !submitDisabled;
     return (
         <Form {...form}>
             <form onSubmit={form.handleSubmit(handleFormSubmit)} className="space-y-8">

--- a/frontend/src/components/spot/SpotRateEntryForm.tsx
+++ b/frontend/src/components/spot/SpotRateEntryForm.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useMemo, useEffect, useRef, useState, useCallback } from "react";
-import { useForm, useFieldArray } from "react-hook-form";
+import { useForm, useFieldArray, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 
 import PageActionBar from "@/components/navigation/PageActionBar";
@@ -20,6 +20,7 @@ import { getSpotFinalizeFormDisabledReason } from "@/lib/spot-finalization";
 import { ChargeBucketSection } from "./ChargeBucketSection";
 import { SpotChargeLineManualReviewSheet } from "./SpotChargeLineManualReviewSheet";
 import { getSpotChargeDisplayLabel } from "@/lib/spot-charge-display";
+import { getSpotChargeFormDisabledReason } from "@/lib/spot-charge-readiness";
 
 type ReviewRequest = {
     chargeLineId: string;
@@ -276,6 +277,10 @@ export function SpotRateEntryForm({
     const formattedVisibleCharges = useMemo<SpotFormInputValues["charges"]>(() => {
         // Only visible buckets are editable in this form.
         const filteredCharges = mergedCharges.filter(c => visibleBuckets.includes(c.bucket));
+        const airfreightCount = filteredCharges.filter((charge) => charge.bucket === "airfreight").length;
+        const hasExplicitPrimaryAirfreight = filteredCharges.some(
+            (charge) => charge.bucket === "airfreight" && charge.is_primary_cost
+        );
 
         return filteredCharges.map((charge) => ({
             // Omit charge.id because react-hook-form useFieldArray conflicts with existing 'id' fields
@@ -286,7 +291,7 @@ export function SpotRateEntryForm({
             currency: charge.currency,
             unit: (charge.min_charge !== null && charge.min_charge !== undefined && charge.unit === 'per_kg') ? 'min_or_per_kg' : charge.unit,
             bucket: charge.bucket,
-            is_primary_cost: charge.is_primary_cost,
+            is_primary_cost: charge.is_primary_cost || (charge.bucket === "airfreight" && airfreightCount === 1 && !hasExplicitPrimaryAirfreight),
             conditional: charge.conditional,
             conditional_acknowledged: charge.conditional_acknowledged,
             conditional_acknowledged_by: charge.conditional_acknowledged_by,
@@ -343,6 +348,10 @@ export function SpotRateEntryForm({
         control: form.control,
         name: "charges",
     });
+    const watchedFormCharges = useWatch({
+        control: form.control,
+        name: "charges",
+    }) || [];
 
     const mapEditableLineToSubmitCharge = (
         line: SpotFormSubmitValues["charges"][number]
@@ -460,17 +469,6 @@ export function SpotRateEntryForm({
             draftLockRef.current = false;
         }
     };
-
-    const isSubmitBusy = Boolean(isLoading || form.formState.isSubmitting || isSavingDraft);
-    const editableChargeCount = fields.length;
-    const effectiveSubmitDisabledReason = getSpotFinalizeFormDisabledReason({
-        finalizeDisabledReason: submitDisabledReason || (submitDisabled ? "Resolve SPOT blockers before creating quote." : null),
-        editableChargeCount,
-        isFormValid: form.formState.isValid,
-        allowEmptySubmit,
-    });
-    const canSubmitEmpty = editableChargeCount === 0 && allowEmptySubmit && !submitDisabled;
-    const canSubmit = !isSubmitBusy && !effectiveSubmitDisabledReason;
 
     const handleEmptySubmitClick = () => {
         if (!canSubmitEmpty || !canSubmit || submitLockRef.current) return;
@@ -618,6 +616,15 @@ export function SpotRateEntryForm({
     const getFieldsByBucket = (bucket: SPEChargeBucket) =>
         fields.map((field, index) => ({ field, index })).filter(item => item.field.bucket === bucket);
 
+    const isSubmitBusy = Boolean(isLoading || form.formState.isSubmitting || isSavingDraft);
+    const formDisabledReason = getSpotChargeFormDisabledReason({
+        charges: watchedFormCharges,
+        isFormValid: form.formState.isValid,
+    });
+    const effectiveSubmitDisabledReason = submitDisabledReason || formDisabledReason;
+    const editableChargeCount = fields.length;
+    const canSubmitEmpty = editableChargeCount === 0 && allowEmptySubmit && !submitDisabled;
+    const canSubmit = !effectiveSubmitDisabledReason && !isSubmitBusy && !submitDisabled;
     return (
         <Form {...form}>
             <form onSubmit={form.handleSubmit(handleFormSubmit)} className="space-y-8">

--- a/frontend/src/hooks/use-spot-mode.ts
+++ b/frontend/src/hooks/use-spot-mode.ts
@@ -401,6 +401,8 @@ export function useSpotMode() {
             service_scope: string;
             output_currency: string;
             customer_id?: string;
+            contact_id?: string;
+            incoterm?: string;
         }
     ): Promise<{ success: boolean; quote_id: string } | null> => {
         if (!state.spe) return null;

--- a/frontend/src/hooks/useQuoteLogic.ts
+++ b/frontend/src/hooks/useQuoteLogic.ts
@@ -322,6 +322,8 @@ export function useQuoteLogic({
                         dest_code: destinationCode,
                         customer_id: data.customer_id,
                         customer_name: selectedCustomer?.name || "",
+                        contact_id: data.contact_id || "",
+                        incoterm: data.incoterm || "",
                         commodity,
                         weight: String(cargoMetrics.chargeableWeight),
                         pieces: String(cargoMetrics.pieces),

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1393,6 +1393,8 @@ export async function createSpotQuote(
     service_scope: string;
     output_currency: string;
     customer_id?: string;
+    contact_id?: string;
+    incoterm?: string;
   }
 ): Promise<{ success: boolean; quote_id: string; quote_number: string }> {
   const url = API_BASE_URL + `/api/v3/spot/envelopes/${speId}/create-quote/`;

--- a/frontend/src/lib/spot-charge-readiness.ts
+++ b/frontend/src/lib/spot-charge-readiness.ts
@@ -1,0 +1,30 @@
+export type SpotChargeReadinessLine = {
+  bucket?: string | null;
+  is_primary_cost?: boolean | null;
+};
+
+export function getSpotChargeFormDisabledReason({
+  charges,
+  isFormValid,
+}: {
+  charges: SpotChargeReadinessLine[];
+  isFormValid: boolean;
+}): string | null {
+  if (charges.length === 0) {
+    return "Add at least one matched or manually entered SPOT charge before creating quote.";
+  }
+
+  const airfreightCharges = charges.filter((charge) => charge.bucket === "airfreight");
+  if (airfreightCharges.length > 0) {
+    const primaryCount = airfreightCharges.filter((charge) => Boolean(charge.is_primary_cost)).length;
+    if (primaryCount !== 1) {
+      return "Select exactly one primary airfreight line before creating quote.";
+    }
+  }
+
+  if (!isFormValid) {
+    return "Resolve invalid SPOT charge line fields before creating quote.";
+  }
+
+  return null;
+}

--- a/frontend/src/lib/spot-finalization.ts
+++ b/frontend/src/lib/spot-finalization.ts
@@ -5,12 +5,28 @@ type FinalizeEnvelopeState = Pick<
   "acknowledgement" | "can_proceed" | "intake_safety" | "is_expired" | "missing_mandatory_fields" | "status"
 >;
 
+const NON_BLOCKING_INTAKE_ISSUE_PATTERNS = [
+  /low-confidence/i,
+  /scanned-pdf fallback/i,
+  /fallback extraction/i,
+];
+
+function hasOnlyNonBlockingIntakeIssues(issues: string[] | undefined): boolean {
+  const cleaned = (issues || []).map((issue) => issue.trim()).filter(Boolean);
+  if (cleaned.length === 0) return false;
+  return cleaned.every((issue) =>
+    NON_BLOCKING_INTAKE_ISSUE_PATTERNS.some((pattern) => pattern.test(issue))
+  );
+}
+
 export function getSpotFinalizeDisabledReason({
   spe,
   unresolvedReviewIssueCount,
+  unresolvedReviewIssueLabels = [],
 }: {
   spe: FinalizeEnvelopeState | null | undefined;
   unresolvedReviewIssueCount: number;
+  unresolvedReviewIssueLabels?: string[];
 }): string | null {
   if (!spe) {
     return "SPOT envelope is still loading.";
@@ -36,12 +52,54 @@ export function getSpotFinalizeDisabledReason({
   }
 
   if (unresolvedReviewIssueCount > 0) {
+    const labels = unresolvedReviewIssueLabels.map((label) => label.trim()).filter(Boolean);
+    if (labels.length > 0) {
+      const shownLabels = labels.slice(0, 3).join(", ");
+      const remainingCount = Math.max(unresolvedReviewIssueCount - 3, 0);
+      const suffix = remainingCount > 0 ? `, and ${remainingCount} more` : "";
+      return `Resolve ${unresolvedReviewIssueCount} issue${unresolvedReviewIssueCount === 1 ? "" : "s"} before creating quote: ${shownLabels}${suffix}.`;
+    }
     return `Resolve ${unresolvedReviewIssueCount} issue${unresolvedReviewIssueCount === 1 ? "" : "s"} before creating quote.`;
   }
 
-  if (!spe.acknowledgement && spe.intake_safety && !spe.intake_safety.is_safe_to_quote) {
+  if (
+    !spe.acknowledgement &&
+    spe.intake_safety &&
+    !spe.intake_safety.is_safe_to_quote &&
+    !hasOnlyNonBlockingIntakeIssues(spe.intake_safety.blocking_issues)
+  ) {
     return spe.intake_safety.blocking_issues?.[0] || "Review imported SPOT source findings before creating quote.";
   }
 
   return null;
+}
+
+export function getSpotFinalizeFormDisabledReason({
+  finalizeDisabledReason,
+  editableChargeCount,
+  isFormValid,
+  allowEmptySubmit,
+}: {
+  finalizeDisabledReason?: string | null;
+  editableChargeCount: number;
+  isFormValid: boolean;
+  allowEmptySubmit: boolean;
+}): string | null {
+  if (finalizeDisabledReason) {
+    return finalizeDisabledReason;
+  }
+
+  if (isFormValid) {
+    return null;
+  }
+
+  if (editableChargeCount === 0 && allowEmptySubmit) {
+    return null;
+  }
+
+  if (editableChargeCount === 0) {
+    return "Add at least one SPOT charge line before creating quote.";
+  }
+
+  return "Complete the visible SPOT charge fields before creating quote.";
 }

--- a/frontend/src/lib/spot-finalization.ts
+++ b/frontend/src/lib/spot-finalization.ts
@@ -40,15 +40,15 @@ export function getSpotFinalizeDisabledReason({
     return "This SPOT quote is no longer active.";
   }
 
-  if (!spe.acknowledgement && spe.status === "ready") {
-    return "SPOT acknowledgement is required before creating quote.";
-  }
-
   if (spe.status !== "draft" && !spe.can_proceed) {
     const missing = spe.missing_mandatory_fields?.length
       ? spe.missing_mandatory_fields.join(", ")
-      : "required rate fields";
+      : "required fields";
     return `Complete missing SPOT fields before creating quote: ${missing}.`;
+  }
+
+  if (!spe.acknowledgement && spe.status === "ready") {
+    return "SPOT acknowledgement is required before creating quote.";
   }
 
   if (unresolvedReviewIssueCount > 0) {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -432,9 +432,18 @@ export interface V3QuoteVersion {
 export interface CanonicalQuoteFxApplied {
   applied: boolean;
   rate: string | null;
+  base_rate?: string | null;
+  base_rate_type?: string | null;
+  direction?: string | null;
+  from_currency?: string | null;
+  to_currency?: string | null;
   source: string | null;
   snapshot_date: string | null;
   caf_percent: string | null;
+  caf_operation?: string | null;
+  effective_fx_after_caf?: string | null;
+  fx_fallbacks?: Array<Record<string, unknown>>;
+  fx_defaults_used?: Array<Record<string, unknown>>;
   currency: string | null;
 }
 
@@ -471,6 +480,7 @@ export interface CanonicalQuoteLineItem {
   calculation_notes: string | null;
   is_spot_sourced: boolean;
   is_manual_override: boolean;
+  fx_applied?: boolean;
   sort_order: number;
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -352,6 +352,7 @@ export interface V3QuoteLine {
   product_code?: string | null;
   description?: string | null;
   leg?: string;
+  bucket?: string | null;
   cost_pgk: string;
   cost_fcy?: string | null;
   cost_fcy_currency?: string | null;
@@ -363,6 +364,21 @@ export interface V3QuoteLine {
   exchange_rate?: string | null;
   cost_source?: string | null;
   cost_source_description?: string | null;
+  basis?: string | null;
+  rule_family?: string | null;
+  service_family?: string | null;
+  unit_type?: string | null;
+  rate?: string | null;
+  rate_source?: string | null;
+  canonical_cost_source?: string | null;
+  is_spot_sourced?: boolean | null;
+  is_manual_override?: boolean | null;
+  calculation_notes?: string | null;
+  is_informational?: boolean;
+  conditional?: boolean;
+  gst_category?: string | null;
+  gst_rate?: string | null;
+  gst_amount?: string | null;
   is_rate_missing: boolean;
 }
 
@@ -445,6 +461,8 @@ export interface CanonicalQuoteLineItem {
   rate: string | null;
   cost_amount: string;
   sell_amount: string;
+  margin_amount: string;
+  margin_percent: string;
   tax_code: string;
   tax_amount: string;
   included_in_total: boolean;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -481,6 +481,7 @@ export interface CanonicalQuoteLineItem {
   is_spot_sourced: boolean;
   is_manual_override: boolean;
   fx_applied?: boolean;
+  subcategory?: string;
   sort_order: number;
 }
 


### PR DESCRIPTION
## Summary
- Restores the modern Pricing Breakdown UI by integrating the previously unmerged pricing-breakdown cleanup work.
- Adds backend `subcategory` metadata to quote result line items so charges can be grouped logically.
- Improves FX/CAF/margin exposure and prevents misleading PGK/PGK 1.000000 display for local-only lines.
- Removes legacy frontend fallback paths so the old Financial Breakdown table cannot silently reappear.

## Verification
- `python backend/manage.py test quotes.tests.test_api_v3` — 12 tests passed.
- `npm run lint` — passed.
- `npm run typecheck` — passed.
- Logical verification completed for DRAFT-975C0EAE-style data, including Agency Fee Destination and Cartage Fuel Surcharge grouping.

## Notes
Root cause was that the modern Pricing Breakdown UI and backend metadata were developed on `feature/pricing-breakdown-ui-ux-cleanup` but never merged into `main`, leaving the quote detail page on the legacy component/contract path.