### PR TITLE
fix: resolve quote rate dimensions during quote rebuild

### DIFF
--- a/backend/quotes/tests/test_state_machine.py
+++ b/backend/quotes/tests/test_state_machine.py
@@ -7,7 +7,6 @@ Tests for quote lifecycle transitions and edit-blocking functionality.
 
 import pytest
 from decimal import Decimal
-from uuid import uuid4
 from datetime import timedelta
 
 from django.contrib.auth import get_user_model
@@ -18,12 +17,10 @@ from quotes.models import Quote, QuoteVersion, QuoteLine, QuoteTotal
 from quotes.state_machine import (
     QuoteImmutableError,
     QuoteStateMachine,
-    QuoteStateError,
     TERMINAL_STATES,
     assert_quote_mutable_for_action,
     is_quote_editable,
     get_status_display_info,
-    VALID_TRANSITIONS,
     LOCKED_STATES,
 )
 from parties.models import Company, Contact
@@ -156,6 +153,62 @@ def finalized_quote(user, setup_basic_data):
         created_by=user,
     )
     return quote
+
+
+def test_build_quote_input_from_payload_uses_resolved_rate_dimensions(monkeypatch, setup_basic_data):
+    from quotes.services.rate_resolution import ResolvedRateDimensions
+    from quotes.views import lifecycle as lifecycle_views
+
+    captured = {}
+
+    def fake_resolve_quote_rate_dimensions(context):
+        captured['context'] = context
+        return ResolvedRateDimensions(
+            buy_currency='AUD',
+            agent_id=123,
+            carrier_id=None,
+            resolution_basis='test_resolved_dimensions',
+            required_components=('freight',),
+            buy_side_components=('freight',),
+        )
+
+    monkeypatch.setattr(
+        lifecycle_views,
+        'resolve_quote_rate_dimensions',
+        fake_resolve_quote_rate_dimensions,
+    )
+
+    payload = {
+        'customer_id': str(setup_basic_data['customer'].id),
+        'contact_id': str(setup_basic_data['contact'].id),
+        'mode': 'AIR',
+        'service_scope': 'D2D',
+        'origin_location_id': str(setup_basic_data['origin_location'].id),
+        'destination_location_id': str(setup_basic_data['destination_location'].id),
+        'incoterm': 'DAP',
+        'payment_term': 'PREPAID',
+        'dimensions': [
+            {
+                'pieces': 1,
+                'length_cm': '10',
+                'width_cm': '10',
+                'height_cm': '10',
+                'gross_weight_kg': '5',
+                'package_type': 'Box',
+            }
+        ],
+    }
+
+    quote_input, validated = lifecycle_views._build_quote_input_from_payload(payload)
+
+    assert str(validated.customer_id) == str(setup_basic_data['customer'].id)
+    assert quote_input.shipment.shipment_type == 'IMPORT'
+    assert quote_input.buy_currency == 'AUD'
+    assert quote_input.agent_id == 123
+    assert quote_input.carrier_id is None
+    assert captured['context'].origin_airport == setup_basic_data['origin_location'].code
+    assert captured['context'].destination_airport == setup_basic_data['destination_location'].code
+    assert captured['context'].service_scope == 'D2D'
 
 
 # --- State Machine Unit Tests ---

--- a/backend/quotes/views/lifecycle.py
+++ b/backend/quotes/views/lifecycle.py
@@ -1,11 +1,11 @@
 import logging
 import copy
+from datetime import date
 from decimal import Decimal
 from dataclasses import replace
 from typing import Any
 
 from django.db import transaction
-from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from rest_framework import viewsets, status, serializers
@@ -15,7 +15,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.decorators import action
 
-from quotes.models import Quote, QuoteVersion, QuoteLine, QuoteTotal, OverrideNote
+from quotes.models import Quote, QuoteVersion, QuoteLine, QuoteTotal
 from quotes.serializers import (
     CanonicalQuoteResultSerializer,
     QuoteListSerializerV3,
@@ -26,9 +26,13 @@ from quotes.quote_result_contract import (
     build_persisted_quote_total_metadata,
     build_quote_result_from_quote,
 )
+from quotes.services.rate_resolution import (
+    RateResolutionContext,
+    resolve_quote_rate_dimensions,
+)
 from services.models import ServiceComponent
 from pricing_v4.adapter import PricingServiceV4Adapter
-from core.dataclasses import QuoteInput, ManualOverride
+from core.dataclasses import ManualOverride
 
 # RBAC permissions
 from accounts.permissions import (
@@ -208,6 +212,20 @@ def _build_quote_input_from_payload(payload: dict):
         origin_location,
         destination_location,
     )
+    resolved_dimensions = resolve_quote_rate_dimensions(
+        RateResolutionContext(
+            customer_id=validated.customer_id,
+            shipment_type=shipment_type,
+            service_scope=validated.service_scope,
+            payment_term=validated.payment_term,
+            origin_airport=origin_location.code,
+            destination_airport=destination_location.code,
+            quote_date=date.today(),
+            override_buy_currency=validated.buy_currency,
+            override_agent_id=validated.agent_id,
+            override_carrier_id=validated.carrier_id,
+        )
+    )
     
     # We need an instance to call _build_quote_input... or make it static.
     # It accesses `self._location_to_ref`.
@@ -219,6 +237,7 @@ def _build_quote_input_from_payload(payload: dict):
         shipment_type,
         origin_location,
         destination_location,
+        resolved_dimensions,
     )
     return quote_input, validated
 


### PR DESCRIPTION
## Overview
This PR fixes quote rebuild logic so rate dimensions are resolved during rebuild.

## Changes
- Updates the quote lifecycle rebuild path to resolve rate dimensions.
- Adds regression coverage for rebuilt quote input using resolved rate dimensions.

## Verification
Ran locally before branch creation:

```bash
python manage.py test quotes
python manage.py test
```

All tests passed.