### PR TITLE
test(frontend): cover quote edit hydration

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "test:quote-store": "node --experimental-strip-types --experimental-specifier-resolution=node scripts/quote-store.test.mjs",
     "test:quote-workflow": "node scripts/quote-workflow-roundtrip.test.mjs",
     "test:quote-detail-mapping": "node scripts/quote-detail-mapping.test.mjs",
+    "test:quote-edit-hydration": "node scripts/quote-edit-hydration.test.mjs",
     "test:crm-quote-prefill": "node scripts/crm-quote-prefill.test.mjs",
     "test:domestic-service-scope": "node scripts/domestic-service-scope.test.mjs",
     "test:spot-finalization": "node scripts/spot-finalization.test.mjs",

--- a/frontend/scripts/quote-edit-hydration.test.mjs
+++ b/frontend/scripts/quote-edit-hydration.test.mjs
@@ -1,0 +1,313 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import ts from "typescript";
+
+const frontendRoot = path.resolve(process.cwd());
+const helperSourcePath = path.join(frontendRoot, "src", "lib", "quote-edit-hydration.ts");
+const workflowSourcePath = path.join(frontendRoot, "src", "lib", "quote-workflow.ts");
+
+function transpile(source, fileName) {
+  return ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName,
+  }).outputText;
+}
+
+async function loadModules() {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "quote-edit-hydration-test-"));
+  const libDir = path.join(tempDir, "lib");
+  const schemaDir = path.join(libDir, "schemas");
+
+  try {
+    await mkdir(schemaDir, { recursive: true });
+
+    const helperSource = await readFile(helperSourcePath, "utf8");
+    const workflowSource = await readFile(workflowSourcePath, "utf8");
+
+    const helperModule = transpile(helperSource, helperSourcePath)
+      .replace(/from ['"]\.\/schemas\/quoteSchema['"]/g, "from './schemas/quoteSchema.mjs'")
+      .replace(/from ['"]\.\/quote-workflow['"]/g, "from './quote-workflow.mjs'");
+
+    await writeFile(path.join(libDir, "quote-edit-hydration.mjs"), helperModule, "utf8");
+    await writeFile(path.join(libDir, "quote-workflow.mjs"), transpile(workflowSource, workflowSourcePath), "utf8");
+    await writeFile(
+      path.join(schemaDir, "quoteSchema.mjs"),
+      `
+export const V3_LOCATION_TYPES = {
+  AIRPORT: 'AIRPORT',
+  PORT: 'PORT',
+  ADDRESS: 'ADDRESS',
+  CITY: 'CITY',
+};
+
+export const V3_PACKAGE_TYPES = {
+  BOX: 'Box',
+  PALLET: 'Pallet',
+  SKID: 'Skid',
+  CRATE: 'Crate',
+  CARTON: 'Carton',
+  DRUM: 'Drum',
+};
+`,
+      "utf8",
+    );
+
+    const helper = await import(`file://${path.join(libDir, "quote-edit-hydration.mjs")}`);
+    const workflow = await import(`file://${path.join(libDir, "quote-workflow.mjs")}`);
+    return { ...helper, ...workflow };
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+function dimension(overrides = {}) {
+  return {
+    pieces: 2,
+    length_cm: 40,
+    width_cm: 30,
+    height_cm: 20,
+    gross_weight_kg: 25,
+    package_type: "Pallet",
+    ...overrides,
+  };
+}
+
+function payload(overrides = {}) {
+  return {
+    customer_id: "customer-latest",
+    contact_id: "contact-latest",
+    mode: "AIR",
+    incoterm: "EXW",
+    payment_term: "COLLECT",
+    service_scope: "D2D",
+    origin_location_id: "origin-latest",
+    destination_location_id: "destination-latest",
+    dimensions: [dimension()],
+    commodity_code: "DG",
+    is_dangerous_goods: true,
+    ...overrides,
+  };
+}
+
+function latestVersion(overrides = {}) {
+  return {
+    id: "version-1",
+    version_number: 1,
+    status: "DRAFT",
+    created_at: "2026-06-01T00:00:00Z",
+    lines: [],
+    totals: {
+      currency: "PGK",
+      total_sell_fcy: "0.00",
+      total_sell_fcy_incl_gst: "0.00",
+      total_sell_fcy_currency: "PGK",
+      has_missing_rates: false,
+    },
+    payload_json: payload(),
+    ...overrides,
+  };
+}
+
+function quote(overrides = {}) {
+  return {
+    id: "quote-1",
+    quote_number: "DRAFT-1234",
+    customer: {
+      id: "customer-ref",
+      company_name: "Acme Logistics",
+    },
+    contact: {
+      id: "contact-ref",
+      name: "Casey Ng",
+    },
+    mode: "AIR",
+    shipment_type: "IMPORT",
+    incoterm: "EXW",
+    payment_term: "COLLECT",
+    service_scope: "D2D",
+    output_currency: "PGK",
+    origin_location: "BNE - Brisbane Airport",
+    destination_location: "POM - Port Moresby",
+    status: "DRAFT",
+    valid_until: "2026-06-30",
+    created_at: "2026-06-01T00:00:00Z",
+    updated_at: "2026-06-01T01:00:00Z",
+    request_details_json: payload({
+      customer_id: "customer-request",
+      contact_id: "contact-request",
+      payment_term: "PREPAID",
+      service_scope: "A2A",
+      origin_location_id: "origin-request",
+      destination_location_id: "destination-request",
+      commodity_code: "GCR",
+      is_dangerous_goods: false,
+    }),
+    latest_version: latestVersion(),
+    quote_result: null,
+    ...overrides,
+  };
+}
+
+const { hydrateQuoteEditForm, buildQuoteComputePayload } = await loadModules();
+
+{
+  const hydrated = hydrateQuoteEditForm(quote());
+
+  assert.equal(hydrated.formData.customer_id, "customer-latest");
+  assert.equal(hydrated.formData.contact_id, "contact-latest");
+  assert.equal(hydrated.formData.payment_term, "COLLECT");
+  assert.equal(hydrated.formData.service_scope, "D2D");
+  assert.equal(hydrated.formData.origin_location_id, "origin-latest");
+  assert.equal(hydrated.formData.destination_location_id, "destination-latest");
+  assert.equal(hydrated.formData.cargo_type, "Dangerous Goods");
+}
+
+{
+  const hydrated = hydrateQuoteEditForm(
+    quote({
+      latest_version: latestVersion({ payload_json: undefined }),
+    }),
+  );
+
+  assert.equal(hydrated.formData.customer_id, "customer-request");
+  assert.equal(hydrated.formData.contact_id, "contact-request");
+  assert.equal(hydrated.formData.payment_term, "PREPAID");
+  assert.equal(hydrated.formData.service_scope, "A2A");
+  assert.equal(hydrated.formData.origin_location_id, "origin-request");
+  assert.equal(hydrated.formData.destination_location_id, "destination-request");
+  assert.equal(hydrated.formData.cargo_type, "General Cargo");
+}
+
+{
+  const hydrated = hydrateQuoteEditForm(
+    quote({
+      latest_version: latestVersion({
+        payload_json: payload({
+          dimensions: [
+            dimension({
+              pieces: 3,
+              length_cm: 55,
+              width_cm: 44,
+              height_cm: 33,
+              gross_weight_kg: 66,
+              package_type: "Crate",
+            }),
+          ],
+        }),
+      }),
+    }),
+  );
+
+  assert.deepEqual(hydrated.formData.dimensions, [
+    {
+      pieces: 3,
+      length_cm: "55",
+      width_cm: "44",
+      height_cm: "33",
+      gross_weight_kg: "66",
+      package_type: "Crate",
+    },
+  ]);
+}
+
+{
+  const hydrated = hydrateQuoteEditForm(
+    quote({
+      latest_version: latestVersion({
+        payload_json: {
+          customer_id: "customer-nested",
+          contact_id: "contact-nested",
+          shipment: {
+            mode: "AIR",
+            incoterm: "DAP",
+            payment_term: "PREPAID",
+            service_scope: "D2A",
+            commodity_code: "PER",
+            is_dangerous_goods: false,
+            origin_location: { id: "origin-nested" },
+            destination_location: { id: "destination-nested" },
+            pieces: [
+              {
+                pieces: 1,
+                length_cm: "10",
+                width_cm: "20",
+                height_cm: "30",
+                gross_weight_kg: "40",
+                package_type: "Skid",
+              },
+            ],
+          },
+        },
+      }),
+    }),
+  );
+
+  assert.equal(hydrated.formData.customer_id, "customer-nested");
+  assert.equal(hydrated.formData.contact_id, "contact-nested");
+  assert.equal(hydrated.formData.payment_term, "PREPAID");
+  assert.equal(hydrated.formData.service_scope, "D2A");
+  assert.equal(hydrated.formData.incoterm, "DAP");
+  assert.equal(hydrated.formData.origin_location_id, "origin-nested");
+  assert.equal(hydrated.formData.destination_location_id, "destination-nested");
+  assert.equal(hydrated.formData.cargo_type, "Perishable / Cold Chain");
+  assert.deepEqual(hydrated.formData.dimensions, [
+    {
+      pieces: 1,
+      length_cm: "10",
+      width_cm: "20",
+      height_cm: "30",
+      gross_weight_kg: "40",
+      package_type: "Skid",
+    },
+  ]);
+}
+
+{
+  const hydrated = hydrateQuoteEditForm(quote());
+
+  assert.equal(hydrated.initialCustomer?.id, "customer-ref");
+  assert.equal(hydrated.initialCustomer?.name, "Acme Logistics");
+  assert.equal(hydrated.initialOrigin?.id, "origin-latest");
+  assert.equal(hydrated.initialOrigin?.code, "BNE");
+  assert.equal(hydrated.initialDestination?.id, "destination-latest");
+  assert.equal(hydrated.initialDestination?.code, "POM");
+  assert.equal(hydrated.formData.origin_airport, "BNE");
+  assert.equal(hydrated.formData.destination_airport, "POM");
+}
+
+{
+  const sourceQuote = quote({ id: "quote-submit" });
+  const hydrated = hydrateQuoteEditForm(sourceQuote);
+  const submitPayload = buildQuoteComputePayload(hydrated.formData, undefined, sourceQuote.id);
+
+  assert.equal(submitPayload.quote_id, "quote-submit");
+  assert.equal(submitPayload.customer_id, hydrated.formData.customer_id);
+  assert.equal(submitPayload.contact_id, hydrated.formData.contact_id);
+}
+
+{
+  const hydrated = hydrateQuoteEditForm(
+    quote({
+      id: "quote-incomplete",
+      status: "INCOMPLETE",
+      latest_version: latestVersion({
+        status: "INCOMPLETE",
+        payload_json: payload({
+          customer_id: "customer-incomplete",
+          service_scope: "D2D",
+        }),
+      }),
+    }),
+  );
+
+  assert.equal(hydrated.formData.quote_id, "quote-incomplete");
+  assert.equal(hydrated.formData.customer_id, "customer-incomplete");
+  assert.equal(hydrated.formData.service_scope, "D2D");
+}
+
+console.log("quote edit hydration checks passed");

--- a/frontend/src/app/quotes/[id]/edit/page.tsx
+++ b/frontend/src/app/quotes/[id]/edit/page.tsx
@@ -6,8 +6,8 @@ import { useToast } from "@/context/toast-context";
 import { useRouter } from "next/navigation";
 import { getQuoteV3, computeQuoteV3 } from "@/lib/api";
 import { getContactsForCompany } from "@/lib/api/parties";
-import { type QuoteFormSchemaV3, V3_LOCATION_TYPES, V3_PACKAGE_TYPES } from "@/lib/schemas/quoteSchema";
-import { CompanySearchResult, LocationSearchResult, Contact, QuoteContactRef, QuoteCustomerRef, V3DimensionInput } from "@/lib/types";
+import { type QuoteFormSchemaV3 } from "@/lib/schemas/quoteSchema";
+import { CompanySearchResult, LocationSearchResult, Contact } from "@/lib/types";
 import QuoteForm from "@/components/forms/QuoteForm";
 import { MissingRatesModal } from "@/components/pricing/MissingRatesModal";
 import { Loader2 } from "lucide-react";
@@ -17,9 +17,9 @@ import { useUnsavedChangesGuard } from "@/hooks/useUnsavedChangesGuard";
 import { useReturnTo } from "@/hooks/useReturnTo";
 import {
     buildQuoteComputePayload,
-    getCargoTypeForCommodityCode,
     getQuoteMissingRateFlags,
 } from "@/lib/quote-workflow";
+import { hydrateQuoteEditForm } from "@/lib/quote-edit-hydration";
 import {
     Breadcrumb,
     BreadcrumbItem,
@@ -85,123 +85,19 @@ export default function EditQuotePage({ params }: { params: Promise<{ id: string
                     setApiError(message);
                     return;
                 }
-                const payload =
-                    (quote.latest_version?.payload_json as Record<string, unknown> | undefined)
-                    ?? (quote.request_details_json as Record<string, unknown> | undefined);
-                if (!payload) throw new Error("No payload found on quote");
-
-                const shipmentPayload = (
-                    payload.shipment && typeof payload.shipment === "object"
-                        ? (payload.shipment as Record<string, unknown>)
-                        : undefined
-                );
-
-                // 1. Prepare Initial Form Data
-                let dimensions: QuoteFormSchemaV3["dimensions"] = [{
-                    pieces: 1,
-                    length_cm: "",
-                    width_cm: "",
-                    height_cm: "",
-                    gross_weight_kg: "",
-                    package_type: "Box",
-                }];
-
-                const rawDimensions = Array.isArray(payload.dimensions)
-                    ? (payload.dimensions as V3DimensionInput[])
-                    : Array.isArray(shipmentPayload?.pieces)
-                        ? (shipmentPayload.pieces as V3DimensionInput[])
-                        : [];
-
-                if (rawDimensions.length > 0) {
-                    dimensions = rawDimensions.map((d: V3DimensionInput) => ({
-                        pieces: d.pieces,
-                        length_cm: String(d.length_cm),
-                        width_cm: String(d.width_cm),
-                        height_cm: String(d.height_cm),
-                        gross_weight_kg: String(d.gross_weight_kg),
-                        package_type: Object.values(V3_PACKAGE_TYPES).includes(d.package_type as typeof V3_PACKAGE_TYPES[keyof typeof V3_PACKAGE_TYPES])
-                            ? (d.package_type as typeof V3_PACKAGE_TYPES[keyof typeof V3_PACKAGE_TYPES])
-                            : V3_PACKAGE_TYPES.BOX,
-                    }));
-                }
-
-                // Helper to extract airport code from location string (format: "CODE - Name")
-                const extractAirportCode = (locationStr: string | undefined | null): string => {
-                    if (!locationStr) return "";
-                    // Try to extract code from "CODE - Name" format
-                    const match = locationStr.match(/^([A-Z]{3})\s*-/);
-                    if (match) return match[1];
-                    // Fallback: if it's already just a 3-letter code
-                    if (/^[A-Z]{3}$/.test(locationStr.trim())) return locationStr.trim();
-                    return "";
-                };
-
-                // Extract airport codes from API response
-                const originAirportCode = extractAirportCode(quote.origin_location as string);
-                const destinationAirportCode = extractAirportCode(quote.destination_location as string);
-
-                const customerId = String(payload.customer_id || "");
-                const contactId = String(
-                    payload.contact_id
-                    || (quote.contact as QuoteContactRef)?.id
-                    || ""
-                );
-                const originLocationId = String(
-                    payload.origin_location_id
-                    || ((shipmentPayload?.origin_location as Record<string, unknown> | undefined)?.id ?? "")
-                );
-                const destinationLocationId = String(
-                    payload.destination_location_id
-                    || ((shipmentPayload?.destination_location as Record<string, unknown> | undefined)?.id ?? "")
-                );
-                const mode = String(payload.mode || shipmentPayload?.mode || "AIR");
-                const incoterm = String(payload.incoterm || shipmentPayload?.incoterm || "EXW");
-                const paymentTerm = String(payload.payment_term || shipmentPayload?.payment_term || "PREPAID");
-                const serviceScope = String(payload.service_scope || shipmentPayload?.service_scope || "A2A");
-                const commodityCode = String(
-                    payload.commodity_code
-                    || shipmentPayload?.commodity_code
-                    || ""
-                );
-                const isDangerousGoods = Boolean(
-                    payload.is_dangerous_goods
-                    ?? shipmentPayload?.is_dangerous_goods
-                );
-
-                const formData: Partial<QuoteFormSchemaV3> = {
-                    quote_id: quote.id, // Important for tracking updates
-                    customer_id: customerId,
-                    contact_id: contactId,
-                    mode: (mode as QuoteFormSchemaV3['mode']) || "AIR",
-                    incoterm: (incoterm as QuoteFormSchemaV3['incoterm']) || "EXW",
-                    payment_term: (paymentTerm as QuoteFormSchemaV3['payment_term']) || "PREPAID",
-                    service_scope: (serviceScope as QuoteFormSchemaV3['service_scope']) || "A2A",
-                    origin_airport: originAirportCode,
-                    destination_airport: destinationAirportCode,
-                    origin_location_id: originLocationId,
-                    destination_location_id: destinationLocationId,
-                    origin_location_type: V3_LOCATION_TYPES.AIRPORT,
-                    destination_location_type: V3_LOCATION_TYPES.AIRPORT,
-                    cargo_type: getCargoTypeForCommodityCode(commodityCode, isDangerousGoods),
-                    dimensions: dimensions,
-                };
-
-                setInitialData(formData);
+                const hydratedQuote = hydrateQuoteEditForm(quote);
+                setInitialData(hydratedQuote.formData);
 
                 // 2. Hydrate UI State (Customer, Contacts, Locations)
 
                 // Customer
-                if (customerId) {
-                    const custRef = quote.customer as QuoteCustomerRef;
-                    if (custRef && typeof custRef === 'object') {
-                        setInitialCustomer({
-                            id: custRef.id || customerId,
-                            name: custRef.company_name || custRef.name || "Customer",
-                        } as CompanySearchResult);
+                if (hydratedQuote.customerId) {
+                    if (hydratedQuote.initialCustomer) {
+                        setInitialCustomer(hydratedQuote.initialCustomer);
                     }
                     // Fetch contacts!
                     try {
-                        const contacts = await getContactsForCompany(customerId);
+                        const contacts = await getContactsForCompany(hydratedQuote.customerId);
                         setInitialContacts(contacts);
                     } catch (e) {
                         console.error("Failed to fetch contacts", e);
@@ -209,24 +105,12 @@ export default function EditQuotePage({ params }: { params: Promise<{ id: string
                 }
 
                 // Locations
-                if (originLocationId) {
-                    setInitialOrigin({
-                        id: originLocationId,
-                        display_name: quote.origin_location as string || originLocationId,
-                        code: originAirportCode || "ORG",
-                        type: 'AIRPORT',
-                        country_code: 'PG'
-                    } as LocationSearchResult);
+                if (hydratedQuote.initialOrigin) {
+                    setInitialOrigin(hydratedQuote.initialOrigin);
                 }
 
-                if (destinationLocationId) {
-                    setInitialDestination({
-                        id: destinationLocationId,
-                        display_name: quote.destination_location as string || destinationLocationId,
-                        code: destinationAirportCode || "DST",
-                        type: 'AIRPORT',
-                        country_code: 'AU'
-                    } as LocationSearchResult);
+                if (hydratedQuote.initialDestination) {
+                    setInitialDestination(hydratedQuote.initialDestination);
                 }
 
             } catch (err) {

--- a/frontend/src/lib/quote-edit-hydration.ts
+++ b/frontend/src/lib/quote-edit-hydration.ts
@@ -1,0 +1,152 @@
+import { V3_LOCATION_TYPES, V3_PACKAGE_TYPES, type QuoteFormSchemaV3 } from './schemas/quoteSchema';
+import {
+  type CompanySearchResult,
+  type LocationSearchResult,
+  type QuoteContactRef,
+  type QuoteCustomerRef,
+  type V3DimensionInput,
+  type V3QuoteComputeResponse,
+} from './types';
+import { getCargoTypeForCommodityCode } from './quote-workflow';
+
+export type QuoteEditHydrationResult = {
+  formData: Partial<QuoteFormSchemaV3>;
+  customerId: string;
+  initialCustomer?: CompanySearchResult;
+  initialOrigin?: LocationSearchResult;
+  initialDestination?: LocationSearchResult;
+};
+
+export function hydrateQuoteEditForm(quote: V3QuoteComputeResponse): QuoteEditHydrationResult {
+  const payload =
+    (quote.latest_version?.payload_json as Record<string, unknown> | undefined)
+    ?? (quote.request_details_json as Record<string, unknown> | undefined);
+  if (!payload) throw new Error("No payload found on quote");
+
+  const shipmentPayload = (
+    payload.shipment && typeof payload.shipment === "object"
+      ? (payload.shipment as Record<string, unknown>)
+      : undefined
+  );
+
+  let dimensions: QuoteFormSchemaV3["dimensions"] = [{
+    pieces: 1,
+    length_cm: "",
+    width_cm: "",
+    height_cm: "",
+    gross_weight_kg: "",
+    package_type: "Box",
+  }];
+
+  const rawDimensions = Array.isArray(payload.dimensions)
+    ? (payload.dimensions as V3DimensionInput[])
+    : Array.isArray(shipmentPayload?.pieces)
+      ? (shipmentPayload.pieces as V3DimensionInput[])
+      : [];
+
+  if (rawDimensions.length > 0) {
+    dimensions = rawDimensions.map((d: V3DimensionInput) => ({
+      pieces: d.pieces,
+      length_cm: String(d.length_cm),
+      width_cm: String(d.width_cm),
+      height_cm: String(d.height_cm),
+      gross_weight_kg: String(d.gross_weight_kg),
+      package_type: Object.values(V3_PACKAGE_TYPES).includes(d.package_type as typeof V3_PACKAGE_TYPES[keyof typeof V3_PACKAGE_TYPES])
+        ? (d.package_type as typeof V3_PACKAGE_TYPES[keyof typeof V3_PACKAGE_TYPES])
+        : V3_PACKAGE_TYPES.BOX,
+    }));
+  }
+
+  const originAirportCode = extractAirportCode(quote.origin_location as string);
+  const destinationAirportCode = extractAirportCode(quote.destination_location as string);
+
+  const customerId = String(payload.customer_id || "");
+  const contactId = String(
+    payload.contact_id
+    || (quote.contact as QuoteContactRef)?.id
+    || ""
+  );
+  const originLocationId = String(
+    payload.origin_location_id
+    || ((shipmentPayload?.origin_location as Record<string, unknown> | undefined)?.id ?? "")
+  );
+  const destinationLocationId = String(
+    payload.destination_location_id
+    || ((shipmentPayload?.destination_location as Record<string, unknown> | undefined)?.id ?? "")
+  );
+  const mode = String(payload.mode || shipmentPayload?.mode || "AIR");
+  const incoterm = String(payload.incoterm || shipmentPayload?.incoterm || "EXW");
+  const paymentTerm = String(payload.payment_term || shipmentPayload?.payment_term || "PREPAID");
+  const serviceScope = String(payload.service_scope || shipmentPayload?.service_scope || "A2A");
+  const commodityCode = String(
+    payload.commodity_code
+    || shipmentPayload?.commodity_code
+    || ""
+  );
+  const isDangerousGoods = Boolean(
+    payload.is_dangerous_goods
+    ?? shipmentPayload?.is_dangerous_goods
+  );
+
+  const formData: Partial<QuoteFormSchemaV3> = {
+    quote_id: quote.id,
+    customer_id: customerId,
+    contact_id: contactId,
+    mode: (mode as QuoteFormSchemaV3['mode']) || "AIR",
+    incoterm: (incoterm as QuoteFormSchemaV3['incoterm']) || "EXW",
+    payment_term: (paymentTerm as QuoteFormSchemaV3['payment_term']) || "PREPAID",
+    service_scope: (serviceScope as QuoteFormSchemaV3['service_scope']) || "A2A",
+    origin_airport: originAirportCode,
+    destination_airport: destinationAirportCode,
+    origin_location_id: originLocationId,
+    destination_location_id: destinationLocationId,
+    origin_location_type: V3_LOCATION_TYPES.AIRPORT,
+    destination_location_type: V3_LOCATION_TYPES.AIRPORT,
+    cargo_type: getCargoTypeForCommodityCode(commodityCode, isDangerousGoods),
+    dimensions: dimensions,
+  };
+
+  const custRef = quote.customer as QuoteCustomerRef;
+  const initialCustomer = customerId && custRef && typeof custRef === 'object'
+    ? ({
+      id: custRef.id || customerId,
+      name: custRef.company_name || custRef.name || "Customer",
+    } as CompanySearchResult)
+    : undefined;
+
+  const initialOrigin = originLocationId
+    ? ({
+      id: originLocationId,
+      display_name: quote.origin_location as string || originLocationId,
+      code: originAirportCode || "ORG",
+      type: 'AIRPORT',
+      country_code: 'PG',
+    } as LocationSearchResult)
+    : undefined;
+
+  const initialDestination = destinationLocationId
+    ? ({
+      id: destinationLocationId,
+      display_name: quote.destination_location as string || destinationLocationId,
+      code: destinationAirportCode || "DST",
+      type: 'AIRPORT',
+      country_code: 'AU',
+    } as LocationSearchResult)
+    : undefined;
+
+  return {
+    formData,
+    customerId,
+    initialCustomer,
+    initialOrigin,
+    initialDestination,
+  };
+}
+
+function extractAirportCode(locationStr: string | undefined | null): string {
+  if (!locationStr) return "";
+  const match = locationStr.match(/^([A-Z]{3})\s*-/);
+  if (match) return match[1];
+  if (/^[A-Z]{3}$/.test(locationStr.trim())) return locationStr.trim();
+  return "";
+}


### PR DESCRIPTION
## Summary

Completes Phase 7A.3 by extracting quote edit hydration logic into a dedicated frontend helper and adding focused test coverage.

## Files changed

- `frontend/package.json` — adds `test:quote-edit-hydration` script
- `frontend/src/app/quotes/[id]/edit/page.tsx` — replaces inline hydration logic with the extracted helper
- `frontend/src/lib/quote-edit-hydration.ts` — new helper for quote edit hydration
- `frontend/scripts/quote-edit-hydration.test.mjs` — new verification script covering hydration behavior

## Verification

Gemini/Antigravity reported the following checks passed locally after rebasing onto `origin/main`:

- `node scripts/quote-detail-mapping.test.mjs`
- `node scripts/quote-edit-hydration.test.mjs`
- `node scripts/quote-workflow-roundtrip.test.mjs`
- `node --experimental-strip-types --experimental-specifier-resolution=node scripts/quote-store.test.mjs`

Fallow summary reported:

- Maintainability Index: `88.8` Good
- Dead Code Issues: `80`, no new dead code introduced
- Duplication: `11.4%`

## Scope guardrails

This PR should be reviewed as a frontend refactor/test coverage slice only.

- No backend changes
- No pricing behavior changes
- No quote lifecycle changes
- No SPOT finalisation changes
- No cargo type, RBAC, or rate-resolution changes

## Manual review notes

Main risk area is functional equivalence of quote edit hydration. Review should confirm the new helper preserves the previous inline behavior in `frontend/src/app/quotes/[id]/edit/page.tsx`.