### PR TITLE
refactor(pricing): extract shared rate row actions

### DIFF
--- a/frontend/src/components/pricing/rate-manager/LaneRateManagerPage.tsx
+++ b/frontend/src/components/pricing/rate-manager/LaneRateManagerPage.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { PageHeader, StandardPageContainer } from '@/components/layout/standard-page';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
   Select,
@@ -37,7 +36,7 @@ import {
 import LaneRateFormModal from './LaneRateFormModal';
 import RateHistorySheet from './RateHistorySheet';
 import { getRateStatus } from '@/lib/pricing/rate-utils';
-import { RateManagerLifecycleNotice, RateManagerToolbar, RateStatusBadge } from './shared-page-components';
+import { RateManagerLifecycleNotice, RateManagerToolbar, RateRowActions, RateStatusBadge } from './shared-page-components';
 
 type ModalState<T extends LaneRateRecord | LaneCOGSRateRecord> =
   | { mode: 'create'; rate: T | null }
@@ -308,25 +307,14 @@ export default function LaneRateManagerPage<T extends LaneRateRecord | LaneCOGSR
                         </div>
                       </TableCell>
                       <TableCell className="text-right">
-                        <div className="flex justify-end gap-2">
-                          <Button variant="outline" size="sm" onClick={() => setHistoryRate(rate)}>
-                            History
-                          </Button>
-                          <Button variant="outline" size="sm" onClick={() => setModalState({ mode: 'revise', rate })}>
-                            New Effective Rate
-                          </Button>
-                          <Button variant="outline" size="sm" onClick={() => setModalState({ mode: 'edit', rate })}>
-                            Edit
-                          </Button>
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => void handleRetire(rate)}
-                            disabled={activeActionId === rate.id}
-                          >
-                            {activeActionId === rate.id ? 'Retiring...' : 'Retire'}
-                          </Button>
-                        </div>
+                        <RateRowActions
+                          rate={rate}
+                          isRetiring={activeActionId === rate.id}
+                          onHistory={setHistoryRate}
+                          onRevise={(selectedRate) => setModalState({ mode: 'revise', rate: selectedRate })}
+                          onEdit={(selectedRate) => setModalState({ mode: 'edit', rate: selectedRate })}
+                          onRetire={(selectedRate) => void handleRetire(selectedRate)}
+                        />
                       </TableCell>
                     </TableRow>
                   );

--- a/frontend/src/components/pricing/rate-manager/LocalRateManagerPage.tsx
+++ b/frontend/src/components/pricing/rate-manager/LocalRateManagerPage.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { PageHeader, StandardPageContainer } from '@/components/layout/standard-page';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
   Select,
@@ -37,7 +36,7 @@ import {
 import LocalRateFormModal from './LocalRateFormModal';
 import RateHistorySheet from './RateHistorySheet';
 import { getRateStatus } from '@/lib/pricing/rate-utils';
-import { RateManagerLifecycleNotice, RateManagerToolbar, RateStatusBadge } from './shared-page-components';
+import { RateManagerLifecycleNotice, RateManagerToolbar, RateRowActions, RateStatusBadge } from './shared-page-components';
 
 type ModalState<T extends LocalRateRecord | LocalCOGSRateRecord> =
   | { mode: 'create'; rate: T | null }
@@ -307,25 +306,14 @@ export default function LocalRateManagerPage<T extends LocalRateRecord | LocalCO
                         <div className="text-xs text-muted-foreground">to {rate.valid_until}</div>
                       </TableCell>
                       <TableCell className="text-right">
-                        <div className="flex justify-end gap-2">
-                          <Button variant="outline" size="sm" onClick={() => setHistoryRate(rate)}>
-                            History
-                          </Button>
-                          <Button variant="outline" size="sm" onClick={() => setModalState({ mode: 'revise', rate })}>
-                            New Effective Rate
-                          </Button>
-                          <Button variant="outline" size="sm" onClick={() => setModalState({ mode: 'edit', rate })}>
-                            Edit
-                          </Button>
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => void handleRetire(rate)}
-                            disabled={activeActionId === rate.id}
-                          >
-                            {activeActionId === rate.id ? 'Retiring...' : 'Retire'}
-                          </Button>
-                        </div>
+                        <RateRowActions
+                          rate={rate}
+                          isRetiring={activeActionId === rate.id}
+                          onHistory={setHistoryRate}
+                          onRevise={(selectedRate) => setModalState({ mode: 'revise', rate: selectedRate })}
+                          onEdit={(selectedRate) => setModalState({ mode: 'edit', rate: selectedRate })}
+                          onRetire={(selectedRate) => void handleRetire(selectedRate)}
+                        />
                       </TableCell>
                     </TableRow>
                   );

--- a/frontend/src/components/pricing/rate-manager/shared-page-components.tsx
+++ b/frontend/src/components/pricing/rate-manager/shared-page-components.tsx
@@ -58,3 +58,36 @@ export function RateManagerLifecycleNotice() {
     </Alert>
   );
 }
+
+export function RateRowActions<T>({
+  rate,
+  isRetiring,
+  onHistory,
+  onRevise,
+  onEdit,
+  onRetire,
+}: {
+  rate: T;
+  isRetiring: boolean;
+  onHistory: (rate: T) => void;
+  onRevise: (rate: T) => void;
+  onEdit: (rate: T) => void;
+  onRetire: (rate: T) => void;
+}) {
+  return (
+    <div className="flex justify-end gap-2">
+      <Button variant="outline" size="sm" onClick={() => onHistory(rate)}>
+        History
+      </Button>
+      <Button variant="outline" size="sm" onClick={() => onRevise(rate)}>
+        New Effective Rate
+      </Button>
+      <Button variant="outline" size="sm" onClick={() => onEdit(rate)}>
+        Edit
+      </Button>
+      <Button variant="outline" size="sm" onClick={() => onRetire(rate)} disabled={isRetiring}>
+        {isRetiring ? 'Retiring...' : 'Retire'}
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Extracted repeated Rate Manager row action buttons into a shared `RateRowActions` component.
- Reused the shared action component in both Lane and Local Rate Manager pages.
- Reduced duplicated page-level JSX while keeping callback ownership in each page.

## Extracted Component

- `RateRowActions`

## Safety / Non-goals

No changes were made to:

- Lane or Local Rate form modals
- Filters or table structure
- Modal state definitions
- Retire logic
- API calls or payloads
- Pricing/rate calculation logic
- Quote calculation logic
- SPOT trigger logic
- Backend code
- CRM code

## Verification

- `npm run lint` passed
- `npm run build` passed
- `npm run typecheck` passed
- `npx fallow dupes` passed with remaining duplication expected

## Notes

This is a tiny follow-up to Phase 6A. It only moves the repeated History / New Effective Rate / Edit / Retire button JSX into a shared component.