### PR TITLE
Stabilisation: use business rules in standard quote classification

### DIFF
--- a/backend/quotes/tests/test_commodity_support.py
+++ b/backend/quotes/tests/test_commodity_support.py
@@ -572,3 +572,49 @@ class QuoteCommodityAPITests(APITestCase):
             ["IMP-AVI-MANUAL-API"],
         )
         self.assertIn("Import AVI manual only (IMP-AVI-MANUAL-API)", payload["detail"])
+
+
+class TestStandardQuoteShipmentClassification(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        aud = Currency.objects.create(code="AUD", name="Australian Dollar")
+        pgk = Currency.objects.create(code="PGK", name="Papua New Guinean Kina")
+        au = Country.objects.create(code="AU", name="Australia", currency=aud)
+        pg = Country.objects.create(code="PG", name="Papua New Guinea", currency=pgk)
+        sg = Country.objects.create(code="SG", name="Singapore")
+
+        cls.pom = create_location(code="POM", name="Port Moresby", country=pg, is_active=True)
+        cls.lae = create_location(code="LAE", name="Lae", country=pg, is_active=True)
+        cls.syd = create_location(code="SYD", name="Sydney", country=au, is_active=True)
+        cls.sin = create_location(code="SIN", name="Singapore", country=sg, is_active=True)
+
+        # Location with missing country
+        cls.missing_country_loc = create_location(code="XXX", name="No Country", country=None, is_active=True)
+
+    def test_classify_shipment_type_air_matrix(self):
+        # PG -> PG = DOMESTIC
+        self.assertEqual(_classify_shipment_type("AIR", self.pom, self.lae), "DOMESTIC")
+        # PG -> AU = EXPORT
+        self.assertEqual(_classify_shipment_type("AIR", self.pom, self.syd), "EXPORT")
+        # AU -> PG = IMPORT
+        self.assertEqual(_classify_shipment_type("AIR", self.syd, self.pom), "IMPORT")
+
+    def test_classify_shipment_type_air_cross_border_fails(self):
+        with self.assertRaisesMessage(ValueError, "Cross-border shipments not involving PNG are not yet supported."):
+            _classify_shipment_type("AIR", self.syd, self.sin)
+
+    def test_classify_shipment_type_missing_locations_fails(self):
+        with self.assertRaisesMessage(ValueError, "Origin and destination locations are required."):
+            _classify_shipment_type("AIR", None, self.pom)
+
+    def test_classify_shipment_type_missing_countries_fails(self):
+        with self.assertRaisesMessage(ValueError, "Origin and destination locations must include countries for AIR mode."):
+            _classify_shipment_type("AIR", self.pom, self.missing_country_loc)
+
+    def test_classify_shipment_type_sea_mode_fails(self):
+        with self.assertRaisesMessage(ValueError, "SEA mode is not yet supported."):
+            _classify_shipment_type("SEA", self.pom, self.syd)
+
+    def test_classify_shipment_type_unsupported_mode_fails(self):
+        with self.assertRaisesMessage(ValueError, "Mode 'ROAD' is not supported."):
+            _classify_shipment_type("ROAD", self.pom, self.syd)

--- a/backend/quotes/views/calculation.py
+++ b/backend/quotes/views/calculation.py
@@ -58,6 +58,8 @@ from core.dataclasses import (
 
 logger = logging.getLogger(__name__)
 
+from core.business_rules import classify_png_shipment
+
 def _classify_shipment_type(mode: str, origin_location: Location, destination_location: Location) -> str:
     if not origin_location or not destination_location:
         raise ValueError("Origin and destination locations are required.")
@@ -69,13 +71,12 @@ def _classify_shipment_type(mode: str, origin_location: Location, destination_lo
         if not org_country or not dest_country:
             raise ValueError("Origin and destination locations must include countries for AIR mode.")
 
-        if org_country == 'PG' and dest_country == 'PG':
-            return Quote.ShipmentType.DOMESTIC
-        if org_country != 'PG' and dest_country == 'PG':
-            return Quote.ShipmentType.IMPORT
-        if org_country == 'PG' and dest_country != 'PG':
-            return Quote.ShipmentType.EXPORT
-        raise ValueError("Cross-border shipments not involving PNG are not yet supported.")
+        try:
+            return classify_png_shipment(org_country, dest_country)
+        except ValueError as exc:
+            if "Out of scope" in str(exc):
+                raise ValueError("Cross-border shipments not involving PNG are not yet supported.")
+            raise ValueError(str(exc))
 
     if mode == 'SEA':
         raise ValueError("SEA mode is not yet supported.")


### PR DESCRIPTION
## Summary

This PR implements Phase 5E of the RateEngine stabilisation work.

It migrates the standard quote shipment classification helper in `backend/quotes/views/calculation.py` to use the centralized backend shipment-classification helper while preserving the existing public behaviour and error contracts.

## Why this matters

`_classify_shipment_type` was the final major backend shipment-classification call site still duplicating the PNG shipment matrix directly inside the quote flow.

This PR delegates the country/corridor classification to:

- `core.business_rules.classify_png_shipment`

while keeping standard quote mode validation local to `calculation.py`.

## Changes

### Standard quote classification

Updated:

- `backend/quotes/views/calculation.py`

Changes:

- Import/use `classify_png_shipment`.
- Replace duplicated PNG shipment matrix inside `_classify_shipment_type`.
- Preserve the existing Location-object function signature.
- Preserve local mode validation:
  - AIR supported
  - SEA rejected
  - unsupported modes rejected
- Preserve existing standard quote error message for non-PNG cross-border routes.

### Tests

Updated:

- `backend/quotes/tests/test_commodity_support.py`

Coverage includes:

- AIR PG → PG = DOMESTIC
- AIR PG → AU = EXPORT
- AIR AU → PG = IMPORT
- AIR AU → SG raises the existing cross-border ValueError message
- missing locations/countries raise the existing ValueError messages
- SEA and unsupported freight modes remain rejected

## Verification

Ran:

```bash
python -m pytest quotes/tests/test_commodity_support.py
python -m pytest quotes/tests/test_quote_compute_selector_validation.py core/tests/test_business_rules.py quotes/tests
```

Results:

```text
12 passed
109 passed
```

## Notes

This PR intentionally does not change:

- pricing engines
- SPOT code
- frontend code
- database schema
- rate selection
- FX/CAF/margin logic
- standard quote mode support

No silent fallback was added.