### PR TITLE
refactor(pricing): extract shared rate weight break editor

### DIFF
--- a/frontend/src/components/pricing/rate-manager/LaneRateFormModal.tsx
+++ b/frontend/src/components/pricing/rate-manager/LaneRateFormModal.tsx
@@ -8,7 +8,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
@@ -39,6 +38,7 @@ import {
   RateFormRevisionNotice,
   RateRetirePreviousOption,
   RateValidityFields,
+  RateWeightBreakEditor,
 } from './shared-form-sections';
 type FormMode = 'create' | 'edit' | 'revise';
 type CounterpartyType = 'agent' | 'carrier';
@@ -439,34 +439,13 @@ export default function LaneRateFormModal<T extends LaneRecord>({
           ) : null}
 
           {pricingMode === 'WEIGHT_BREAKS' ? (
-            <div className="space-y-3 rounded-lg border p-4">
-              <div className="flex items-center justify-between">
-                <div>
-                  <div className="font-medium">Weight Breaks</div>
-                  <div className="text-sm text-muted-foreground">Enter ascending `min_kg` tiers with one rate per tier.</div>
-                </div>
-                <Button type="button" variant="outline" size="sm" onClick={addWeightBreak}>
-                  Add Tier
-                </Button>
-              </div>
-              {weightBreaks.map((row, index) => (
-                <div key={`${index}-${row.min_kg}-${row.rate}`} className="grid gap-3 md:grid-cols-[1fr_1fr_auto]">
-                  <Input
-                    value={row.min_kg}
-                    onChange={(event) => updateWeightBreak(index, 'min_kg', event.target.value)}
-                    placeholder="Min KG"
-                  />
-                  <Input
-                    value={row.rate}
-                    onChange={(event) => updateWeightBreak(index, 'rate', event.target.value)}
-                    placeholder="Rate"
-                  />
-                  <Button type="button" variant="ghost" onClick={() => removeWeightBreak(index)}>
-                    Remove
-                  </Button>
-                </div>
-              ))}
-            </div>
+            <RateWeightBreakEditor
+              weightBreaks={weightBreaks}
+              helperText="Enter ascending `min_kg` tiers with one rate per tier."
+              onAddWeightBreak={addWeightBreak}
+              onUpdateWeightBreak={updateWeightBreak}
+              onRemoveWeightBreak={removeWeightBreak}
+            />
           ) : null}
 
           <RateChargeBoundsFields

--- a/frontend/src/components/pricing/rate-manager/LocalRateFormModal.tsx
+++ b/frontend/src/components/pricing/rate-manager/LocalRateFormModal.tsx
@@ -8,7 +8,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
@@ -39,6 +38,7 @@ import {
   RateFormRevisionNotice,
   RateRetirePreviousOption,
   RateValidityFields,
+  RateWeightBreakEditor,
 } from './shared-form-sections';
 
 type FormMode = 'create' | 'edit' | 'revise';
@@ -449,34 +449,13 @@ export default function LocalRateFormModal<T extends LocalRateRecord | LocalCOGS
           ) : null}
 
           {rateType === 'PER_KG' ? (
-            <div className="space-y-3 rounded-lg border p-4">
-              <div className="flex items-center justify-between">
-                <div>
-                  <div className="font-medium">Weight Breaks</div>
-                  <div className="text-sm text-muted-foreground">Optional. Leave blank if this row is not tiered.</div>
-                </div>
-                <Button type="button" variant="outline" size="sm" onClick={addWeightBreak}>
-                  Add Tier
-                </Button>
-              </div>
-              {weightBreaks.map((row, index) => (
-                <div key={`${index}-${row.min_kg}-${row.rate}`} className="grid gap-3 md:grid-cols-[1fr_1fr_auto]">
-                  <Input
-                    value={row.min_kg}
-                    onChange={(event) => updateWeightBreak(index, 'min_kg', event.target.value)}
-                    placeholder="Min KG"
-                  />
-                  <Input
-                    value={row.rate}
-                    onChange={(event) => updateWeightBreak(index, 'rate', event.target.value)}
-                    placeholder="Rate"
-                  />
-                  <Button type="button" variant="ghost" onClick={() => removeWeightBreak(index)}>
-                    Remove
-                  </Button>
-                </div>
-              ))}
-            </div>
+            <RateWeightBreakEditor
+              weightBreaks={weightBreaks}
+              helperText="Optional. Leave blank if this row is not tiered."
+              onAddWeightBreak={addWeightBreak}
+              onUpdateWeightBreak={updateWeightBreak}
+              onRemoveWeightBreak={removeWeightBreak}
+            />
           ) : null}
 
           <RateChargeBoundsFields

