### PR TITLE
Add pricing rate scope audit

### DIFF
--- a/backend/pricing_v4/admin.py
+++ b/backend/pricing_v4/admin.py
@@ -4,6 +4,7 @@ Admin configuration for pricing_v4 models.
 """
 
 from django.contrib import admin
+from django.db.models import Q
 from .models import (
     Carrier,
     Agent,
@@ -18,6 +19,76 @@ from .models import (
     CustomerDiscount,
     CommodityChargeRule,
 )
+from .services.pricing_rate_scope import LOCAL_CATEGORIES, PricingRateScope, classify_pricing_rate_scope
+
+
+RATE_SCOPE_LANE_Q = (
+    Q(product_code__category='FREIGHT') |
+    Q(product_code__code__icontains='FRT') |
+    Q(product_code__code__icontains='FREIGHT') |
+    Q(product_code__description__icontains='Air Freight') |
+    Q(product_code__description__icontains='Linehaul') |
+    Q(product_code__description__icontains='Lane Freight')
+)
+RATE_SCOPE_DESTINATION_Q = (
+    Q(product_code__code__icontains='-DEST') |
+    Q(product_code__code__icontains='DELIVERY') |
+    Q(product_code__code__icontains='CARTAGE') |
+    Q(product_code__description__icontains='Destination') |
+    Q(product_code__description__icontains='Delivery') |
+    Q(product_code__description__icontains='Cartage') |
+    Q(product_code__description__icontains='Customs Clearance') |
+    Q(product_code__domain='IMPORT', product_code__category__in=LOCAL_CATEGORIES)
+)
+RATE_SCOPE_ORIGIN_Q = (
+    Q(product_code__code__icontains='-ORIGIN') |
+    Q(product_code__code__icontains='PICKUP') |
+    Q(product_code__description__icontains='Origin') |
+    Q(product_code__description__icontains='Pickup') |
+    Q(product_code__description__icontains='Pick Up') |
+    Q(product_code__description__icontains='Collection') |
+    Q(product_code__description__icontains='AWB') |
+    Q(product_code__description__icontains='Screen') |
+    Q(product_code__description__icontains='X-Ray') |
+    Q(product_code__description__icontains='Build Up') |
+    Q(product_code__domain='EXPORT', product_code__category__in=LOCAL_CATEGORIES)
+)
+RATE_SCOPE_LOCAL_Q = Q(product_code__domain='DOMESTIC', product_code__category__in=LOCAL_CATEGORIES)
+RATE_SCOPE_KNOWN_Q = (
+    RATE_SCOPE_LANE_Q |
+    RATE_SCOPE_ORIGIN_Q |
+    RATE_SCOPE_DESTINATION_Q |
+    RATE_SCOPE_LOCAL_Q
+)
+
+
+class PricingRateScopeFilter(admin.SimpleListFilter):
+    title = 'computed scope'
+    parameter_name = 'computed_scope'
+
+    def lookups(self, request, model_admin):
+        return tuple((scope.value, scope.value) for scope in PricingRateScope)
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if value == PricingRateScope.LANE:
+            return queryset.filter(RATE_SCOPE_LANE_Q)
+        if value == PricingRateScope.ORIGIN:
+            return queryset.filter(RATE_SCOPE_ORIGIN_Q)
+        if value == PricingRateScope.DESTINATION:
+            return queryset.filter(RATE_SCOPE_DESTINATION_Q)
+        if value == PricingRateScope.LOCAL:
+            return queryset.filter(RATE_SCOPE_LOCAL_Q)
+        if value == PricingRateScope.UNKNOWN:
+            return queryset.exclude(RATE_SCOPE_KNOWN_Q)
+        return queryset
+
+
+def computed_rate_scope(obj):
+    return classify_pricing_rate_scope(obj).value
+
+
+computed_rate_scope.short_description = 'Computed Scope'
 
 
 @admin.register(Carrier)
@@ -118,8 +189,9 @@ class ChargeAliasAdmin(admin.ModelAdmin):
 
 @admin.register(ExportCOGS)
 class ExportCOGSAdmin(admin.ModelAdmin):
-    list_display = ['product_code', 'origin_airport', 'destination_airport', 'currency', 'get_counterparty', 'valid_from', 'valid_until']
-    list_filter = ['origin_airport', 'destination_airport', 'currency', 'carrier', 'agent']
+    list_display = ['product_code', computed_rate_scope, 'origin_airport', 'destination_airport', 'currency', 'get_counterparty', 'valid_from', 'valid_until']
+    list_filter = [PricingRateScopeFilter, 'origin_airport', 'destination_airport', 'currency', 'carrier', 'agent']
+    list_select_related = ['product_code', 'carrier', 'agent']
     search_fields = ['product_code__code']
     ordering = ['product_code', 'origin_airport', 'destination_airport']
     
@@ -130,8 +202,9 @@ class ExportCOGSAdmin(admin.ModelAdmin):
 
 @admin.register(ExportSellRate)
 class ExportSellRateAdmin(admin.ModelAdmin):
-    list_display = ['product_code', 'origin_airport', 'destination_airport', 'currency', 'valid_from', 'valid_until']
-    list_filter = ['origin_airport', 'destination_airport', 'currency']
+    list_display = ['product_code', computed_rate_scope, 'origin_airport', 'destination_airport', 'currency', 'valid_from', 'valid_until']
+    list_filter = [PricingRateScopeFilter, 'origin_airport', 'destination_airport', 'currency']
+    list_select_related = ['product_code']
     search_fields = ['product_code__code']
     ordering = ['product_code', 'origin_airport', 'destination_airport']
 
@@ -150,8 +223,9 @@ class ImportCOGSAdmin(admin.ModelAdmin):
 
 @admin.register(ImportSellRate)
 class ImportSellRateAdmin(admin.ModelAdmin):
-    list_display = ['product_code', 'origin_airport', 'destination_airport', 'currency', 'architecture_role', 'valid_from', 'valid_until']
-    list_filter = ['origin_airport', 'destination_airport', 'currency']
+    list_display = ['product_code', computed_rate_scope, 'origin_airport', 'destination_airport', 'currency', 'architecture_role', 'valid_from', 'valid_until']
+    list_filter = [PricingRateScopeFilter, 'origin_airport', 'destination_airport', 'currency']
+    list_select_related = ['product_code']
     search_fields = ['product_code__code']
     ordering = ['product_code', 'origin_airport', 'destination_airport']
 
@@ -162,16 +236,18 @@ class ImportSellRateAdmin(admin.ModelAdmin):
 
 @admin.register(DomesticCOGS)
 class DomesticCOGSAdmin(admin.ModelAdmin):
-    list_display = ['product_code', 'origin_zone', 'destination_zone', 'currency', 'agent', 'valid_from', 'valid_until']
-    list_filter = ['origin_zone', 'destination_zone', 'agent']
+    list_display = ['product_code', computed_rate_scope, 'origin_zone', 'destination_zone', 'currency', 'agent', 'valid_from', 'valid_until']
+    list_filter = [PricingRateScopeFilter, 'origin_zone', 'destination_zone', 'agent']
+    list_select_related = ['product_code', 'agent', 'carrier']
     search_fields = ['product_code__code']
     ordering = ['product_code', 'origin_zone', 'destination_zone']
 
 
 @admin.register(DomesticSellRate)
 class DomesticSellRateAdmin(admin.ModelAdmin):
-    list_display = ['product_code', 'origin_zone', 'destination_zone', 'currency', 'architecture_role', 'valid_from', 'valid_until']
-    list_filter = ['origin_zone', 'destination_zone']
+    list_display = ['product_code', computed_rate_scope, 'origin_zone', 'destination_zone', 'currency', 'architecture_role', 'valid_from', 'valid_until']
+    list_filter = [PricingRateScopeFilter, 'origin_zone', 'destination_zone']
+    list_select_related = ['product_code']
     search_fields = ['product_code__code']
     ordering = ['product_code', 'origin_zone', 'destination_zone']
 
@@ -271,8 +347,9 @@ from .models import LocalSellRate, LocalCOGSRate
 
 @admin.register(LocalSellRate)
 class LocalSellRateAdmin(admin.ModelAdmin):
-    list_display = ['product_code', 'location', 'direction', 'payment_term', 'currency', 'architecture_role', 'rate_type', 'amount', 'valid_from', 'valid_until']
-    list_filter = ['location', 'direction', 'payment_term', 'currency', 'rate_type']
+    list_display = ['product_code', computed_rate_scope, 'location', 'direction', 'payment_term', 'currency', 'architecture_role', 'rate_type', 'amount', 'valid_from', 'valid_until']
+    list_filter = [PricingRateScopeFilter, 'location', 'direction', 'payment_term', 'currency', 'rate_type']
+    list_select_related = ['product_code', 'percent_of_product_code']
     search_fields = ['product_code__code', 'location']
     ordering = ['location', 'direction', 'product_code']
     autocomplete_fields = ['product_code', 'percent_of_product_code']
@@ -304,8 +381,9 @@ class LocalSellRateAdmin(admin.ModelAdmin):
 
 @admin.register(LocalCOGSRate)
 class LocalCOGSRateAdmin(admin.ModelAdmin):
-    list_display = ['product_code', 'location', 'direction', 'get_counterparty', 'currency', 'architecture_role', 'rate_type', 'amount', 'valid_from', 'valid_until']
-    list_filter = ['location', 'direction', 'currency', 'rate_type', 'agent', 'carrier']
+    list_display = ['product_code', computed_rate_scope, 'location', 'direction', 'get_counterparty', 'currency', 'architecture_role', 'rate_type', 'amount', 'valid_from', 'valid_until']
+    list_filter = [PricingRateScopeFilter, 'location', 'direction', 'currency', 'rate_type', 'agent', 'carrier']
+    list_select_related = ['product_code', 'agent', 'carrier', 'percent_of_product_code']
     search_fields = ['product_code__code', 'location']
     ordering = ['location', 'direction', 'product_code']
     autocomplete_fields = ['product_code', 'agent', 'carrier', 'percent_of_product_code']

--- a/backend/pricing_v4/docs/pricing_rate_scope_audit.md
+++ b/backend/pricing_v4/docs/pricing_rate_scope_audit.md
@@ -1,0 +1,42 @@
+# Pricing Rate Scope Audit Notes
+
+This is a follow-up visibility pass to the ImportCOGS-specific audit. It does not change schema, selectors, quote math, seed data, or production data.
+
+## Tables Covered
+
+- `ExportCOGS`
+- `ExportSellRate`
+- `ImportSellRate`
+- `DomesticCOGS`
+- `DomesticSellRate`
+- `LocalCOGSRate`
+- `LocalSellRate`
+
+`ImportCOGS` is intentionally excluded so the ImportCOGS audit PR stays small and reviewable.
+
+## Scope Signals
+
+- `LANE`: freight or lane-dependent charges that require both route endpoints or zones.
+- `ORIGIN`: export/import origin-side local charges.
+- `DESTINATION`: export/import destination-side local charges.
+- `LOCAL`: domestic local charges without a safe origin/destination side.
+- `UNKNOWN`: rows that cannot be safely classified from local row/product fields.
+
+## Audit Focus
+
+The dry-run audit reports:
+
+- Non-lane candidates stored in lane-shaped tables.
+- Lane candidates stored in local tables.
+- Likely duplicate non-lane rows repeated across lane endpoints.
+- UNKNOWN rows that need explicit review.
+
+## Phase 2 Direction
+
+Future normalization should:
+
+- Add explicit scope only after table-specific data review.
+- Keep lane rows requiring both route endpoints or zones.
+- Keep local rows keyed by direction/location, not full lane.
+- Normalize duplicated non-lane lane-table rows into local tables or scoped rows.
+- Preserve deterministic selector behavior and current quote output during migration.

--- a/backend/pricing_v4/management/commands/audit_pricing_rate_scope.py
+++ b/backend/pricing_v4/management/commands/audit_pricing_rate_scope.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Iterable
+
+from django.core.management.base import BaseCommand
+
+from pricing_v4.models import (
+    DomesticCOGS,
+    DomesticSellRate,
+    ExportCOGS,
+    ExportSellRate,
+    ImportSellRate,
+    LocalCOGSRate,
+    LocalSellRate,
+)
+from pricing_v4.services.pricing_rate_scope import PricingRateScope, classify_pricing_rate_scope
+
+
+LANE_TABLES = (
+    ExportCOGS,
+    ExportSellRate,
+    ImportSellRate,
+    DomesticCOGS,
+    DomesticSellRate,
+)
+LOCAL_TABLES = (
+    LocalCOGSRate,
+    LocalSellRate,
+)
+
+
+@dataclass(frozen=True)
+class DuplicateSignature:
+    table_name: str
+    product_code: str
+    counterparty_type: str
+    counterparty_code: str
+    currency: str
+    amount_signature: tuple[str, ...]
+    fixed_endpoint_name: str
+    fixed_endpoint_value: str
+
+
+class Command(BaseCommand):
+    help = "Dry-run audit of lane-vs-local scope risk across pricing rate tables."
+
+    def handle(self, *args, **options):
+        lane_rows = list(_iter_lane_rows())
+        local_rows = list(_iter_local_rows())
+
+        non_lane_in_lane_tables = [
+            row for row in lane_rows
+            if classify_pricing_rate_scope(row) in {
+                PricingRateScope.ORIGIN,
+                PricingRateScope.DESTINATION,
+                PricingRateScope.LOCAL,
+            }
+        ]
+        lane_in_local_tables = [
+            row for row in local_rows
+            if classify_pricing_rate_scope(row) == PricingRateScope.LANE
+        ]
+        unknown_rows = [
+            row for row in [*lane_rows, *local_rows]
+            if classify_pricing_rate_scope(row) == PricingRateScope.UNKNOWN
+        ]
+        duplicate_groups = _duplicate_non_lane_groups(non_lane_in_lane_tables)
+
+        self.stdout.write("Pricing rate scope audit (dry run)")
+        self.stdout.write("No rows were changed.")
+        self.stdout.write("")
+        _write_rows(self.stdout, "Non-lane candidates stored in lane-shaped tables:", non_lane_in_lane_tables)
+        self.stdout.write("")
+        _write_rows(self.stdout, "Lane candidates stored in local tables:", lane_in_local_tables)
+        self.stdout.write("")
+        _write_duplicate_groups(self.stdout, duplicate_groups)
+        self.stdout.write("")
+        _write_rows(self.stdout, "UNKNOWN scope rows:", unknown_rows)
+        self.stdout.write("")
+        self.stdout.write("Phase 2 direction:")
+        self.stdout.write("- Add explicit scope only after table-specific data review.")
+        self.stdout.write("- Keep lane rows requiring both route endpoints or zones.")
+        self.stdout.write("- Keep local rows keyed by direction/location, not full lane.")
+        self.stdout.write("- Normalize duplicated non-lane lane-table rows into local tables or scoped rows.")
+        self.stdout.write("- Preserve current selector ordering and quote output while migrating.")
+
+
+def _iter_lane_rows():
+    for model_cls in LANE_TABLES:
+        queryset = model_cls.objects.select_related("product_code")
+        if _has_counterparty_fields(model_cls):
+            queryset = queryset.select_related("agent", "carrier")
+        for row in queryset.order_by("product_code__code", "id"):
+            yield row
+
+
+def _iter_local_rows():
+    for model_cls in LOCAL_TABLES:
+        queryset = model_cls.objects.select_related("product_code")
+        if _has_counterparty_fields(model_cls):
+            queryset = queryset.select_related("agent", "carrier")
+        for row in queryset.order_by("product_code__code", "location", "direction", "id"):
+            yield row
+
+
+def _has_counterparty_fields(model_cls) -> bool:
+    fields = {field.name for field in model_cls._meta.fields}
+    return {"agent", "carrier"}.issubset(fields)
+
+
+def _duplicate_non_lane_groups(rows: Iterable[object]):
+    groups = defaultdict(list)
+    for row in rows:
+        for signature in _duplicate_signatures(row):
+            groups[signature].append(row)
+    return {
+        signature: members
+        for signature, members in groups.items()
+        if len({_variable_endpoint(row, signature.fixed_endpoint_name) for row in members}) > 1
+    }
+
+
+def _duplicate_signatures(row: object) -> list[DuplicateSignature]:
+    table_name = type(row).__name__
+    counterparty_type, counterparty_code = _counterparty(row)
+    base = {
+        "table_name": table_name,
+        "product_code": row.product_code.code,
+        "counterparty_type": counterparty_type,
+        "counterparty_code": counterparty_code,
+        "currency": getattr(row, "currency", ""),
+        "amount_signature": _amount_signature(row),
+    }
+    signatures = []
+    origin_value = _origin_value(row)
+    destination_value = _destination_value(row)
+    if origin_value:
+        signatures.append(
+            DuplicateSignature(
+                **base,
+                fixed_endpoint_name="origin",
+                fixed_endpoint_value=origin_value,
+            )
+        )
+    if destination_value:
+        signatures.append(
+            DuplicateSignature(
+                **base,
+                fixed_endpoint_name="destination",
+                fixed_endpoint_value=destination_value,
+            )
+        )
+    return signatures
+
+
+def _write_rows(stdout, title: str, rows: list[object]):
+    stdout.write(title)
+    if not rows:
+        stdout.write("- none")
+        return
+    for row in rows:
+        scope = classify_pricing_rate_scope(row)
+        stdout.write(
+            "- "
+            f"{type(row).__name__} #{row.id} {row.product_code.code} "
+            f"scope={scope.value} endpoint={_endpoint_label(row)} "
+            f"counterparty={':'.join(_counterparty(row))} "
+            f"currency={getattr(row, 'currency', '')} amount={_amount_signature(row)}"
+        )
+
+
+def _write_duplicate_groups(stdout, duplicate_groups):
+    stdout.write("Likely duplicate non-lane rows in lane-shaped tables:")
+    if not duplicate_groups:
+        stdout.write("- none")
+        return
+    for signature, members in duplicate_groups.items():
+        variable_endpoint_name = "destination" if signature.fixed_endpoint_name == "origin" else "origin"
+        variables = ", ".join(sorted({_variable_endpoint(row, signature.fixed_endpoint_name) for row in members}))
+        ids = ", ".join(f"{type(row).__name__}#{row.id}" for row in members)
+        stdout.write(
+            "- "
+            f"{signature.table_name} {signature.product_code} "
+            f"{signature.counterparty_type}:{signature.counterparty_code} "
+            f"{signature.currency} amount={signature.amount_signature} "
+            f"{signature.fixed_endpoint_name}={signature.fixed_endpoint_value} "
+            f"{variable_endpoint_name}s={variables} row_ids={ids}"
+        )
+
+
+def _endpoint_label(row: object) -> str:
+    if hasattr(row, "origin_airport"):
+        return f"{row.origin_airport}->{row.destination_airport}"
+    if hasattr(row, "origin_zone"):
+        return f"{row.origin_zone}->{row.destination_zone}"
+    return f"{row.direction}@{row.location}"
+
+
+def _origin_value(row: object) -> str:
+    return str(getattr(row, "origin_airport", getattr(row, "origin_zone", "")) or "")
+
+
+def _destination_value(row: object) -> str:
+    return str(getattr(row, "destination_airport", getattr(row, "destination_zone", "")) or "")
+
+
+def _variable_endpoint(row: object, fixed_endpoint_name: str) -> str:
+    if fixed_endpoint_name == "origin":
+        return _destination_value(row)
+    return _origin_value(row)
+
+
+def _counterparty(row: object) -> tuple[str, str]:
+    agent = getattr(row, "agent", None)
+    carrier = getattr(row, "carrier", None)
+    if getattr(row, "agent_id", None) and agent:
+        return ("agent", agent.code)
+    if getattr(row, "carrier_id", None) and carrier:
+        return ("carrier", carrier.code)
+    return ("none", "")
+
+
+def _amount_signature(row: object) -> tuple[str, ...]:
+    return (
+        _decimal_value(getattr(row, "rate_per_kg", None)),
+        _decimal_value(getattr(row, "rate_per_shipment", None)),
+        _decimal_value(getattr(row, "amount", None)),
+        str(getattr(row, "rate_type", "") or ""),
+        _decimal_value(getattr(row, "min_charge", None)),
+        _decimal_value(getattr(row, "max_charge", None)),
+        _decimal_value(getattr(row, "percent_rate", None)),
+        str(getattr(row, "weight_breaks", None) or ""),
+    )
+
+
+def _decimal_value(value: Decimal | None) -> str:
+    if value is None:
+        return ""
+    return str(value.normalize())

--- a/backend/pricing_v4/services/pricing_rate_scope.py
+++ b/backend/pricing_v4/services/pricing_rate_scope.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+
+class PricingRateScope(StrEnum):
+    LANE = "LANE"
+    ORIGIN = "ORIGIN"
+    DESTINATION = "DESTINATION"
+    LOCAL = "LOCAL"
+    UNKNOWN = "UNKNOWN"
+
+
+LOCAL_CATEGORIES = {
+    "AGENCY",
+    "CARTAGE",
+    "CLEARANCE",
+    "DOCUMENTATION",
+    "HANDLING",
+    "REGULATORY",
+    "SCREENING",
+    "SECURITY",
+    "SURCHARGE",
+    "TERMINAL",
+}
+
+LANE_CODE_TOKENS = (
+    "FRT",
+    "FREIGHT",
+)
+LANE_TEXT_TOKENS = (
+    "AIR FREIGHT",
+    "LINEHAUL",
+    "LANE FREIGHT",
+)
+
+ORIGIN_CODE_TOKENS = (
+    "-ORIGIN",
+    "PICKUP",
+    "PICK-UP",
+    "PICK_UP",
+)
+ORIGIN_TEXT_TOKENS = (
+    "ORIGIN",
+    "PICKUP",
+    "PICK UP",
+    "PICK-UP",
+    "COLLECTION",
+    "AWB",
+    "SCREEN",
+    "X-RAY",
+    "XRAY",
+    "BUILD UP",
+    "BUILDUP",
+)
+
+DESTINATION_CODE_TOKENS = (
+    "-DEST",
+    "DELIVERY",
+    "CARTAGE",
+)
+DESTINATION_TEXT_TOKENS = (
+    "DESTINATION",
+    "DELIVERY",
+    "CARTAGE",
+    "CUSTOMS CLEARANCE",
+    "DEST",
+)
+
+
+def classify_pricing_rate_scope(row_or_product: Any) -> PricingRateScope:
+    """
+    Classify a rate row's intended storage scope without database lookups.
+
+    This is intentionally conservative. It uses only local fields already on the
+    row/product and keeps unclear rows UNKNOWN so follow-up data work remains
+    explicit instead of being inferred into a lane or local bucket.
+    """
+    product = getattr(row_or_product, "product_code", row_or_product)
+    code = str(getattr(product, "code", "") or "").upper()
+    description = str(getattr(product, "description", "") or "").upper()
+    category = str(getattr(product, "category", "") or "").upper()
+    domain = str(getattr(product, "domain", "") or "").upper()
+    text = f"{code} {description} {category}"
+
+    if category == "FREIGHT" or _has_any(code, LANE_CODE_TOKENS) or _has_any(text, LANE_TEXT_TOKENS):
+        return PricingRateScope.LANE
+
+    if _has_any(code, ORIGIN_CODE_TOKENS) or _has_any(text, ORIGIN_TEXT_TOKENS):
+        return PricingRateScope.ORIGIN
+
+    if _has_any(code, DESTINATION_CODE_TOKENS) or _has_any(text, DESTINATION_TEXT_TOKENS):
+        return PricingRateScope.DESTINATION
+
+    if category in LOCAL_CATEGORIES:
+        if domain == "EXPORT":
+            return PricingRateScope.ORIGIN
+        if domain == "IMPORT":
+            return PricingRateScope.DESTINATION
+        if domain == "DOMESTIC":
+            return PricingRateScope.LOCAL
+
+    return PricingRateScope.UNKNOWN
+
+
+def _has_any(value: str, tokens: tuple[str, ...]) -> bool:
+    return any(token in value for token in tokens)

--- a/backend/pricing_v4/tests/test_pricing_rate_scope_audit.py
+++ b/backend/pricing_v4/tests/test_pricing_rate_scope_audit.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from pricing_v4.models import (
+    Agent,
+    DomesticCOGS,
+    DomesticSellRate,
+    ExportSellRate,
+    LocalSellRate,
+    ProductCode,
+)
+from pricing_v4.services.pricing_rate_scope import PricingRateScope, classify_pricing_rate_scope
+from pricing_v4.services.rate_selector import (
+    RateSelectionContext,
+    select_export_sell_rate,
+    select_local_sell_rate,
+)
+
+
+class PricingRateScopeClassificationTests(TestCase):
+    def test_classifies_lane_local_and_unknown_products_without_db_lookup(self):
+        cases = [
+            (_product("EXP-FRT-AIR", "Export Air Freight", "EXPORT", "FREIGHT"), PricingRateScope.LANE),
+            (_product("EXP-DOC", "Documentation Fee", "EXPORT", "DOCUMENTATION"), PricingRateScope.ORIGIN),
+            (_product("EXP-DELIVERY-DEST", "Destination Delivery", "EXPORT", "CARTAGE"), PricingRateScope.DESTINATION),
+            (_product("IMP-CLEAR", "Customs Clearance", "IMPORT", "CLEARANCE"), PricingRateScope.DESTINATION),
+            (_product("IMP-PICKUP", "Pickup Charge", "IMPORT", "CARTAGE"), PricingRateScope.ORIGIN),
+            (_product("DOM-DOC", "Documentation Fee", "DOMESTIC", "DOCUMENTATION"), PricingRateScope.LOCAL),
+            (_product("DOM-MISC", "Domestic Miscellaneous", "DOMESTIC", "SPECIAL"), PricingRateScope.UNKNOWN),
+        ]
+
+        for product, expected_scope in cases:
+            with self.subTest(product=product.code):
+                self.assertEqual(classify_pricing_rate_scope(product), expected_scope)
+
+
+class PricingRateScopeAuditCommandTests(TestCase):
+    def setUp(self):
+        self.valid_from = date.today() - timedelta(days=1)
+        self.valid_until = date.today() + timedelta(days=30)
+        self.agent = Agent.objects.create(
+            code="SCOPE-AG",
+            name="Scope Audit Agent",
+            country_code="PG",
+            agent_type="ORIGIN",
+        )
+        self.export_doc = _create_product(1110, "EXP-DOC", "Documentation Fee", "EXPORT", "DOCUMENTATION")
+        self.export_freight = _create_product(1101, "EXP-FRT-AIR", "Export Air Freight", "EXPORT", "FREIGHT", "KG")
+        self.domestic_doc = _create_product(3310, "DOM-DOC", "Documentation Fee", "DOMESTIC", "DOCUMENTATION")
+        self.unknown = _create_product(3399, "DOM-MISC", "Domestic Miscellaneous", "DOMESTIC", "SPECIAL")
+
+    def test_audit_reports_scope_risks_without_changing_rows(self):
+        ExportSellRate.objects.create(
+            product_code=self.export_doc,
+            origin_airport="POM",
+            destination_airport="BNE",
+            currency="PGK",
+            rate_per_shipment=Decimal("35.00"),
+            valid_from=self.valid_from,
+            valid_until=self.valid_until,
+        )
+        ExportSellRate.objects.create(
+            product_code=self.export_doc,
+            origin_airport="POM",
+            destination_airport="SYD",
+            currency="PGK",
+            rate_per_shipment=Decimal("35.00"),
+            valid_from=self.valid_from,
+            valid_until=self.valid_until,
+        )
+        DomesticCOGS.objects.create(
+            product_code=self.domestic_doc,
+            origin_zone="POM",
+            destination_zone="LAE",
+            agent=self.agent,
+            currency="PGK",
+            rate_per_shipment=Decimal("40.00"),
+            valid_from=self.valid_from,
+            valid_until=self.valid_until,
+        )
+        DomesticCOGS.objects.create(
+            product_code=self.domestic_doc,
+            origin_zone="POM",
+            destination_zone="HGU",
+            agent=self.agent,
+            currency="PGK",
+            rate_per_shipment=Decimal("40.00"),
+            valid_from=self.valid_from,
+            valid_until=self.valid_until,
+        )
+        LocalSellRate.objects.create(
+            product_code=self.export_freight,
+            location="POM",
+            direction="EXPORT",
+            payment_term="PREPAID",
+            currency="PGK",
+            rate_type="PER_KG",
+            amount=Decimal("5.00"),
+            valid_from=self.valid_from,
+            valid_until=self.valid_until,
+        )
+        DomesticSellRate.objects.create(
+            product_code=self.unknown,
+            origin_zone="POM",
+            destination_zone="LAE",
+            currency="PGK",
+            rate_per_shipment=Decimal("9.00"),
+            valid_from=self.valid_from,
+            valid_until=self.valid_until,
+        )
+        before_counts = {
+            "ExportSellRate": ExportSellRate.objects.count(),
+            "DomesticCOGS": DomesticCOGS.objects.count(),
+            "DomesticSellRate": DomesticSellRate.objects.count(),
+            "LocalSellRate": LocalSellRate.objects.count(),
+        }
+        out = StringIO()
+
+        call_command("audit_pricing_rate_scope", stdout=out)
+
+        self.assertEqual(
+            {
+                "ExportSellRate": ExportSellRate.objects.count(),
+                "DomesticCOGS": DomesticCOGS.objects.count(),
+                "DomesticSellRate": DomesticSellRate.objects.count(),
+                "LocalSellRate": LocalSellRate.objects.count(),
+            },
+            before_counts,
+        )
+        report = out.getvalue()
+        self.assertIn("No rows were changed.", report)
+        self.assertIn("Non-lane candidates stored in lane-shaped tables:", report)
+        self.assertIn("ExportSellRate", report)
+        self.assertIn("EXP-DOC", report)
+        self.assertIn("DomesticCOGS", report)
+        self.assertIn("DOM-DOC", report)
+        self.assertIn("Lane candidates stored in local tables:", report)
+        self.assertIn("LocalSellRate", report)
+        self.assertIn("EXP-FRT-AIR", report)
+        self.assertIn("Likely duplicate non-lane rows in lane-shaped tables:", report)
+        self.assertIn("destinations=BNE, SYD", report)
+        self.assertIn("UNKNOWN scope rows:", report)
+        self.assertIn("DOM-MISC", report)
+
+
+class PricingRateScopeSelectorRegressionTests(TestCase):
+    def setUp(self):
+        self.valid_from = date.today() - timedelta(days=1)
+        self.valid_until = date.today() + timedelta(days=30)
+        self.valid_until_next = date.today() + timedelta(days=60)
+        self.export_freight = _create_product(1101, "EXP-FRT-AIR", "Export Air Freight", "EXPORT", "FREIGHT", "KG")
+        self.import_clear = _create_product(2220, "IMP-CLEAR", "Customs Clearance", "IMPORT", "CLEARANCE")
+
+    def test_audit_helpers_do_not_change_selector_results(self):
+        older = ExportSellRate.objects.create(
+            product_code=self.export_freight,
+            origin_airport="POM",
+            destination_airport="BNE",
+            currency="PGK",
+            rate_per_kg=Decimal("4.00"),
+            valid_from=self.valid_from,
+            valid_until=self.valid_until_next,
+        )
+        newer = ExportSellRate.objects.create(
+            product_code=self.export_freight,
+            origin_airport="POM",
+            destination_airport="BNE",
+            currency="PGK",
+            rate_per_kg=Decimal("4.50"),
+            valid_from=date.today(),
+            valid_until=self.valid_until_next,
+        )
+        local = LocalSellRate.objects.create(
+            product_code=self.import_clear,
+            location="POM",
+            direction="IMPORT",
+            payment_term="COLLECT",
+            currency="PGK",
+            rate_type="FIXED",
+            amount=Decimal("300.00"),
+            valid_from=self.valid_from,
+            valid_until=self.valid_until,
+        )
+
+        for row in [older, newer, local]:
+            classify_pricing_rate_scope(row)
+        call_command("audit_pricing_rate_scope", stdout=StringIO())
+
+        export_result = select_export_sell_rate(
+            RateSelectionContext(
+                product_code_id=self.export_freight.id,
+                quote_date=date.today(),
+                origin_airport="POM",
+                destination_airport="BNE",
+                currency="PGK",
+            )
+        )
+        local_result = select_local_sell_rate(
+            RateSelectionContext(
+                product_code_id=self.import_clear.id,
+                quote_date=date.today(),
+                location="POM",
+                direction="IMPORT",
+                payment_term="COLLECT",
+                currency="PGK",
+            )
+        )
+
+        self.assertEqual(export_result.record.id, newer.id)
+        self.assertNotEqual(export_result.record.id, older.id)
+        self.assertEqual(local_result.record.id, local.id)
+
+
+def _create_product(id, code, description, domain, category, default_unit="SHIPMENT"):
+    return ProductCode.objects.create(
+        id=id,
+        code=code,
+        description=description,
+        domain=domain,
+        category=category,
+        is_gst_applicable=True,
+        gst_treatment="STANDARD",
+        gst_rate=Decimal("0.10"),
+        gl_revenue_code="4000",
+        gl_cost_code="5000",
+        default_unit=default_unit,
+    )
+
+
+def _product(code, description, domain, category):
+    return ProductCode(code=code, description=description, domain=domain, category=category)


### PR DESCRIPTION
## Summary

Adds a separate follow-up audit/visibility layer for lane-vs-local duplication risk across these tables:

- `ExportCOGS`
- `ExportSellRate`
- `ImportSellRate`
- `DomesticCOGS`
- `DomesticSellRate`
- `LocalCOGSRate`
- `LocalSellRate`

This intentionally excludes `ImportCOGS` so PR #35 remains small and reviewable.

## What Changed

- Added `classify_pricing_rate_scope` with `LANE`, `ORIGIN`, `DESTINATION`, `LOCAL`, and `UNKNOWN` classifications using only local row/product fields.
- Added read-only computed scope columns and filters in Django admin for the covered rate tables.
- Added `python manage.py audit_pricing_rate_scope` as a dry-run report for:
  - non-lane candidates stored in lane-shaped tables,
  - lane candidates stored in local tables,
  - likely duplicate non-lane rows repeated across lane endpoints,
  - UNKNOWN rows.
- Added focused tests for classification, dry-run reporting, no row mutation, and selector behavior staying unchanged.
- Added Phase 2 notes for future table-specific normalization.

## Files Changed

- `backend/pricing_v4/services/pricing_rate_scope.py` - local-field-only classifier.
- `backend/pricing_v4/admin.py` - computed admin scope visibility/filtering for covered tables.
- `backend/pricing_v4/management/commands/audit_pricing_rate_scope.py` - dry-run audit command.
- `backend/pricing_v4/tests/test_pricing_rate_scope_audit.py` - regression coverage.
- `backend/pricing_v4/docs/pricing_rate_scope_audit.md` - future normalization notes.

## Intentionally Not Changed

- No migrations.
- No schema changes.
- No selector changes.
- No quote math changes.
- No seed data changes.
- No production data changes.
- No ImportCOGS changes; that remains isolated in PR #35.

## Audit Result Against Real/Dev DB

Ran from `C:\tmp\pricing-rate-scope-audit\backend` with `DATABASE_URL` pointing at `C:\Users\commercial.manager\dev\Project-RateEngine\backend\db.sqlite3`.

`python manage.py help | findstr audit` confirmed:

- `audit_pricing_rate_scope`

`python manage.py audit_pricing_rate_scope` reported:

- Non-lane candidates stored in lane-shaped tables: none.
- Lane candidates stored in local tables: none.
- Likely duplicate non-lane rows in lane-shaped tables: none.
- UNKNOWN scope rows: none.

No rows were changed.

## Validation

- `python backend/manage.py test pricing_v4.tests.test_pricing_rate_scope_audit`
- `python backend/manage.py test pricing_v4.tests.test_pricing_rate_scope_audit pricing_v4.tests.test_rate_selector pricing_v4.tests.test_rate_table_separation pricing_v4.tests.test_rate_admin_api`
- `python backend/manage.py migrate --noinput` against isolated clean-worktree SQLite DB
- `python backend/manage.py audit_pricing_rate_scope` against isolated clean-worktree SQLite DB
- `python manage.py help | findstr audit` from clean PR worktree against real/dev DB config
- `python manage.py audit_pricing_rate_scope` from clean PR worktree against real/dev DB config
- `git diff --cached --check`
- `graphify update .`

Validation used process-local environment variables in the clean worktree because it does not carry the main checkout `.env`.

## Phase 2 Recommendation

Use this audit output to review table-specific data before any normalization. Keep lane rows endpoint-complete, keep local rows keyed by direction/location, normalize duplicate local charges out of lane-shaped tables only after review, and preserve deterministic selector ordering and quote output during migration.