### PR TITLE
feat(obs): Phase 5G-D - GCP Ops Integration & Error Reporting

### DIFF
--- a/backend/core/logging_utils.py
+++ b/backend/core/logging_utils.py
@@ -1,0 +1,104 @@
+import json
+import logging
+import traceback
+from datetime import datetime
+from pythonjsonlogger import json as jsonlogger
+from django.conf import settings
+
+# --- SIGNAL DEFINITIONS ---
+SIGNAL_QUOTE_CREATED = "SIGNAL:QUOTE_CREATED"
+SIGNAL_SPOT_TRIGGERED = "SIGNAL:SPOT_TRIGGERED"
+SIGNAL_AI_EXTRACTION_FAILED = "SIGNAL:AI_EXTRACTION_FAILED"
+SIGNAL_MISSING_RATE = "SIGNAL:MISSING_RATE"
+SIGNAL_LOGIN_SUCCESS = "SIGNAL:LOGIN_SUCCESS"
+SIGNAL_LOGIN_FAILED = "SIGNAL:LOGIN_FAILED"
+
+logger = logging.getLogger(__name__)
+
+class GCPJSONFormatter(jsonlogger.JsonFormatter):
+    """
+    Custom JSON formatter for Google Cloud Operations.
+    - Maps levelname to severity.
+    - Injects serviceContext for Error Reporting.
+    - Links request trace context.
+    - Masks potential secrets.
+    """
+    def add_fields(self, log_record, record, message_dict):
+        super().add_fields(log_record, record, message_dict)
+        
+        # 1. GCP Severity mapping
+        # https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#logseverity
+        severity_map = {
+            'DEBUG': 'DEBUG',
+            'INFO': 'INFO',
+            'WARNING': 'WARNING',
+            'ERROR': 'ERROR',
+            'CRITICAL': 'CRITICAL',
+        }
+        log_record['severity'] = severity_map.get(record.levelname, 'INFO')
+
+        # 2. Trace correlation
+        # Cloud Logging uses logging.googleapis.com/trace for correlation
+        project_id = getattr(settings, 'GCP_PROJECT_ID', None)
+        trace_id = getattr(record, 'trace_id', None)
+        if project_id and trace_id:
+            log_record['logging.googleapis.com/trace'] = f"projects/{project_id}/traces/{trace_id}"
+        
+        # 3. Request correlation
+        log_record['request_id'] = getattr(record, 'request_id', None)
+        log_record['user_id'] = getattr(record, 'user_id', None)
+
+        # 4. Error Reporting metadata
+        # Only include for ERROR or higher
+        if record.levelno >= logging.ERROR:
+            # Service context is required for grouping in GCP Error Reporting
+            log_record['serviceContext'] = {
+                'service': 'rateengine-backend',
+                'version': getattr(settings, 'APP_VERSION', 'unknown'),
+            }
+            
+            # GCP looks for 'stack_trace' or '@type' to trigger Error Reporting
+            if record.exc_info:
+                log_record['stack_trace'] = "".join(traceback.format_exception(*record.exc_info))
+            elif not log_record.get('stack_trace') and record.levelname in ['ERROR', 'CRITICAL']:
+                # If no exception info but it's an error, provide a basic stack
+                log_record['stack_trace'] = "".join(traceback.format_stack())
+
+        # 5. Masking
+        # Simple recursive masking for keys that look like secrets or contain sm://
+        self._mask_record(log_record)
+
+    def _mask_record(self, data):
+        """Recursively mask potential secrets in the log record."""
+        if not isinstance(data, dict):
+            return
+
+        sensitive_keys = {'password', 'token', 'secret', 'key', 'authorization'}
+        for key, value in data.items():
+            if any(s in key.lower() for s in sensitive_keys):
+                data[key] = "********"
+            elif isinstance(value, str) and value.startswith("sm://"):
+                data[key] = "sm://********"
+            elif isinstance(value, dict):
+                self._mask_record(value)
+
+
+def log_signal(signal_type: str, message: str, **kwargs):
+    """
+    Emits a structured SIGNAL log for commercial/operational events.
+    """
+    log_data = {
+        'signal_type': signal_type,
+        'commercial_event': True,
+        **kwargs
+    }
+    # We log at INFO level so these aren't treated as errors, 
+    # but the prefix allows Log-based Metrics to find them.
+    logger.info(f"{signal_type}: {message}", extra=log_data)
+
+
+def log_exception(message: str, **kwargs):
+    """
+    Helper to log an exception with extra context for Error Reporting.
+    """
+    logger.exception(message, extra=kwargs)

