### PR TITLE
feat(security): implement Phase 5E: Google Secret Manager integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ RateEngine is deployed as stateless containers on Google Cloud Run.
 - **Port Handling**: Applications must listen on the dynamic `$PORT` environment variable provided by the platform.
 - **Migrations**: Database migrations are handled via Cloud Run Jobs, not at container startup. Never run `python manage.py migrate` in a production web service entrypoint. Use `backend/entrypoint.migrate.sh` for all automated migration executions.
 - **Security**: Strict SSL/HSTS and proxy awareness are mandatory for production environments.
-- **Secrets**: Production secrets must be managed via Google Secret Manager, never committed to the repo or baked into images.
+- **Secrets**: Production secrets must be managed via Google Secret Manager, never committed to the repo or baked into images. Use the `sm://SECRET_NAME` URI convention in environment variables for resolution.
 
 ## graphify
 

--- a/backend/core/secrets.py
+++ b/backend/core/secrets.py
@@ -1,0 +1,80 @@
+import os
+import re
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+class SecretResolver:
+    """
+    Resolves secrets from environment variables or Google Secret Manager.
+    
+    Supported formats for environment variable values:
+    1. Plain string: Returns as-is (backward compatible).
+    2. sm://SECRET_NAME: Fetches 'latest' version of SECRET_NAME from GOOGLE_CLOUD_PROJECT.
+    3. sm://SECRET_NAME/VERSION: Fetches specific version.
+    4. sm://projects/PROJECT_ID/secrets/SECRET_NAME/versions/VERSION: Full GCP resource path.
+    """
+    
+    def __init__(self):
+        self._client = None
+        self._project_id = os.environ.get("GOOGLE_CLOUD_PROJECT")
+
+    @property
+    def client(self):
+        """Lazy-load the Secret Manager client."""
+        if self._client is None:
+            try:
+                from google.cloud import secretmanager
+                self._client = secretmanager.SecretManagerServiceClient()
+            except ImportError:
+                raise ImportError(
+                    "google-cloud-secret-manager is required to resolve 'sm://' secrets. "
+                    "Install it with 'pip install google-cloud-secret-manager'."
+                )
+        return self._client
+
+    def resolve(self, value: Optional[str]) -> Optional[str]:
+        """Resolves the value if it's an 'sm://' reference, otherwise returns as-is."""
+        if not isinstance(value, str) or not value.startswith("sm://"):
+            return value
+
+        # Remove prefix
+        path = value[5:]
+        
+        # Determine the full resource name
+        if path.startswith("projects/"):
+            # Full resource path provided: projects/*/secrets/*/versions/*
+            resource_name = path
+        else:
+            # Short format provided: SECRET_NAME or SECRET_NAME/VERSION
+            if not self._project_id:
+                raise RuntimeError(
+                    f"Cannot resolve secret '{path}': GOOGLE_CLOUD_PROJECT environment variable is not set."
+                )
+            
+            parts = path.split("/")
+            secret_id = parts[0]
+            version_id = parts[1] if len(parts) > 1 else "latest"
+            resource_name = f"projects/{self._project_id}/secrets/{secret_id}/versions/{version_id}"
+
+        try:
+            # We specifically do NOT log the resolved value.
+            # We only log that we are attempting to resolve a secret.
+            logger.info("Resolving secret from Google Secret Manager: %s", resource_name.split("/versions/")[0])
+            
+            response = self.client.access_secret_version(request={"name": resource_name})
+            return response.payload.data.decode("UTF-8")
+        except Exception as e:
+            # Fail clearly if production requires a secret but it cannot be resolved.
+            raise RuntimeError(f"Failed to resolve secret from Secret Manager ({resource_name}): {str(e)}")
+
+# Singleton instance
+_resolver = SecretResolver()
+
+def get_secret(env_var_name: str, default: Optional[str] = None) -> Optional[str]:
+    """
+    Retrieves an environment variable and resolves it if it's a Secret Manager reference.
+    """
+    raw_value = os.environ.get(env_var_name, default)
+    return _resolver.resolve(raw_value)

