### PR TITLE
Plan ImportCOGS consolidation Phase 3A

### DIFF
--- a/backend/pricing_v4/management/commands/plan_import_cogs_consolidation.py
+++ b/backend/pricing_v4/management/commands/plan_import_cogs_consolidation.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from dataclasses import dataclass, fields
+from decimal import Decimal
+from datetime import date
+from typing import Iterable, Any
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from pricing_v4.models import ImportCOGS
+from pricing_v4.services.import_cogs_scope import ImportCOGSScope, classify_import_cogs_scope
+from pricing_v4.services.rate_scope_transition import computed_transition_scope, explicit_scope
+
+
+@dataclass(frozen=True)
+class ImportCOGSPlanSignature:
+    product_code: str
+    scope: str
+    counterparty_type: str
+    counterparty_code: str
+    currency: str
+    rate_per_kg: Decimal | None
+    rate_per_shipment: Decimal | None
+    min_charge: Decimal | None
+    max_charge: Decimal | None
+    percent_rate: Decimal | None
+    weight_breaks_json: str
+    is_additive: bool
+    valid_from: date
+    valid_until: date
+    
+    # Location fields depend on scope
+    origin_airport: str | None
+    destination_airport: str | None
+
+    @classmethod
+    def from_row(cls, row: ImportCOGS) -> ImportCOGSPlanSignature:
+        scope = classify_import_cogs_scope(row)
+        counterparty_type, counterparty_code = _counterparty(row)
+        
+        return cls(
+            product_code=row.product_code.code,
+            scope=str(scope),
+            counterparty_type=counterparty_type,
+            counterparty_code=counterparty_code,
+            currency=row.currency,
+            rate_per_kg=_normalize_decimal(row.rate_per_kg),
+            rate_per_shipment=_normalize_decimal(row.rate_per_shipment),
+            min_charge=_normalize_decimal(row.min_charge),
+            max_charge=_normalize_decimal(row.max_charge),
+            percent_rate=_normalize_decimal(row.percent_rate),
+            weight_breaks_json=json.dumps(row.weight_breaks, sort_keys=True) if row.weight_breaks else "null",
+            is_additive=row.is_additive,
+            valid_from=row.valid_from,
+            valid_until=row.valid_until,
+            # For ORIGIN scope, we group by origin_airport, destination_airport is allowed to differ
+            origin_airport=row.origin_airport if scope == ImportCOGSScope.ORIGIN else None,
+            # For DESTINATION scope, we group by destination_airport, origin_airport is allowed to differ
+            destination_airport=row.destination_airport if scope == ImportCOGSScope.DESTINATION else None,
+        )
+
+
+def _normalize_decimal(val: Decimal | None) -> Decimal | None:
+    if val is None:
+        return None
+    return val.normalize()
+
+
+def _counterparty(row: ImportCOGS) -> tuple[str, str]:
+    if row.agent_id:
+        return ("agent", row.agent.code)
+    if row.carrier_id:
+        return ("carrier", row.carrier.code)
+    return ("none", "")
+
+
+class Command(BaseCommand):
+    help = "Produce a dry-run consolidation plan for ImportCOGS non-lane rates."
+
+    def handle(self, *args, **options):
+        # Use a transaction that we will roll back just in case, 
+        # though we don't plan to mutate anything.
+        with transaction.atomic():
+            rows = list(
+                ImportCOGS.objects.select_related("product_code", "agent", "carrier")
+                .order_by("product_code__code", "origin_airport", "destination_airport", "id")
+            )
+            
+            self.stdout.write("ImportCOGS Consolidation Planner (Dry Run)")
+            self.stdout.write("=" * 40)
+            
+            groups = defaultdict(list)
+            for row in rows:
+                scope = classify_import_cogs_scope(row)
+                if scope not in {ImportCOGSScope.ORIGIN, ImportCOGSScope.DESTINATION}:
+                    continue
+                
+                sig = ImportCOGSPlanSignature.from_row(row)
+                groups[sig].append(row)
+            
+            consolidated_count = 0
+            candidate_count = 0
+            
+            for sig, members in groups.items():
+                candidate_count += 1
+                if len(members) > 1:
+                    consolidated_count += 1
+                    self._report_group(sig, members)
+                else:
+                    self._report_single(sig, members[0])
+            
+            self.stdout.write("=" * 40)
+            self.stdout.write(f"Summary: {candidate_count} consolidation candidates found.")
+            self.stdout.write(f"Groups with actual duplicates: {consolidated_count}")
+            self.stdout.write("No rows were mutated. Dry run complete.")
+            
+            # Safety rollback
+            transaction.set_rollback(True)
+
+    def _report_group(self, sig: ImportCOGSPlanSignature, members: list[ImportCOGS]):
+        self.stdout.write(f"\n[GROUP] {sig.product_code} ({sig.scope})")
+        self.stdout.write(f"  Target: {sig.origin_airport or '*' } -> {sig.destination_airport or '*'}")
+        self.stdout.write(f"  Members ({len(members)}):")
+        for m in members:
+            self.stdout.write(f"    - #{m.id} {m.origin_airport}->{m.destination_airport}")
+        
+        self.stdout.write("  Fields identical:")
+        sig_dict = sig.__dict__
+        for field in fields(sig):
+            if field.name in {"origin_airport", "destination_airport"}:
+                continue
+            self.stdout.write(f"    - {field.name}: {sig_dict[field.name]}")
+        
+        self.stdout.write("  Fields differing:")
+        if sig.scope == str(ImportCOGSScope.ORIGIN):
+            dests = ", ".join(sorted({m.destination_airport for m in members}))
+            self.stdout.write(f"    - destination_airport: {dests}")
+        else:
+            origins = ", ".join(sorted({m.origin_airport for m in members}))
+            self.stdout.write(f"    - origin_airport: {origins}")
+        
+        self.stdout.write("  Safe to consolidate: YES (Exact match on all required fields)")
+        self.stdout.write(f"  Action: Replace {len(members)} rows with 1 normalized row.")
+
+    def _report_single(self, sig: ImportCOGSPlanSignature, row: ImportCOGS):
+        self.stdout.write(f"\n[SINGLE] {sig.product_code} ({sig.scope})")
+        self.stdout.write(f"  Current: {row.origin_airport}->{row.destination_airport} (ID #{row.id})")
+        self.stdout.write(f"  Target: {sig.origin_airport or '*' } -> {sig.destination_airport or '*'}")
+        self.stdout.write("  Safe to normalize: YES")
+        self.stdout.write("  Action: Update 1 row to be normalized (clear redundant location).")

