### PR TITLE
feat(obs): implement Phase 5G-C - Health & Readiness Optimization

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -104,8 +104,8 @@ jobs:
           flags: |
             --add-cloudsql-instances=${{ env.INSTANCE_CONNECTION_NAME }}
             --set-env-vars=INSTANCE_CONNECTION_NAME=${{ env.INSTANCE_CONNECTION_NAME }},DJANGO_DEBUG=False
-            --liveness-probe-path=/api/health/
-            --startup-probe-path=/api/health/
+            --liveness-probe-path=/api/health/liveness/
+            --startup-probe-path=/api/health/readiness/
     outputs:
       url: ${{ steps.deploy.outputs.url }}
 

--- a/backend/core/tests/test_health.py
+++ b/backend/core/tests/test_health.py
@@ -1,0 +1,55 @@
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+from unittest.mock import patch
+from django.db import connection
+from django.db.utils import OperationalError
+
+class HealthCheckTests(APITestCase):
+    def test_liveness_endpoint(self):
+        """Liveness should return 200 without checking DB."""
+        url = reverse('core:health-liveness')
+        response = self.client.get(url)
+        
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data['status'] == 'ok'
+        assert data['check_type'] == 'liveness'
+        assert data['service'] == 'rateengine-backend'
+        assert 'timestamp' in data
+
+    def test_readiness_endpoint_success(self):
+        """Readiness should return 200 when DB is up."""
+        url = reverse('core:health-readiness')
+        response = self.client.get(url)
+        
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data['status'] == 'ok'
+        assert data['check_type'] == 'readiness'
+        assert data['dependencies']['database'] == 'ok'
+
+    @patch('django.db.backends.utils.CursorWrapper.execute')
+    def test_readiness_endpoint_db_failure(self, mock_execute):
+        """Readiness should return 503 when DB is down."""
+        mock_execute.side_effect = OperationalError("DB is down")
+        
+        url = reverse('core:health-readiness')
+        # We need to ensure we are testing the actual view logic
+        response = self.client.get(url)
+        
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        data = response.json()
+        assert data['status'] == 'unavailable'
+        assert data['dependencies']['database'] == 'unavailable'
+
+    def test_legacy_health_endpoint_compatibility(self):
+        """Legacy /api/health/ should still work and include DB status."""
+        url = reverse('core:health-check')
+        response = self.client.get(url)
+        
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data['check_type'] == 'combined'
+        assert 'database' in data

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -3,6 +3,8 @@
 from django.urls import path
 from .views import (
     HealthCheckAPIView,
+    LivenessCheckAPIView,
+    ReadinessCheckAPIView,
     LocationV3SearchView,
     LocationV3DetailView,
     AirportSearchAPIView,
@@ -15,6 +17,8 @@ app_name = 'core'
 
 urlpatterns = [
     path('health/', HealthCheckAPIView.as_view(), name='health-check'),
+    path('health/liveness/', LivenessCheckAPIView.as_view(), name='health-liveness'),
+    path('health/readiness/', ReadinessCheckAPIView.as_view(), name='health-readiness'),
     # --- V3 ENDPOINT ---
     path('v3/locations/search/', LocationV3SearchView.as_view(), name='location-search-v3'),
     path('v3/locations/<uuid:location_id>/', LocationV3DetailView.as_view(), name='location-detail-v3'),

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -122,11 +122,33 @@ class LocationV3DetailView(APIView):
         return Response(data)
 
 
-class HealthCheckAPIView(APIView):
-    """
-    Lightweight unauthenticated health endpoint for load balancers and Cloud Run.
-    """
+from django.utils import timezone
 
+class LivenessCheckAPIView(APIView):
+    """
+    Process-only health check for Cloud Run liveness probe.
+    Does NOT check dependencies like database.
+    """
+    permission_classes = [AllowAny]
+    authentication_classes = []
+
+    def get(self, request, *args, **kwargs):
+        return Response(
+            {
+                "status": "ok",
+                "service": "rateengine-backend",
+                "check_type": "liveness",
+                "timestamp": timezone.now().isoformat(),
+            },
+            status=200,
+        )
+
+
+class ReadinessCheckAPIView(APIView):
+    """
+    Dependency-aware health check for Cloud Run readiness/startup probe.
+    Confirms database connectivity.
+    """
     permission_classes = [AllowAny]
     authentication_classes = []
 
@@ -142,7 +164,42 @@ class HealthCheckAPIView(APIView):
         status_code = 200 if database_ok else 503
         return Response(
             {
+                "status": "ok" if database_ok else "unavailable",
+                "service": "rateengine-backend",
+                "check_type": "readiness",
+                "timestamp": timezone.now().isoformat(),
+                "dependencies": {
+                    "database": "ok" if database_ok else "unavailable"
+                }
+            },
+            status=status_code,
+        )
+
+
+class HealthCheckAPIView(APIView):
+    """
+    Legacy combined health endpoint kept for backward compatibility.
+    """
+    permission_classes = [AllowAny]
+    authentication_classes = []
+
+    def get(self, request, *args, **kwargs):
+        # Delegate to readiness logic for backward compatibility (DB check included)
+        database_ok = True
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT 1")
+                cursor.fetchone()
+        except OperationalError:
+            database_ok = False
+
+        status_code = 200 if database_ok else 503
+        return Response(
+            {
                 "status": "ok" if database_ok else "degraded",
+                "service": "rateengine-backend",
+                "check_type": "combined",
+                "timestamp": timezone.now().isoformat(),
                 "database": "ok" if database_ok else "unavailable",
             },
             status=status_code,

--- a/docs/observability_phase5g_audit.md
+++ b/docs/observability_phase5g_audit.md
@@ -41,7 +41,7 @@
 
 ## Architecture Plan: "Observability Foundation"
 
-### 5G-B: Request Correlation & Log Enrichment
+### 5G-B: Request Correlation & Log Enrichment (Implemented)
 - **Middleware:** Implement a `CorrelationMiddleware` that:
     - Generates a unique `request_id`.
     - Supports incoming `X-Request-ID` or `X-Cloud-Trace-Context`.

--- a/docs/observability_phase5g_audit.md
+++ b/docs/observability_phase5g_audit.md
@@ -49,7 +49,7 @@
 - **Logger Context:** Add a filter to the Django logging configuration that automatically injects `request_id`, `user_id`, and `trace_id` into all log records.
 - **API Response:** Include `X-Request-ID` in headers to allow frontend/support to report specific IDs.
 
-### 5G-C: Health & Readiness Optimization
+### 5G-C: Health & Readiness Optimization (Implemented)
 - **New Pattern:** Split health checks into two endpoints:
     - `/api/health/liveness/`: Returns 200 OK immediately if the process is running (no DB check).
     - `/api/health/readiness/`: Performs the DB check (current logic).

--- a/docs/observability_phase5g_c.md
+++ b/docs/observability_phase5g_c.md
@@ -1,0 +1,51 @@
+# Phase 5G-C: Health & Readiness Optimization
+
+## Overview
+This phase optimizes how RateEngine reports its health to Google Cloud Run. By splitting a single health check into distinct **Liveness** and **Readiness** probes, we improve system stability and prevent unnecessary container restarts during transient dependency failures.
+
+## Health Endpoints
+
+### 1. Liveness Check (`/api/health/liveness/`)
+- **Purpose:** Confirms the Django process is running and responding to requests.
+- **Dependency:** None (Process-only).
+- **Cloud Run Probe:** `liveness`
+- **Behavior:** Returns `200 OK` as long as the web server is alive.
+- **Why no DB?** If the database is temporarily unreachable, the container should **not** be restarted. Restarting a container doesn't fix a database issue and can lead to a "thundering herd" effect where many containers restart and hammer the DB simultaneously once it recovers.
+
+### 2. Readiness Check (`/api/health/readiness/`)
+- **Purpose:** Confirms the application is ready to serve traffic, including dependencies.
+- **Dependency:** Database (Cloud SQL).
+- **Cloud Run Probe:** `startup`
+- **Behavior:** Returns `200 OK` only if database connectivity is verified. Returns `503 Service Unavailable` otherwise.
+- **Why DB?** Traffic should not be routed to a container that cannot fulfill requests requiring database access (which is almost all RateEngine requests).
+
+### 3. Combined Check (`/api/health/`)
+- **Purpose:** Backward compatibility for external monitoring or legacy probes.
+- **Behavior:** Performs a full dependency check (same as readiness).
+
+## Cloud Run Configuration
+The deployment workflow (`.github/workflows/deploy-production.yml`) has been updated with the following flags:
+
+```yaml
+--liveness-probe-path=/api/health/liveness/
+--startup-probe-path=/api/health/readiness/
+```
+
+## Response Schema
+All health endpoints return a consistent structured JSON format:
+
+```json
+{
+  "status": "ok",
+  "service": "rateengine-backend",
+  "check_type": "liveness|readiness|combined",
+  "timestamp": "2026-05-19T12:00:00.000Z",
+  "dependencies": {
+    "database": "ok"
+  }
+}
+```
+
+## Security
+- **No Connection Leaks:** The endpoints confirm connectivity but never return connection strings, IP addresses, or internal error messages.
+- **Unauthenticated:** These endpoints do not require authentication to allow Cloud Run's infrastructure to probe them without managing application-level credentials.


### PR DESCRIPTION
## Overview
This PR implements Phase 5G-C by splitting backend health checks into dedicated liveness and readiness endpoints for Cloud Run.

## Changes
- Adds `/api/health/liveness/` as a process-only health check.
- Adds `/api/health/readiness/` as a database-aware readiness check.
- Keeps `/api/health/` for backward compatibility.
- Updates Cloud Run probe paths in `deploy-production.yml`.
- Adds health endpoint tests.
- Adds `docs/observability_phase5g_c.md`.

## Verification
- Health and correlation tests passed locally.
- Django system check passed.
- Scope is limited to observability/runtime health behavior.