--- a/backend/core/tests/test_secrets.py
+++ b/backend/core/tests/test_secrets.py
@@ -1,0 +1,88 @@
+import os
+import pytest
+from unittest.mock import MagicMock, patch
+from core.secrets import SecretResolver, get_secret
+
+class TestSecretResolver:
+    def test_resolve_plain_value(self):
+        resolver = SecretResolver()
+        assert resolver.resolve("plain_value") == "plain_value"
+        assert resolver.resolve(None) is None
+        assert resolver.resolve(123) == 123
+
+    def test_resolve_sm_short_path_no_project(self):
+        with patch.dict(os.environ, {}, clear=True):
+            resolver = SecretResolver()
+            with pytest.raises(RuntimeError, match="GOOGLE_CLOUD_PROJECT environment variable is not set"):
+                resolver.resolve("sm://MY_SECRET")
+
+    @patch("google.cloud.secretmanager.SecretManagerServiceClient")
+    def test_resolve_sm_short_path_with_project(self, mock_client_class):
+        mock_client = mock_client_class.return_value
+        mock_response = MagicMock()
+        mock_response.payload.data.decode.return_value = "secret_value"
+        mock_client.access_secret_version.return_value = mock_response
+
+        with patch.dict(os.environ, {"GOOGLE_CLOUD_PROJECT": "test-project"}):
+            resolver = SecretResolver()
+            result = resolver.resolve("sm://MY_SECRET")
+            
+            assert result == "secret_value"
+            mock_client.access_secret_version.assert_called_once_with(
+                request={"name": "projects/test-project/secrets/MY_SECRET/versions/latest"}
+            )
+
+    @patch("google.cloud.secretmanager.SecretManagerServiceClient")
+    def test_resolve_sm_versioned_path(self, mock_client_class):
+        mock_client = mock_client_class.return_value
+        mock_response = MagicMock()
+        mock_response.payload.data.decode.return_value = "v2_value"
+        mock_client.access_secret_version.return_value = mock_response
+
+        with patch.dict(os.environ, {"GOOGLE_CLOUD_PROJECT": "test-project"}):
+            resolver = SecretResolver()
+            result = resolver.resolve("sm://MY_SECRET/2")
+            
+            assert result == "v2_value"
+            mock_client.access_secret_version.assert_called_once_with(
+                request={"name": "projects/test-project/secrets/MY_SECRET/versions/2"}
+            )
+
+    @patch("google.cloud.secretmanager.SecretManagerServiceClient")
+    def test_resolve_sm_full_path(self, mock_client_class):
+        mock_client = mock_client_class.return_value
+        mock_response = MagicMock()
+        mock_response.payload.data.decode.return_value = "full_path_value"
+        mock_client.access_secret_version.return_value = mock_response
+
+        resolver = SecretResolver()
+        full_path = "projects/other-project/secrets/OTHER_SECRET/versions/5"
+        result = resolver.resolve(f"sm://{full_path}")
+        
+        assert result == "full_path_value"
+        mock_client.access_secret_version.assert_called_once_with(
+            request={"name": full_path}
+        )
+
+    @patch("google.cloud.secretmanager.SecretManagerServiceClient")
+    def test_resolve_failure(self, mock_client_class):
+        mock_client = mock_client_class.return_value
+        mock_client.access_secret_version.side_effect = Exception("API Error")
+
+        with patch.dict(os.environ, {"GOOGLE_CLOUD_PROJECT": "test-project"}):
+            resolver = SecretResolver()
+            with pytest.raises(RuntimeError, match="Failed to resolve secret from Secret Manager"):
+                resolver.resolve("sm://MY_SECRET")
+
+    @patch("core.secrets._resolver.resolve")
+    def test_get_secret_wrapper(self, mock_resolve):
+        mock_resolve.return_value = "resolved"
+        with patch.dict(os.environ, {"MY_VAR": "raw"}):
+            assert get_secret("MY_VAR") == "resolved"
+            mock_resolve.assert_called_once_with("raw")
+
+    @patch("core.secrets._resolver.resolve")
+    def test_get_secret_default(self, mock_resolve):
+        mock_resolve.side_effect = lambda x: x
+        assert get_secret("NON_EXISTENT", default="fallback") == "fallback"
+        mock_resolve.assert_called_once_with("fallback")

