### PR TITLE
docs: add PNG on-forwarding and quote display impact audits

### DIFF
--- a/docs/audits/business-rule-next-phase-audit.md
+++ b/docs/audits/business-rule-next-phase-audit.md
@@ -1,0 +1,109 @@
+# Audit Report: PNG Domestic On-Forwarding & Special Cargo Hybrid SPOT Workflow
+
+## 1. Executive Summary & Risk Level
+
+* **Risk Level:** **High**. 
+* **Primary Concern:** 
+  1. The international engines (`ImportPricingEngine`, `ExportPricingEngine`) assume a single direct international leg and lack any concept of domestic on-forwarding or pre-carriage inside PNG (e.g., `BNE → LAE` routed as `BNE → POM` + `POM → LAE`).
+  2. The `DomesticPricingEngine` enforces door service restrictions at initialisation, throwing a hard `ValueError` if a door scope is requested for non-office PNG locations (e.g., `HGU`), causing the quote flow to crash instead of triggering a SPOT/manual review workflow or falling back to airport collection/lodge.
+  3. Special cargo hybrid SPOT merges currently use a strict **bucket-level override** strategy in the `PricingServiceV4Adapter`. While this prevents appending spot freight charges, it is a blunt instrument that completely wipes out standard local charges in the same bucket if any spot charge is present in that bucket.
+
+---
+
+## 2. Current Behaviour & Gaps
+
+### A. PNG Domestic On-Forwarding / Pre-Carriage in International Quotes
+
+#### Current Behaviour:
+1. **Direction Classification (`backend/core/business_rules.py`):**
+   * Enforces strict PG-to-PG (`DOMESTIC`), PG-to-non-PG (`EXPORT`), and non-PG-to-PG (`IMPORT`) classification.
+   * Cross-border lanes with no PG origin or destination throw a `ValueError` immediately.
+2. **Scope Rules (`A2A`, `D2A`, `A2D`, `D2D`):**
+   * In `DomesticPricingEngine`, door cartage service is strictly locked to `POM` and `LAE` (`self.DOOR_PORTS = ['POM', 'LAE']`).
+   * A hard `ValueError` is thrown at initialisation if a door pickup/delivery is requested for any other PNG location (e.g., `D2D` to `HGU`).
+3. **Leg Processing (`backend/pricing_v4/engine/`):**
+   * `ImportPricingEngine` and `ExportPricingEngine` only calculate `ORIGIN`, `FREIGHT`, and `DESTINATION` legs for the primary international lane. They cannot dispatch to `DomesticPricingEngine` or load domestic rate cards for internal PNG legs.
+   * `A2A` is treated as a default fallback scope, but true domestic `A2A` is rare in real operations, where door service or airport lodge/collection is preferred.
+
+#### Gaps Identified:
+* **No Multi-Leg Routing Engine:** There is no routing coordinator or multi-leg dispatcher to split `BNE → LAE` into `BNE → POM` (International Import) and `POM → LAE` (Domestic On-forwarding).
+* **Cartage Crash vs. SPOT Trigger:** Requests for door services at unserviceable PNG locations (e.g., door delivery to `HGU`) crash the pricing adapter with a `ValueError` instead of gracefully routing to the SPOT manual-sourcing workflow.
+* **No Airport Lodge/Collection Rules:** There is no programmatic distinction between door delivery (which EFM does not offer outside `POM`/`LAE`) and airport-lodge/collection (where the customer retrieves cargo from the local airport).
+
+#### Corrected Business Rules (Clarification):
+* **Serviceability to Airport:** Non-POM/LAE PNG airports (like `HGU` or `RAB`) can still be serviceable to the airport.
+* **Standard Rates Coverage:** If airport-to-airport (A2A) domestic rates exist, they must **not** trigger SPOT.
+* **Office Coverage Boundary:** POM/LAE office coverage only affects true door pickup/delivery (cartage legs), not airport-to-airport freight.
+* **D2A Imports Standard Path:** D2A imports to airports like `HGU` or `RAB` (where destination is the airport and consignee collects) should remain standard if all rates exist in the database.
+
+---
+
+### B. Special Cargo Hybrid SPOT Workflow
+
+#### Current Behaviour:
+1. **SPOT Trigger Logic (`backend/quotes/spot_services.py`):**
+   * `SpotTriggerEvaluator.evaluate` determines if a quote must enter SPOT mode based on rate availability or commodity rules.
+   * Database rules in `CommodityChargeRule` can trigger SPOT or manual entry via `requires_spot` or `requires_manual` modes.
+2. **Merge Strategy (`backend/pricing_v4/adapter.py`):**
+   * The `_merge_charge_lines` method performs a bucket-level replacement:
+     ```python
+     spot_buckets = {l.bucket for l in spot_lines}
+     final_lines = [l for l in standard_lines if l.bucket not in spot_buckets]
+     final_lines.extend(spot_lines)
+     ```
+   * If a SPOT envelope contains charges in the `airfreight` bucket, all standard `airfreight` charges are discarded, and only the spot lines are kept.
+
+#### Gaps Identified:
+* **All-or-Nothing Bucket Wipeout:** If a spot charge overrides a bucket (e.g., `origin_charges`), it discards all other standard local charges in that same bucket, even if those standard charges (like documentation fees or regulatory fees) are still valid and required.
+* **Crash Discards Local Charges:** If the standard engine crashes (due to the domestic door scope validation), `calculate_charges` falls back to a SPOT-only overlay where standard lines are completely empty. This discards valid local charges that the standard engine *could* have resolved.
+
+---
+
+## 3. Files Reviewed
+
+1. `backend/core/business_rules.py` (Shipment classification logic)
+2. `backend/pricing_v4/engine/domestic_engine.py` (Domestic pricing engine & cartage validation)
+3. `backend/pricing_v4/engine/import_engine.py` (Import engine active legs & scope handling)
+4. `backend/pricing_v4/engine/export_engine.py` (Export engine structure)
+5. `backend/pricing_v4/adapter.py` (Standard & SPOT merge/calculation coordinator)
+6. `backend/pricing_v4/category_rules.py` (ProductCode category classification)
+7. `backend/quotes/spot_services.py` (SPOT trigger & scope validation)
+
+---
+
+## 4. Proposed Safe Implementation Phases
+
+### Phase 1: Graceful Scope Fallback & SPOT Promotion (No Crash)
+* **Goal:** Prevent the pricing engine from throwing hard `ValueError` crashes for unserviceable door scopes.
+* **Action:** 
+  * Modify `DomesticPricingEngine` to set a custom warning flag (e.g., `is_unserviceable_door = True`) instead of raising `ValueError` in `_validate_service_scope()`.
+  * Update `PricingServiceV4Adapter` and `SpotTriggerEvaluator` to catch unserviceable scopes and cleanly trigger the SPOT / manual review workflow with `SpotTriggerReason.REQUIRES_ASSUMPTIONS` or a new reason `UNSERVICEABLE_DOOR_CARRIAGE`.
+  * Expose an "Airport Collection/Lodge" flag on the quote so users know the shipment must be collected by the consignee at the local PNG airport instead of expecting door delivery.
+
+### Phase 2: Refined Hybrid SPOT Merging (Granular Overrides)
+* **Goal:** Stop bucket-level wipeouts of standard local charges.
+* **Action:**
+  * Refine `_merge_charge_lines` in the adapter to merge charges at the **ProductCode category level** or **line-by-line** rather than wiping out whole buckets.
+  * Ensure known local charges (like regulatory surcharges, screening fees, or documentation fees) are preserved, while replacing only the specific freight or cartage lines that are overridden by the SPOT envelope.
+
+### Phase 3: Multi-Leg Routing Dispatcher
+* **Goal:** Enable PNG domestic on-forwarding within international quotes.
+* **Action:**
+  * Implement a `MultiLegPricingDispatcher` that detects when an international shipment destination or origin requires internal PNG transit (e.g., `LAE` via `POM`).
+  * Programmatically split the quote into:
+    1. International Leg (`BNE → POM` via `ImportPricingEngine`).
+    2. Domestic Leg (`POM → LAE` via `DomesticPricingEngine`).
+  * Consolidate the line items from both engines into a unified `QuoteCharges` response, maintaining proper leg separation (`ORIGIN`, `MAIN`, `DOMESTIC_ONFORWARDING`, `DESTINATION`).
+
+---
+
+## 5. Test Scenarios Needed
+
+### A. Domestic Scope Restrictions
+* **Test 1 (POM/LAE Door Service):** Verify `POM` and `LAE` support `D2D`, `D2A`, `A2D` without warnings.
+* **Test 2 (Non-Office Location Door Service):** Verify `HGU` with `D2D` does not crash, but correctly triggers a SPOT workflow.
+* **Test 3 (Non-Office Airport Collection):** Verify `HGU` with `A2A` prints a clear instruction note regarding airport collection.
+
+### B. Hybrid SPOT Merging
+* **Test 4 (Preservation of Local Surcharges):** Verify that when a SPOT envelope overrides `airfreight` charges, local charges in `origin_charges` or `destination_charges` (such as documentation fees) are preserved and not discarded.
+* **Test 5 (Specific Surcharge Replacement):** Verify that if a SPOT envelope contains a specific cartage charge, only the standard cartage charge is replaced, leaving other local handling charges intact.

