### PR TITLE
Add ImportCOGS scope audit visibility

### DIFF
--- a/backend/pricing_v4/admin.py
+++ b/backend/pricing_v4/admin.py
@@ -4,6 +4,7 @@ Admin configuration for pricing_v4 models.
 """
 
 from django.contrib import admin
+from django.db.models import Q
 from .models import (
     Carrier,
     Agent,
@@ -18,6 +19,64 @@ from .models import (
     CustomerDiscount,
     CommodityChargeRule,
 )
+from .services.import_cogs_scope import ImportCOGSScope, classify_import_cogs_scope
+
+
+IMPORT_COGS_ORIGIN_SCOPE_Q = (
+    Q(product_code__code__icontains='-ORIGIN') |
+    Q(product_code__code__icontains='IMP-PICKUP') |
+    Q(product_code__code__icontains='IMP-FSC-PICKUP') |
+    Q(product_code__description__icontains='Origin') |
+    Q(product_code__description__icontains='Pickup') |
+    Q(product_code__description__icontains='AWB') |
+    Q(product_code__description__icontains='X-Ray') |
+    Q(product_code__description__icontains='Screen')
+)
+IMPORT_COGS_DESTINATION_SCOPE_Q = (
+    Q(product_code__code__icontains='-DEST') |
+    Q(product_code__code__icontains='IMP-CLEAR') |
+    Q(product_code__code__icontains='IMP-CARTAGE') |
+    Q(product_code__code__icontains='IMP-FSC-CARTAGE') |
+    Q(product_code__description__icontains='Destination') |
+    Q(product_code__description__icontains='Customs Clearance') |
+    Q(product_code__description__icontains='Cartage') |
+    Q(product_code__description__icontains='Delivery') |
+    Q(product_code__description__icontains='Handling') |
+    Q(product_code__description__icontains='Terminal')
+)
+IMPORT_COGS_LANE_SCOPE_Q = (
+    Q(product_code__category='FREIGHT') |
+    Q(product_code__code__icontains='IMP-FRT') |
+    Q(product_code__code__icontains='FRT-AIR') |
+    Q(product_code__description__icontains='Import Air Freight') |
+    Q(product_code__description__icontains='Linehaul') |
+    Q(product_code__description__icontains='Lane Freight')
+)
+IMPORT_COGS_KNOWN_SCOPE_Q = (
+    IMPORT_COGS_ORIGIN_SCOPE_Q |
+    IMPORT_COGS_DESTINATION_SCOPE_Q |
+    IMPORT_COGS_LANE_SCOPE_Q
+)
+
+
+class ImportCOGSScopeFilter(admin.SimpleListFilter):
+    title = 'computed scope'
+    parameter_name = 'computed_scope'
+
+    def lookups(self, request, model_admin):
+        return tuple((scope.value, scope.value) for scope in ImportCOGSScope)
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if value == ImportCOGSScope.ORIGIN:
+            return queryset.filter(IMPORT_COGS_ORIGIN_SCOPE_Q)
+        if value == ImportCOGSScope.DESTINATION:
+            return queryset.filter(IMPORT_COGS_DESTINATION_SCOPE_Q)
+        if value == ImportCOGSScope.LANE:
+            return queryset.filter(IMPORT_COGS_LANE_SCOPE_Q)
+        if value == ImportCOGSScope.UNKNOWN:
+            return queryset.exclude(IMPORT_COGS_KNOWN_SCOPE_Q)
+        return queryset
 
 
 @admin.register(Carrier)
@@ -138,14 +197,19 @@ class ExportSellRateAdmin(admin.ModelAdmin):
 
 @admin.register(ImportCOGS)
 class ImportCOGSAdmin(admin.ModelAdmin):
-    list_display = ['product_code', 'origin_airport', 'destination_airport', 'currency', 'get_counterparty', 'valid_from', 'valid_until']
-    list_filter = ['origin_airport', 'destination_airport', 'currency', 'carrier', 'agent']
+    list_display = ['product_code', 'computed_scope', 'origin_airport', 'destination_airport', 'currency', 'get_counterparty', 'valid_from', 'valid_until']
+    list_filter = [ImportCOGSScopeFilter, 'origin_airport', 'destination_airport', 'currency', 'carrier', 'agent']
+    list_select_related = ['product_code', 'carrier', 'agent']
     search_fields = ['product_code__code']
     ordering = ['product_code', 'origin_airport', 'destination_airport']
     
     def get_counterparty(self, obj):
         return obj.carrier or obj.agent
     get_counterparty.short_description = 'Counterparty'
+
+    def computed_scope(self, obj):
+        return classify_import_cogs_scope(obj).value
+    computed_scope.short_description = 'Computed Scope'
 
 
 @admin.register(ImportSellRate)

--- a/backend/pricing_v4/docs/import_cogs_scope_normalization.md
+++ b/backend/pricing_v4/docs/import_cogs_scope_normalization.md
@@ -1,0 +1,34 @@
+# ImportCOGS Scope Normalization Notes
+
+This is a Phase 2 preparation note only. The current `ImportCOGS` selector remains lane-based and still requires `origin_airport` plus `destination_airport`.
+
+## Current State
+
+`ImportCOGS` stores lane freight and some standard local charges in the same lane-shaped table. That makes valid lane freight duplication look similar to likely invalid local-charge duplication:
+
+- `LANE`: import air freight and lane-dependent freight rates.
+- `ORIGIN`: origin documentation, origin AWB, origin agency, origin x-ray/screening, pickup, pickup FSC, and origin CTO charges.
+- `DESTINATION`: destination terminal/handling, customs clearance, delivery/cartage, delivery FSC, and destination handling charges.
+- `UNKNOWN`: rows that cannot be safely classified from local row/product fields.
+
+## Phase 2 Direction
+
+Future normalization should:
+
+- Add an explicit `scope` field with `LANE`, `ORIGIN`, `DESTINATION`, and `UNKNOWN`.
+- Allow `ORIGIN` rows to store `destination_airport = null`.
+- Allow `DESTINATION` rows to store `origin_airport = null`.
+- Keep `LANE` rows requiring both `origin_airport` and `destination_airport`.
+- Add uniqueness constraints per scope.
+- Migrate duplicated origin/destination charges into normalized scoped rows.
+- Preserve deterministic selector behavior, including `order_by('-valid_from', '-updated_at', '-id')`.
+- Preserve quote totals and quote output during the migration.
+
+## Non-Goals For Phase 1
+
+- No destructive migrations.
+- No row deletion.
+- No seed data changes.
+- No pricing selection changes.
+- No quote output changes.
+- No runtime dependency on `audit_import_cogs_scope`.

--- a/backend/pricing_v4/management/commands/audit_import_cogs_scope.py
+++ b/backend/pricing_v4/management/commands/audit_import_cogs_scope.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Iterable
+
+from django.core.management.base import BaseCommand
+
+from pricing_v4.models import ImportCOGS
+from pricing_v4.services.import_cogs_scope import ImportCOGSScope, classify_import_cogs_scope
+
+
+@dataclass(frozen=True)
+class RowSignature:
+    product_code: str
+    counterparty_type: str
+    counterparty_code: str
+    currency: str
+    amount_signature: tuple[str, ...]
+    origin_airport: str
+    origin_country: str
+
+
+@dataclass(frozen=True)
+class CoverageSignature:
+    product_code: str
+    counterparty_type: str
+    counterparty_code: str
+    currency: str
+    amount_signature: tuple[str, ...]
+
+
+class Command(BaseCommand):
+    help = "Dry-run audit of ImportCOGS rows for future scoped normalization."
+
+    def handle(self, *args, **options):
+        rows = list(
+            ImportCOGS.objects.select_related("product_code", "agent", "carrier")
+            .order_by("product_code__code", "origin_airport", "destination_airport", "id")
+        )
+
+        duplicate_groups = self._duplicate_non_lane_groups(rows)
+        unknown_rows = [row for row in rows if classify_import_cogs_scope(row) == ImportCOGSScope.UNKNOWN]
+        orphan_groups = self._possible_orphan_groups(rows)
+
+        self.stdout.write("ImportCOGS scope audit (dry run)")
+        self.stdout.write("No rows were changed.")
+        self.stdout.write("")
+        self._write_duplicate_groups(duplicate_groups)
+        self.stdout.write("")
+        self._write_unknown_rows(unknown_rows)
+        self.stdout.write("")
+        self._write_orphan_groups(orphan_groups)
+        self.stdout.write("")
+        self.stdout.write("Phase 2 direction:")
+        self.stdout.write("- Add explicit scope field: LANE, ORIGIN, DESTINATION, UNKNOWN.")
+        self.stdout.write("- Allow ORIGIN rows to have destination_airport = null.")
+        self.stdout.write("- Allow DESTINATION rows to have origin_airport = null.")
+        self.stdout.write("- Keep LANE rows requiring both origin_airport and destination_airport.")
+        self.stdout.write("- Add uniqueness constraints per scope.")
+        self.stdout.write("- Migrate duplicated origin/destination charges into normalized scoped rows.")
+        self.stdout.write("- Preserve deterministic selector ordering and current quote output during migration.")
+
+    def _duplicate_non_lane_groups(self, rows: Iterable[ImportCOGS]):
+        groups = defaultdict(list)
+        for row in rows:
+            scope = classify_import_cogs_scope(row)
+            if scope in {ImportCOGSScope.LANE, ImportCOGSScope.UNKNOWN}:
+                continue
+            groups[_row_signature(row)].append(row)
+        return {
+            signature: members
+            for signature, members in groups.items()
+            if len({row.destination_airport for row in members}) > 1
+        }
+
+    def _possible_orphan_groups(self, rows: Iterable[ImportCOGS]):
+        coverage = defaultdict(lambda: defaultdict(set))
+        for row in rows:
+            scope = classify_import_cogs_scope(row)
+            if scope in {ImportCOGSScope.LANE, ImportCOGSScope.UNKNOWN}:
+                continue
+            signature = _coverage_signature(row)
+            coverage[signature][row.origin_airport].add(row.destination_airport)
+
+        orphan_groups = []
+        for signature, by_origin in coverage.items():
+            if len(by_origin) < 2:
+                continue
+            expected_destinations = set().union(*by_origin.values())
+            for origin, destinations in by_origin.items():
+                missing = expected_destinations - destinations
+                if missing:
+                    orphan_groups.append((signature, origin, sorted(missing)))
+        return orphan_groups
+
+    def _write_duplicate_groups(self, duplicate_groups):
+        self.stdout.write("Likely duplicate non-lane rows:")
+        if not duplicate_groups:
+            self.stdout.write("- none")
+            return
+        for signature, members in duplicate_groups.items():
+            destinations = ", ".join(sorted({row.destination_airport for row in members}))
+            ids = ", ".join(str(row.id) for row in members)
+            self.stdout.write(
+                "- "
+                f"{signature.product_code} {signature.counterparty_type}:{signature.counterparty_code} "
+                f"{signature.currency} amount={signature.amount_signature} "
+                f"origin={signature.origin_airport} origin_country={signature.origin_country} "
+                f"destinations={destinations} row_ids={ids}"
+            )
+
+    def _write_unknown_rows(self, unknown_rows):
+        self.stdout.write("UNKNOWN scope rows:")
+        if not unknown_rows:
+            self.stdout.write("- none")
+            return
+        for row in unknown_rows:
+            counterparty_type, counterparty_code, origin_country = _counterparty(row)
+            self.stdout.write(
+                "- "
+                f"#{row.id} {row.product_code.code} {row.origin_airport}->{row.destination_airport} "
+                f"{counterparty_type}:{counterparty_code} origin_country={origin_country} "
+                f"currency={row.currency} amount={_amount_signature(row)}"
+            )
+
+    def _write_orphan_groups(self, orphan_groups):
+        self.stdout.write("Possible orphan/missing companion charges:")
+        if not orphan_groups:
+            self.stdout.write("- none safely inferable")
+            return
+        for signature, origin, missing_destinations in orphan_groups:
+            self.stdout.write(
+                "- "
+                f"{signature.product_code} {signature.counterparty_type}:{signature.counterparty_code} "
+                f"{signature.currency} amount={signature.amount_signature} origin={origin} "
+                f"missing_destinations={', '.join(missing_destinations)}"
+            )
+
+
+def _row_signature(row: ImportCOGS) -> RowSignature:
+    counterparty_type, counterparty_code, origin_country = _counterparty(row)
+    return RowSignature(
+        product_code=row.product_code.code,
+        counterparty_type=counterparty_type,
+        counterparty_code=counterparty_code,
+        currency=row.currency,
+        amount_signature=_amount_signature(row),
+        origin_airport=row.origin_airport,
+        origin_country=origin_country,
+    )
+
+
+def _coverage_signature(row: ImportCOGS) -> CoverageSignature:
+    counterparty_type, counterparty_code, _origin_country = _counterparty(row)
+    return CoverageSignature(
+        product_code=row.product_code.code,
+        counterparty_type=counterparty_type,
+        counterparty_code=counterparty_code,
+        currency=row.currency,
+        amount_signature=_amount_signature(row),
+    )
+
+
+def _counterparty(row: ImportCOGS) -> tuple[str, str, str]:
+    if row.agent_id:
+        return ("agent", row.agent.code, row.agent.country_code or "")
+    if row.carrier_id:
+        return ("carrier", row.carrier.code, "")
+    return ("none", "", "")
+
+
+def _amount_signature(row: ImportCOGS) -> tuple[str, ...]:
+    return (
+        _decimal_value(row.rate_per_kg),
+        _decimal_value(row.rate_per_shipment),
+        _decimal_value(row.min_charge),
+        _decimal_value(row.max_charge),
+        _decimal_value(row.percent_rate),
+        str(row.weight_breaks or ""),
+    )
+
+
+def _decimal_value(value: Decimal | None) -> str:
+    if value is None:
+        return ""
+    return str(value.normalize())

--- a/backend/pricing_v4/services/import_cogs_scope.py
+++ b/backend/pricing_v4/services/import_cogs_scope.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+
+class ImportCOGSScope(StrEnum):
+    LANE = "LANE"
+    ORIGIN = "ORIGIN"
+    DESTINATION = "DESTINATION"
+    UNKNOWN = "UNKNOWN"
+
+
+ORIGIN_CODE_TOKENS = (
+    "-ORIGIN",
+    "IMP-PICKUP",
+    "IMP-FSC-PICKUP",
+)
+ORIGIN_TEXT_TOKENS = (
+    "ORIGIN",
+    "PICKUP",
+    "PICK UP",
+    "AWB",
+    "X-RAY",
+    "XRAY",
+    "SCREEN",
+)
+
+DESTINATION_CODE_TOKENS = (
+    "-DEST",
+    "IMP-CLEAR",
+    "IMP-CARTAGE",
+    "IMP-FSC-CARTAGE",
+)
+DESTINATION_TEXT_TOKENS = (
+    "DESTINATION",
+    "CUSTOMS CLEARANCE",
+    "CARTAGE",
+    "DELIVERY",
+    "HANDLING",
+    "TERMINAL",
+)
+
+LANE_CODE_TOKENS = (
+    "IMP-FRT",
+    "FRT-AIR",
+)
+LANE_TEXT_TOKENS = (
+    "IMPORT AIR FREIGHT",
+    "LINEHAUL",
+    "LANE FREIGHT",
+)
+
+
+def classify_import_cogs_scope(row_or_product: Any) -> ImportCOGSScope:
+    """
+    Classify the intended scope of an ImportCOGS row without database lookups.
+
+    The helper intentionally uses only fields already present on the row or its
+    attached product_code. Ambiguous import charges stay UNKNOWN so cleanup work
+    remains visible instead of being guessed into a future normalized scope.
+    """
+    product = getattr(row_or_product, "product_code", row_or_product)
+    code = str(getattr(product, "code", "") or "").upper()
+    description = str(getattr(product, "description", "") or "").upper()
+    category = str(getattr(product, "category", "") or "").upper()
+    text = f"{code} {description} {category}"
+
+    if _has_any(code, ORIGIN_CODE_TOKENS) or _has_any(text, ORIGIN_TEXT_TOKENS):
+        return ImportCOGSScope.ORIGIN
+
+    if _has_any(code, DESTINATION_CODE_TOKENS) or _has_any(text, DESTINATION_TEXT_TOKENS):
+        return ImportCOGSScope.DESTINATION
+
+    if category == "FREIGHT" or _has_any(code, LANE_CODE_TOKENS) or _has_any(text, LANE_TEXT_TOKENS):
+        return ImportCOGSScope.LANE
+
+    return ImportCOGSScope.UNKNOWN
+
+
+def _has_any(value: str, tokens: tuple[str, ...]) -> bool:
+    return any(token in value for token in tokens)

--- a/backend/pricing_v4/tests/test_import_cogs_scope_audit.py
+++ b/backend/pricing_v4/tests/test_import_cogs_scope_audit.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+from datetime import date, timedelta
+from decimal import Decimal
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from pricing_v4.engine.import_engine import ImportPricingEngine, PaymentTerm, ServiceScope
+from pricing_v4.models import Agent, ImportCOGS, LocalCOGSRate, LocalSellRate, ProductCode
+from pricing_v4.services.import_cogs_scope import ImportCOGSScope, classify_import_cogs_scope
+from pricing_v4.services.rate_selector import RateNotFoundError, RateSelectionContext, select_import_cogs_rate
+
+
+class ImportCOGSScopeClassificationTests(TestCase):
+    def test_classifies_lane_origin_destination_and_unknown_without_db_lookup(self):
+        cases = [
+            (_product("IMP-FRT-AIR", "Import Air Freight", "FREIGHT"), ImportCOGSScope.LANE),
+            (_product("IMP-DOC-ORIGIN", "Import Documentation Fee Origin", "DOCUMENTATION"), ImportCOGSScope.ORIGIN),
+            (_product("IMP-AWB-ORIGIN", "Origin AWB Fee", "DOCUMENTATION"), ImportCOGSScope.ORIGIN),
+            (_product("IMP-SCREEN-ORIGIN", "Origin X-Ray Screening", "SCREENING"), ImportCOGSScope.ORIGIN),
+            (_product("IMP-CLEAR", "Customs Clearance", "CLEARANCE"), ImportCOGSScope.DESTINATION),
+            (_product("IMP-CARTAGE-DEST", "Delivery Cartage", "CARTAGE"), ImportCOGSScope.DESTINATION),
+            (_product("IMP-MISC", "Import Miscellaneous", "REGULATORY"), ImportCOGSScope.UNKNOWN),
+        ]
+
+        for product, expected_scope in cases:
+            with self.subTest(product=product.code):
+                self.assertEqual(classify_import_cogs_scope(product), expected_scope)
+
+
+class ImportCOGSLaneLookupRegressionTests(TestCase):
+    def setUp(self):
+        self.valid_from = date.today() - timedelta(days=1)
+        self.valid_until = date.today() + timedelta(days=30)
+        self.agent = Agent.objects.create(code="EFM-AU", name="EFM Australia", country_code="AU", agent_type="ORIGIN")
+        self.freight = _create_product(2001, "IMP-FRT-AIR", "Import Air Freight", "FREIGHT", "KG")
+
+    def test_lane_freight_lookup_is_resolved_by_origin_and_destination(self):
+        bne_pom = self._create_import_cogs("BNE", "POM", Decimal("5.00"))
+        syd_pom = self._create_import_cogs("SYD", "POM", Decimal("6.00"))
+
+        result = select_import_cogs_rate(
+            RateSelectionContext(
+                product_code_id=self.freight.id,
+                quote_date=date.today(),
+                origin_airport="BNE",
+                destination_airport="POM",
+                currency="AUD",
+                agent_id=self.agent.id,
+            )
+        )
+
+        self.assertEqual(result.record.id, bne_pom.id)
+        self.assertNotEqual(result.record.id, syd_pom.id)
+
+    def test_lane_freight_does_not_fallback_to_a_different_destination(self):
+        self._create_import_cogs("BNE", "POM", Decimal("5.00"))
+
+        with self.assertRaises(RateNotFoundError):
+            select_import_cogs_rate(
+                RateSelectionContext(
+                    product_code_id=self.freight.id,
+                    quote_date=date.today(),
+                    origin_airport="BNE",
+                    destination_airport="LAE",
+                    currency="AUD",
+                    agent_id=self.agent.id,
+                )
+            )
+
+    def test_missing_lane_buy_data_still_reports_not_found(self):
+        with self.assertRaises(RateNotFoundError):
+            select_import_cogs_rate(
+                RateSelectionContext(
+                    product_code_id=self.freight.id,
+                    quote_date=date.today(),
+                    origin_airport="BNE",
+                    destination_airport="POM",
+                    currency="AUD",
+                    agent_id=self.agent.id,
+                )
+            )
+
+    def _create_import_cogs(self, origin, destination, rate):
+        return ImportCOGS.objects.create(
+            product_code=self.freight,
+            origin_airport=origin,
+            destination_airport=destination,
+            agent=self.agent,
+            currency="AUD",
+            rate_per_kg=rate,
+            valid_from=self.valid_from,
+            valid_until=self.valid_until,
+        )
+
+
+class AuditImportCOGSScopeCommandTests(TestCase):
+    def setUp(self):
+        self.valid_from = date(2025, 1, 1)
+        self.valid_until = date(2026, 12, 31)
+        self.agent = Agent.objects.create(code="EFM-AU", name="EFM Australia", country_code="AU", agent_type="ORIGIN")
+        self.doc_origin = _create_product(2010, "IMP-DOC-ORIGIN", "Import Documentation Fee Origin", "DOCUMENTATION")
+        self.unknown = _create_product(2098, "IMP-MISC", "Import Miscellaneous", "REGULATORY")
+
+    def test_audit_reports_duplicate_non_lane_unknown_and_orphan_candidates_without_changes(self):
+        self._create_import_cogs(self.doc_origin, "BNE", "POM", Decimal("80.00"))
+        self._create_import_cogs(self.doc_origin, "BNE", "LAE", Decimal("80.00"))
+        self._create_import_cogs(self.doc_origin, "SYD", "POM", Decimal("80.00"))
+        self._create_import_cogs(self.unknown, "BNE", "POM", Decimal("12.00"))
+        before_ids = list(ImportCOGS.objects.values_list("id", flat=True).order_by("id"))
+        out = StringIO()
+
+        call_command("audit_import_cogs_scope", stdout=out)
+
+        self.assertEqual(list(ImportCOGS.objects.values_list("id", flat=True).order_by("id")), before_ids)
+        report = out.getvalue()
+        self.assertIn("No rows were changed.", report)
+        self.assertIn("Likely duplicate non-lane rows:", report)
+        self.assertIn("IMP-DOC-ORIGIN", report)
+        self.assertIn("destinations=LAE, POM", report)
+        self.assertIn("UNKNOWN scope rows:", report)
+        self.assertIn("IMP-MISC", report)
+        self.assertIn("missing_destinations=LAE", report)
+
+    def _create_import_cogs(self, product_code, origin, destination, amount):
+        return ImportCOGS.objects.create(
+            product_code=product_code,
+            origin_airport=origin,
+            destination_airport=destination,
+            agent=self.agent,
+            currency="AUD",
+            rate_per_shipment=amount,
+            valid_from=self.valid_from,
+            valid_until=self.valid_until,
+        )
+
+
+class ImportCOGSQuoteSnapshotRegressionTests(TestCase):
+    def setUp(self):
+        self.valid_from = date.today() - timedelta(days=30)
+        self.valid_until = date.today() + timedelta(days=365)
+        self.origin_agent = Agent.objects.create(code="EFM-AU", name="EFM Australia", country_code="AU", agent_type="ORIGIN")
+        self.destination_agent = Agent.objects.create(code="EFM-PG", name="EFM PNG", country_code="PG", agent_type="DESTINATION")
+        self.products = {
+            "IMP-FRT-AIR": _create_product(2001, "IMP-FRT-AIR", "Import Air Freight", "FREIGHT", "KG"),
+            "IMP-DOC-ORIGIN": _create_product(2010, "IMP-DOC-ORIGIN", "Import Documentation Fee Origin", "DOCUMENTATION"),
+            "IMP-AWB-ORIGIN": _create_product(2011, "IMP-AWB-ORIGIN", "Origin AWB Fee", "DOCUMENTATION"),
+            "IMP-AGENCY-ORIGIN": _create_product(2012, "IMP-AGENCY-ORIGIN", "Import Agency Fee Origin", "AGENCY"),
+            "IMP-CLEAR": _create_product(2020, "IMP-CLEAR", "Customs Clearance", "CLEARANCE"),
+            "IMP-AGENCY-DEST": _create_product(2021, "IMP-AGENCY-DEST", "Destination Agency Fee", "AGENCY"),
+            "IMP-DOC-DEST": _create_product(2022, "IMP-DOC-DEST", "Destination Documentation Fee", "DOCUMENTATION"),
+            "IMP-CTO-ORIGIN": _create_product(2030, "IMP-CTO-ORIGIN", "Origin CTO Fee", "HANDLING", "KG"),
+            "IMP-SCREEN-ORIGIN": _create_product(2040, "IMP-SCREEN-ORIGIN", "Origin X-Ray Screening", "SCREENING", "KG"),
+            "IMP-PICKUP": _create_product(2050, "IMP-PICKUP", "Origin Pickup", "CARTAGE", "KG"),
+            "IMP-FSC-PICKUP": _create_product(2060, "IMP-FSC-PICKUP", "Origin Pickup FSC", "SURCHARGE", "PERCENT"),
+            "IMP-HANDLING-DEST": _create_product(2070, "IMP-HANDLING-DEST", "Destination Handling", "HANDLING", "KG"),
+            "IMP-LOADING-DEST": _create_product(2071, "IMP-LOADING-DEST", "Destination Loading Fee", "HANDLING"),
+            "IMP-CARTAGE-DEST": _create_product(2072, "IMP-CARTAGE-DEST", "Delivery Cartage", "CARTAGE"),
+            "IMP-FSC-CARTAGE-DEST": _create_product(2080, "IMP-FSC-CARTAGE-DEST", "Delivery FSC", "SURCHARGE", "PERCENT"),
+        }
+        self.products["IMP-FSC-PICKUP"].percent_of_product_code = self.products["IMP-PICKUP"]
+        self.products["IMP-FSC-PICKUP"].save(update_fields=["percent_of_product_code"])
+        self.products["IMP-FSC-CARTAGE-DEST"].percent_of_product_code = self.products["IMP-CARTAGE-DEST"]
+        self.products["IMP-FSC-CARTAGE-DEST"].save(update_fields=["percent_of_product_code"])
+        self._seed_import_origin_cogs()
+        self._seed_destination_local_rates()
+
+    def test_quote_json_snapshot_is_identical_after_scope_audit_helpers_run(self):
+        before = self._quote_snapshot()
+        out = StringIO()
+
+        for row in ImportCOGS.objects.select_related("product_code"):
+            classify_import_cogs_scope(row)
+        call_command("audit_import_cogs_scope", stdout=out)
+        after = self._quote_snapshot()
+
+        self.assertEqual(after, before)
+        self.assertEqual(before["origin"], "BNE")
+        self.assertEqual(before["destination"], "POM")
+        self.assertEqual(before["service_scope"], "D2D")
+        self.assertEqual(before["line_codes"], [
+            "IMP-FRT-AIR",
+            "IMP-DOC-ORIGIN",
+            "IMP-AWB-ORIGIN",
+            "IMP-AGENCY-ORIGIN",
+            "IMP-CLEAR",
+            "IMP-AGENCY-DEST",
+            "IMP-DOC-DEST",
+            "IMP-CTO-ORIGIN",
+            "IMP-SCREEN-ORIGIN",
+            "IMP-PICKUP",
+            "IMP-FSC-PICKUP",
+            "IMP-HANDLING-DEST",
+            "IMP-LOADING-DEST",
+            "IMP-CARTAGE-DEST",
+            "IMP-FSC-CARTAGE-DEST",
+        ])
+        self.assertFalse(any(line["is_rate_missing"] for line in before["line_items"]))
+
+    def _quote_snapshot(self):
+        engine = ImportPricingEngine(
+            quote_date=date.today(),
+            origin="BNE",
+            destination="POM",
+            chargeable_weight_kg=Decimal("125"),
+            payment_term=PaymentTerm.COLLECT,
+            service_scope=ServiceScope.D2D,
+        )
+        result = _stable_json(engine.calculate_quote())
+        return {
+            "origin": result["origin"],
+            "destination": result["destination"],
+            "service_scope": result["service_scope"],
+            "total_cost_pgk": result["total_cost_pgk"],
+            "total_sell_pgk": result["total_sell_pgk"],
+            "total_sell_incl_gst": result["total_sell_incl_gst"],
+            "line_codes": [line["product_code"] for line in result["line_items"]],
+            "line_items": result["line_items"],
+        }
+
+    def _seed_import_origin_cogs(self):
+        rows = [
+            ("IMP-FRT-AIR", {"rate_per_kg": Decimal("6.75"), "min_charge": Decimal("330.00")}),
+            ("IMP-DOC-ORIGIN", {"rate_per_shipment": Decimal("80.00")}),
+            ("IMP-AWB-ORIGIN", {"rate_per_shipment": Decimal("25.00")}),
+            ("IMP-AGENCY-ORIGIN", {"rate_per_shipment": Decimal("175.00")}),
+            ("IMP-CTO-ORIGIN", {"rate_per_kg": Decimal("0.30"), "min_charge": Decimal("30.00")}),
+            ("IMP-SCREEN-ORIGIN", {"rate_per_kg": Decimal("0.36"), "min_charge": Decimal("70.00")}),
+            ("IMP-PICKUP", {"rate_per_kg": Decimal("0.26"), "min_charge": Decimal("85.00")}),
+            ("IMP-FSC-PICKUP", {"percent_rate": Decimal("20.00")}),
+        ]
+        for code, values in rows:
+            ImportCOGS.objects.create(
+                product_code=self.products[code],
+                origin_airport="BNE",
+                destination_airport="POM",
+                agent=self.origin_agent,
+                currency="AUD",
+                valid_from=self.valid_from,
+                valid_until=self.valid_until,
+                **values,
+            )
+
+    def _seed_destination_local_rates(self):
+        rows = [
+            ("IMP-CLEAR", {"amount": Decimal("300.00"), "rate_type": "FIXED"}),
+            ("IMP-AGENCY-DEST", {"amount": Decimal("50.00"), "rate_type": "FIXED"}),
+            ("IMP-DOC-DEST", {"amount": Decimal("50.00"), "rate_type": "FIXED"}),
+            ("IMP-HANDLING-DEST", {"amount": Decimal("0.05"), "rate_type": "PER_KG", "min_charge": Decimal("50.00")}),
+            ("IMP-LOADING-DEST", {"amount": Decimal("50.00"), "rate_type": "FIXED"}),
+            ("IMP-CARTAGE-DEST", {"amount": Decimal("0.00"), "rate_type": "FIXED"}),
+            ("IMP-FSC-CARTAGE-DEST", {"amount": Decimal("0.00"), "rate_type": "PERCENT"}),
+        ]
+        for code, values in rows:
+            LocalCOGSRate.objects.create(
+                product_code=self.products[code],
+                location="POM",
+                direction="IMPORT",
+                agent=self.destination_agent,
+                currency="PGK",
+                valid_from=self.valid_from,
+                valid_until=self.valid_until,
+                **values,
+            )
+            LocalSellRate.objects.create(
+                product_code=self.products[code],
+                location="POM",
+                direction="IMPORT",
+                payment_term="COLLECT",
+                currency="PGK",
+                valid_from=self.valid_from,
+                valid_until=self.valid_until,
+                **values,
+            )
+
+
+def _create_product(id, code, description, category, default_unit="SHIPMENT"):
+    return ProductCode.objects.create(
+        id=id,
+        code=code,
+        description=description,
+        domain="IMPORT",
+        category=category,
+        is_gst_applicable=True,
+        gst_treatment="STANDARD",
+        gst_rate=Decimal("0.10"),
+        gl_revenue_code="4000",
+        gl_cost_code="5000",
+        default_unit=default_unit,
+    )
+
+
+def _product(code, description, category):
+    return ProductCode(code=code, description=description, category=category, domain="IMPORT")
+
+
+def _stable_json(value):
+    if is_dataclass(value):
+        return _stable_json(asdict(value))
+    if isinstance(value, dict):
+        return {key: _stable_json(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_stable_json(item) for item in value]
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, date):
+        return value.isoformat()
+    return value

--- a/backend/quotes/tests/test_public_quote_api.py
+++ b/backend/quotes/tests/test_public_quote_api.py
@@ -480,9 +480,9 @@ class QuotePublicDetailAPITest(APITestCase):
             [line["description"] for line in destination_groups["Customs / Regulatory"]["lines"]],
             ["Customs Clearance (Dest)", "Agency Fee (Dest)"],
         )
-        self.assertEqual(destination_groups["Pickup / Delivery / Cartage"]["subtotal"], "165.00")
+        self.assertEqual(destination_groups["Local Transport / Cartage"]["subtotal"], "165.00")
         self.assertEqual(
-            [line["description"] for line in destination_groups["Pickup / Delivery / Cartage"]["lines"]],
+            [line["description"] for line in destination_groups["Local Transport / Cartage"]["lines"]],
             ["Cartage & Delivery (Dest)", "Cartage Fuel Surcharge (V4)"],
         )
         self.assertEqual(destination_groups["Documentation"]["subtotal"], "150.00")
@@ -491,7 +491,7 @@ class QuotePublicDetailAPITest(APITestCase):
         self.assertEqual(destination_groups["Other Charges"]["subtotal"], "10.00")
 
         self.assertEqual(buckets["Freight"]["subtotal"], "4000.53")
-        self.assertEqual(freight_groups["Freight / Carrier Charges"]["subtotal"], "3975.53")
+        self.assertEqual(freight_groups["Freight / Carrier"]["subtotal"], "3975.53")
         self.assertEqual(freight_groups["Carrier Surcharges"]["subtotal"], "25.00")
 
     def test_public_quote_includes_branding_payload(self):

--- a/backend/quotes/views/public.py
+++ b/backend/quotes/views/public.py
@@ -275,7 +275,7 @@ def _public_group_line_sort_key(group_name: str, line_data: dict) -> tuple[int, 
             priority = 0
         elif "agency fee" in description:
             priority = 1
-    elif group_name == "Pickup / Delivery / Cartage":
+    elif group_name == "Local Transport / Cartage":
         if "cartage fuel surcharge" in description:
             priority = 1
         elif "fuel surcharge" in description:


### PR DESCRIPTION
## Summary

Adds non-runtime visibility for future ImportCOGS scope normalization:

- Adds a local-field-only `classify_import_cogs_scope` helper with `LANE`, `ORIGIN`, `DESTINATION`, and `UNKNOWN` classifications.
- Surfaces computed scope in Django admin with a read-only list column and lightweight filter.
- Adds `python manage.py audit_import_cogs_scope` as a dry-run report for likely duplicate non-lane rows, UNKNOWN rows, and safely inferable companion-charge gaps.
- Adds regression/snapshot tests documenting current ImportCOGS lane lookup behavior and proving the helper/admin/audit path does not change quote JSON output.
- Adds Phase 2 normalization notes for explicit scope, nullable endpoint fields by scope, scoped uniqueness, duplicated-row migration, and deterministic selector preservation.

## Files Changed

- `backend/pricing_v4/services/import_cogs_scope.py` - new pure helper for ImportCOGS scope classification.
- `backend/pricing_v4/admin.py` - displays and filters the computed scope in ImportCOGS admin without schema changes.
- `backend/pricing_v4/management/commands/audit_import_cogs_scope.py` - dry-run audit command; no runtime dependency.
- `backend/pricing_v4/tests/test_import_cogs_scope_audit.py` - helper, selector, audit-command, and quote snapshot regression coverage.
- `backend/pricing_v4/docs/import_cogs_scope_normalization.md` - Phase 2 TODO/migration notes.

## Intentionally Not Changed

- No migrations.
- No database schema changes.
- No seed data changes.
- No row deletion or data mutation.
- No pricing selector changes.
- No quote math/output changes.
- No legacy Spot-rate CRUD work.

## Audit Results From Local DB

`python backend/manage.py audit_import_cogs_scope` reported:

- Likely duplicate non-lane rows: none.
- UNKNOWN scope rows: none.
- Possible orphan/missing companion charges: none safely inferable.

## Validation

- `python backend/manage.py test pricing_v4.tests.test_import_cogs_scope_audit`
- `python backend/manage.py test pricing_v4.tests.test_import_cogs_scope_audit pricing_v4.tests.test_rate_selector pricing_v4.tests.test_import_engine`
- `python backend/manage.py test pricing_v4.tests.test_import_cogs_api pricing_v4.tests.test_dedupe_import_cogs_command pricing_v4.tests.test_normalize_import_origin_cogs_command`
- `python backend/manage.py audit_import_cogs_scope`
- `git diff --check -- backend\pricing_v4\admin.py backend\pricing_v4\services\import_cogs_scope.py backend\pricing_v4\management\commands\audit_import_cogs_scope.py backend\pricing_v4\tests\test_import_cogs_scope_audit.py backend\pricing_v4\docs\import_cogs_scope_normalization.md`
- `graphify update .`

Notes: tests emit existing warnings about DRF Decimal `min_value` and missing test FX rates defaulting to `1.0`; they do not fail the checks above.

## Phase 2 Recommendation

Add explicit scoped ImportCOGS persistence only after this visibility layer is reviewed. Proposed direction: `scope` field, nullable `destination_airport` for ORIGIN rows, nullable `origin_airport` for DESTINATION rows, both endpoints required for LANE, scoped uniqueness constraints, duplicate origin/destination consolidation, and unchanged deterministic selector ordering.