--- a/backend/core/middleware.py
+++ b/backend/core/middleware.py
@@ -1,46 +1,10 @@
 import uuid
 import logging
-from threading import local
 from typing import Optional
-
-# Thread-local storage for request-specific context
-_context = local()
-
-logger = logging.getLogger(__name__)
-
-def set_request_id(request_id: str):
-    """Store the request ID in the current thread's context."""
-    _context.request_id = request_id
-
-def get_request_id() -> Optional[str]:
-    """Retrieve the request ID from the current thread's context."""
-    return getattr(_context, 'request_id', None)
-
-def set_trace_id(trace_id: str):
-    """Store the GCP trace ID in the current thread's context."""
-    _context.trace_id = trace_id
-
-def get_trace_id() -> Optional[str]:
-    """Retrieve the GCP trace ID from the current thread's context."""
-    return getattr(_context, 'trace_id', None)
-
-def set_user_id(user_id: str):
-    """Store the authenticated user ID in the current thread's context."""
-    _context.user_id = user_id
-
-def get_user_id() -> Optional[str]:
-    """Retrieve the user ID from the current thread's context."""
-    return getattr(_context, 'user_id', None)
-
-def clear_request_context():
-    """Clear all request-specific data from thread-local storage."""
-    if hasattr(_context, 'request_id'):
-        del _context.request_id
-    if hasattr(_context, 'trace_id'):
-        del _context.trace_id
-    if hasattr(_context, 'user_id'):
-        del _context.user_id
-
+from .middleware_utils import (
+    set_request_id, set_trace_id, set_user_id, clear_request_context,
+    get_request_id, get_trace_id, get_user_id
+)
 
 class RequestContextFilter(logging.Filter):
     """
@@ -51,6 +15,20 @@ class RequestContextFilter(logging.Filter):
         record.trace_id = get_trace_id()
         record.user_id = get_user_id()
         return True
+
+class UserContextMiddleware:
+    """
+    Middleware that captures user ID after authentication has occurred.
+    Should be placed AFTER AuthenticationMiddleware.
+    """
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if hasattr(request, 'user') and request.user.is_authenticated:
+            set_user_id(str(request.user.id))
+        
+        return self.get_response(request)
 
 
 class CorrelationIdMiddleware:
@@ -84,18 +62,13 @@ class CorrelationIdMiddleware:
 
         # 5. Process request
         try:
-            # We can't set user_id here yet because authentication happens later in the middleware chain
             response = self.get_response(request)
             
-            # 6. Inject user_id if authenticated
-            if hasattr(request, 'user') and request.user.is_authenticated:
-                set_user_id(str(request.user.id))
-            
-            # 7. Return ID in response headers
+            # 6. Return ID in response headers
             response['X-Request-ID'] = request_id
             return response
         finally:
-            # 8. Always clear context to avoid leak between requests in threaded workers
+            # 7. Always clear context to avoid leak between requests in threaded workers
             clear_request_context()
 
     def _is_valid_uuid(self, val: str) -> bool:

--- a/backend/core/middleware_utils.py
+++ b/backend/core/middleware_utils.py
@@ -1,0 +1,42 @@
+import uuid
+import logging
+from threading import local
+from typing import Optional
+
+# Thread-local storage for request-specific context
+_context = local()
+
+logger = logging.getLogger(__name__)
+
+def set_request_id(request_id: str):
+    """Store the request ID in the current thread's context."""
+    _context.request_id = request_id
+
+def get_request_id() -> Optional[str]:
+    """Retrieve the request ID from the current thread's context."""
+    return getattr(_context, 'request_id', None)
+
+def set_trace_id(trace_id: str):
+    """Store the GCP trace ID in the current thread's context."""
+    _context.trace_id = trace_id
+
+def get_trace_id() -> Optional[str]:
+    """Retrieve the GCP trace ID from the current thread's context."""
+    return getattr(_context, 'trace_id', None)
+
+def set_user_id(user_id: str):
+    """Store the authenticated user ID in the current thread's context."""
+    _context.user_id = user_id
+
+def get_user_id() -> Optional[str]:
+    """Retrieve the user ID from the current thread's context."""
+    return getattr(_context, 'user_id', None)
+
+def clear_request_context():
+    """Clear all request-specific data from thread-local storage."""
+    if hasattr(_context, 'request_id'):
+        del _context.request_id
+    if hasattr(_context, 'trace_id'):
+        del _context.trace_id
+    if hasattr(_context, 'user_id'):
+        del _context.user_id

