### PR TITLE
docs: add Deployment Guardrails to GEMINI.md

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -17,6 +17,17 @@ Gemini CLI must follow `AGENTS.md`. This file is Gemini-specific operating guida
 - Main frontend area: `frontend/`.
 - API is versioned and served through DRF.
 
+## Deployment Guardrails
+
+- Follow AGENTS.md as the authoritative source for deployment rules.
+- Production target is Google Cloud Run using stateless containers.
+- Web containers must not run database migrations on startup.
+- Services must bind to the dynamic `$PORT`.
+- Do not copy `.env` files or secrets into images.
+- Containers should run as non-root where practical.
+- Docker build/run verification is required for deployment-related PRs.
+- Cloud SQL, Secret Manager, and GCS are the intended production services.
+
 ## Common Commands
 
 Backend setup and run:


### PR DESCRIPTION
## Overview
This PR adds a concise Deployment Guardrails section to `GEMINI.md` to remind Gemini CLI of core Cloud Run constraints without duplicating `AGENTS.md`.

## Deployment Guardrails Added
- Authoritative source: `AGENTS.md`
- Target: stateless containers on Cloud Run
- No startup migrations in web containers
- Dynamic `$PORT` binding
- No secrets in images
- Non-root containers where practical
- Docker build/run verification required
- Intended services: Cloud SQL, Secret Manager, and GCS

This keeps Gemini aligned with the project’s Cloud Run production-readiness architecture.