--- a/backend/pricing_v4/tests/test_import_cogs_consolidation_planner.py
+++ b/backend/pricing_v4/tests/test_import_cogs_consolidation_planner.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from decimal import Decimal
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from pricing_v4.models import Agent, ImportCOGS, ProductCode
+from pricing_v4.services.import_cogs_scope import ImportCOGSScope
+from pricing_v4.engine.import_engine import ImportPricingEngine, ServiceScope, PaymentTerm
+
+
+class ImportCOGSConsolidationPlannerTests(TestCase):
+    def setUp(self):
+        self.valid_from = date.today() - timedelta(days=1)
+        self.valid_until = date.today() + timedelta(days=30)
+        self.agent = Agent.objects.create(code="EFM-AU", name="EFM Australia", country_code="AU", agent_type="ORIGIN")
+        self.doc_origin = ProductCode.objects.create(
+            id=2001,
+            code="IMP-DOC-ORIGIN",
+            description="Origin Documentation",
+            category="DOCUMENTATION",
+            domain="IMPORT",
+            default_unit="SHIPMENT",
+            is_gst_applicable=True,
+        )
+        self.pickup = ProductCode.objects.create(
+            id=2002,
+            code="IMP-PICKUP",
+            description="Origin Pickup",
+            category="PICKUP",
+            domain="IMPORT",
+            default_unit="KG",
+            is_gst_applicable=True,
+        )
+
+    def test_safe_duplicate_groups_are_detected(self):
+        # Create 3 rows for IMP-DOC-ORIGIN from BNE to different destinations
+        # These are safe to consolidate because they are identical in all required fields
+        r1 = self._create_cogs(self.doc_origin, "BNE", "POM", Decimal("80.00"))
+        r2 = self._create_cogs(self.doc_origin, "BNE", "LAE", Decimal("80.00"))
+        r3 = self._create_cogs(self.doc_origin, "BNE", "MAG", Decimal("80.00"))
+
+        out = StringIO()
+        call_command("plan_import_cogs_consolidation", stdout=out)
+        output = out.getvalue()
+
+        self.assertIn("[GROUP] IMP-DOC-ORIGIN (ORIGIN)", output)
+        self.assertIn("Target: BNE -> *", output)
+        self.assertIn(f"- #{r1.id} BNE->POM", output)
+        self.assertIn(f"- #{r2.id} BNE->LAE", output)
+        self.assertIn(f"- #{r3.id} BNE->MAG", output)
+        self.assertIn("Safe to consolidate: YES", output)
+        self.assertIn("Replace 3 rows with 1 normalized row.", output)
+
+    def test_differing_rates_are_not_grouped_together(self):
+        # Different rates for same product/origin
+        r1 = self._create_cogs(self.doc_origin, "BNE", "POM", Decimal("80.00"))
+        r2 = self._create_cogs(self.doc_origin, "BNE", "LAE", Decimal("90.00")) # Different amount
+
+        out = StringIO()
+        call_command("plan_import_cogs_consolidation", stdout=out)
+        output = out.getvalue()
+
+        # They should be reported as two separate SINGLE rows (candidates for normalization, but not consolidation together)
+        self.assertIn(f"[SINGLE] IMP-DOC-ORIGIN (ORIGIN)\n  Current: BNE->POM (ID #{r1.id})", output)
+        self.assertIn(f"[SINGLE] IMP-DOC-ORIGIN (ORIGIN)\n  Current: BNE->LAE (ID #{r2.id})", output)
+        self.assertNotIn("[GROUP] IMP-DOC-ORIGIN", output)
+
+    def test_differing_agents_are_not_grouped_together(self):
+        agent2 = Agent.objects.create(code="OTHER-AG", name="Other Agent", country_code="AU")
+        r1 = self._create_cogs(self.doc_origin, "BNE", "POM", Decimal("80.00"), agent=self.agent)
+        r2 = self._create_cogs(self.doc_origin, "BNE", "LAE", Decimal("80.00"), agent=agent2)
+
+        out = StringIO()
+        call_command("plan_import_cogs_consolidation", stdout=out)
+        output = out.getvalue()
+
+        self.assertIn(f"ID #{r1.id}", output)
+        self.assertIn(f"ID #{r2.id}", output)
+        self.assertNotIn("[GROUP]", output)
+
+    def test_differing_validity_is_not_grouped_together(self):
+        r1 = self._create_cogs(self.doc_origin, "BNE", "POM", Decimal("80.00"))
+        r2 = self._create_cogs(self.doc_origin, "BNE", "LAE", Decimal("80.00"))
+        r2.valid_from = self.valid_from + timedelta(days=1)
+        r2.save()
+
+        out = StringIO()
+        call_command("plan_import_cogs_consolidation", stdout=out)
+        output = out.getvalue()
+
+        self.assertNotIn("[GROUP]", output)
+
+    def test_command_is_dry_run_only_and_no_rows_mutated(self):
+        self._create_cogs(self.doc_origin, "BNE", "POM", Decimal("80.00"))
+        
+        initial_ids = set(ImportCOGS.objects.values_list("id", flat=True))
+        initial_data = list(ImportCOGS.objects.values())
+
+        out = StringIO()
+        call_command("plan_import_cogs_consolidation", stdout=out)
+
+        final_ids = set(ImportCOGS.objects.values_list("id", flat=True))
+        final_data = list(ImportCOGS.objects.values())
+
+        self.assertEqual(initial_ids, final_ids)
+        self.assertEqual(initial_data, final_data)
+        self.assertIn("No rows were mutated. Dry run complete.", out.getvalue())
+
+    def test_quote_output_remains_unchanged(self):
+        # This test ensures that running the command doesn't affect pricing logic results
+        # which depends on the database remaining exactly the same.
+        self._create_cogs(self.doc_origin, "BNE", "POM", Decimal("80.00"))
+        
+        engine = ImportPricingEngine(
+            quote_date=date.today(),
+            origin="BNE",
+            destination="POM",
+            chargeable_weight_kg=Decimal("100"),
+            payment_term=PaymentTerm.PREPAID,
+            service_scope=ServiceScope.D2D,
+            preferred_agent_id=self.agent.id,
+        )
+        
+        initial_quote = engine.calculate_quote()
+        
+        # Run the command
+        call_command("plan_import_cogs_consolidation", stdout=StringIO())
+        
+        final_quote = engine.calculate_quote()
+        
+        self.assertEqual(initial_quote.total_cost, final_quote.total_cost)
+        self.assertEqual(len(initial_quote.line_items), len(final_quote.line_items))
+
+    def _create_cogs(self, product, origin, destination, amount, agent=None):
+        return ImportCOGS.objects.create(
+            product_code=product,
+            origin_airport=origin,
+            destination_airport=destination,
+            agent=agent or self.agent,
+            currency="AUD",
+            rate_per_shipment=amount,
+            valid_from=self.valid_from,
+            valid_until=self.valid_until,
+            is_additive=True
+        )