--- a/backend/core/tests/test_logging.py
+++ b/backend/core/tests/test_logging.py
@@ -1,0 +1,81 @@
+import logging
+import pytest
+from unittest.mock import MagicMock, patch
+from core.logging_utils import GCPJSONFormatter, log_signal, SIGNAL_QUOTE_CREATED
+
+class TestGCPJSONFormatter:
+    def test_severity_mapping(self):
+        formatter = GCPJSONFormatter()
+        
+        # Test INFO mapping
+        record_info = MagicMock(levelname='INFO', levelno=logging.INFO, exc_info=None)
+        log_record_info = {}
+        formatter.add_fields(log_record_info, record_info, {})
+        assert log_record_info['severity'] == 'INFO'
+        
+        # Test ERROR mapping
+        record_error = MagicMock(levelname='ERROR', levelno=logging.ERROR, exc_info=None)
+        log_record_error = {}
+        formatter.add_fields(log_record_error, record_error, {})
+        assert log_record_info['severity'] == 'INFO' # Check original object wasn't mutated globally
+        assert log_record_error['severity'] == 'ERROR'
+
+    def test_trace_correlation(self):
+        formatter = GCPJSONFormatter()
+        record = MagicMock(levelname='INFO', levelno=logging.INFO, exc_info=None, trace_id='trace-123')
+        log_record = {}
+        
+        with patch('django.conf.settings.GCP_PROJECT_ID', 'test-project'):
+            formatter.add_fields(log_record, record, {})
+            assert log_record['logging.googleapis.com/trace'] == 'projects/test-project/traces/trace-123'
+
+    def test_error_reporting_metadata(self):
+        formatter = GCPJSONFormatter()
+        # Mock record with exception info
+        try:
+            raise ValueError("Test Error")
+        except ValueError:
+            import sys
+            exc_info = sys.exc_info()
+            
+        record = MagicMock(levelname='ERROR', levelno=logging.ERROR, exc_info=exc_info)
+        log_record = {}
+        
+        with patch('django.conf.settings.APP_VERSION', '2.0.0'):
+            formatter.add_fields(log_record, record, {})
+            assert log_record['serviceContext']['service'] == 'rateengine-backend'
+            assert log_record['serviceContext']['version'] == '2.0.0'
+            assert 'stack_trace' in log_record
+            assert 'ValueError: Test Error' in log_record['stack_trace']
+
+    def test_masking_secrets(self):
+        formatter = GCPJSONFormatter()
+        log_record = {
+            'message': 'test',
+            'password': 'secret-password',
+            'deep': {'token': 'secret-token'},
+            'sm_ref': 'sm://my-secret'
+        }
+        formatter._mask_record(log_record)
+        
+        assert log_record['password'] == '********'
+        assert log_record['deep']['token'] == '********'
+        assert log_record['sm_ref'] == 'sm://********'
+
+
+class TestSignalLogging:
+    @patch('core.logging_utils.logger.info')
+    def test_log_signal_emits_correct_fields(self, mock_logger_info):
+        log_signal(
+            SIGNAL_QUOTE_CREATED, 
+            "New quote for customer 5", 
+            quote_id='q-123', 
+            customer_id=5
+        )
+        
+        args, kwargs = mock_logger_info.call_args
+        assert f"{SIGNAL_QUOTE_CREATED}: New quote for customer 5" in args[0]
+        assert kwargs['extra']['signal_type'] == SIGNAL_QUOTE_CREATED
+        assert kwargs['extra']['commercial_event'] is True
+        assert kwargs['extra']['quote_id'] == 'q-123'
+        assert kwargs['extra']['customer_id'] == 5

