### PR TITLE
refactor(pricing): extract shared rate charge bounds fields

### DIFF
--- a/frontend/src/components/pricing/rate-manager/LaneRateFormModal.tsx
+++ b/frontend/src/components/pricing/rate-manager/LaneRateFormModal.tsx
@@ -34,6 +34,7 @@ import {
 } from '@/lib/api';
 import { isoDateWithOffset, cleanWeightBreaks } from '@/lib/pricing/rate-utils';
 import {
+  RateChargeBoundsFields,
   RateFormFooter,
   RateFormRevisionNotice,
   RateRetirePreviousOption,
@@ -468,16 +469,12 @@ export default function LaneRateFormModal<T extends LaneRecord>({
             </div>
           ) : null}
 
-          <div className="grid gap-4 md:grid-cols-2">
-            <div className="space-y-2">
-              <Label>Minimum Charge</Label>
-              <Input value={minCharge} onChange={(event) => setMinCharge(event.target.value)} placeholder="Optional" />
-            </div>
-            <div className="space-y-2">
-              <Label>Maximum Charge</Label>
-              <Input value={maxCharge} onChange={(event) => setMaxCharge(event.target.value)} placeholder="Optional" />
-            </div>
-          </div>
+          <RateChargeBoundsFields
+            minCharge={minCharge}
+            maxCharge={maxCharge}
+            onMinChargeChange={setMinCharge}
+            onMaxChargeChange={setMaxCharge}
+          />
 
           <RateValidityFields
             validFrom={validFrom}

--- a/frontend/src/components/pricing/rate-manager/LocalRateFormModal.tsx
+++ b/frontend/src/components/pricing/rate-manager/LocalRateFormModal.tsx
@@ -34,6 +34,7 @@ import {
 } from '@/lib/api';
 import { isoDateWithOffset, cleanWeightBreaks } from '@/lib/pricing/rate-utils';
 import {
+  RateChargeBoundsFields,
   RateFormFooter,
   RateFormRevisionNotice,
   RateRetirePreviousOption,
@@ -478,16 +479,12 @@ export default function LocalRateFormModal<T extends LocalRateRecord | LocalCOGS
             </div>
           ) : null}
 
-          <div className="grid gap-4 md:grid-cols-2">
-            <div className="space-y-2">
-              <Label>Minimum Charge</Label>
-              <Input value={minCharge} onChange={(event) => setMinCharge(event.target.value)} placeholder="Optional" />
-            </div>
-            <div className="space-y-2">
-              <Label>Maximum Charge</Label>
-              <Input value={maxCharge} onChange={(event) => setMaxCharge(event.target.value)} placeholder="Optional" />
-            </div>
-          </div>
+          <RateChargeBoundsFields
+            minCharge={minCharge}
+            maxCharge={maxCharge}
+            onMinChargeChange={setMinCharge}
+            onMaxChargeChange={setMaxCharge}
+          />
 
           <RateValidityFields
             validFrom={validFrom}

--- a/frontend/src/components/pricing/rate-manager/shared-form-sections.tsx
+++ b/frontend/src/components/pricing/rate-manager/shared-form-sections.tsx
@@ -66,6 +66,31 @@ export function RateValidityFields({
   );
 }
 
+export function RateChargeBoundsFields({
+  minCharge,
+  maxCharge,
+  onMinChargeChange,
+  onMaxChargeChange,
+}: {
+  minCharge: string;
+  maxCharge: string;
+  onMinChargeChange: (value: string) => void;
+  onMaxChargeChange: (value: string) => void;
+}) {
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <div className="space-y-2">
+        <Label>Minimum Charge</Label>
+        <Input value={minCharge} onChange={(event) => onMinChargeChange(event.target.value)} placeholder="Optional" />
+      </div>
+      <div className="space-y-2">
+        <Label>Maximum Charge</Label>
+        <Input value={maxCharge} onChange={(event) => onMaxChargeChange(event.target.value)} placeholder="Optional" />
+      </div>
+    </div>
+  );
+}
+
 export function RateFormFooter({
   saving,
   loadingOptions,


### PR DESCRIPTION
## Summary

- Extracted the shared Minimum Charge / Maximum Charge form section into `RateChargeBoundsFields`.
- Reused the shared component in both Lane and Local Rate form modals.
- Kept `minCharge` and `maxCharge` state parent-owned in each modal.

## Safety / Non-goals

No changes were made to:

- Weight break editor
- Counterparty selector
- Submit handlers
- Payload construction
- Validation logic
- API calls
- Async option loading
- Product selectors
- Route/location fields
- Pricing/rate calculation logic
- Quote logic
- SPOT logic
- Backend code
- CRM code
- Manager page files

## Verification

- `npm run lint` passed
- `npm run build` passed
- `npm run typecheck` passed
- `npx fallow dupes` passed with remaining duplication expected

## Notes

This is the low-risk Phase 6B.2a modal consolidation slice. Weight break editor extraction remains intentionally deferred.