### PR TITLE
Stabilisation: isolate CRM side effects from quote lifecycle

### DIFF
--- a/backend/quotes/signals.py
+++ b/backend/quotes/signals.py
@@ -4,11 +4,13 @@ Django signals for Quote lifecycle event tracking.
 Auto-creates QuoteEvent entries when quote status changes.
 """
 
+import logging
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 
 from .models import Quote, QuoteEvent
 
+logger = logging.getLogger(__name__)
 
 # Store original status before save
 _original_statuses = {}
@@ -24,101 +26,110 @@ def _sync_crm_for_quote_event(instance: Quote, event_type: str, user=None) -> No
     if not opportunity:
         return
 
-    from crm.models import Opportunity
-    from crm.services import (
-        create_quote_system_interaction,
-        mark_opportunity_lost,
-        mark_opportunity_quoted,
-        mark_opportunity_won,
-    )
-    from quotes.state_machine import ACTIVE_STATES
-
-    quote_id_outcome = f"quote_id={instance.id}"
-
-    if event_type == QuoteEvent.EventType.CREATED:
-        create_quote_system_interaction(
-            opportunity,
-            instance,
-            user,
-            "QUOTE_CREATED",
-            _crm_quote_summary(instance, "created"),
-            outcomes=quote_id_outcome,
+    try:
+        from crm.models import Opportunity
+        from crm.services import (
+            create_quote_system_interaction,
+            mark_opportunity_lost,
+            mark_opportunity_quoted,
+            mark_opportunity_won,
         )
-        return
+        from quotes.state_machine import ACTIVE_STATES
 
-    if event_type == QuoteEvent.EventType.FINALIZED:
-        create_quote_system_interaction(
-            opportunity,
-            instance,
-            user,
-            "QUOTE_FINALIZED",
-            _crm_quote_summary(instance, "finalized"),
-            outcomes=quote_id_outcome,
-        )
-        mark_opportunity_quoted(opportunity, quote=instance, actor=user)
-        return
+        quote_id_outcome = f"quote_id={instance.id}"
 
-    if event_type == QuoteEvent.EventType.SENT:
-        create_quote_system_interaction(
-            opportunity,
-            instance,
-            user,
-            "QUOTE_SENT",
-            _crm_quote_summary(instance, "sent"),
-            outcomes=quote_id_outcome,
-        )
-        mark_opportunity_quoted(opportunity, quote=instance, actor=user)
-        return
-
-    if event_type == QuoteEvent.EventType.ACCEPTED:
-        create_quote_system_interaction(
-            opportunity,
-            instance,
-            user,
-            "QUOTE_ACCEPTED",
-            _crm_quote_summary(instance, "accepted"),
-            outcomes=quote_id_outcome,
-        )
-        mark_opportunity_won(
-            opportunity,
-            actor=user,
-            reason=f"Quote {instance.quote_number or instance.id} accepted.",
-            source_type="QUOTE_ACCEPTED",
-            source_id=str(instance.id),
-        )
-        return
-
-    if event_type == QuoteEvent.EventType.LOST:
-        create_quote_system_interaction(
-            opportunity,
-            instance,
-            user,
-            "QUOTE_LOST",
-            _crm_quote_summary(instance, "lost"),
-            outcomes=quote_id_outcome,
-        )
-        opportunity.refresh_from_db()
-        if opportunity.status in {Opportunity.Status.WON, Opportunity.Status.LOST}:
+        if event_type == QuoteEvent.EventType.CREATED:
+            create_quote_system_interaction(
+                opportunity,
+                instance,
+                user,
+                "QUOTE_CREATED",
+                _crm_quote_summary(instance, "created"),
+                outcomes=quote_id_outcome,
+            )
             return
-        has_other_active_quotes = instance.opportunity.quotes.exclude(pk=instance.pk).filter(
-            status__in=ACTIVE_STATES,
-        ).exists()
-        if not has_other_active_quotes:
-            mark_opportunity_lost(
+
+        if event_type == QuoteEvent.EventType.FINALIZED:
+            create_quote_system_interaction(
+                opportunity,
+                instance,
+                user,
+                "QUOTE_FINALIZED",
+                _crm_quote_summary(instance, "finalized"),
+                outcomes=quote_id_outcome,
+            )
+            mark_opportunity_quoted(opportunity, quote=instance, actor=user)
+            return
+
+        if event_type == QuoteEvent.EventType.SENT:
+            create_quote_system_interaction(
+                opportunity,
+                instance,
+                user,
+                "QUOTE_SENT",
+                _crm_quote_summary(instance, "sent"),
+                outcomes=quote_id_outcome,
+            )
+            mark_opportunity_quoted(opportunity, quote=instance, actor=user)
+            return
+
+        if event_type == QuoteEvent.EventType.ACCEPTED:
+            create_quote_system_interaction(
+                opportunity,
+                instance,
+                user,
+                "QUOTE_ACCEPTED",
+                _crm_quote_summary(instance, "accepted"),
+                outcomes=quote_id_outcome,
+            )
+            mark_opportunity_won(
                 opportunity,
                 actor=user,
-                reason=f"Quote {instance.quote_number or instance.id} marked lost.",
+                reason=f"Quote {instance.quote_number or instance.id} accepted.",
+                source_type="QUOTE_ACCEPTED",
+                source_id=str(instance.id),
             )
-        return
+            return
 
-    if event_type == QuoteEvent.EventType.EXPIRED:
-        create_quote_system_interaction(
-            opportunity,
-            instance,
-            user,
-            "QUOTE_EXPIRED",
-            _crm_quote_summary(instance, "expired"),
-            outcomes=quote_id_outcome,
+        if event_type == QuoteEvent.EventType.LOST:
+            create_quote_system_interaction(
+                opportunity,
+                instance,
+                user,
+                "QUOTE_LOST",
+                _crm_quote_summary(instance, "lost"),
+                outcomes=quote_id_outcome,
+            )
+            opportunity.refresh_from_db()
+            if opportunity.status in {Opportunity.Status.WON, Opportunity.Status.LOST}:
+                return
+            has_other_active_quotes = instance.opportunity.quotes.exclude(pk=instance.pk).filter(
+                status__in=ACTIVE_STATES,
+            ).exists()
+            if not has_other_active_quotes:
+                mark_opportunity_lost(
+                    opportunity,
+                    actor=user,
+                    reason=f"Quote {instance.quote_number or instance.id} marked lost.",
+                )
+            return
+
+        if event_type == QuoteEvent.EventType.EXPIRED:
+            create_quote_system_interaction(
+                opportunity,
+                instance,
+                user,
+                "QUOTE_EXPIRED",
+                _crm_quote_summary(instance, "expired"),
+                outcomes=quote_id_outcome,
+            )
+    except Exception as exc:
+        logger.exception(
+            "CRM event synchronization failed. Quote ID: %s, Customer ID: %s, Event: %s, Error: %s",
+            instance.id,
+            getattr(instance.customer, "id", None),
+            event_type,
+            exc,
         )
 
 
@@ -161,7 +172,14 @@ def create_quote_event(sender, instance, created, **kwargs):
             event_type=QuoteEvent.EventType.CREATED,
             metadata={'initial_status': instance.status}
         )
-        _sync_crm_for_quote_event(instance, QuoteEvent.EventType.CREATED, user=instance.created_by)
+        try:
+            _sync_crm_for_quote_event(instance, QuoteEvent.EventType.CREATED, user=instance.created_by)
+        except Exception as exc:
+            logger.exception(
+                "CRM post-save sync failed during quote creation. Quote ID: %s, Error: %s",
+                instance.id,
+                exc,
+            )
     elif original_status and original_status != instance.status:
         # Status changed
         event_type = status_to_event.get(instance.status)
@@ -184,4 +202,12 @@ def create_quote_event(sender, instance, created, **kwargs):
                     'new_status': instance.status
                 }
             )
-            _sync_crm_for_quote_event(instance, event_type, user=user)
+            try:
+                _sync_crm_for_quote_event(instance, event_type, user=user)
+            except Exception as exc:
+                logger.exception(
+                    "CRM post-save sync failed during status transition. Quote ID: %s, Event: %s, Error: %s",
+                    instance.id,
+                    event_type,
+                    exc,
+                )

--- a/backend/quotes/tests/test_crm_resilience.py
+++ b/backend/quotes/tests/test_crm_resilience.py
@@ -1,0 +1,222 @@
+# backend/quotes/tests/test_crm_resilience.py
+
+from datetime import date, timedelta
+from decimal import Decimal
+from unittest.mock import patch
+from django.contrib.auth import get_user_model
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from core.models import Country, Currency
+from core.tests.helpers import create_location
+from parties.models import Company, Contact
+from pricing_v4.models import Carrier, DomesticCOGS, DomesticSellRate, ProductCode
+from services.models import ServiceComponent
+from quotes.models import Quote
+
+
+class CRMResilienceTests(APITestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            username="crm-resilience",
+            password="testpass123",
+            role="manager",
+        )
+        self.client.force_authenticate(self.user)
+
+        pgk = Currency.objects.get_or_create(code="PGK", defaults={"name": "Papua New Guinean Kina", "minor_units": 2})[0]
+        pg = Country.objects.get_or_create(code="PG", defaults={"name": "Papua New Guinea", "currency": pgk})[0]
+
+        self.origin = create_location(code="POM", name="Port Moresby", country=pg, is_active=True)
+        self.destination = create_location(code="LAE", name="Lae", country=pg, is_active=True)
+        self.customer = Company.objects.create(name="CRM Customer", company_type="CUSTOMER", is_customer=True)
+        self.contact = Contact.objects.create(
+            company=self.customer,
+            first_name="Crm",
+            last_name="Resilient",
+            email="crm@example.com",
+        )
+
+        self.carrier = Carrier.objects.create(
+            code="CRM-PX",
+            name="CRM Carrier",
+            carrier_type="AIRLINE",
+        )
+
+        self.freight_pc = ProductCode.objects.get_or_create(
+            id=6001,
+            defaults={
+                "code": "DOM-FRT-AIR",
+                "description": "Domestic Air Freight CRM",
+                "domain": "DOMESTIC",
+                "category": "FREIGHT",
+                "is_gst_applicable": True,
+                "gst_rate": Decimal("0.10"),
+                "gl_revenue_code": "4100",
+                "gl_cost_code": "5100",
+                "default_unit": "KG",
+            }
+        )[0]
+
+        ServiceComponent.objects.get_or_create(
+            code="DOM-FRT-AIR",
+            defaults={
+                "description": "Domestic Air Freight CRM",
+                "mode": "AIR",
+                "leg": "MAIN",
+                "category": "TRANSPORT",
+                "unit": "KG",
+                "audience": "BOTH",
+            }
+        )
+
+        self.valid_from = date.today() - timedelta(days=1)
+        self.valid_until = date.today() + timedelta(days=30)
+
+        # Seed freight rates so standard quote can compute successfully
+        DomesticCOGS.objects.create(
+            product_code=self.freight_pc,
+            origin_zone="POM",
+            destination_zone="LAE",
+            carrier=self.carrier,
+            currency="PGK",
+            rate_per_kg=Decimal("6.00"),
+            valid_from=self.valid_from,
+            valid_until=self.valid_until,
+        )
+        DomesticSellRate.objects.create(
+            product_code=self.freight_pc,
+            origin_zone="POM",
+            destination_zone="LAE",
+            currency="PGK",
+            rate_per_kg=Decimal("9.00"),
+            valid_from=self.valid_from,
+            valid_until=self.valid_until,
+        )
+
+    def _payload(self):
+        return {
+            "customer_id": str(self.customer.id),
+            "contact_id": str(self.contact.id),
+            "mode": "AIR",
+            "service_scope": "A2A",
+            "origin_location_id": str(self.origin.id),
+            "destination_location_id": str(self.destination.id),
+            "incoterm": "EXW",
+            "payment_term": "PREPAID",
+            "dimensions": [
+                {
+                    "pieces": 1,
+                    "length_cm": "10",
+                    "width_cm": "10",
+                    "height_cm": "10",
+                    "gross_weight_kg": "25",
+                    "package_type": "Box",
+                }
+            ],
+            "commodity_code": "GCR",
+        }
+
+    @patch("quotes.views.calculation.resolve_quote_opportunity")
+    @patch("quotes.views.calculation.logger")
+    def test_quote_creation_succeeds_when_crm_opportunity_resolution_fails(self, mock_logger, mock_resolve):
+        # Mock opportunity resolution to raise an exception
+        mock_resolve.side_effect = RuntimeError("Simulated Opportunity DB Failure")
+
+        response = self.client.post("/api/v3/quotes/compute/", self._payload(), format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["status"], "DRAFT")
+        self.assertIsNone(response.data["opportunity"])
+
+        # Assert the exception was logged
+        mock_logger.exception.assert_called()
+        log_msg = mock_logger.exception.call_args[0][0]
+        self.assertIn("CRM opportunity resolution failed during quote creation", log_msg)
+
+    @patch("quotes.views.calculation.create_auto_quote_opportunity_interaction")
+    @patch("quotes.views.calculation.logger")
+    def test_quote_creation_succeeds_when_crm_interaction_auto_creation_fails(self, mock_logger, mock_create):
+        # Mock auto interaction creation to raise an exception
+        mock_create.side_effect = ValueError("Simulated Interaction Validation Error")
+
+        # Mock resolve_quote_opportunity to return a dummy opportunity and opportunity_was_auto_created = True
+        from crm.models import Opportunity
+        dummy_opportunity = Opportunity.objects.create(
+            company=self.customer,
+            title="POM to LAE CRM opportunity",
+            service_type="AIR",
+            direction="DOMESTIC",
+            scope="A2A",
+        )
+
+        with patch("quotes.views.calculation.resolve_quote_opportunity", return_value=(dummy_opportunity, True)):
+            response = self.client.post("/api/v3/quotes/compute/", self._payload(), format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["status"], "DRAFT")
+        self.assertEqual(str(response.data["opportunity"]), str(dummy_opportunity.id))
+
+        # Assert the exception was logged
+        mock_logger.exception.assert_called()
+        log_msg = mock_logger.exception.call_args[0][0]
+        self.assertIn("CRM opportunity interaction auto-creation failed", log_msg)
+
+    @patch("quotes.signals.logger")
+    def test_quote_status_transition_succeeds_when_crm_sync_fails(self, mock_logger):
+        from crm.models import Opportunity
+        opportunity = Opportunity.objects.create(
+            company=self.customer,
+            title="Transition opportunity",
+            service_type="AIR",
+            direction="DOMESTIC",
+            scope="A2A",
+        )
+        # Create a Quote in DRAFT status
+        quote = Quote.objects.create(
+            customer=self.customer,
+            contact=self.contact,
+            mode="AIR",
+            shipment_type="DOMESTIC",
+            incoterm="EXW",
+            payment_term="PREPAID",
+            service_scope="A2A",
+            status="DRAFT",
+            created_by=self.user,
+            opportunity=opportunity,
+        )
+
+        # Transition status to FINALIZED while post-save CRM sync raises an exception
+        with patch("quotes.signals._sync_crm_for_quote_event", side_effect=RuntimeError("Simulated Post-Save CRM Event Sync Failure")) as mock_sync:
+            transition_payload = {
+                "action": "finalize",
+            }
+            response = self.client.post(
+                f"/api/v3/quotes/{quote.id}/transition/",
+                transition_payload,
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["status"], "FINALIZED")
+
+        # Now test that the internal post-save signal try-except catch works when NOT mocked from the outside
+        with patch("crm.services.create_quote_system_interaction", side_effect=ValueError("Sync Database Down")):
+            # Reset transition to SENT
+            sent_payload = {
+                "action": "send",
+            }
+            res_sent = self.client.post(
+                f"/api/v3/quotes/{quote.id}/transition/",
+                sent_payload,
+                format="json",
+            )
+            # Should transition successfully despite CRM post-save interaction logging raising ValueError
+            self.assertEqual(res_sent.status_code, status.HTTP_200_OK)
+            self.assertEqual(res_sent.data["status"], "SENT")
+            
+            # Assert the exception was cleanly logged
+            mock_logger.exception.assert_called()
+            log_msg = mock_logger.exception.call_args[0][0]
+            self.assertIn("CRM event synchronization failed", log_msg)

--- a/backend/quotes/views/calculation.py
+++ b/backend/quotes/views/calculation.py
@@ -487,19 +487,29 @@ class QuoteComputeV3APIView(generics.CreateAPIView):
         is_new_quote = quote is None
         origin_location = Location.objects.filter(id=validated_data.origin_location_id).first()
         destination_location = Location.objects.filter(id=validated_data.destination_location_id).first()
-        opportunity, opportunity_was_auto_created = resolve_quote_opportunity(
-            customer=customer,
-            opportunity_id=validated_data.opportunity_id,
-            existing_quote=quote,
-            mode=validated_data.mode,
-            shipment_type=shipment_type,
-            service_scope=validated_data.service_scope,
-            origin_location=origin_location,
-            destination_location=destination_location,
-            actor=request.user,
-            quote_status=initial_status,
-            persist=True,
-        )
+        opportunity = None
+        opportunity_was_auto_created = False
+        try:
+            opportunity, opportunity_was_auto_created = resolve_quote_opportunity(
+                customer=customer,
+                opportunity_id=validated_data.opportunity_id,
+                existing_quote=quote,
+                mode=validated_data.mode,
+                shipment_type=shipment_type,
+                service_scope=validated_data.service_scope,
+                origin_location=origin_location,
+                destination_location=destination_location,
+                actor=request.user,
+                quote_status=initial_status,
+                persist=True,
+            )
+        except Exception as exc:
+            logger.exception(
+                "CRM opportunity resolution failed during quote creation. Proceeding without opportunity link. Customer ID: %s, Shipment Type: %s, Error: %s",
+                validated_data.customer_id,
+                shipment_type,
+                exc,
+            )
 
         if is_new_quote:
             # --- Create the Quote object ---
@@ -570,8 +580,16 @@ class QuoteComputeV3APIView(generics.CreateAPIView):
             latest_version = quote.versions.order_by('-version_number').first()
             version_number = 1 if latest_version is None else latest_version.version_number + 1
 
-        if opportunity_was_auto_created:
-            create_auto_quote_opportunity_interaction(opportunity, quote, request.user)
+        if opportunity and opportunity_was_auto_created:
+            try:
+                create_auto_quote_opportunity_interaction(opportunity, quote, request.user)
+            except Exception as exc:
+                logger.exception(
+                    "CRM opportunity interaction auto-creation failed. Quote ID: %s, Opportunity ID: %s, Error: %s",
+                    getattr(quote, "id", None),
+                    opportunity.id,
+                    exc,
+                )
 
         # Create the QuoteVersion
         version = QuoteVersion.objects.create(

--- a/backend/quotes/views/calculation.py
+++ b/backend/quotes/views/calculation.py
@@ -4,6 +4,7 @@ from datetime import date
 from decimal import Decimal
 
 from django.db import transaction
+from django.http import Http404
 from django.shortcuts import get_object_or_404
 from rest_framework import generics, status
 from rest_framework.response import Response
@@ -503,6 +504,8 @@ class QuoteComputeV3APIView(generics.CreateAPIView):
                 quote_status=initial_status,
                 persist=True,
             )
+        except Http404:
+            raise
         except Exception as exc:
             logger.exception(
                 "CRM opportunity resolution failed during quote creation. Proceeding without opportunity link. Customer ID: %s, Shipment Type: %s, Error: %s",


### PR DESCRIPTION
## Summary

This PR implements Phase 2 of the RateEngine stabilisation work.

It isolates CRM side effects from the core quote lifecycle so quote creation, saving, and status transitions are not blocked by CRM opportunity or interaction logging failures.

## Why this matters

Quote creation must remain authoritative. CRM logging is useful, but it should not be able to crash or roll back a valid quote calculation or status transition.

## Changes

### Backend quote calculation

- Wrapped `resolve_quote_opportunity` in defensive exception handling.
- If CRM opportunity resolution fails, the quote still saves without an opportunity link.
- Wrapped `create_auto_quote_opportunity_interaction` in defensive exception handling.
- CRM interaction logging failures are logged but do not block quote creation.

### Quote lifecycle signals

- Hardened CRM sync calls in quote post-save signal handling.
- CRM failures during quote creation or quote status transitions are logged but do not roll back the quote operation.

### Tests

Added:

- `backend/quotes/tests/test_crm_resilience.py`

The new tests verify:

- Quote creation succeeds when CRM opportunity resolution fails.
- Quote creation succeeds when CRM auto-interaction logging fails.
- Quote status transitions succeed when CRM post-save sync fails.
- CRM failures are logged.

## Verification

Ran:

```bash
pytest quotes/tests/test_crm_resilience.py quotes/tests/test_quote_stabilisation_regression.py quotes/tests/test_rate_availability_service.py quotes/tests/test_spot_mode.py quotes/tests/test_currency_rules.py quotes/tests/test_completeness.py