--- a/backend/rate_engine/settings.py
+++ b/backend/rate_engine/settings.py
@@ -144,6 +144,7 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'core.middleware.UserContextMiddleware', # Capture user ID for logging context
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
@@ -416,12 +417,16 @@ SPOT_ALLOWED_NON_PNG_LANES = [
 # =============================================================================
 # Structured logging for production environments (outputs to console for containers)
 
+# Google Cloud Operations Configuration
+GCP_PROJECT_ID = os.environ.get('GOOGLE_CLOUD_PROJECT', '')
+APP_VERSION = os.environ.get('APP_VERSION', '1.0.0')
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
     'formatters': {
         'json': {
-            '()': 'pythonjsonlogger.json.JsonFormatter',
+            '()': 'core.logging_utils.GCPJSONFormatter',
             'format': '%(levelname)s %(asctime)s %(module)s %(request_id)s %(trace_id)s %(user_id)s %(message)s',
         },
         'verbose': {

--- a/docs/observability_phase5g_d.md
+++ b/docs/observability_phase5g_d.md
@@ -1,0 +1,53 @@
+# Phase 5G-D: GCP Ops Integration & Error Reporting
+
+## Overview
+This phase integrates RateEngine's structured logging with Google Cloud Operations (formerly Stackdriver). It enables automated **Error Reporting**, improves log correlation via **Cloud Trace**, and introduces a **SIGNAL** standard for commercial and operational metrics.
+
+## Logging Enhancements
+
+### 1. GCP Structured Logging
+The `GCPJSONFormatter` (implemented in `backend/core/logging_utils.py`) extends the standard JSON formatter to satisfy GCP-specific requirements:
+- **Severity Mapping:** Maps standard Python log levels (INFO, ERROR, etc.) to the `severity` field required by Cloud Logging.
+- **Trace Context:** Injects `logging.googleapis.com/trace` using the `GCP_PROJECT_ID` and the request's `trace_id`, enabling "Trace-to-Logs" correlation in the GCP Console.
+- **Request Metadata:** Includes `request_id` and `user_id` as top-level searchable fields.
+
+### 2. Cloud Error Reporting
+To support automated grouping and alerting in **Google Cloud Error Reporting**, all logs with level `ERROR` or higher now include:
+- **`serviceContext`:** Identifies the service as `rateengine-backend` and includes the `APP_VERSION`.
+- **`stack_trace`:** Emits a formatted string of the exception stack trace. GCP uses this field to trigger the Error Reporting dashboard.
+
+### 3. Secret Masking
+The logging formatter includes a recursive masking filter. Any key containing `password`, `token`, `secret`, or `key` is masked with `********`. Additionally, any value starting with `sm://` (Secret Manager references) is automatically masked to prevent accidental credential leakage in logs.
+
+## SIGNAL Logging Standard
+We have established a `SIGNAL:` logging pattern for high-value business events. These logs are intended to drive **Log-based Metrics** in GCP for dashboards and alerting.
+
+### Supported Signals
+| Prefix | Description | Key Fields |
+| :--- | :--- | :--- |
+| `SIGNAL:QUOTE_CREATED` | A new quote was successfully saved. | `quote_id`, `customer_id`, `total_amount` |
+| `SIGNAL:SPOT_TRIGGERED` | A shipment requires manual SPOT intervention. | `reason_code`, `origin`, `destination` |
+| `SIGNAL:AI_EXTRACTION_FAILED` | AI intake failed to parse a document. | `source_type`, `error_type` |
+| `SIGNAL:MISSING_RATE` | Pricing failed due to a missing rate card. | `route_code`, `bucket` |
+| `SIGNAL:LOGIN_SUCCESS` | Successful user authentication. | `user_id`, `username` |
+| `SIGNAL:LOGIN_FAILED` | Failed authentication attempt. | `username`, `reason` |
+
+### Usage
+Use the `log_signal` helper from `core.logging_utils`:
+```python
+from core.logging_utils import log_signal, SIGNAL_QUOTE_CREATED
+
+log_signal(SIGNAL_QUOTE_CREATED, "Quote QT-123 created", quote_id="QT-123", customer_id=45)
+```
+
+## Recommended Alerts (GCP)
+Based on these signals, we recommend configuring the following alerts in the Google Cloud Console:
+1. **High Error Rate:** `severity >= ERROR` count > X over 5 minutes.
+2. **AI Extraction Failure Spike:** `jsonPayload.signal_type = "SIGNAL:AI_EXTRACTION_FAILED"` count > Y.
+3. **Missing Rate Alert:** `jsonPayload.signal_type = "SIGNAL:MISSING_RATE"` for identifying pricing coverage gaps.
+4. **Brute Force Detection:** `jsonPayload.signal_type = "SIGNAL:LOGIN_FAILED"` count from a single IP/User.
+
+## Security Rules
+- **No Payloads:** Never log raw request bodies or large document payloads.
+- **No Secrets:** The `GCPJSONFormatter` provides a safety net, but developers must still avoid explicitly logging sensitive variables.
+- **User IDs:** Log database `user_id` only; avoid logging PII like full names or email addresses where possible.


### PR DESCRIPTION
## Overview
This PR implements Phase 5G-D: GCP Ops Integration & Error Reporting.

It upgrades RateEngine’s production logging so logs are more useful in Google Cloud Logging, Error Reporting, and future operational dashboards.

## Changes
- Created `GCPJSONFormatter` for structured Cloud Logging and Error Reporting compatibility.
- Implemented `log_signal` utility for standardized commercial event tracking.
- Added `UserContextMiddleware` to inject `user_id` into logging context after authentication.
- Refactored request context helpers into shared `middleware_utils.py`.
- Integrated the new formatter and middleware into Django settings.
- Added unit tests for GCP field mapping, masking, and signal logs.
- Documented GCP integration and recommended alerting rules.

## Scope of Change
Observability only.

This PR does not change quote creation, pricing, FX/CAF, GST, margin, SPOT behavior, public quote display, charge grouping, or CRM quote logging.

## What Was Intentionally NOT Changed
- No business logic changes.
- No deployment changes.
- No dashboard creation yet.
- No real GCP resources or project values added.
- No secrets, tokens, cookies, request bodies, or document payloads are logged.

## Risk Areas
- Logging format changes may affect how logs appear in local/debug vs production mode.
- Future async server usage would need context handling reviewed.

## Tests Run
- `core/tests/test_logging.py` passed.
- `core/tests/test_correlation.py` passed.
- `core/tests/test_health.py` passed.
- `python manage.py check` passed.

## Documentation
- Added `docs/observability_phase5g_d.md`.

## Reviewer Checklist
- [x] This PR solves one concern only.
- [x] It does not duplicate existing logic.
- [x] It does not revive legacy code.
- [x] It does not create another source of truth.
- [x] It does not affect quote creation, pricing, FX/CAF, GST, margin, SPOT, public quote display, charge grouping, or CRM quote logging.
- [x] Existing observability documentation was updated/extended.