--- a/backend/quotes/ai_intake_service.py
+++ b/backend/quotes/ai_intake_service.py
@@ -366,9 +366,10 @@ def _merge_pattern_fallback_charges(
 
 def get_gemini_client():
     """Get configured Gemini client. Returns None if not configured."""
-    api_key = os.environ.get("GEMINI_API_KEY")
+    from django.conf import settings
+    api_key = getattr(settings, "GEMINI_API_KEY", None)
     if not api_key:
-        logger.error("GEMINI_API_KEY environment variable not set")
+        logger.error("GEMINI_API_KEY not configured in settings")
         return None
 
     try:
@@ -514,9 +515,10 @@ def _call_gemini_structured(model, prompt: str, response_schema: type[BaseModel]
 
 def _extract_pdf_text_with_gemini(pdf_content: bytes, context: Optional[dict] = None) -> str:
     """Use Gemini multimodal input to transcribe a PDF when text extraction is insufficient."""
-    api_key = os.environ.get("GEMINI_API_KEY")
+    from django.conf import settings
+    api_key = getattr(settings, "GEMINI_API_KEY", None)
     if not api_key:
-        raise RuntimeError("GEMINI_API_KEY environment variable not set")
+        raise RuntimeError("GEMINI_API_KEY not configured in settings")
 
     try:
         from google import genai as genai_sdk
@@ -549,9 +551,10 @@ def _extract_pdf_text_with_gemini(pdf_content: bytes, context: Optional[dict] = 
 
 def _extract_pdf_text_from_page_images_with_gemini(pdf_content: bytes, context: Optional[dict] = None) -> str:
     """Render PDF pages to images and use Gemini to transcribe layout-heavy or scanned documents."""
-    api_key = os.environ.get("GEMINI_API_KEY")
+    from django.conf import settings
+    api_key = getattr(settings, "GEMINI_API_KEY", None)
     if not api_key:
-        raise RuntimeError("GEMINI_API_KEY environment variable not set")
+        raise RuntimeError("GEMINI_API_KEY not configured in settings")
 
     try:
         from google import genai as genai_sdk

--- a/backend/rate_engine/settings.py
+++ b/backend/rate_engine/settings.py
@@ -15,6 +15,7 @@ import os
 import dj_database_url
 from django.core.exceptions import ImproperlyConfigured
 from dotenv import load_dotenv
+from core.secrets import get_secret
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -24,15 +25,15 @@ load_dotenv(BASE_DIR / '.env')
 
 
 def _env_bool(name: str, default: bool = False) -> bool:
-    value = os.environ.get(name)
+    value = get_secret(name)
     if value is None:
         return default
-    return value.strip().lower() in {'1', 'true', 'yes', 'on'}
+    return str(value).strip().lower() in {'1', 'true', 'yes', 'on'}
 
 
 def _env_list(name: str) -> list[str]:
-    raw = os.environ.get(name, '')
-    return [item.strip() for item in raw.split(',') if item.strip()]
+    raw = get_secret(name, '')
+    return [item.strip() for item in str(raw).split(',') if item.strip()]
 
 
 
@@ -47,7 +48,7 @@ DEBUG = _env_bool('DJANGO_DEBUG', False)
 
 # SECURITY: SECRET_KEY must be set in environment (no fallback in production)
 _dev_secret_key = 'django-insecure-dev-only-key-do-not-use-in-production'
-_secret_key = os.environ.get('DJANGO_SECRET_KEY', '').strip()
+_secret_key = get_secret('DJANGO_SECRET_KEY', '').strip()
 if not _secret_key:
     # Only allow insecure default in explicit development mode
     if DEBUG:
@@ -170,7 +171,7 @@ WSGI_APPLICATION = 'rate_engine.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases
 # Development may fall back to SQLite, but production must provide DATABASE_URL.
-_database_url = os.environ.get('DATABASE_URL', '').strip()
+_database_url = get_secret('DATABASE_URL', '').strip()
 if not DEBUG and not _database_url:
     raise ImproperlyConfigured("DATABASE_URL must be set in production")
 
@@ -183,7 +184,7 @@ if _database_url:
     
     # Cloud SQL support: Use Unix sockets if INSTANCE_CONNECTION_NAME is provided
     # This is the standard pattern for Cloud Run -> Cloud SQL connectivity.
-    _instance_connection_name = os.environ.get('INSTANCE_CONNECTION_NAME')
+    _instance_connection_name = get_secret('INSTANCE_CONNECTION_NAME')
     if _instance_connection_name and _default_db['ENGINE'] == 'django.db.backends.postgresql':
         _default_db['HOST'] = f'/cloudsql/{_instance_connection_name}'
 else:
@@ -253,7 +254,7 @@ SERVE_MEDIA_FILES = _env_bool('SERVE_MEDIA_FILES', DEBUG)
 USE_GCS = _env_bool('USE_GCS', False)
 
 if USE_GCS:
-    GS_BUCKET_NAME = os.environ.get('GS_BUCKET_NAME')
+    GS_BUCKET_NAME = get_secret('GS_BUCKET_NAME')
     if not GS_BUCKET_NAME:
         raise ImproperlyConfigured("GS_BUCKET_NAME is required when USE_GCS is True")
     
@@ -360,9 +361,10 @@ except ValueError:
 
 # AI intake model configuration (Gemini)
 GEMINI_MODEL_NAME = (
-    os.environ.get('GEMINI_MODEL_NAME', 'gemini-2.5-flash-lite').strip()
+    get_secret('GEMINI_MODEL_NAME', 'gemini-2.5-flash-lite').strip()
     or 'gemini-2.5-flash-lite'
 )
+GEMINI_API_KEY = get_secret('GEMINI_API_KEY')
 
 # Explicit SPOT coverage overrides for known lanes.
 SPOT_ROUTE_COVERAGE = {

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -50,3 +50,4 @@ google-genai
 whitenoise>=6.6.0
 django-storages[google]>=1.14.4
 python-json-logger>=2.0.7
+google-cloud-secret-manager>=2.28.0

--- a/docs/production_readiness_phase5e.md
+++ b/docs/production_readiness_phase5e.md
@@ -1,0 +1,39 @@
+# Phase 5E: Secret Manager Integration
+
+## Overview
+This phase prepares RateEngine for secure production secret management using Google Secret Manager (GSM). It introduces a flexible `SecretResolver` that allows production environments to reference secrets via a special URI scheme while maintaining zero-config compatibility for local development.
+
+## Secret Resolution Strategy
+The `SecretResolver` (implemented in `backend/core/secrets.py`) acts as a proxy for environment variables. It detects strings starting with `sm://` and attempts to resolve them using the Google Cloud Secret Manager API.
+
+### Supported URI Formats
+1.  **Short Format (Default Project):** `sm://SECRET_NAME`
+    *   Resolves the `latest` version of `SECRET_NAME`.
+    *   Requires `GOOGLE_CLOUD_PROJECT` environment variable to be set.
+2.  **Versioned Short Format:** `sm://SECRET_NAME/VERSION`
+    *   Resolves a specific version (e.g., `sm://DJANGO_SECRET_KEY/2`).
+3.  **Full Resource Path:** `sm://projects/PROJECT_ID/secrets/SECRET_NAME/versions/VERSION`
+    *   Used for cross-project secret access or explicit resource mapping.
+
+### Local Development / Fallback
+If an environment variable value does **not** start with `sm://`, the resolver returns it as a plain string. This ensures that existing `.env` files and standard environment variables continue to work without modification or GCP credentials.
+
+## Protected Production Settings
+The following settings have been updated to use the secret resolver:
+*   `DJANGO_SECRET_KEY`
+*   `DATABASE_URL`
+*   `ALLOWED_HOSTS` (List resolved via `sm://`)
+*   `CORS_ALLOWED_ORIGINS` (List)
+*   `CSRF_TRUSTED_ORIGINS` (List)
+*   `INSTANCE_CONNECTION_NAME` (Cloud SQL)
+*   `GS_BUCKET_NAME` (Cloud Storage)
+*   `GEMINI_API_KEY` (AI Intake)
+
+## IAM Requirements
+For the resolver to function in production (e.g., on Cloud Run), the service account running the application must have the following IAM role:
+*   `roles/secretmanager.secretAccessor`
+
+## Security Principles
+1.  **No Leaks:** Secret values are never logged. The resolver only logs the *attempt* to resolve a specific secret name.
+2.  **Fail Fast:** In production, if an `sm://` reference cannot be resolved (due to missing permissions, network errors, or non-existent secrets), the application will raise a `RuntimeError` and fail to start, preventing an insecure or broken state.
+3.  **Lazy Loading:** The Google Cloud SDK is only imported and initialized if an `sm://` secret is actually requested, keeping the local environment lean.


### PR DESCRIPTION
## Overview
This PR implements Phase 5E: Secret Manager Integration, preparing RateEngine for secure production secret management while maintaining zero-config compatibility for local development.

## Changes
- Introduces `SecretResolver` in `backend/core/secrets.py` supporting `sm://` Secret Manager references.
- Integrates secret resolution into Django settings for sensitive production variables.
- Refactors Gemini AI intake to consume `GEMINI_API_KEY` from Django settings instead of direct environment access.
- Adds mocked unit tests for secret resolution and failure handling.
- Adds Phase 5E production readiness documentation.
- Updates `AGENTS.md` with the Secret Management Policy and `sm://` convention.

## Scope Control
This PR is intentionally limited to secret-management readiness. Earlier unrelated schema, SPOT, migration recovery, and debris files were removed from this branch before PR creation.

## Verification Required
CI must confirm:
1. Backend tests pass.
2. Container integrity checks pass.
3. Secret resolver tests pass.
4. Django system checks pass in local/dev mode.
5. Production-mode dummy env checks remain compatible without requiring real GCP credentials.

## Known Follow-ups
- Cloud Run service account must receive `roles/secretmanager.secretAccessor` during deployment.
- Real Secret Manager resources and values will be created outside this PR.
- Artifact Registry and Cloud Run deployment workflows remain Phase 5F scope.