### PR TITLE
chore(frontend): use canonical rate weight break type

### DIFF
--- a/frontend/src/lib/pricing/rate-utils.ts
+++ b/frontend/src/lib/pricing/rate-utils.ts
@@ -1,7 +1,4 @@
-export interface RateWeightBreak {
-  min_kg: number;
-  rate: string;
-}
+import type { RateWeightBreak } from '../api';
 
 export function isoDateWithOffset(offsetDays = 0): string {
   const base = new Date();


### PR DESCRIPTION
## Summary

- Removed the duplicate local `RateWeightBreak` export from `frontend/src/lib/pricing/rate-utils.ts`.
- Reused the canonical frontend API contract type from `frontend/src/lib/api.ts`.
- Resolves the Fallow duplicate export warning for `RateWeightBreak`.

## Safety / Non-goals

No changes were made to:

- Quote calculation logic
- SPOT trigger logic
- Pricing/rate calculation logic
- Service scope logic
- RBAC/security logic
- FX, CAF, or margin logic
- Rate Manager UI behavior

## Verification

- `npm run lint` passed
- `npm run build` passed
- `npm run typecheck` passed
- `npx fallow dead-code` rerun; duplicate export warning is gone, remaining issues are pre-existing unused exports/types/dev dependency.

## Notes

No generated Fallow reports, graphify output, task logs, or audit docs were committed.