### PR TITLE
fix: enforce IDOR protection on quote retrieval

### DIFF
--- a/backend/quotes/reporting_views.py
+++ b/backend/quotes/reporting_views.py
@@ -13,6 +13,7 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 
 from .models import Quote, QuoteTotal, QuoteVersion, QuoteEvent
+from .selectors import get_quotes_for_user
 from parties.models import Company
 from accounts.permissions import IsManagerOrAdmin, IsFinanceOrAdmin
 
@@ -78,9 +79,9 @@ class ReportsViewSet(viewsets.ViewSet):
             return timeframe, today.replace(month=1, day=1), today
         return 'monthly', today.replace(day=1), today
 
-    def _build_activity_series(self, timeframe, start_date, end_date):
+    def _build_activity_series(self, timeframe, start_date, end_date, user):
         quote_dates = (
-            Quote.objects.exclude(is_archived=True)
+            get_quotes_for_user(user, Quote.objects.exclude(is_archived=True))
             .filter(created_at__date__gte=start_date, created_at__date__lte=end_date)
             .values_list('created_at__date', flat=True)
         )
@@ -140,14 +141,15 @@ class ReportsViewSet(viewsets.ViewSet):
                 buckets[quote_date.month]['count'] += 1
         return list(buckets.values()), 'Year to date'
 
-    def _quotes_with_financials(self, start_date=None, end_date=None, user_id=None, mode=None):
+    def _quotes_with_financials(self, user, start_date=None, end_date=None, user_id=None, mode=None):
         """
         Get quotes annotated with their latest version's financial totals.
         Optionally filter by date range, user, and mode.
         """
         latest_total = self._get_latest_total_subquery()
 