--- a/frontend/src/components/pricing/rate-manager/shared-form-sections.tsx
+++ b/frontend/src/components/pricing/rate-manager/shared-form-sections.tsx
@@ -7,6 +7,11 @@ import { DialogFooter } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
+type RateWeightBreakDraft = {
+  min_kg: string;
+  rate: string;
+};
+
 export function RateFormRevisionNotice() {
   return (
     <Alert>
@@ -87,6 +92,51 @@ export function RateChargeBoundsFields({
         <Label>Maximum Charge</Label>
         <Input value={maxCharge} onChange={(event) => onMaxChargeChange(event.target.value)} placeholder="Optional" />
       </div>
+    </div>
+  );
+}
+
+export function RateWeightBreakEditor({
+  weightBreaks,
+  helperText,
+  onAddWeightBreak,
+  onUpdateWeightBreak,
+  onRemoveWeightBreak,
+}: {
+  weightBreaks: RateWeightBreakDraft[];
+  helperText: string;
+  onAddWeightBreak: () => void;
+  onUpdateWeightBreak: (index: number, field: keyof RateWeightBreakDraft, value: string) => void;
+  onRemoveWeightBreak: (index: number) => void;
+}) {
+  return (
+    <div className="space-y-3 rounded-lg border p-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="font-medium">Weight Breaks</div>
+          <div className="text-sm text-muted-foreground">{helperText}</div>
+        </div>
+        <Button type="button" variant="outline" size="sm" onClick={onAddWeightBreak}>
+          Add Tier
+        </Button>
+      </div>
+      {weightBreaks.map((row, index) => (
+        <div key={`${index}-${row.min_kg}-${row.rate}`} className="grid gap-3 md:grid-cols-[1fr_1fr_auto]">
+          <Input
+            value={row.min_kg}
+            onChange={(event) => onUpdateWeightBreak(index, 'min_kg', event.target.value)}
+            placeholder="Min KG"
+          />
+          <Input
+            value={row.rate}
+            onChange={(event) => onUpdateWeightBreak(index, 'rate', event.target.value)}
+            placeholder="Rate"
+          />
+          <Button type="button" variant="ghost" onClick={() => onRemoveWeightBreak(index)}>
+            Remove
+          </Button>
+        </div>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Extracted the duplicated Weight Break Editor UI into `RateWeightBreakEditor`.
- Reused the shared editor in both Lane and Local Rate form modals.
- Kept weight break state, add/remove/update callbacks, cleanup, submit handlers, and payload construction parent-owned.

## Safety / Non-goals

No changes were made to:

- `cleanWeightBreaks`
- Payload construction
- Submit handlers
- Validation logic
- Create/edit/revise branching
- API calls
- Async option loading
- Product selectors
- Lane/local render conditions
- Route/location fields
- Pricing/rate calculation logic
- Quote logic
- SPOT logic
- Backend code
- CRM code
- Manager page files

## Verification

- `npm run lint` passed
- `npm run build` passed
- `npm run typecheck` passed
- `npx fallow dupes` passed with remaining duplication expected

## Notes

This is the final planned low/moderate-risk Rate Manager modal extraction slice. After this PR, Rate Manager cleanup should pause for a fresh baseline before further refactoring.