--- a/docs/pricing_v4_normalization_plan.md
+++ b/docs/pricing_v4_normalization_plan.md
@@ -1,0 +1,54 @@
+# Pricing V4 Normalization Plan: ImportCOGS
+
+## Phase 3A: Consolidation Planning (Origin-Scoped Rates)
+
+### Findings
+The initial audit of `ImportCOGS` identified 14 rows (IDs #100-#113) classified as `ORIGIN` scope. These rows represent origin-side charges (e.g., Documentation, Pickup, Screening) for shipments from BNE and SYD to POM.
+
+- **Current State**: These charges are stored with explicit `origin_airport` and `destination_airport` (POM), even though they are independent of the destination.
+- **Normalization Opportunity**: These rows can be "normalized" by clearing the `destination_airport` field, making them valid for ANY destination from that origin.
+- **Consolidation**: No actual "duplicates" (multiple rows for the same origin/product with identical rates) were found in the current dev database. However, the planner is now equipped to detect and group such rows if they appear.
+
+### Consolidation Groups
+The `plan_import_cogs_consolidation` command identifies the following candidates:
+
+1. **SINGLE** candidates (Normalization only): 14 rows found.
+   - Example: `#100 IMP-AGENCY-ORIGIN BNE->POM` -> Target: `BNE -> *`
+   - All 14 rows are safe to normalize as they currently exist for only one destination (POM) per origin.
+
+2. **GROUP** candidates (Actual Consolidation): 0 groups found.
+   - If a row for `BNE->POM` and `BNE->SIN` existed with identical rates, they would be grouped.
+
+---
+
+## Phase 3B: Proposed Migration Approach
+
+### Strategy: "Normalize and Deduplicate"
+The goal of Phase 3B is to transition the identified rows to the normalized schema where `destination_airport` is `NULL` for `ORIGIN` scope and `origin_airport` is `NULL` for `DESTINATION` scope.
+
+1. **Step 1: Create Target Rows**
+   - For each group (or single row) identified in Phase 3A, create one new "Normalized" row.
+   - The normalized row will have the redundant location field set to `NULL`.
+   - The normalized row will inherit all other fields (product, amounts, currency, validity, etc.).
+
+2. **Step 2: Update References**
+   - If any other tables refer to these `ImportCOGS` IDs, they must be updated to point to the new normalized ID.
+   - (Currently, no tables are known to refer to specific `ImportCOGS` row IDs by foreign key in a way that prevents deletion).
+
+3. **Step 3: Delete Redundant Rows**
+   - Once the normalized row is created, delete the original redundant rows.
+
+4. **Step 4: Enforce Constraints**
+   - Add database-level constraints to prevent future redundant data:
+     - If `scope == 'ORIGIN'`, `destination_airport` MUST be `NULL`.
+     - If `scope == 'DESTINATION'`, `origin_airport` MUST be `NULL`.
+     - If `scope == 'LANE'`, both MUST be NOT `NULL`.
+
+### Rollback Plan
+- **Migration Rollback**: Standard Django migration `unapply` will remove the constraints but cannot automatically restore deleted rows.
+- **Data Recovery**: A JSON backup of the rows being deleted should be taken before the migration.
+- **Verification**: The `ImportPricingEngine` regression suite must pass before and after the migration.
+
+### Risks
+- **Selector Logic**: The `select_import_cogs_rate` selector must be updated to handle `NULL` values in the location fields. This was partially addressed in Phase 2 but needs full validation.
+- **Ambiguity**: If multiple rates match an origin (e.g. one specific to a destination and one global), the selector must have clear tie-breaking rules (Specific > Global).


### PR DESCRIPTION
## Summary

Adds a safe, dry-run ImportCOGS consolidation planner for Phase 3A.

This PR does not consolidate, delete, or mutate any rate rows. It only reports candidate origin-scoped ImportCOGS rows and proposes normalized target rows for later Phase 3B review.

## Context

Phase 2 identified 14 ImportCOGS origin-scoped rows (#100-#113) that still carry destination airport values. Phase 3A inspects those candidates and adds a planner to determine whether any true duplicate groups are safe for future consolidation.

## Scope

- Add/extend dry-run consolidation planning for ImportCOGS origin-scoped rates.
- Require exact commercial-signature matching before marking groups safe.
- Reject unsafe groups when amount, currency, counterparty, validity, weight breaks, additive flag, or other key commercial fields differ.
- Preserve quote output and selector behavior.

## Hard Guarantees

- No row deletion.
- No duplicate consolidation.
- No DB mutation from the planner.
- No quote behavior change.
- No selector behavior change.

## Findings Reported by Codex

- Actual duplicate groups found: 0.
- Normalization candidates: 14.
- Each candidate is a single-row normalization candidate where an ORIGIN-scoped charge currently has `destination_airport=POM`; future Phase 3B may normalize this to destination `NULL` after review.

## Validation Reported by Codex

- Planner/audit command runs successfully.
- Migration check passed with no pending migrations.
- `git diff --check` passed.
- `graphify update .` passed.
- 17 engine and quote API regression tests passed.

## Notes

This is review-only groundwork. Phase 3B should be a separate PR and should not begin until this planner is reviewed and merged.