--- a/docs/audits/quote-display-impact-audit.md
+++ b/docs/audits/quote-display-impact-audit.md
@@ -1,0 +1,101 @@
+# Audit Report: Quote Display & Output Impact Analysis
+
+## 1. Executive Summary & Risk Level
+
+* **Risk Level:** **High**.
+* **Primary Concern:** 
+  1. The database models (`QuoteLine`), frontend display (`QuoteFinancialBreakdown.tsx`), and PDF generation service (`pdf_service.py`) are hardcoded to a rigid **three-bucket architecture**: `ORIGIN`, `FREIGHT`/`MAIN`, and `DESTINATION`.
+  2. There is no structural representation, display capability, or layout layout in either the UI or the PDF to handle **multi-leg routes** (e.g., `BNE → POM → LAE` involving domestic on-forwarding, or `HGU → POM → SIN` involving pre-carriage).
+  3. Hybrid SPOT display—where known local charges and SPOT charges appear together—is currently blocked by the bucket-level override strategy, which completely wipes out standard lines in any overridden bucket.
+
+---
+
+## 2. Structural & UI Audit Questions
+
+### Can the Quote-Line Model show multiple legs?
+* **No.** The `QuoteLine.leg` database field is designed around the choices: `ORIGIN`, `MAIN` (or `FREIGHT`), and `DESTINATION`. 
+* There is no field to model a fourth leg like `DOMESTIC_ONFORWARDING` or `DOMESTIC_PRE_CARRIAGE`, nor is there a sequence index to represent multi-leg hops (e.g., leg 1, leg 2).
+
+### Can the UI/PDF show leg-specific charges?
+* **No.** Both the frontend summary and PDF generation group charges strictly by their `leg` or `bucket` value. 
+* Any on-forwarding charges categorized as `DESTINATION` will simply merge with international destination local charges, concealing the fact that the cargo is moving via domestic air freight to a second airport inside PNG.
+
+### Can they show airport collection/lodgement notes?
+* **Partially.** Currently, notes can only be entered as general `calculation_notes` on individual lines or in the generic `totals.notes` field (which render as conditional footnotes at the bottom of the breakdown or PDF).
+* There is no dedicated UI element, warning card, or prominent visual highlight to instruct the user or customer: *"Consignee must collect at airport (HGU) - Door service is unavailable."*
+
+### Can they show door service restrictions for non-office PNG locations?
+* **No.** Because the `DomesticPricingEngine` crashes immediately when requesting door service outside `POM`/`LAE`, the quote calculation never succeeds. 
+* Consequently, the UI cannot display a quote with a warning banner or explain why door delivery was restricted.
+
+### Can they show known charges + SPOT charges together?
+* **No.** Because the `adapter.py` overrides charges at the entire bucket level, standard local charges (like documentation fees) are wiped out if a spot charge is introduced in the same bucket. 
+* The UI and PDF will only show standard charges *or* spot charges, never both merged together within the same bucket.
+
+---
+
+## 3. Component-by-Component Impact
+
+### A. Frontend Quote Summary & Financial Breakdown (`QuoteFinancialBreakdown.tsx`)
+* **Current Behavior:** Hardcodes the buckets `ORIGIN`, `FREIGHT`, and `DESTINATION`. Inside the buckets, charges are sorted by predefined `SUBCATEGORY_ORDER` (e.g., "Customs / Regulatory", "Documentation", "Local Transport / Cartage").
+* **Impact:** Domestic on-forwarding charges would get dumped into the generic `DESTINATION` bucket under "Local Transport / Cartage", mixing them with customs clearance and import agency fees. The customer cannot visually differentiate international destination handling from domestic air transit.
+
+### B. PDF Quote Output (`pdf_service.py`)
+* **Current Behavior:** Groups lines strictly into `Origin Charges`, `International Freight`, and `Destination Charges` sub-tables:
+  ```python
+  if leg == 'ORIGIN':
+      bucket_name = 'Origin Charges'
+  elif leg == 'MAIN':
+      bucket_name = 'International Freight'
+  elif leg == 'DESTINATION':
+      bucket_name = 'Destination Charges'
+  ```
+* **Impact:** Multi-leg shipments cannot be printed with clear, separate cost breakdowns for domestic transit. The grand totals and sub-tables would be misleading for complex routes.
+
+### C. Customer-Facing Public Quote Page
+* **Current Behavior:** Reuses the same layout logic as `QuoteFinancialBreakdown.tsx` to render the customer's secure online view.
+* **Impact:** High confusion risk: a customer receiving a quote for `BNE → POM → HGU` might assume they are receiving door delivery at `HGU` because there is no clear customer-facing explanation of the "Consignee Collects at Airport" restriction.
+
+---
+
+## 4. Files Reviewed
+
+1. `backend/quotes/models.py` (Database model for `QuoteLine` and legs)
+2. `backend/quotes/pdf_service.py` (PDF generation, buckets, layout)
+3. `frontend/src/components/QuoteFinancialBreakdown.tsx` (UI financial card, buckets mapping)
+4. `frontend/src/components/spot/ChargeBucketSection.tsx` (SPOT-specific UI components)
+5. `frontend/src/lib/types.ts` (TypeScript types mapping quote lines)
+
+---
+
+## 5. Recommended Phased Implementation
+
+### Phase 1: Support Merged Standard & Spot Charges (Data Model & Adapter)
+* **Goal:** Enable hybrid SPOT quotes where standard local charges and spot charges coexist.
+* **Action:**
+  * Modify the merge strategy in `PricingServiceV4Adapter._merge_charge_lines` to operate at the **ProductCode category level** instead of the entire bucket.
+  * Update `QuoteFinancialBreakdown.tsx` to display a distinct badge for `SPOT` sourced lines next to standard rate card lines in the same bucket section.
+
+### Phase 2: Add Structural Warning Banners & Movement Explanations (UI/PDF)
+* **Goal:** Visually communicate airport collection/lodgement rules and door service restrictions.
+* **Action:**
+  * Add a `RoutingWarning` banner to the top of `QuoteFinancialBreakdown.tsx` when a non-office PNG airport (e.g., `HGU`, `GKA`) is selected.
+  * Inject explicit terms to the PDF generator via `_build_terms_and_conditions()`: *"Door service is unavailable at HGU. Consignee must collect cargo at the airport terminal."*
+
+### Phase 3: Leg Refactoring for Multi-Leg Routes
+* **Goal:** Seamlessly display domestic legs in the UI and PDF.
+* **Action:**
+  * Expand `QuoteLine.leg` choices (or add a separate sequence-based `leg_sequence` field) to model transit steps.
+  * Update `QuoteFinancialBreakdown.tsx` and `pdf_service.py` to dynamically render a fourth sub-table/bucket (e.g., `PNG Domestic Transit`) if domestic on-forwarding or pre-carriage is active.
+
+---
+
+## 6. Required Test Scenarios
+
+### A. UI Layout Integrity
+* **Test 1 (Hybrid Spot Display):** Verify that standard documentation fees and spot airfreight charges appear together under `Origin Charges` in `QuoteFinancialBreakdown.tsx`.
+* **Test 2 (Airport Collection Badge):** Verify that a shipment to `HGU` renders a clear warning icon indicating "Airport Collection Required" in the quote summary view.
+
+### B. PDF Verification
+* **Test 3 (PDF Bucket Subtotals):** Verify that injecting a custom `PNG Domestic Transit` line does not break PDF layout alignment or subtotal arithmetic.
+* **Test 4 (Terms Formatting):** Verify that the custom terms and conditions note regarding airport collection is printed on the PDF when the destination is a non-office PNG airport.


### PR DESCRIPTION
## Summary

Adds audit documentation for the next-phase business-rule work around PNG domestic on-forwarding/pre-carriage, special cargo hybrid SPOT behaviour, and quote display/PDF impact.

## What Changed

- Added business-rule audit notes for PNG on-forwarding/pre-carriage and airport-vs-door service assumptions.
- Added quote display impact audit covering frontend charge grouping, quote lines, PDF output, and customer-facing quote clarity.
- Captured corrected business rule: non-POM/LAE PNG airports can still be serviceable to airport and should not automatically trigger SPOT when valid airport-to-airport rates exist.
- Captured DG/special cargo principle: special cargo should trigger SPOT/manual review while preserving known local charges.

## Scope Control

Documentation only.

No changes made to:

- Pricing logic
- SPOT trigger logic
- Quote calculation logic
- Rate selection
- Models
- Migrations
- Frontend UI
- PDF generation
- Tests

## Risk

Low. This PR documents future design risks and business rules only. No runtime behaviour changes.

## Notes

This PR should be reviewed as planning/reference material. It should not be treated as implementation approval for multi-leg routing or special-cargo logic.