### PR TITLE
Stabilisation: use business rules in SPOT scope validation

### DIFF
--- a/backend/quotes/spot_services.py
+++ b/backend/quotes/spot_services.py
@@ -244,17 +244,11 @@ class ScopeValidator:
             destination_airport=destination_airport,
         )
 
-        if origin_country == cls.PNG_COUNTRY_CODE:
+        try:
+            classify_png_shipment(origin_country, destination_country)
             return True, None
-        
-        if destination_country == cls.PNG_COUNTRY_CODE:
-            return True, None
-        
-        return False, (
-            f"Out of scope: RateEngine only supports shipments to or from "
-            f"Papua New Guinea (PNG). Received {origin_country} → {destination_country}. "
-            f"No pricing can be generated for this route."
-        )
+        except ValueError as exc:
+            return False, str(exc)
 
 
 # =============================================================================

--- a/backend/quotes/tests/test_spot_mode.py
+++ b/backend/quotes/tests/test_spot_mode.py
@@ -115,6 +115,15 @@ class TestScopeValidation:
         assert is_valid is True
         assert error is None
 
+    def test_scope_invalid_for_missing_blank_countries(self):
+        """Missing or blank countries without airport codes must be rejected."""
+        is_valid, error = ScopeValidator.validate(
+            origin_country="",
+            destination_country=""
+        )
+        assert is_valid is False
+        assert "supports routes to or from PNG" in error or "Out of scope" in error or "Missing country data" in error
+
 
 # =============================================================================
 # SPOT TRIGGER TESTS


### PR DESCRIPTION
## Summary

This PR implements Phase 5D of the RateEngine stabilisation work.

It migrates `ScopeValidator.validate` to use the centralized backend shipment-classification helper while preserving the existing scope-validation return interface.

## Why this matters

`ScopeValidator.validate` previously duplicated the PNG scope rule directly inside `spot_services.py`.

This PR delegates the rule to:

- `core.business_rules.classify_png_shipment`

so SPOT scope validation uses the same source of truth as the other migrated backend paths.

## Changes

### SPOT scope validation

Updated:

- `backend/quotes/spot_services.py`

Changes:

- Import/use `classify_png_shipment`.
- Replace duplicated PNG scope validation logic inside `ScopeValidator.validate`.
- Preserve the public return interface:
  - valid route: `(True, None)`
  - invalid route: `(False, error_message)`
- Valid routes remain:
  - PG → PG
  - PG → non-PG
  - non-PG → PG
- Invalid routes remain rejected:
  - non-PG → non-PG
  - missing/blank countries

### Tests

Updated:

- `backend/quotes/tests/test_spot_mode.py`

Coverage includes:

- standard valid PNG lanes;
- invalid non-PNG corridor rejection;
- missing/blank country rejection;
- existing airport/station country-resolution behaviour.

## Verification

Ran:

```bash
pytest quotes/tests/test_spot_mode.py
pytest quotes/tests/test_spot_flow_api.py
pytest core/tests/test_business_rules.py
```

Results:

```text
29 passed, 5 warnings
25 passed, 15 warnings
5 passed
```

## Notes

This PR does not modify:

- pricing logic
- SPOT charge normalization
- SPOT AI intake
- SPOT schemas
- SPOT views
- frontend code
- database schema
- rate selection
- FX/CAF/margin logic

This PR is intentionally limited to SPOT scope validation only.