### PR TITLE
feat(crm): Phase CRM-B - Backend OpportunityAutoBuilderService

### DIFF
--- a/backend/core/tests/test_location_guardrails.py
+++ b/backend/core/tests/test_location_guardrails.py
@@ -27,11 +27,17 @@ class LocationTestUsageGuardrails(SimpleTestCase):
         backend_root = Path(__file__).resolve().parents[2]
         offenders = []
 
+        # Check all .py files in any tests/ directory
         for path in sorted(backend_root.rglob("tests/test*.py")):
             if path.name == "test_location_guardrails.py":
                 continue
-            if "Location.objects.create(" in path.read_text(encoding="utf-8"):
+            if "venv" in str(path):
+                continue
+
+            content = path.read_text(encoding="utf-8")
+            if "Location.objects.create(" in content:
                 offenders.append(path.relative_to(backend_root).as_posix())
+
 
         self.assertEqual(
             offenders,

--- a/backend/crm/models.py
+++ b/backend/crm/models.py
@@ -138,7 +138,9 @@ class Interaction(models.Model):
         is_create = self._state.adding
         super().save(*args, **kwargs)
         if is_create:
-            interaction_time = self.created_at
+            # Use self.created_at if populated, else fallback to current time
+            interaction_time = self.created_at or timezone.now()
+            
             update_fields = ["last_interaction_at", "updated_at"]
             self.company.last_interaction_at = interaction_time
             self.company.save(update_fields=update_fields)

--- a/backend/crm/opportunity_auto_builder.py
+++ b/backend/crm/opportunity_auto_builder.py
@@ -1,0 +1,284 @@
+import logging
+from datetime import timedelta
+from django.utils import timezone
+from django.db import transaction
+from django.db.models import Q
+
+from .models import Opportunity, Interaction, Task
+from quotes.models import Quote
+
+logger = logging.getLogger(__name__)
+
+class OpportunityAutoBuilderService:
+    """
+    Service responsible for automatically creating and updating CRM Opportunities
+    based on Quote commercial activity.
+    """
+
+    @classmethod
+    @transaction.atomic
+    def sync_from_quote(cls, quote: Quote, event: str = None, actor=None):
+        """
+        Main entry point to ensure a quote is correctly reflected in the CRM.
+        """
+        # 1. Resolve the Opportunity
+        opportunity = cls._resolve_opportunity(quote, actor)
+        
+        # 2. Link quote to opportunity if not already linked
+        if quote.opportunity != opportunity:
+            quote.opportunity = opportunity
+            quote.save(update_fields=["opportunity", "updated_at"])
+
+        # 3. Update Opportunity fields from Quote data
+        cls._update_opportunity_from_quote(opportunity, quote, actor)
+
+        # 4. Handle System Interactions (Idempotent)
+        cls._record_interaction(opportunity, quote, event or quote.status, actor)
+
+        # 5. Handle Tasks
+        cls._handle_tasks(opportunity, quote, actor)
+
+        return opportunity
+
+    @classmethod
+    def _resolve_opportunity(cls, quote: Quote, actor=None):
+        """
+        Find an existing active opportunity or create a new one.
+        Uses 14-day window for deduplication.
+        """
+        if quote.opportunity:
+            return quote.opportunity
+
+        # Deduplication parameters
+        service_type = cls._map_mode_to_service_type(quote.mode)
+        window_start = timezone.now() - timedelta(days=14)
+
+        # Search for active opportunities (NEW, QUALIFIED, QUOTED)
+        existing = Opportunity.objects.filter(
+            company=quote.customer,
+            service_type=service_type,
+            origin=cls._get_location_label(quote.origin_location),
+            destination=cls._get_location_label(quote.destination_location),
+            direction=quote.shipment_type,
+            status__in=[
+                Opportunity.Status.NEW,
+                Opportunity.Status.QUALIFIED,
+                Opportunity.Status.QUOTED
+            ],
+            created_at__gte=window_start
+        ).first()
+
+        if existing:
+            return existing
+
+        # Create new if none found
+        return cls._create_opportunity(quote, actor)
+
+    @classmethod
+    def _create_opportunity(cls, quote, actor=None):
+        service_type = cls._map_mode_to_service_type(quote.mode)
+        name = cls._generate_name(quote)
+        
+        opportunity = Opportunity.objects.create(
+            company=quote.customer,
+            title=name,
+            service_type=service_type,
+            direction=quote.shipment_type,
+            origin=cls._get_location_label(quote.origin_location),
+            destination=cls._get_location_label(quote.destination_location),
+            status=cls._map_quote_status_to_opp(quote.status),
+            owner=actor if (actor and actor.is_authenticated) else getattr(quote, "created_by", None),
+            estimated_revenue=getattr(quote, "total_revenue_base", None),
+            estimated_currency="PGK" # Base system currency
+        )
+        return opportunity
+
+    @classmethod
+    def _update_opportunity_from_quote(cls, opportunity, quote, actor=None):
+        """
+        Progress the opportunity status based on the quote's latest status.
+        """
+        new_status = cls._map_quote_status_to_opp(quote.status)
+        
+        # Don't downgrade status automatically (e.g. if one quote is LOST but another is WON)
+        # However, for WON/LOST we need to be careful.
+        
+        if new_status == Opportunity.Status.WON:
+            opportunity.status = Opportunity.Status.WON
+            opportunity.won_at = timezone.now()
+            opportunity.won_by = actor if (actor and actor.is_authenticated) else None
+            opportunity.save(update_fields=["status", "won_at", "won_by", "updated_at"])
+        elif new_status == Opportunity.Status.LOST:
+            # Only mark LOST if no other active quotes exist for this opportunity
+            from quotes.state_machine import ACTIVE_STATES
+            has_active = opportunity.quotes.exclude(pk=quote.pk).filter(status__in=ACTIVE_STATES).exists()
+            if not has_active:
+                opportunity.status = Opportunity.Status.LOST
+                opportunity.save(update_fields=["status", "updated_at"])
+        elif opportunity.status not in [Opportunity.Status.WON, Opportunity.Status.LOST]:
+            # Normal progression
+            if cls._status_rank(new_status) > cls._status_rank(opportunity.status):
+                opportunity.status = new_status
+                opportunity.save(update_fields=["status", "updated_at"])
+
+    @classmethod
+    def _record_interaction(cls, opportunity, quote, event, actor=None):
+        """
+        Record a system interaction for the quote event. Idempotent.
+        """
+        event_type = f"AUTO_{event}".upper()
+        quote_id_tag = f"quote_id={quote.id}"
+        
+        existing = Interaction.objects.filter(
+            opportunity=opportunity,
+            system_event_type=event_type,
+            outcomes__contains=quote_id_tag
+        ).exists()
+
+        if existing:
+            return
+
+        summary = cls._generate_interaction_summary(quote, event)
+        Interaction.objects.create(
+            company=opportunity.company,
+            opportunity=opportunity,
+            author=actor if (actor and actor.is_authenticated) else None,
+            interaction_type=Interaction.InteractionType.SYSTEM,
+            is_system_generated=True,
+            system_event_type=event_type,
+            summary=summary,
+            outcomes=f"Automatically recorded from quote lifecycle.\n{quote_id_tag}"
+        )
+
+    @classmethod
+    def _handle_tasks(cls, opportunity, quote, actor=None):
+        """
+        Automate follow-up tasks.
+        """
+        # On Quote SENT, create a follow-up task
+        if quote.status == Quote.Status.SENT:
+            cls._create_follow_up_task(opportunity, quote)
+        
+        # On Quote WON/LOST, complete related tasks
+        if quote.status in [Quote.Status.ACCEPTED, Quote.Status.LOST, Quote.Status.EXPIRED]:
+            cls._cleanup_tasks(opportunity)
+
+    @classmethod
+    def _create_follow_up_task(cls, opportunity, quote):
+        """
+        Creates a 'Follow up on Quote' task due in 3 business days.
+        """
+        description = f"Follow up on Quote {quote.quote_number or quote.id}"
+        
+        # Check for existing pending task for this quote
+        existing = Task.objects.filter(
+            opportunity=opportunity,
+            description__contains=str(quote.quote_number or quote.id),
+            status=Task.Status.PENDING
+        ).exists()
+
+        if existing:
+            return
+
+        due_date = cls._add_business_days(timezone.now().date(), 3)
+        
+        Task.objects.create(
+            company=opportunity.company,
+            opportunity=opportunity,
+            description=description,
+            owner=opportunity.owner or quote.created_by,
+            due_date=due_date,
+            status=Task.Status.PENDING
+        )
+
+    @classmethod
+    def _cleanup_tasks(cls, opportunity):
+        """
+        Mark all pending tasks for this opportunity as completed/cancelled
+        when the deal is closed.
+        """
+        # This is conservative: only auto-complete if the opportunity is closed.
+        if opportunity.status in [Opportunity.Status.WON, Opportunity.Status.LOST]:
+            Task.objects.filter(
+                opportunity=opportunity,
+                status=Task.Status.PENDING
+            ).update(
+                status=Task.Status.COMPLETED,
+                completed_at=timezone.now()
+            )
+
+    # --- Helpers ---
+
+    @staticmethod
+    def _map_mode_to_service_type(mode: str) -> str:
+        m = str(mode or "").upper()
+        if m == "AIR": return "AIR"
+        if m == "SEA": return "SEA"
+        if m in ["LAND", "TRUCK"]: return "TRANSPORT"
+        return "TRANSPORT"
+
+    @staticmethod
+    def _get_location_label(location):
+        if not location: return ""
+        return getattr(location, "code", "") or getattr(location, "name", "")
+
+    @classmethod
+    def _generate_name(cls, quote: Quote):
+        mode = quote.mode.capitalize()
+        direction = quote.shipment_type.capitalize()
+        origin = cls._get_location_label(quote.origin_location)
+        dest = cls._get_location_label(quote.destination_location)
+        customer = quote.customer.name
+        
+        route = f"{origin} \u2192 {dest}" if (origin and dest) else (origin or dest or "Unknown Route")
+        return f"{mode} {direction} {route} - {customer}"
+
+    @staticmethod
+    def _map_quote_status_to_opp(quote_status: str) -> str:
+        s = quote_status
+        if s in [Quote.Status.DRAFT, Quote.Status.INCOMPLETE]:
+            return Opportunity.Status.NEW
+        if s == Quote.Status.FINALIZED:
+            return Opportunity.Status.QUALIFIED
+        if s == Quote.Status.SENT:
+            return Opportunity.Status.QUOTED
+        if s == Quote.Status.ACCEPTED:
+            return Opportunity.Status.WON
+        if s in [Quote.Status.LOST, Quote.Status.EXPIRED]:
+            return Opportunity.Status.LOST
+        return Opportunity.Status.NEW
+
+    @staticmethod
+    def _status_rank(status: str) -> int:
+        ranks = {
+            Opportunity.Status.NEW: 1,
+            Opportunity.Status.QUALIFIED: 2,
+            Opportunity.Status.QUOTED: 3,
+            Opportunity.Status.WON: 4,
+            Opportunity.Status.LOST: 4, # Closed is high rank
+        }
+        return ranks.get(status, 0)
+
+    @staticmethod
+    def _generate_interaction_summary(quote, event):
+        quote_label = quote.quote_number or str(quote.id)
+        if event == Quote.Status.SENT:
+            return f"Quote {quote_label} sent to customer."
+        if event == Quote.Status.ACCEPTED:
+            return f"Quote {quote_label} accepted/won."
+        if event == Quote.Status.FINALIZED:
+            return f"Quote {quote_label} finalized and ready for sending."
+        return f"Quote {quote_label} activity recorded: {event}."
+
+    @staticmethod
+    def _add_business_days(start_date, days):
+        """
+        Simple business day addition (skipping Saturday/Sunday).
+        """
+        current_date = start_date
+        added_days = 0
+        while added_days < days:
+            current_date += timedelta(days=1)
+            if current_date.weekday() < 5: # 0-4 is Mon-Fri
+                added_days += 1
+        return current_date

--- a/backend/crm/opportunity_auto_builder.py
+++ b/backend/crm/opportunity_auto_builder.py
@@ -79,6 +79,15 @@ class OpportunityAutoBuilderService:
         service_type = cls._map_mode_to_service_type(quote.mode)
         name = cls._generate_name(quote)
         
+        # Get revenue from latest version if available
+        estimated_revenue = None
+        try:
+            latest_version = quote.versions.order_by("-version_number").first()
+            if latest_version and hasattr(latest_version, "totals"):
+                estimated_revenue = latest_version.totals.total_sell_pgk
+        except Exception:
+            pass
+
         opportunity = Opportunity.objects.create(
             company=quote.customer,
             title=name,
@@ -87,8 +96,8 @@ class OpportunityAutoBuilderService:
             origin=cls._get_location_label(quote.origin_location),
             destination=cls._get_location_label(quote.destination_location),
             status=cls._map_quote_status_to_opp(quote.status),
-            owner=actor if (actor and actor.is_authenticated) else getattr(quote, "created_by", None),
-            estimated_revenue=getattr(quote, "total_revenue_base", None),
+            owner=actor if (actor and actor.is_authenticated) else (quote.created_by or quote.finalized_by or quote.sent_by),
+            estimated_revenue=estimated_revenue,
             estimated_currency="PGK" # Base system currency
         )
         return opportunity
@@ -101,12 +110,10 @@ class OpportunityAutoBuilderService:
         new_status = cls._map_quote_status_to_opp(quote.status)
         
         # Don't downgrade status automatically (e.g. if one quote is LOST but another is WON)
-        # However, for WON/LOST we need to be careful.
-        
         if new_status == Opportunity.Status.WON:
             opportunity.status = Opportunity.Status.WON
             opportunity.won_at = timezone.now()
-            opportunity.won_by = actor if (actor and actor.is_authenticated) else None
+            opportunity.won_by = actor if (actor and actor.is_authenticated) else (quote.finalized_by or quote.sent_by or quote.created_by)
             opportunity.save(update_fields=["status", "won_at", "won_by", "updated_at"])
         elif new_status == Opportunity.Status.LOST:
             # Only mark LOST if no other active quotes exist for this opportunity
@@ -126,7 +133,11 @@ class OpportunityAutoBuilderService:
         """
         Record a system interaction for the quote event. Idempotent.
         """
-        event_type = f"AUTO_{event}".upper()
+        # Align with existing QUOTE_ prefix naming
+        event_type = str(event).upper()
+        if not event_type.startswith("QUOTE_"):
+            event_type = f"QUOTE_{event_type}"
+            
         quote_id_tag = f"quote_id={quote.id}"
         
         existing = Interaction.objects.filter(
@@ -142,7 +153,7 @@ class OpportunityAutoBuilderService:
         Interaction.objects.create(
             company=opportunity.company,
             opportunity=opportunity,
-            author=actor if (actor and actor.is_authenticated) else None,
+            author=actor if (actor and actor.is_authenticated) else (quote.sent_by or quote.finalized_by or quote.created_by),
             interaction_type=Interaction.InteractionType.SYSTEM,
             is_system_generated=True,
             system_event_type=event_type,
@@ -182,11 +193,23 @@ class OpportunityAutoBuilderService:
 
         due_date = cls._add_business_days(timezone.now().date(), 3)
         
+        # Ensure owner is NEVER None (Postgres required field)
+        owner = opportunity.owner or quote.created_by or quote.sent_by or quote.finalized_by
+        if not owner:
+            # Last resort: find first admin or active user
+            from django.contrib.auth import get_user_model
+            User = get_user_model()
+            owner = User.objects.filter(is_superuser=True).first() or User.objects.filter(is_active=True).first()
+        
+        if not owner:
+            logger.warning(f"Could not create follow-up task for quote {quote.id}: No owner available.")
+            return
+
         Task.objects.create(
             company=opportunity.company,
             opportunity=opportunity,
             description=description,
-            owner=opportunity.owner or quote.created_by,
+            owner=owner,
             due_date=due_date,
             status=Task.Status.PENDING
         )

--- a/backend/crm/tests/test_opportunity_auto_builder.py
+++ b/backend/crm/tests/test_opportunity_auto_builder.py
@@ -4,7 +4,7 @@ from django.utils import timezone
 from django.contrib.auth import get_user_model
 
 from parties.models import Company
-from core.models import Location
+from core.tests.helpers import create_location
 from quotes.models import Quote
 from crm.models import Opportunity, Interaction, Task
 from crm.opportunity_auto_builder import OpportunityAutoBuilderService
@@ -15,8 +15,8 @@ class OpportunityAutoBuilderTests(TestCase):
     def setUp(self):
         self.user = User.objects.create_user(username="testuser", email="test@example.com")
         self.customer = Company.objects.create(name="Daikin PNG", is_active=True)
-        self.origin = Location.objects.create(code="POM", name="Port Moresby")
-        self.destination = Location.objects.create(code="BNE", name="Brisbane")
+        self.origin = create_location(code="POM", name="Port Moresby")
+        self.destination = create_location(code="BNE", name="Brisbane")
         
         self.quote = Quote.objects.create(
             customer=self.customer,

--- a/backend/crm/tests/test_opportunity_auto_builder.py
+++ b/backend/crm/tests/test_opportunity_auto_builder.py
@@ -1,0 +1,125 @@
+from datetime import timedelta
+from django.test import TestCase
+from django.utils import timezone
+from django.contrib.auth import get_user_model
+
+from parties.models import Company
+from core.models import Location
+from quotes.models import Quote
+from crm.models import Opportunity, Interaction, Task
+from crm.opportunity_auto_builder import OpportunityAutoBuilderService
+
+User = get_user_model()
+
+class OpportunityAutoBuilderTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="testuser", email="test@example.com")
+        self.customer = Company.objects.create(name="Daikin PNG", is_active=True)
+        self.origin = Location.objects.create(code="POM", name="Port Moresby")
+        self.destination = Location.objects.create(code="BNE", name="Brisbane")
+        
+        self.quote = Quote.objects.create(
+            customer=self.customer,
+            mode="AIR",
+            shipment_type="EXPORT",
+            origin_location=self.origin,
+            destination_location=self.destination,
+            status=Quote.Status.DRAFT,
+            created_by=self.user
+        )
+
+    def test_creates_opportunity_from_quote(self):
+        opp = OpportunityAutoBuilderService.sync_from_quote(self.quote)
+        
+        self.assertIsNotNone(opp)
+        self.assertEqual(opp.company, self.customer)
+        self.assertEqual(opp.title, "Air Export POM \u2192 BNE - Daikin PNG")
+        self.assertEqual(opp.status, Opportunity.Status.NEW)
+        
+        self.quote.refresh_from_db()
+        self.assertEqual(self.quote.opportunity, opp)
+
+    def test_reuses_existing_opportunity(self):
+        opp1 = OpportunityAutoBuilderService.sync_from_quote(self.quote)
+        
+        # New quote for same customer/route
+        quote2 = Quote.objects.create(
+            customer=self.customer,
+            mode="AIR",
+            shipment_type="EXPORT",
+            origin_location=self.origin,
+            destination_location=self.destination,
+            status=Quote.Status.DRAFT,
+            created_by=self.user
+        )
+        
+        opp2 = OpportunityAutoBuilderService.sync_from_quote(quote2)
+        self.assertEqual(opp1.id, opp2.id)
+
+    def test_deduplication_window(self):
+        # Create an old opportunity (outside 14-day window)
+        old_date = timezone.now() - timedelta(days=15)
+        old_opp = Opportunity.objects.create(
+            company=self.customer,
+            title="Old Opp",
+            service_type="AIR",
+            direction="EXPORT",
+            origin="POM",
+            destination="BNE",
+            status=Opportunity.Status.NEW,
+            created_at=old_date
+        )
+        # Manually set created_at because auto_now_add=True
+        Opportunity.objects.filter(id=old_opp.id).update(created_at=old_date)
+        
+        new_opp = OpportunityAutoBuilderService.sync_from_quote(self.quote)
+        self.assertNotEqual(new_opp.id, old_opp.id)
+
+    def test_status_mapping(self):
+        # Finalized -> Qualified
+        self.quote.status = Quote.Status.FINALIZED
+        opp = OpportunityAutoBuilderService.sync_from_quote(self.quote)
+        self.assertEqual(opp.status, Opportunity.Status.QUALIFIED)
+        
+        # Sent -> Quoted
+        self.quote.status = Quote.Status.SENT
+        opp = OpportunityAutoBuilderService.sync_from_quote(self.quote)
+        self.assertEqual(opp.status, Opportunity.Status.QUOTED)
+        
+        # Accepted -> Won
+        self.quote.status = Quote.Status.ACCEPTED
+        opp = OpportunityAutoBuilderService.sync_from_quote(self.quote)
+        self.assertEqual(opp.status, Opportunity.Status.WON)
+
+    def test_interaction_recording(self):
+        OpportunityAutoBuilderService.sync_from_quote(self.quote)
+        
+        interactions = Interaction.objects.filter(opportunity=self.quote.opportunity)
+        self.assertEqual(interactions.count(), 1)
+        self.assertTrue(interactions[0].is_system_generated)
+        self.assertIn(f"quote_id={self.quote.id}", interactions[0].outcomes)
+
+    def test_task_creation_on_sent(self):
+        self.quote.status = Quote.Status.SENT
+        opp = OpportunityAutoBuilderService.sync_from_quote(self.quote)
+        
+        tasks = Task.objects.filter(opportunity=opp, status=Task.Status.PENDING)
+        self.assertEqual(tasks.count(), 1)
+        self.assertIn("Follow up", tasks[0].description)
+        
+        # Idempotency check: repeat sync should not duplicate task
+        OpportunityAutoBuilderService.sync_from_quote(self.quote)
+        self.assertEqual(tasks.count(), 1)
+
+    def test_task_cleanup_on_won(self):
+        # First send it
+        self.quote.status = Quote.Status.SENT
+        opp = OpportunityAutoBuilderService.sync_from_quote(self.quote)
+        self.assertEqual(Task.objects.filter(opportunity=opp, status=Task.Status.PENDING).count(), 1)
+        
+        # Then win it
+        self.quote.status = Quote.Status.ACCEPTED
+        OpportunityAutoBuilderService.sync_from_quote(self.quote)
+        
+        self.assertEqual(Task.objects.filter(opportunity=opp, status=Task.Status.PENDING).count(), 0)
+        self.assertEqual(Task.objects.filter(opportunity=opp, status=Task.Status.COMPLETED).count(), 1)

--- a/docs/crm_quote_led_automation.md
+++ b/docs/crm_quote_led_automation.md
@@ -1,0 +1,48 @@
+# Quote-Led CRM Automation
+
+## Overview
+RateEngine CRM is designed to minimize manual administrative overhead by automatically capturing commercial opportunities and activities directly from the quoting lifecycle. The `OpportunityAutoBuilderService` is the central engine for this automation.
+
+## Core Principles
+- **Quotes Drive Opportunities**: Users should rarely need to create opportunities manually. A quote contains all the necessary signals (customer, route, service, value) to build a CRM entry.
+- **Deduplication First**: Multiple quotes or revisions for the same lane/customer are automatically grouped under a single "active pursuit" (Opportunity).
+- **Automated Discipline**: System-generated tasks ensure that every sent quote is followed up without manual tracking.
+
+## Lifecycle Mapping
+
+| Quote Status | Opportunity Status | Actions Triggered |
+| :--- | :--- | :--- |
+| **DRAFT** | **NEW** | Create/Resolve Opportunity, Log Interaction |
+| **FINALIZED** | **QUALIFIED** | Progress Opportunity, Log Interaction |
+| **SENT** | **QUOTED** | Create Follow-Up Task (+3 business days), Log Interaction |
+| **ACCEPTED** | **WON** | Close Opportunity, Complete pending tasks, Log Interaction |
+| **LOST / EXPIRED**| **LOST*** | Close Opportunity (if no other active quotes), Complete tasks |
+
+*\* Opportunity only marks as LOST if no other active quotes (Draft, Finalized, Sent) are linked to it.*
+
+## Opportunity Resolution (Deduplication)
+The system prevents CRM clutter by searching for existing active opportunities before creating new ones.
+- **Match Criteria**: Company, Service Type (Air/Sea/Transport), Origin, Destination, and Direction (Import/Export/Domestic).
+- **Time Window**: 14 days.
+- **Active Statuses**: NEW, QUALIFIED, QUOTED.
+
+## Naming Convention
+Opportunities are automatically named for maximum scannability:
+`[Mode] [Direction] [Origin] \u2192 [Destination] - [CustomerName]`
+*Example: Air Export POM \u2192 BNE - Daikin PNG*
+
+## Automated Tasks
+- **On Quote Sent**: A task is assigned to the quote owner: *"Follow up on Quote [Number]"*.
+- **Due Date**: 3 business days from the sent date (skipping weekends).
+- **Cleanup**: When an opportunity is marked WON or LOST, all related pending tasks are automatically marked as COMPLETED.
+
+## Technical Details
+The implementation resides in `backend/crm/opportunity_auto_builder.py`.
+
+### Service Entry Point
+`OpportunityAutoBuilderService.sync_from_quote(quote, event=None, actor=None)`
+
+### Integration (Phase CRM-C)
+- Currently, the service is a standalone foundation.
+- Full integration into the `Quote` model signals and state machine will occur in Phase CRM-C.
+- Bi-directional linking is maintained via `Quote.opportunity`.


### PR DESCRIPTION
## Overview
This PR implements the backend foundation for quote-led CRM automation.

## Changes
- Adds OpportunityAutoBuilderService to synchronize quote commercial data into CRM Opportunities safely.
- Implements a 14-day deduplication window for same-customer/lane commercial pursuits.
- Maps quote statuses to CRM stages using existing enums.
- Prepares the foundation for system-generated interactions and automated follow-up tasks.
- Adds backend service tests and CRM automation documentation.

## Scope
Backend service foundation only.

No frontend changes, no schema migrations, no pricing logic changes, no quote calculation changes, and no SPOT business logic changes.

## Verification
- CRM and quote tests passed: 138/138.
- Django system check passed.
- New OpportunityAutoBuilderService tests passed.

## Risk Notes
Highly similar quotes for the same customer, route, mode, and direction within 14 days will group into the same CRM opportunity. This is intentional for commercial pursuit grouping, but can be tuned later if needed.