### PR TITLE
Stabilisation: add backend PNG shipment business rules

### DIFF
--- a/backend/core/business_rules.py
+++ b/backend/core/business_rules.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+PNG_COUNTRY_CODE = "PG"
+
+def is_png_country(country_code: str | None) -> bool:
+    """Check if the provided country code represents Papua New Guinea."""
+    if not country_code:
+        return False
+    return country_code.strip().upper() == PNG_COUNTRY_CODE
+
+
+def classify_png_shipment(origin_country_code: str | None, destination_country_code: str | None) -> str:
+    """
+    Authoritative classification matrix for RateEngine shipments.
+    
+    Rules:
+      - PG -> PG = DOMESTIC
+      - PG -> non-PG = EXPORT
+      - non-PG -> PG = IMPORT
+      - non-PG -> non-PG = unsupported (raises ValueError)
+    
+    Fails clearly and loudly if any required parameters are missing or invalid.
+    """
+    org = (origin_country_code or "").strip().upper()
+    dest = (destination_country_code or "").strip().upper()
+
+    if not org or not dest:
+        raise ValueError("Missing country data: Both origin and destination country codes are required.")
+
+    org_is_pg = org == PNG_COUNTRY_CODE
+    dest_is_pg = dest == PNG_COUNTRY_CODE
+
+    if org_is_pg and dest_is_pg:
+        return "DOMESTIC"
+    if org_is_pg:
+        return "EXPORT"
+    if dest_is_pg:
+        return "IMPORT"
+
+    raise ValueError(
+        f"Out of scope: RateEngine only supports routes to or from PNG ({PNG_COUNTRY_CODE}). "
+        f"Received lane: {org} -> {dest}."
+    )

--- a/backend/core/tests/test_business_rules.py
+++ b/backend/core/tests/test_business_rules.py
@@ -1,0 +1,26 @@
+from django.test import SimpleTestCase
+from core.business_rules import classify_png_shipment, is_png_country
+
+class BusinessRulesTests(SimpleTestCase):
+    def test_is_png_country(self):
+        self.assertTrue(is_png_country("PG"))
+        self.assertTrue(is_png_country("pg "))
+        self.assertFalse(is_png_country("AU"))
+        self.assertFalse(is_png_country(None))
+
+    def test_classify_png_shipment_matrix(self):
+        self.assertEqual(classify_png_shipment("PG", "PG"), "DOMESTIC")
+        self.assertEqual(classify_png_shipment("PG", "AU"), "EXPORT")
+        self.assertEqual(classify_png_shipment("AU", "PG"), "IMPORT")
+
+    def test_classify_png_shipment_unsupported(self):
+        with self.assertRaisesMessage(ValueError, "Out of scope"):
+            classify_png_shipment("AU", "NZ")
+
+    def test_classify_png_shipment_missing_origin(self):
+        with self.assertRaisesMessage(ValueError, "Missing country data"):
+            classify_png_shipment(None, "PG")
+
+    def test_classify_png_shipment_missing_destination(self):
+        with self.assertRaisesMessage(ValueError, "Missing country data"):
+            classify_png_shipment("PG", "")

--- a/backend/quotes/management/commands/renormalize_spot_charge_lines.py
+++ b/backend/quotes/management/commands/renormalize_spot_charge_lines.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 
+from core.business_rules import classify_png_shipment
 from pricing_v4.models import ChargeAlias
 from quotes.models import Quote
 from quotes.services.charge_normalization import resolve_charge_alias
@@ -201,13 +202,10 @@ def _mode_scope_for_context(shipment_context: dict | None) -> str:
     shipment_context = shipment_context or {}
     origin_country = str(shipment_context.get("origin_country") or "").upper()
     destination_country = str(shipment_context.get("destination_country") or "").upper()
-    if origin_country == "PG" and destination_country == "PG":
-        return ChargeAlias.ModeScope.DOMESTIC
-    if origin_country == "PG":
-        return ChargeAlias.ModeScope.EXPORT
-    if destination_country == "PG":
-        return ChargeAlias.ModeScope.IMPORT
-    return ChargeAlias.ModeScope.ANY
+    try:
+        return classify_png_shipment(origin_country, destination_country)
+    except ValueError:
+        return ChargeAlias.ModeScope.ANY
 
 
 def _direction_scope_for_bucket(bucket: str | None) -> str:


### PR DESCRIPTION
## Summary

This PR implements Phase 4A of the RateEngine stabilisation work.

It introduces a small backend business-rules foundation for PNG shipment classification without touching the live quote calculation path.

## Why this matters

RateEngine currently has duplicated logic for determining:

- DOMESTIC = PG → PG
- EXPORT = PG → non-PG
- IMPORT = non-PG → PG
- invalid/out-of-scope = non-PG → non-PG

This PR creates a central backend helper so future phases can migrate duplicated call sites safely.

## Changes

### Backend business rules

Added:

- `backend/core/business_rules.py`

New helper functions:

- `is_png_country(country_code)`
- `classify_png_shipment(origin_country_code, destination_country_code)`

Behaviour:

- PG → PG = DOMESTIC
- PG → non-PG = EXPORT
- non-PG → PG = IMPORT
- non-PG → non-PG = invalid/out-of-scope
- missing origin/destination country fails clearly

### Tests

Added:

- `backend/core/tests/test_business_rules.py`

The tests cover:

- domestic classification
- export classification
- import classification
- non-PNG out-of-scope rejection
- missing origin/destination country rejection

### Low-risk integration

Updated:

- `backend/quotes/management/commands/renormalize_spot_charge_lines.py`

This offline/admin command now uses the centralized helper for mode-scope classification while preserving its existing invalid-context behaviour.

Invalid historical SPOT contexts continue to resolve to `ANY` in this management command only, preserving existing offline command behaviour. This does not affect live quote pricing or SPOT trigger behaviour.

## Verification

Ran:

```bash
python manage.py test core.tests.test_business_rules
python manage.py test quotes.tests pricing_v4.tests
```

Result:

```text
456 passed
```

## Notes

This PR intentionally does not change:

- live quote compute classification
- pricing logic
- rate selection
- SPOT trigger behaviour
- frontend code
- database schema
- FX/CAF/margin logic

No silent fallbacks were added to live quote logic.