### PR TITLE
refactor(pricing): extract shared rate manager helpers

### DIFF
--- a/frontend/src/components/pricing/rate-manager/LaneRateFormModal.tsx
+++ b/frontend/src/components/pricing/rate-manager/LaneRateFormModal.tsx
@@ -33,9 +33,8 @@ import {
   type PricingCarrierOption,
   type ProductCodeOption,
   type RateRevisionOptions,
-  type RateWeightBreak,
 } from '@/lib/api';
-
+import { isoDateWithOffset, cleanWeightBreaks } from '@/lib/pricing/rate-utils';
 type FormMode = 'create' | 'edit' | 'revise';
 type CounterpartyType = 'agent' | 'carrier';
 type PricingMode = 'PER_KG' | 'PER_SHIPMENT' | 'ADDITIVE' | 'PERCENT' | 'WEIGHT_BREAKS';
@@ -86,11 +85,7 @@ function initialWeightBreaks(rate: LaneRecord | null | undefined): WeightBreakDr
   }));
 }
 
-function isoDateWithOffset(offsetDays = 0): string {
-  const base = new Date();
-  base.setDate(base.getDate() + offsetDays);
-  return base.toISOString().split('T')[0];
-}
+
 
 export default function LaneRateFormModal<T extends LaneRecord>({
   open,
@@ -264,14 +259,7 @@ export default function LaneRateFormModal<T extends LaneRecord>({
     } else if (pricingMode === 'PERCENT') {
       payload.percent_rate = percentRate.trim() || null;
     } else if (pricingMode === 'WEIGHT_BREAKS') {
-      payload.weight_breaks = weightBreaks
-        .filter((row) => row.min_kg.trim() !== '' || row.rate.trim() !== '')
-        .map(
-          (row): RateWeightBreak => ({
-            min_kg: Number(row.min_kg),
-            rate: row.rate.trim(),
-          }),
-        );
+      payload.weight_breaks = cleanWeightBreaks(weightBreaks);
     }
 
     setSaving(true);

--- a/frontend/src/components/pricing/rate-manager/LaneRateManagerPage.tsx
+++ b/frontend/src/components/pricing/rate-manager/LaneRateManagerPage.tsx
@@ -39,6 +39,7 @@ import {
 } from '@/lib/api';
 import LaneRateFormModal from './LaneRateFormModal';
 import RateHistorySheet from './RateHistorySheet';
+import { getRateStatus } from '@/lib/pricing/rate-utils';
 
 type ModalState<T extends LaneRateRecord | LaneCOGSRateRecord> =
   | { mode: 'create'; rate: T | null }
@@ -66,12 +67,7 @@ interface LaneRateManagerPageProps<T extends LaneRateRecord | LaneCOGSRateRecord
   loadHistory: (id: number | string) => Promise<RateChangeLogEntry[]>;
 }
 
-function getStatusLabel(rate: LaneRateRecord | LaneCOGSRateRecord): 'ACTIVE' | 'EXPIRED' | 'SCHEDULED' {
-  const today = new Date().toISOString().split('T')[0];
-  if (rate.valid_until < today) return 'EXPIRED';
-  if (rate.valid_from > today) return 'SCHEDULED';
-  return 'ACTIVE';
-}
+
 
 function statusBadge(status: 'ACTIVE' | 'EXPIRED' | 'SCHEDULED') {
   if (status === 'ACTIVE') {
@@ -139,7 +135,7 @@ export default function LaneRateManagerPage<T extends LaneRateRecord | LaneCOGSR
   const filteredRates = useMemo(
     () =>
       rates.filter((rate) => {
-        const status = getStatusLabel(rate);
+        const status = getRateStatus(rate);
         if (statusFilter !== 'all' && status !== statusFilter) return false;
         if (productFilter !== 'all' && String(rate.product_code) !== productFilter) return false;
         if (currencyFilter !== 'all' && rate.currency !== currencyFilter) return false;
@@ -304,7 +300,7 @@ export default function LaneRateManagerPage<T extends LaneRateRecord | LaneCOGSR
               </TableHeader>
               <TableBody>
                 {filteredRates.map((rate) => {
-                  const status = getStatusLabel(rate);
+                  const status = getRateStatus(rate);
                   const basis = rate.weight_breaks?.length
                     ? 'Weight breaks'
                     : rate.percent_rate

--- a/frontend/src/components/pricing/rate-manager/LocalRateFormModal.tsx
+++ b/frontend/src/components/pricing/rate-manager/LocalRateFormModal.tsx
@@ -33,8 +33,8 @@ import {
   type PricingCarrierOption,
   type ProductCodeOption,
   type RateRevisionOptions,
-  type RateWeightBreak,
 } from '@/lib/api';
+import { isoDateWithOffset, cleanWeightBreaks } from '@/lib/pricing/rate-utils';
 
 type FormMode = 'create' | 'edit' | 'revise';
 type CounterpartyType = 'agent' | 'carrier';
@@ -58,12 +58,6 @@ interface LocalRateFormModalProps<T extends LocalRateRecord | LocalCOGSRateRecor
   updateRate: (id: number | string, payload: Partial<LocalRateUpsertPayload>) => Promise<T>;
   reviseRate: (id: number | string, payload: LocalRateUpsertPayload & RateRevisionOptions) => Promise<T>;
   onSuccess: () => void | Promise<void>;
-}
-
-function isoDateWithOffset(offsetDays = 0): string {
-  const base = new Date();
-  base.setDate(base.getDate() + offsetDays);
-  return base.toISOString().split('T')[0];
 }
 
 function initialWeightBreaks(rate: LocalRateRecord | null | undefined): WeightBreakDraft[] {
@@ -231,14 +225,7 @@ export default function LocalRateFormModal<T extends LocalRateRecord | LocalCOGS
       additive_flat_amount: additiveFlatAmount.trim() || null,
       min_charge: minCharge.trim() || null,
       max_charge: maxCharge.trim() || null,
-      weight_breaks: weightBreaks
-        .filter((row) => row.min_kg.trim() !== '' || row.rate.trim() !== '')
-        .map(
-          (row): RateWeightBreak => ({
-            min_kg: Number(row.min_kg),
-            rate: row.rate.trim(),
-          }),
-        ),
+      weight_breaks: cleanWeightBreaks(weightBreaks),
       percent_of_product_code: percentOfProductCode ? Number(percentOfProductCode) : null,
       valid_from: validFrom,
       valid_until: validUntil,

--- a/frontend/src/components/pricing/rate-manager/LocalRateManagerPage.tsx
+++ b/frontend/src/components/pricing/rate-manager/LocalRateManagerPage.tsx
@@ -39,6 +39,7 @@ import {
 } from '@/lib/api';
 import LocalRateFormModal from './LocalRateFormModal';
 import RateHistorySheet from './RateHistorySheet';
+import { getRateStatus } from '@/lib/pricing/rate-utils';
 
 type ModalState<T extends LocalRateRecord | LocalCOGSRateRecord> =
   | { mode: 'create'; rate: T | null }
@@ -60,12 +61,7 @@ interface LocalRateManagerPageProps<T extends LocalRateRecord | LocalCOGSRateRec
   loadHistory: (id: number | string) => Promise<RateChangeLogEntry[]>;
 }
 
-function getStatusLabel(rate: LocalRateRecord | LocalCOGSRateRecord): 'ACTIVE' | 'EXPIRED' | 'SCHEDULED' {
-  const today = new Date().toISOString().split('T')[0];
-  if (rate.valid_until < today) return 'EXPIRED';
-  if (rate.valid_from > today) return 'SCHEDULED';
-  return 'ACTIVE';
-}
+
 
 function statusBadge(status: 'ACTIVE' | 'EXPIRED' | 'SCHEDULED') {
   if (status === 'ACTIVE') {
@@ -133,7 +129,7 @@ export default function LocalRateManagerPage<T extends LocalRateRecord | LocalCO
   const filteredRates = useMemo(
     () =>
       rates.filter((rate) => {
-        const status = getStatusLabel(rate);
+        const status = getRateStatus(rate);
         if (statusFilter !== 'all' && status !== statusFilter) return false;
         if (productFilter !== 'all' && String(rate.product_code) !== productFilter) return false;
         if (directionFilter !== 'all' && rate.direction !== directionFilter) return false;
@@ -307,7 +303,7 @@ export default function LocalRateManagerPage<T extends LocalRateRecord | LocalCO
               </TableHeader>
               <TableBody>
                 {filteredRates.map((rate) => {
-                  const status = getStatusLabel(rate);
+                  const status = getRateStatus(rate);
                   const basis = rate.weight_breaks?.length
                     ? 'Weight breaks'
                     : rate.rate_type === 'PERCENT'

--- a/frontend/src/lib/pricing/rate-utils.ts
+++ b/frontend/src/lib/pricing/rate-utils.ts
@@ -1,0 +1,26 @@
+export interface RateWeightBreak {
+  min_kg: number;
+  rate: string;
+}
+
+export function isoDateWithOffset(offsetDays = 0): string {
+  const base = new Date();
+  base.setDate(base.getDate() + offsetDays);
+  return base.toISOString().split('T')[0];
+}
+
+export function getRateStatus(rate: { valid_from: string; valid_until: string }): 'ACTIVE' | 'EXPIRED' | 'SCHEDULED' {
+  const today = new Date().toISOString().split('T')[0];
+  if (rate.valid_until < today) return 'EXPIRED';
+  if (rate.valid_from > today) return 'SCHEDULED';
+  return 'ACTIVE';
+}
+
+export function cleanWeightBreaks(weightBreaks: Array<{ min_kg: string; rate: string }>): RateWeightBreak[] {
+  return weightBreaks
+    .filter((row) => row.min_kg.trim() !== '' || row.rate.trim() !== '')
+    .map((row) => ({
+      min_kg: Number(row.min_kg),
+      rate: row.rate.trim(),
+    }));
+}


### PR DESCRIPTION
## Summary

- Extracted shared pure/stateless Rate Manager helpers into `frontend/src/lib/pricing/rate-utils.ts`.
- Reused helpers across lane/local rate manager pages and form modals.
- Reduced duplication between Lane and Local Rate Manager components without changing UI markup, API flow, or pricing behavior.

## Extracted Helpers

- `isoDateWithOffset`
- `getRateStatus`
- `cleanWeightBreaks`

## Safety / Non-goals

No changes were made to:

- Quote calculation logic
- SPOT trigger logic
- Backend pricing logic
- API contracts or payload structures
- Form submission wrappers
- React hooks/state lifecycle
- Modal open/close logic
- UI markup/layout

## Verification

- `npm run lint` passed
- `npm run build` passed
- `npx fallow dupes` rerun after refactor

## Notes

Generated Fallow reports/logs were not committed. Remaining duplication is largely outside this targeted Rate Manager helper extraction phase.