### PR TITLE
refactor(pricing): extract shared rate form basic sections

### DIFF
--- a/frontend/src/components/pricing/rate-manager/LaneRateFormModal.tsx
+++ b/frontend/src/components/pricing/rate-manager/LaneRateFormModal.tsx
@@ -5,7 +5,6 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
@@ -20,7 +19,6 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Checkbox } from '@/components/ui/checkbox';
 import { useToast } from '@/context/toast-context';
 import {
   getProductCodes,
@@ -35,6 +33,12 @@ import {
   type RateRevisionOptions,
 } from '@/lib/api';
 import { isoDateWithOffset, cleanWeightBreaks } from '@/lib/pricing/rate-utils';
+import {
+  RateFormFooter,
+  RateFormRevisionNotice,
+  RateRetirePreviousOption,
+  RateValidityFields,
+} from './shared-form-sections';
 type FormMode = 'create' | 'edit' | 'revise';
 type CounterpartyType = 'agent' | 'carrier';
 type PricingMode = 'PER_KG' | 'PER_SHIPMENT' | 'ADDITIVE' | 'PERCENT' | 'WEIGHT_BREAKS';
@@ -307,13 +311,7 @@ export default function LaneRateFormModal<T extends LaneRecord>({
         </DialogHeader>
 
         <div className="space-y-4 py-2">
-          {initialRate?.is_active && isRevision ? (
-            <Alert>
-              <AlertDescription>
-                This revision is prefilled from the selected row. Save it as a new effective-dated rate instead of overwriting the current one.
-              </AlertDescription>
-            </Alert>
-          ) : null}
+          {initialRate?.is_active && isRevision ? <RateFormRevisionNotice /> : null}
 
           {formError ? (
             <Alert variant="destructive">
@@ -481,44 +479,29 @@ export default function LaneRateFormModal<T extends LaneRecord>({
             </div>
           </div>
 
-          <div className="grid gap-4 md:grid-cols-2">
-            <div className="space-y-2">
-              <Label>Valid From</Label>
-              <Input type="date" value={validFrom} onChange={(event) => setValidFrom(event.target.value)} />
-            </div>
-            <div className="space-y-2">
-              <Label>Valid Until</Label>
-              <Input type="date" value={validUntil} onChange={(event) => setValidUntil(event.target.value)} />
-            </div>
-          </div>
+          <RateValidityFields
+            validFrom={validFrom}
+            validUntil={validUntil}
+            onValidFromChange={setValidFrom}
+            onValidUntilChange={setValidUntil}
+          />
 
           {isRevision ? (
-            <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
-              <div className="flex items-start gap-3">
-                <Checkbox
-                  id="lane-retire-previous"
-                  checked={retirePrevious}
-                  onCheckedChange={(checked) => setRetirePrevious(Boolean(checked))}
-                />
-                <div className="space-y-1">
-                  <Label htmlFor="lane-retire-previous">Auto-retire the prior row</Label>
-                  <div className="text-sm text-muted-foreground">
-                    Recommended. When enabled, the current row will end the day before the new revision starts.
-                  </div>
-                </div>
-              </div>
-            </div>
+            <RateRetirePreviousOption
+              id="lane-retire-previous"
+              checked={retirePrevious}
+              onCheckedChange={(checked) => setRetirePrevious(Boolean(checked))}
+            />
           ) : null}
         </div>
 
-        <DialogFooter>
-          <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
-            Cancel
-          </Button>
-          <Button type="button" onClick={handleSubmit} disabled={saving || loadingOptions}>
-            {saving ? 'Saving...' : isEditing ? 'Save Changes' : isRevision ? 'Create Revision' : 'Create Rate'}
-          </Button>
-        </DialogFooter>
+        <RateFormFooter
+          saving={saving}
+          loadingOptions={loadingOptions}
+          submitLabel={saving ? 'Saving...' : isEditing ? 'Save Changes' : isRevision ? 'Create Revision' : 'Create Rate'}
+          onCancel={() => onOpenChange(false)}
+          onSubmit={handleSubmit}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/components/pricing/rate-manager/LocalRateFormModal.tsx
+++ b/frontend/src/components/pricing/rate-manager/LocalRateFormModal.tsx
@@ -5,7 +5,6 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
@@ -20,7 +19,6 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Checkbox } from '@/components/ui/checkbox';
 import { useToast } from '@/context/toast-context';
 import {
   getProductCodes,
@@ -35,6 +33,12 @@ import {
   type RateRevisionOptions,
 } from '@/lib/api';
 import { isoDateWithOffset, cleanWeightBreaks } from '@/lib/pricing/rate-utils';
+import {
+  RateFormFooter,
+  RateFormRevisionNotice,
+  RateRetirePreviousOption,
+  RateValidityFields,
+} from './shared-form-sections';
 
 type FormMode = 'create' | 'edit' | 'revise';
 type CounterpartyType = 'agent' | 'carrier';
@@ -274,13 +278,7 @@ export default function LocalRateFormModal<T extends LocalRateRecord | LocalCOGS
         </DialogHeader>
 
         <div className="space-y-4 py-2">
-          {initialRate?.is_active && isRevision ? (
-            <Alert>
-              <AlertDescription>
-                This revision is prefilled from the selected row. Save it as a new effective-dated rate instead of overwriting the current one.
-              </AlertDescription>
-            </Alert>
-          ) : null}
+          {initialRate?.is_active && isRevision ? <RateFormRevisionNotice /> : null}
 
           {formError ? (
             <Alert variant="destructive">
@@ -491,44 +489,29 @@ export default function LocalRateFormModal<T extends LocalRateRecord | LocalCOGS
             </div>
           </div>
 
-          <div className="grid gap-4 md:grid-cols-2">
-            <div className="space-y-2">
-              <Label>Valid From</Label>
-              <Input type="date" value={validFrom} onChange={(event) => setValidFrom(event.target.value)} />
-            </div>
-            <div className="space-y-2">
-              <Label>Valid Until</Label>
-              <Input type="date" value={validUntil} onChange={(event) => setValidUntil(event.target.value)} />
-            </div>
-          </div>
+          <RateValidityFields
+            validFrom={validFrom}
+            validUntil={validUntil}
+            onValidFromChange={setValidFrom}
+            onValidUntilChange={setValidUntil}
+          />
 
           {isRevision ? (
-            <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
-              <div className="flex items-start gap-3">
-                <Checkbox
-                  id="local-retire-previous"
-                  checked={retirePrevious}
-                  onCheckedChange={(checked) => setRetirePrevious(Boolean(checked))}
-                />
-                <div className="space-y-1">
-                  <Label htmlFor="local-retire-previous">Auto-retire the prior row</Label>
-                  <div className="text-sm text-muted-foreground">
-                    Recommended. When enabled, the current row will end the day before the new revision starts.
-                  </div>
-                </div>
-              </div>
-            </div>
+            <RateRetirePreviousOption
+              id="local-retire-previous"
+              checked={retirePrevious}
+              onCheckedChange={(checked) => setRetirePrevious(Boolean(checked))}
+            />
           ) : null}
         </div>
 
-        <DialogFooter>
-          <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
-            Cancel
-          </Button>
-          <Button type="button" onClick={handleSubmit} disabled={saving || loadingOptions}>
-            {saving ? 'Saving...' : isEditing ? 'Save Changes' : isRevision ? 'Create Revision' : 'Create Rate'}
-          </Button>
-        </DialogFooter>
+        <RateFormFooter
+          saving={saving}
+          loadingOptions={loadingOptions}
+          submitLabel={saving ? 'Saving...' : isEditing ? 'Save Changes' : isRevision ? 'Create Revision' : 'Create Rate'}
+          onCancel={() => onOpenChange(false)}
+          onSubmit={handleSubmit}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/components/pricing/rate-manager/shared-form-sections.tsx
+++ b/frontend/src/components/pricing/rate-manager/shared-form-sections.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { DialogFooter } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+export function RateFormRevisionNotice() {
+  return (
+    <Alert>
+      <AlertDescription>
+        This revision is prefilled from the selected row. Save it as a new effective-dated rate instead of overwriting the current one.
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+export function RateRetirePreviousOption({
+  id,
+  checked,
+  onCheckedChange,
+}: {
+  id: string;
+  checked: boolean;
+  onCheckedChange: (checked: boolean | 'indeterminate') => void;
+}) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
+      <div className="flex items-start gap-3">
+        <Checkbox id={id} checked={checked} onCheckedChange={onCheckedChange} />
+        <div className="space-y-1">
+          <Label htmlFor={id}>Auto-retire the prior row</Label>
+          <div className="text-sm text-muted-foreground">
+            Recommended. When enabled, the current row will end the day before the new revision starts.
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function RateValidityFields({
+  validFrom,
+  validUntil,
+  onValidFromChange,
+  onValidUntilChange,
+}: {
+  validFrom: string;
+  validUntil: string;
+  onValidFromChange: (value: string) => void;
+  onValidUntilChange: (value: string) => void;
+}) {
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <div className="space-y-2">
+        <Label>Valid From</Label>
+        <Input type="date" value={validFrom} onChange={(event) => onValidFromChange(event.target.value)} />
+      </div>
+      <div className="space-y-2">
+        <Label>Valid Until</Label>
+        <Input type="date" value={validUntil} onChange={(event) => onValidUntilChange(event.target.value)} />
+      </div>
+    </div>
+  );
+}
+
+export function RateFormFooter({
+  saving,
+  loadingOptions,
+  submitLabel,
+  onCancel,
+  onSubmit,
+}: {
+  saving: boolean;
+  loadingOptions: boolean;
+  submitLabel: string;
+  onCancel: () => void;
+  onSubmit: () => void;
+}) {
+  return (
+    <DialogFooter>
+      <Button type="button" variant="outline" onClick={onCancel} disabled={saving}>
+        Cancel
+      </Button>
+      <Button type="button" onClick={onSubmit} disabled={saving || loadingOptions}>
+        {submitLabel}
+      </Button>
+    </DialogFooter>
+  );
+}


### PR DESCRIPTION
## Summary

- Extracted low-risk shared form UI sections from Lane and Local Rate form modals.
- Added `shared-form-sections.tsx` for repeated modal sections.
- Kept modal state, validation, payload construction, submit handlers, API calls, and lane/local-specific fields in the parent modal files.

## Extracted Components

- `RateFormRevisionNotice`
- `RateRetirePreviousOption`
- `RateValidityFields`
- `RateFormFooter`

## Safety / Non-goals

No changes were made to:

- Payload construction
- Submit handlers
- Create/edit/revise branching
- Validation logic
- API calls
- Async option loading
- Product selectors
- Route/location fields
- Pricing/rate calculation logic
- Quote logic
- SPOT logic
- Backend code
- CRM code

## Verification

- `npm run lint` passed
- `npm run build` passed
- `npm run typecheck` passed
- `npx fallow dupes` passed with remaining duplication expected

## Notes

This is the first low-risk modal consolidation slice. The larger weight break editor, counterparty selector, and modal payload/submission logic remain intentionally untouched.