-        qs = Quote.objects.annotate(
+        # SECURITY FIX: Enforce IDOR/RBAC protection on reporting data
+        qs = get_quotes_for_user(user, Quote.objects.all()).annotate(
             latest_total_sell_pgk=Subquery(latest_total.values('total_sell_pgk')[:1]),
             latest_total_cost_pgk=Subquery(latest_total.values('total_cost_pgk')[:1]),
         ).exclude(is_archived=True)
@@ -179,7 +181,7 @@ class ReportsViewSet(viewsets.ViewSet):
         user_id = request.query_params.get('user_id')
         mode = request.query_params.get('mode')
 
-        qs = self._quotes_with_financials(start_date, end_date, user_id, mode)
+        qs = self._quotes_with_financials(request.user, start_date, end_date, user_id, mode)
 
         # Count by status
         counts = qs.aggregate(
@@ -201,8 +203,8 @@ class ReportsViewSet(viewsets.ViewSet):
             from django.db.models import Min, Max
             from django.db.models.functions import Extract
 
-            # Get quotes with both events in the date range
-            quotes_with_events = Quote.objects.filter(
+            # SECURITY FIX: Enforce IDOR/RBAC protection
+            quotes_with_events = get_quotes_for_user(request.user, Quote.objects.all()).filter(
                 created_at__date__gte=start_date,
                 created_at__date__lte=end_date,
                 events__event_type=QuoteEvent.EventType.CREATED
@@ -264,7 +266,7 @@ class ReportsViewSet(viewsets.ViewSet):
         user_id = request.query_params.get('user_id')
         mode = request.query_params.get('mode')
 
-        qs = self._quotes_with_financials(start_date, end_date, user_id, mode)
+        qs = self._quotes_with_financials(request.user, start_date, end_date, user_id, mode)
 
         # Only include finalized/sent/accepted quotes in financials
         financial_statuses = [Quote.Status.FINALIZED, Quote.Status.SENT, Quote.Status.ACCEPTED]
@@ -333,7 +335,7 @@ class ReportsViewSet(viewsets.ViewSet):
         start_date, end_date = self._parse_date_params(request)
         mode = request.query_params.get('mode')
 
-        qs = self._quotes_with_financials(start_date, end_date, mode=mode)
+        qs = self._quotes_with_financials(request.user, start_date, end_date, mode=mode)
 
         # Group by user
         performance = qs.values(
@@ -404,7 +406,7 @@ class ReportsViewSet(viewsets.ViewSet):
         user_id = request.query_params.get('user_id')
         mode = request.query_params.get('mode')
 
-        qs = self._quotes_with_financials(start_date, end_date, user_id, mode)
+        qs = self._quotes_with_financials(request.user, start_date, end_date, user_id, mode)
 
         # Include all statuses except DRAFT
         qs = qs.exclude(status=Quote.Status.DRAFT).select_related(
@@ -472,7 +474,7 @@ class ReportsViewSet(viewsets.ViewSet):
         timeframe, start_date, end_date = self._get_dashboard_timeframe_range(timeframe)
 
         latest_total = self._get_latest_total_subquery()
-        financial_quotes = Quote.objects.annotate(
+        financial_quotes = get_quotes_for_user(request.user, Quote.objects.all()).annotate(
             latest_total_sell_pgk=Subquery(latest_total.values('total_sell_pgk')[:1]),
             latest_total_sell_pgk_incl_gst=Subquery(latest_total.values('total_sell_pgk_incl_gst')[:1]),
             latest_total_cost_pgk=Subquery(latest_total.values('total_cost_pgk')[:1]),
@@ -526,7 +528,7 @@ class ReportsViewSet(viewsets.ViewSet):
             value=Sum('latest_total_sell_pgk_incl_gst')
         )
 
-        activity_series, activity_label = self._build_activity_series(timeframe, start_date, end_date)
+        activity_series, activity_label = self._build_activity_series(timeframe, start_date, end_date, request.user)
         
         return Response({
             'timeframe': timeframe,
@@ -557,7 +559,8 @@ class ReportsViewSet(viewsets.ViewSet):
         target_user_id = self._get_user_scope(request)
         
         # Base QuerySet for the selected period
-        qs_period = Quote.objects.filter(
+        # SECURITY FIX: Enforce IDOR/RBAC protection
+        qs_period = get_quotes_for_user(request.user, Quote.objects.all()).filter(
             created_at__date__gte=start_date,
             created_at__date__lte=end_date
         ).exclude(is_archived=True)
@@ -586,7 +589,8 @@ class ReportsViewSet(viewsets.ViewSet):
 
         revenue_statuses = [Quote.Status.FINALIZED, Quote.Status.ACCEPTED]
 
-        qs_top_customers = Quote.objects.filter(
+        # SECURITY FIX: Enforce IDOR/RBAC protection
+        qs_top_customers = get_quotes_for_user(request.user, Quote.objects.all()).filter(
             status__in=revenue_statuses
         ).exclude(is_archived=True)
 
@@ -630,7 +634,8 @@ class ReportsViewSet(viewsets.ViewSet):
             quote_version__quote_id=OuterRef('pk')
         ).order_by('-quote_version__version_number').values('total_sell_pgk')[:1]
 
-        quotes_with_latest_total = Quote.objects.annotate(
+        # SECURITY FIX: Enforce IDOR/RBAC protection
+        quotes_with_latest_total = get_quotes_for_user(request.user, Quote.objects.all()).annotate(
             latest_total_sell_pgk=Subquery(latest_total_subquery)
         )
 
@@ -673,7 +678,8 @@ class ReportsViewSet(viewsets.ViewSet):
             quote_version__quote_id=OuterRef('pk')
         ).order_by('-quote_version__version_number').values('total_sell_pgk')[:1]
 
-        quotes_with_latest_total = Quote.objects.annotate(
+        # SECURITY FIX: Enforce IDOR/RBAC protection
+        quotes_with_latest_total = get_quotes_for_user(request.user, Quote.objects.all()).annotate(
             latest_total_sell_pgk=Subquery(latest_total_subquery)
         )
 

--- a/backend/quotes/selectors.py
+++ b/backend/quotes/selectors.py
@@ -1,14 +1,92 @@
 from django.shortcuts import get_object_or_404
 from django.core.exceptions import PermissionDenied, ObjectDoesNotExist
-from django.db.models import QuerySet
-from quotes.models import Quote
+from django.db.models import QuerySet, Q
+from quotes.models import Quote, SpotPricingEnvelopeDB
+
+def get_spes_for_user(user, queryset: QuerySet | None = None) -> QuerySet:
+    """
+    Apply departmental and role-based visibility filters to a SpotPricingEnvelopeDB queryset.
+
+    Rules:
+    - Admin/Finance: Global access.
+    - Managers: Own department's SPEs + own SPEs.
+    - Sales: Own SPEs only.
+    """
+    if queryset is None:
+        queryset = SpotPricingEnvelopeDB.objects.all()
+
+    if not user or not user.is_authenticated:
+        return queryset.none()
+
+    role = getattr(user, 'role', '')
+    is_global = (
+        getattr(user, 'is_admin', False) or
+        getattr(user, 'is_finance', False) or
+        role in ('admin', 'finance')
+    )
+
+    if is_global:
+        return queryset
+
+    # Manager View: Restricted by Department
+    if getattr(user, 'is_manager', False) or role == 'manager':
+        dept = getattr(user, 'department', None)
+        if dept:
+            return queryset.filter(
+                Q(created_by__department=dept) |
+                Q(created_by=user)
+            )
+        return queryset.filter(created_by=user)
+
+    # Sales / Standard View: Own SPEs only
+    return queryset.filter(created_by=user)
+
+
+def get_quotes_for_user(user, queryset: QuerySet | None = None) -> QuerySet:
+    """
+    Apply departmental and role-based visibility filters to a Quote queryset.
+
+    Rules:
+    - Admin/Finance: Global access.
+    - Managers: Own department's quotes + own quotes.
+    - Sales: Own quotes only.
+    """
+    if queryset is None:
+        queryset = Quote.objects.all()
+
+    if not user or not user.is_authenticated:
+        return queryset.none()
+
+    role = getattr(user, 'role', '')
+    is_global = (
+        getattr(user, 'is_admin', False) or
+        getattr(user, 'is_finance', False) or
+        role in ('admin', 'finance')
+    )
+
+    if is_global:
+        return queryset
+
+    # Manager View: Restricted by Department
+    if getattr(user, 'is_manager', False) or role == 'manager':
+        dept = getattr(user, 'department', None)
+        if dept:
+            return queryset.filter(
+                Q(created_by__department=dept) |
+                Q(created_by=user)
+            )
+        return queryset.filter(created_by=user)
+
+    # Sales / Standard View: Own quotes only
+    return queryset.filter(created_by=user)
+
 
 def get_quote_for_user(user, quote_id: str, queryset: QuerySet | None = None) -> Quote:
     """
     Retrieve a quote by ID while strictly enforcing RBAC ownership rules.
     
     Rules:
-    - Manager/Admin/Finance: Can access ALL quotes.
+    - Manager/Admin/Finance: Can access ALL quotes (Managers restricted by department).
     - Sales: Can ONLY access quotes strictly created by themselves.
     
     Args:
@@ -20,47 +98,22 @@ def get_quote_for_user(user, quote_id: str, queryset: QuerySet | None = None) ->
         Quote object.
         
     Raises:
-        Http404: If quote doesn't exist.
-        PermissionDenied: If user exists but is not allowed to access this quote.
+        Http404: If quote doesn't exist or user is not allowed to access this quote.
+        PermissionDenied: If user is not authenticated.
     """
     if queryset is None:
         queryset = Quote.objects.all()
         
-    # 1. Fetch the object independently of permission first to differentiate 404 vs 403
-    quote = get_object_or_404(queryset, id=quote_id)
-    
-    # 2. Check Permissions
     if not user or not user.is_authenticated:
          raise PermissionDenied("Authentication required.")
 
-    # Check for privileged roles (Global Access)
-    # Only Admin (and Finance who monitors everything) get global view.
-    # Managers are now restricted by department.
-    role = getattr(user, 'role', '')
-    is_global_admin = (
-        getattr(user, 'is_admin', False) or 
-        getattr(user, 'is_finance', False) or
-        role in ('admin', 'finance')
-    )
+    # Use the shared filter logic
+    accessible_qs = get_quotes_for_user(user, queryset)
     
-    if is_global_admin:
-        return quote
-        
-    # Check Manager Departmental Access
-    is_manager = getattr(user, 'is_manager', False) or role == 'manager'
-    if is_manager:
-        user_dept = getattr(user, 'department', None)
-        if user_dept:
-             # Check if creator is in the same department
-            creator_dept = getattr(quote.created_by, 'department', None)
-            if creator_dept == user_dept:
-                return quote
-
-    # 3. Creator Check (Sales / Fallback for Managers)
-    # Must match created_by
-    if quote.created_by_id == user.id:
-        return quote
-    
-    # Permission Denied / 404
-    from django.http import Http404
-    raise Http404("No Quote matches the given query.") 
+    try:
+        return accessible_qs.get(id=quote_id)
+    except Quote.DoesNotExist:
+        # We differentiate 404 vs 403 by checking if it exists at all
+        # To avoid leaking existence, we raise 404 in both cases where access is denied.
+        from django.http import Http404
+        raise Http404("No Quote matches the given query.") 

--- a/backend/quotes/spot_views.py
+++ b/backend/quotes/spot_views.py
@@ -69,7 +69,7 @@ from quotes.quote_result_contract import (
     build_persisted_line_item_metadata,
     build_persisted_quote_total_metadata,
 )
-from quotes.selectors import get_quote_for_user
+from quotes.selectors import get_quote_for_user, get_spes_for_user
 from quotes.currency_rules import determine_quote_currency
 from quotes.services.charge_normalization import resolve_charge_alias
 
@@ -85,19 +85,20 @@ def _user_is_manager_or_admin(user) -> bool:
     return getattr(user, "role", None) in ("manager", "admin")
 
 
-def _user_can_access_spe(user, spe_db: SpotPricingEnvelopeDB) -> bool:
-    if not user or not user.is_authenticated:
-        return False
-    if _user_is_manager_or_admin(user):
-        return True
-    return spe_db.created_by_id == user.id
-
-
 def _get_spe_or_404(user, envelope_id, queryset=None):
-    spe_db = get_object_or_404(queryset or SpotPricingEnvelopeDB, id=envelope_id)
-    if not _user_can_access_spe(user, spe_db):
-        raise PermissionDenied("You do not have access to this SPOT envelope.")
-    return spe_db
+    if queryset is None:
+        queryset = SpotPricingEnvelopeDB.objects.all()
+
+    # Use the shared filter logic for IDOR/RBAC protection
+    accessible_qs = get_spes_for_user(user, queryset)
+
+    try:
+        return accessible_qs.get(id=envelope_id)
+    except SpotPricingEnvelopeDB.DoesNotExist:
+        # To avoid leaking existence, we raise 403 or 404.
+        # For consistency with get_quote_for_user, let's use 404.
+        from django.http import Http404
+        raise Http404("No SpotPricingEnvelopeDB matches the given query.")
 
 
 def _spe_queryset():
@@ -1301,9 +1302,11 @@ class SpotEnvelopeListCreateAPIView(APIView):
     
     def get(self, request):
         """List SPEs created by user."""
-        spe_qs = _spe_queryset()
-        if not _user_is_manager_or_admin(request.user):
-            spe_qs = spe_qs.filter(created_by=request.user)
+        user = request.user
+        base_qs = _spe_queryset()
+
+        # SECURITY FIX: Enforce IDOR/RBAC protection on SPE listing
+        spe_qs = get_spes_for_user(user, base_qs)
 
         # Filter by status if provided
         status_param = request.query_params.get('status')

--- a/backend/quotes/tests/test_reporting_views.py
+++ b/backend/quotes/tests/test_reporting_views.py
@@ -127,6 +127,11 @@ class TestReportsViewSet:
         assert mode_entry['revenue'] == 1500.0
 
     def test_sales_performance(self, api_client, manager_user, sales_user, quote_factory):
+        manager_user.department = 'Sales'
+        manager_user.save()
+        sales_user.department = 'Sales'
+        sales_user.save()
+
         api_client.force_authenticate(user=manager_user)
         
         quote_factory(sales_user, Quote.Status.FINALIZED, 2000)

--- a/backend/quotes/views/lifecycle.py
+++ b/backend/quotes/views/lifecycle.py
@@ -35,7 +35,7 @@ from accounts.permissions import (
     CanFinalizeQuotes,
     CanEditQuotes,
 )
-from quotes.selectors import get_quote_for_user
+from quotes.selectors import get_quote_for_user, get_quotes_for_user
 
 logger = logging.getLogger(__name__)
 
@@ -244,41 +244,12 @@ class QuoteV3ViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         user = self.request.user
         # Prefetch related data to optimize query
-        qs = Quote.objects.all().select_related(
+        base_qs = Quote.objects.all().select_related(
             'customer', 'contact', 'origin_location', 'destination_location'
         ).prefetch_related('spot_envelopes').order_by('-created_at')
 
-        # 1. Role-Based Visibility
-        if user.is_authenticated:
-            role = getattr(user, 'role', '')
-            
-            # Global View: Admin & Finance
-            is_global = (
-                getattr(user, 'is_admin', False) or 
-                getattr(user, 'is_finance', False) or 
-                role in ('admin', 'finance')
-            )
-            
-            if is_global:
-                pass # See all
-                
-            # Manager View: Restricted by Department
-            elif getattr(user, 'is_manager', False) or role == 'manager':
-                dept = getattr(user, 'department', None)
-                if dept:
-                    # See quotes from same department users OR own quotes
-                    qs = qs.filter(
-                        Q(created_by__department=dept) | 
-                        Q(created_by=user)
-                    )
-                else:
-                    # No department assigned -> Fallback to own quotes only?
-                    # Or see "unassigned"? Strict interpretation suggests restricted.
-                    qs = qs.filter(created_by=user)
-
-            # Sales / Standard View: Own quotes only
-            else:
-                qs = qs.filter(created_by=user)
+        # 1. Role-Based Visibility & IDOR Protection
+        qs = get_quotes_for_user(user, base_qs)
 
         # 2. Filtering (Manual implementation since django-filter is not installed)
         mode = self.request.query_params.get('mode')


### PR DESCRIPTION
## Summary

Clean rebuild of PR #22 from current `main`.

This PR enforces backend-level IDOR protection for quote, SPOT envelope, and reporting access by centralizing visibility through selectors.

## Files changed

- `backend/quotes/reporting_views.py`
- `backend/quotes/selectors.py`
- `backend/quotes/spot_views.py`
- `backend/quotes/tests/test_reporting_views.py`
- `backend/quotes/views/lifecycle.py`

## Security behavior

- Unauthorized quote/SPE access returns `404 Not Found`, not `403 Forbidden`, to avoid leaking object existence.
- Sales users are restricted to their own records.
- Managers are scoped to their department/team records.
- Reporting dashboards are restricted to accessible quote data.

## Verification

- `pytest quotes/tests`
- `pytest accounts/tests.py`
- `pytest quotes/tests/test_reporting_views.py`

Reported results:

```text
332 tests passed
0 failures
```

## Notes

No changes to:

- `backend/core/business_rules.py`
- `backend/quotes/views/calculation.py`
- `backend/quotes/spot_services.py`
- `backend/quotes/spot_schemas.py`
- `backend/pricing_v4/`
- migrations
- models
- frontend

This PR replaces the stale original PR #22 with a clean branch built from current `main`.