### PR TITLE
Stabilisation: use backend business rules in SPOT view classification

### DIFF
--- a/backend/quotes/spot_views.py
+++ b/backend/quotes/spot_views.py
@@ -33,6 +33,7 @@ from rest_framework.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404
 
 from core.security import validate_pdf_upload
+from core.business_rules import classify_png_shipment
 from pricing_v4.models import ChargeAlias, ProductCode
 from quotes.spot_services import (
     ScopeValidator,
@@ -912,11 +913,7 @@ def _resolve_missing_components_for_context(ctx: dict) -> Optional[list[str]]:
 
 
 def _infer_shipment_type(origin_country: str, destination_country: str) -> str:
-    if origin_country == "PG" and destination_country == "PG":
-        return "DOMESTIC"
-    if origin_country == "PG":
-        return "EXPORT"
-    return "IMPORT"
+    return classify_png_shipment(origin_country, destination_country)
 
 
 def _build_spe_from_db(

--- a/backend/quotes/tests/test_spot_views_inference.py
+++ b/backend/quotes/tests/test_spot_views_inference.py
@@ -1,0 +1,20 @@
+from django.test import SimpleTestCase
+from quotes.spot_views import _infer_shipment_type
+
+class SpotViewsInferenceTests(SimpleTestCase):
+    def test_infer_shipment_type_domestic(self):
+        self.assertEqual(_infer_shipment_type("PG", "PG"), "DOMESTIC")
+
+    def test_infer_shipment_type_export(self):
+        self.assertEqual(_infer_shipment_type("PG", "AU"), "EXPORT")
+
+    def test_infer_shipment_type_import(self):
+        self.assertEqual(_infer_shipment_type("AU", "PG"), "IMPORT")
+
+    def test_infer_shipment_type_invalid_cross_border(self):
+        with self.assertRaisesMessage(ValueError, "Out of scope"):
+            _infer_shipment_type("AU", "NZ")
+
+    def test_infer_shipment_type_missing_data(self):
+        with self.assertRaisesMessage(ValueError, "Missing country data"):
+            _infer_shipment_type(None, "PG")


### PR DESCRIPTION
## Summary

This PR implements Phase 5A of the RateEngine stabilisation work.

It migrates the low-risk SPOT view shipment-type inference helper to use the centralized backend business-rules helper.

## Why this matters

`spot_views._infer_shipment_type` previously duplicated the PNG shipment classification matrix and silently defaulted to `IMPORT` for invalid non-PNG corridors.

This PR removes that silent fallback and delegates classification to:

- `core.business_rules.classify_png_shipment`

## Changes

### SPOT view classification

Updated:

- `backend/quotes/spot_views.py`

Changes:

- Replaced duplicated inline classification logic with `classify_png_shipment`.
- Preserved valid classifications:
  - PG → PG = DOMESTIC
  - PG → non-PG = EXPORT
  - non-PG → PG = IMPORT
- Invalid non-PNG corridors no longer silently become IMPORT.
- Missing country data fails clearly via the centralized helper.

### Tests

Added:

- `backend/quotes/tests/test_spot_views_inference.py`

The tests verify:

- PG → PG = DOMESTIC
- PG → AU = EXPORT
- AU → PG = IMPORT
- AU → NZ raises `ValueError` instead of silently returning IMPORT
- missing data raises `ValueError`

## Verification

Ran:

```bash
python manage.py test quotes.tests.test_spot_views_inference
python manage.py test core.tests.test_business_rules
python manage.py test quotes.tests
```

Result:

```text
157 passed
```

## Notes

This PR intentionally does not change:

- pricing logic
- SPOT trigger logic
- schema validation
- `calculation.py`
- frontend code
- database schema
- rate selection
- FX/CAF/margin logic

No silent fallback to IMPORT remains in this SPOT view helper.