### PR TITLE
refactor(pricing): extract shared rate manager page components

### DIFF
--- a/frontend/src/components/pricing/rate-manager/LaneRateManagerPage.tsx
+++ b/frontend/src/components/pricing/rate-manager/LaneRateManagerPage.tsx
@@ -1,13 +1,10 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import Link from 'next/link';
-import { PlusCircle, RefreshCw } from 'lucide-react';
 import { PageHeader, StandardPageContainer } from '@/components/layout/standard-page';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Badge } from '@/components/ui/badge';
 import {
   Select,
   SelectContent,
@@ -40,6 +37,7 @@ import {
 import LaneRateFormModal from './LaneRateFormModal';
 import RateHistorySheet from './RateHistorySheet';
 import { getRateStatus } from '@/lib/pricing/rate-utils';
+import { RateManagerLifecycleNotice, RateManagerToolbar, RateStatusBadge } from './shared-page-components';
 
 type ModalState<T extends LaneRateRecord | LaneCOGSRateRecord> =
   | { mode: 'create'; rate: T | null }
@@ -65,18 +63,6 @@ interface LaneRateManagerPageProps<T extends LaneRateRecord | LaneCOGSRateRecord
   reviseRate: (id: number | string, payload: LaneRateUpsertPayload & RateRevisionOptions) => Promise<T>;
   retireRate: (id: number | string) => Promise<{ deleted?: boolean; detail?: string } | T>;
   loadHistory: (id: number | string) => Promise<RateChangeLogEntry[]>;
-}
-
-
-
-function statusBadge(status: 'ACTIVE' | 'EXPIRED' | 'SCHEDULED') {
-  if (status === 'ACTIVE') {
-    return <Badge className="border-emerald-200 bg-emerald-50 text-emerald-700">Active</Badge>;
-  }
-  if (status === 'SCHEDULED') {
-    return <Badge className="border-blue-200 bg-blue-50 text-blue-700">Scheduled</Badge>;
-  }
-  return <Badge variant="outline" className="border-slate-300 text-slate-600">Expired</Badge>;
 }
 
 export default function LaneRateManagerPage<T extends LaneRateRecord | LaneCOGSRateRecord>({
@@ -198,28 +184,14 @@ export default function LaneRateManagerPage<T extends LaneRateRecord | LaneCOGSR
     <StandardPageContainer>
       <PageHeader title={title} description={description} />
 
-      <div className="flex flex-wrap gap-3">
-        <Button onClick={() => setModalState({ mode: 'create', rate: null })}>
-          <PlusCircle className="mr-2 h-4 w-4" />
-          Add {pathLabel}
-        </Button>
-        <Button variant="outline" onClick={() => void loadRates()} disabled={loading}>
-          <RefreshCw className="mr-2 h-4 w-4" />
-          Refresh
-        </Button>
-        <Button variant="outline" asChild>
-          <Link href="/pricing/manage">All Rate Managers</Link>
-        </Button>
-        <Button variant="outline" asChild>
-          <Link href="/pricing/rate-cards">Back To Rate Overview</Link>
-        </Button>
-      </div>
+      <RateManagerToolbar
+        pathLabel={pathLabel}
+        loading={loading}
+        onAdd={() => setModalState({ mode: 'create', rate: null })}
+        onRefresh={() => void loadRates()}
+      />
 
-      <Alert>
-        <AlertDescription>
-          Use <span className="font-medium">New Effective Rate</span> for active rows whenever possible. Direct edits are available for corrections, but the preferred workflow is to create a new effective-dated row.
-        </AlertDescription>
-      </Alert>
+      <RateManagerLifecycleNotice />
 
       <Card className="border-slate-200 shadow-sm">
         <CardHeader className="gap-4">
@@ -313,7 +285,7 @@ export default function LaneRateManagerPage<T extends LaneRateRecord | LaneCOGSR
 
                   return (
                     <TableRow key={rate.id}>
-                      <TableCell>{statusBadge(status)}</TableCell>
+                      <TableCell><RateStatusBadge status={status} /></TableCell>
                       <TableCell>
                         <div className="font-medium">{rate.product_code_code}</div>
                         <div className="text-xs text-muted-foreground">{rate.product_code_description}</div>

--- a/frontend/src/components/pricing/rate-manager/LocalRateManagerPage.tsx
+++ b/frontend/src/components/pricing/rate-manager/LocalRateManagerPage.tsx
@@ -1,13 +1,10 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import Link from 'next/link';
-import { PlusCircle, RefreshCw } from 'lucide-react';
 import { PageHeader, StandardPageContainer } from '@/components/layout/standard-page';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Badge } from '@/components/ui/badge';
 import {
   Select,
   SelectContent,
@@ -40,6 +37,7 @@ import {
 import LocalRateFormModal from './LocalRateFormModal';
 import RateHistorySheet from './RateHistorySheet';
 import { getRateStatus } from '@/lib/pricing/rate-utils';
+import { RateManagerLifecycleNotice, RateManagerToolbar, RateStatusBadge } from './shared-page-components';
 
 type ModalState<T extends LocalRateRecord | LocalCOGSRateRecord> =
   | { mode: 'create'; rate: T | null }
@@ -59,18 +57,6 @@ interface LocalRateManagerPageProps<T extends LocalRateRecord | LocalCOGSRateRec
   reviseRate: (id: number | string, payload: LocalRateUpsertPayload & RateRevisionOptions) => Promise<T>;
   retireRate: (id: number | string) => Promise<{ deleted?: boolean; detail?: string } | T>;
   loadHistory: (id: number | string) => Promise<RateChangeLogEntry[]>;
-}
-
-
-
-function statusBadge(status: 'ACTIVE' | 'EXPIRED' | 'SCHEDULED') {
-  if (status === 'ACTIVE') {
-    return <Badge className="border-emerald-200 bg-emerald-50 text-emerald-700">Active</Badge>;
-  }
-  if (status === 'SCHEDULED') {
-    return <Badge className="border-blue-200 bg-blue-50 text-blue-700">Scheduled</Badge>;
-  }
-  return <Badge variant="outline" className="border-slate-300 text-slate-600">Expired</Badge>;
 }
 
 export default function LocalRateManagerPage<T extends LocalRateRecord | LocalCOGSRateRecord>({
@@ -188,28 +174,14 @@ export default function LocalRateManagerPage<T extends LocalRateRecord | LocalCO
     <StandardPageContainer>
       <PageHeader title={title} description={description} />
 
-      <div className="flex flex-wrap gap-3">
-        <Button onClick={() => setModalState({ mode: 'create', rate: null })}>
-          <PlusCircle className="mr-2 h-4 w-4" />
-          Add {pathLabel}
-        </Button>
-        <Button variant="outline" onClick={() => void loadRates()} disabled={loading}>
-          <RefreshCw className="mr-2 h-4 w-4" />
-          Refresh
-        </Button>
-        <Button variant="outline" asChild>
-          <Link href="/pricing/manage">All Rate Managers</Link>
-        </Button>
-        <Button variant="outline" asChild>
-          <Link href="/pricing/rate-cards">Back To Rate Overview</Link>
-        </Button>
-      </div>
+      <RateManagerToolbar
+        pathLabel={pathLabel}
+        loading={loading}
+        onAdd={() => setModalState({ mode: 'create', rate: null })}
+        onRefresh={() => void loadRates()}
+      />
 
-      <Alert>
-        <AlertDescription>
-          Use <span className="font-medium">New Effective Rate</span> for active rows whenever possible. Direct edits are available for corrections, but the preferred workflow is to create a new effective-dated row.
-        </AlertDescription>
-      </Alert>
+      <RateManagerLifecycleNotice />
 
       <Card className="border-slate-200 shadow-sm">
         <CardHeader className="gap-4">
@@ -316,7 +288,7 @@ export default function LocalRateManagerPage<T extends LocalRateRecord | LocalCO
 
                   return (
                     <TableRow key={rate.id}>
-                      <TableCell>{statusBadge(status)}</TableCell>
+                      <TableCell><RateStatusBadge status={status} /></TableCell>
                       <TableCell>
                         <div className="font-medium">{rate.product_code_code}</div>
                         <div className="text-xs text-muted-foreground">{rate.product_code_description}</div>

--- a/frontend/src/components/pricing/rate-manager/shared-page-components.tsx
+++ b/frontend/src/components/pricing/rate-manager/shared-page-components.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import Link from 'next/link';
+import { PlusCircle, RefreshCw } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+
+export type RateStatus = 'ACTIVE' | 'EXPIRED' | 'SCHEDULED';
+
+export function RateStatusBadge({ status }: { status: RateStatus }) {
+  if (status === 'ACTIVE') {
+    return <Badge className="border-emerald-200 bg-emerald-50 text-emerald-700">Active</Badge>;
+  }
+  if (status === 'SCHEDULED') {
+    return <Badge className="border-blue-200 bg-blue-50 text-blue-700">Scheduled</Badge>;
+  }
+  return <Badge variant="outline" className="border-slate-300 text-slate-600">Expired</Badge>;
+}
+
+export function RateManagerToolbar({
+  pathLabel,
+  loading,
+  onAdd,
+  onRefresh,
+}: {
+  pathLabel: string;
+  loading: boolean;
+  onAdd: () => void;
+  onRefresh: () => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-3">
+      <Button onClick={onAdd}>
+        <PlusCircle className="mr-2 h-4 w-4" />
+        Add {pathLabel}
+      </Button>
+      <Button variant="outline" onClick={onRefresh} disabled={loading}>
+        <RefreshCw className="mr-2 h-4 w-4" />
+        Refresh
+      </Button>
+      <Button variant="outline" asChild>
+        <Link href="/pricing/manage">All Rate Managers</Link>
+      </Button>
+      <Button variant="outline" asChild>
+        <Link href="/pricing/rate-cards">Back To Rate Overview</Link>
+      </Button>
+    </div>
+  );
+}
+
+export function RateManagerLifecycleNotice() {
+  return (
+    <Alert>
+      <AlertDescription>
+        Use <span className="font-medium">New Effective Rate</span> for active rows whenever possible. Direct edits are available for corrections, but the preferred workflow is to create a new effective-dated row.
+      </AlertDescription>
+    </Alert>
+  );
+}


### PR DESCRIPTION
## Summary

- Extracted shared page-level Rate Manager components.
- Reused shared components across Lane and Local Rate Manager pages.
- Removed duplicated presentational/page UI code while keeping business logic separate.

## Extracted Components

- `RateStatusBadge`
- `RateManagerToolbar`
- `RateManagerLifecycleNotice`

## Safety / Non-goals

No changes were made to:

- Lane or Local Rate form modals
- Pricing/rate calculation logic
- Quote calculation logic
- SPOT trigger logic
- Service scope logic
- API contracts or payload structures
- Backend code
- CRM duplication

## Verification

- `npm run lint` passed
- `npm run build` passed
- `npm run typecheck` passed
- `npx fallow dupes` passed with remaining duplication expected

## Notes

The previous large page-level clone between `LaneRateManagerPage.tsx` and `LocalRateManagerPage.tsx` was removed. The larger form modal duplication remains intentionally untouched for a later phase.