### PR TITLE
Phase 3.5 — Production Hardening & Operational Readiness

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,59 @@
+# =============================================================================
+# RateEngine Production .dockerignore
+# =============================================================================
+
+# Virtual Environments
+.venv/
+venv/
+env/
+ENV/
+
+# Redundant Frontend/Backend Modules
+node_modules/
+
+# Python Compilation & Testing Caches
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache/
+.coverage
+htmlcov/
+.mypy_cache/
+.ruff_cache/
+.tox/
+
+# Local Databases and Volatile Caches
+db.sqlite3
+*.sqlite3
+*.db
+*.sqlite3-journal
+*.sqlite3-wal
+
+# Log files & Debug Outputs
+logs/
+*.log
+*.traceback
+out.txt
+out2.txt
+patch_both.diff
+patch_pytest.diff
+
+# Local Media and Django Assets
+media/
+staticfiles/
+test_staticfiles/
+test_staticfiles_output/
+
+# Sensitive Variables
+.env
+.env.*
+
+# Knowledge Graph & CLI Toolings
+graphify-out/
+
+# System Files & Git Files
+.git/
+.gitignore
+.DS_Store
+Thumbs.db

--- a/backend/.gcloudignore
+++ b/backend/.gcloudignore
@@ -1,0 +1,51 @@
+# =============================================================================
+# RateEngine Production .gcloudignore
+# =============================================================================
+
+# System files & git
+.git/
+.gitignore
+.DS_Store
+Thumbs.db
+
+# Virtual Environments
+.venv/
+venv/
+env/
+ENV/
+
+# Package manager dependencies
+node_modules/
+
+# Compilation and test caches
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+# Databases, local configs and secrets
+db.sqlite3
+*.sqlite3
+*.db
+.env
+.env.*
+
+# Logs and patch files
+logs/
+*.log
+*.traceback
+*.diff
+out.txt
+out2.txt
+
+# Media & static files
+media/
+staticfiles/
+test_staticfiles/
+test_staticfiles_output/
+
+# Knowledge Graph
+graphify-out/

--- a/backend/.gitattributes
+++ b/backend/.gitattributes
@@ -1,0 +1,2 @@
+entrypoint.prod.sh text eol=lf
+entrypoint.migrate.sh text eol=lf

--- a/backend/core/tests/test_health.py
+++ b/backend/core/tests/test_health.py
@@ -53,3 +53,19 @@ class HealthCheckTests(APITestCase):
         data = response.json()
         assert data['check_type'] == 'combined'
         assert 'database' in data
+
+    def test_healthz_endpoint(self):
+        """Lightweight healthz endpoint should return 200 and {"status": "ok"}."""
+        url = reverse('healthz')
+        response = self.client.get(url)
+        
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {"status": "ok"}
+
+    def test_healthz_slash_endpoint(self):
+        """healthz with slash should also work."""
+        url = reverse('healthz_slash')
+        response = self.client.get(url)
+        
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {"status": "ok"}

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -122,7 +122,11 @@ class LocationV3DetailView(APIView):
         return Response(data)
 
 
+from django.http import JsonResponse
 from django.utils import timezone
+
+def healthz(request):
+    return JsonResponse({"status": "ok"})
 
 class LivenessCheckAPIView(APIView):
     """

--- a/backend/rate_engine/urls.py
+++ b/backend/rate_engine/urls.py
@@ -3,6 +3,7 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.shortcuts import redirect
 from django.urls import include, path
+from core.views import healthz
 
 
 def root_redirect(_request):
@@ -11,6 +12,8 @@ def root_redirect(_request):
 
 urlpatterns = [
     path('', root_redirect),
+    path('healthz', healthz, name='healthz'),
+    path('healthz/', healthz, name='healthz_slash'),
     path('admin/', admin.site.urls),
     
     # Include your app's URLs


### PR DESCRIPTION
## Summary

Production hardening for the Cloud Run pilot deployment.

## Changes

- Add backend `.dockerignore` and `.gcloudignore` to reduce Cloud Build context size and prevent local artifacts from being uploaded.
- Add `.gitattributes` to preserve LF line endings for Linux shell entrypoints.
- Add lightweight unauthenticated `/healthz/` endpoint.
- Add health endpoint tests.
- Register `/healthz/` in root URLs.

## Verification

- Cloud SQL backups enabled and verified externally.
- Cloud Run service redeployed successfully.
- `/healthz/` returns HTTP 200 with `{ "status": "ok" }`.
- Full test suite reported passing: 471 tests OK.

## Notes

No pricing, SPOT, RBAC, IDOR, Firebase, frontend, or domain changes are included.