### PR TITLE
refactor(frontend): extract internal inspection alert

### DIFF
--- a/frontend/src/app/quotes/[id]/page.tsx
+++ b/frontend/src/app/quotes/[id]/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { useAuth } from "@/context/auth-context";
 import {
@@ -17,17 +16,17 @@ import {
   QuoteComputeResult,
 } from "@/lib/types";
 import QuoteFinancialBreakdown from "@/components/QuoteFinancialBreakdown";
+import InternalInspectionAlert from "@/components/quotes/InternalInspectionAlert";
 
 import RoutingWarning from "@/components/RoutingWarning";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Loader2, ArrowLeft, CheckCircle, CheckCircle2, Pencil, ArrowRight } from "lucide-react";
+import { Loader2, ArrowLeft, CheckCircle, CheckCircle2, Pencil } from "lucide-react";
 import { QuoteStatusBadge, QuoteStatusActions } from "@/components/QuoteStatusBadge";
 import { formatServiceScope } from "@/lib/display";
-import { getCustomerName, getEffectiveQuoteStatus } from "@/lib/quote-helpers";
+import { getEffectiveQuoteStatus } from "@/lib/quote-helpers";
 import type { SPECommodity, TriggerResult } from "@/lib/spot-types";
-import { ExternalLink } from "lucide-react";
 import {
   normalizeAirportCode,
   normalizeCountryCode,
@@ -387,138 +386,13 @@ export default function QuoteDetailPage() {
 
       {/* Scrollable Content Area with bottom padding for footer */}
       <div className="pb-32 space-y-6">
-        {/* --- INTERNAL USE ONLY: AGENT & WEIGHT VISIBILITY --- */}
-        <div className="md:col-span-1">
-          <Alert className="bg-slate-50 border-slate-200 shadow-sm relative overflow-hidden">
-            {/* "Internal Only" Badge */}
-            <div className="absolute top-0 right-0 bg-slate-200 text-slate-600 text-[10px] font-bold px-2 py-0.5 rounded-bl">
-              INTERNAL USE ONLY
-            </div>
-
-            <AlertDescription className="grid grid-cols-2 lg:grid-cols-5 gap-4 text-sm mt-1">
-              {/* Customer */}
-              <div>
-                <p className="text-xs font-semibold text-slate-500 uppercase">Customer</p>
-                <p className="font-medium text-slate-900 truncate" title={getCustomerName(quote.customer)}>
-                  {getCustomerName(quote.customer)}
-                </p>
-              </div>
-
-              {/* Sales Rep */}
-              <div>
-                <p className="text-xs font-semibold text-slate-500 uppercase">Sales Rep</p>
-                <p className="font-medium text-slate-900">
-                  {quote.created_by || <span className="text-slate-400 italic">Unassigned</span>}
-                </p>
-              </div>
-
-              {/* Rate Provider */}
-              <div>
-                <p className="text-xs font-semibold text-slate-500 uppercase">Rate Provider</p>
-                <p className="font-medium text-slate-900 truncate" title={quote.rate_provider || "Internal"}>
-                  {quote.rate_provider || <span className="text-slate-400 italic">Internal</span>}
-                </p>
-              </div>
-
-              {/* Routing */}
-              <div>
-                <p className="text-xs font-semibold text-slate-500 uppercase">Routing</p>
-                <div className="font-medium text-slate-900 flex items-center gap-1">
-                  <span>{quote.origin_location?.split('-')[0] || quote.origin_location}</span>
-                  <ArrowRight className="h-3 w-3" />
-                  <span>{quote.destination_location?.split('-')[0] || quote.destination_location}</span>
-                </div>
-              </div>
-
-              {/* Opportunity Link */}
-              <div>
-                <p className="text-xs font-semibold text-slate-500 uppercase">Opportunity</p>
-                <p className="font-medium text-slate-900">
-                  {quote.opportunity ? (
-                    <Link
-                      href={`/crm/opportunities/${quote.opportunity}`}
-                      className="text-primary hover:underline flex items-center gap-1"
-                    >
-                      View CRM
-                      <ExternalLink className="h-3 w-3" />
-                    </Link>
-                  ) : (
-                    <span className="text-slate-400 italic">None</span>
-                  )}
-                </p>
-              </div>
-
-              {isDomesticQuote ? (
-                <div>
-                  <p className="text-xs font-semibold text-slate-500 uppercase">Service Scope</p>
-                  <p className="font-medium text-slate-900">{resolvedServiceScope}</p>
-                </div>
-              ) : (
-                <div>
-                  <p className="text-xs font-semibold text-slate-500 uppercase">FX Rate</p>
-                  <div className="font-medium text-slate-900 text-xs">
-                    {fxEntries.length > 1 ? (
-                      <span className="text-slate-600">Multiple FX rates used</span>
-                    ) : fxEntries.length === 1 ? (
-                      <div>{fxEntries[0][0]}: {String(fxEntries[0][1])}</div>
-                    ) : (
-                      <span className="text-slate-400 italic">Base (PGK)</span>
-                    )}
-                  </div>
-                </div>
-              )}
-
-              {/* Total Weight */}
-              <div>
-                <p className="text-xs font-semibold text-slate-500 uppercase">Total Weight</p>
-                <p className="font-medium text-slate-900">
-                  {shipmentMetrics.totalWeightKg > 0
-                    ? `${shipmentMetrics.totalWeightKg.toLocaleString()} kg`
-                    : "0 kg"}
-                </p>
-              </div>
-
-              {/* Volumetric Weight */}
-              <div>
-                <p className="text-xs font-semibold text-slate-500 uppercase">Volumetric Weight</p>
-                <p className="font-medium text-slate-900">
-                  {shipmentMetrics.volumetricWeightKg > 0
-                    ? `${shipmentMetrics.volumetricWeightKg.toLocaleString()} kg`
-                    : "0 kg"}
-                </p>
-              </div>
-
-              {/* Chargeable Weight (CW) */}
-              <div>
-                <p className="text-xs font-semibold text-slate-500 uppercase">Chargeable Weight (CW)</p>
-                <p className="font-medium text-slate-900">
-                  {shipmentMetrics.chargeableWeightKg > 0
-                    ? `${shipmentMetrics.chargeableWeightKg.toLocaleString()} kg`
-                    : "0 kg"}
-                </p>
-              </div>
-
-              {/* Validity */}
-              <div>
-                <p className="text-xs font-semibold text-slate-500 uppercase">Validity</p>
-                <p className="font-medium text-slate-900">
-                  7 Days
-                </p>
-              </div>
-
-              {/* Payment Terms */}
-              <div>
-                <p className="text-xs font-semibold text-slate-500 uppercase">Payment Terms</p>
-                <p className="font-medium text-slate-900">
-                  {(() => {
-                    const term = (quote.payment_term || "Collect").toLowerCase();
-                    return term === 'credit' ? 'Credit (30 Days)' : term.charAt(0).toUpperCase() + term.slice(1);
-                  })()}
-                </p>
-              </div>
-            </AlertDescription>
-          </Alert>
-        </div>
+        <InternalInspectionAlert
+          quote={quote}
+          isDomesticQuote={isDomesticQuote}
+          resolvedServiceScope={resolvedServiceScope}
+          fxEntries={fxEntries}
+          shipmentMetrics={shipmentMetrics}
+        />
 
         {/* Display routing warning if VIA routing is required */}
         {computeResult?.routing && (

--- a/frontend/src/components/quotes/InternalInspectionAlert.tsx
+++ b/frontend/src/components/quotes/InternalInspectionAlert.tsx
@@ -1,0 +1,159 @@
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import Link from "next/link";
+import { ArrowRight, ExternalLink } from "lucide-react";
+import { getCustomerName } from "@/lib/quote-helpers";
+import type { V3QuoteComputeResponse } from "@/lib/types";
+
+export interface InternalInspectionAlertProps {
+  quote: V3QuoteComputeResponse;
+  isDomesticQuote: boolean;
+  resolvedServiceScope: string;
+  fxEntries: Array<[string, string]>;
+  shipmentMetrics: {
+    totalWeightKg: number;
+    volumetricWeightKg: number;
+    chargeableWeightKg: number;
+  };
+}
+
+export default function InternalInspectionAlert({
+  quote,
+  isDomesticQuote,
+  resolvedServiceScope,
+  fxEntries,
+  shipmentMetrics,
+}: InternalInspectionAlertProps) {
+  return (
+    <div className="md:col-span-1">
+      <Alert className="bg-slate-50 border-slate-200 shadow-sm relative overflow-hidden">
+        {/* "Internal Only" Badge */}
+        <div className="absolute top-0 right-0 bg-slate-200 text-slate-600 text-[10px] font-bold px-2 py-0.5 rounded-bl">
+          INTERNAL USE ONLY
+        </div>
+
+        <AlertDescription className="grid grid-cols-2 lg:grid-cols-5 gap-4 text-sm mt-1">
+          {/* Customer */}
+          <div>
+            <p className="text-xs font-semibold text-slate-500 uppercase">Customer</p>
+            <p className="font-medium text-slate-900 truncate" title={getCustomerName(quote.customer)}>
+              {getCustomerName(quote.customer)}
+            </p>
+          </div>
+
+          {/* Sales Rep */}
+          <div>
+            <p className="text-xs font-semibold text-slate-500 uppercase">Sales Rep</p>
+            <p className="font-medium text-slate-900">
+              {quote.created_by || <span className="text-slate-400 italic">Unassigned</span>}
+            </p>
+          </div>
+
+          {/* Rate Provider */}
+          <div>
+            <p className="text-xs font-semibold text-slate-500 uppercase">Rate Provider</p>
+            <p className="font-medium text-slate-900 truncate" title={quote.rate_provider || "Internal"}>
+              {quote.rate_provider || <span className="text-slate-400 italic">Internal</span>}
+            </p>
+          </div>
+
+          {/* Routing */}
+          <div>
+            <p className="text-xs font-semibold text-slate-500 uppercase">Routing</p>
+            <div className="font-medium text-slate-900 flex items-center gap-1">
+              <span>{quote.origin_location?.split('-')[0] || quote.origin_location}</span>
+              <ArrowRight className="h-3 w-3" />
+              <span>{quote.destination_location?.split('-')[0] || quote.destination_location}</span>
+            </div>
+          </div>
+
+          {/* Opportunity Link */}
+          <div>
+            <p className="text-xs font-semibold text-slate-500 uppercase">Opportunity</p>
+            <p className="font-medium text-slate-900">
+              {quote.opportunity ? (
+                <Link
+                  href={`/crm/opportunities/${quote.opportunity}`}
+                  className="text-primary hover:underline flex items-center gap-1"
+                >
+                  View CRM
+                  <ExternalLink className="h-3 w-3" />
+                </Link>
+              ) : (
+                <span className="text-slate-400 italic">None</span>
+              )}
+            </p>
+          </div>
+
+          {isDomesticQuote ? (
+            <div>
+              <p className="text-xs font-semibold text-slate-500 uppercase">Service Scope</p>
+              <p className="font-medium text-slate-900">{resolvedServiceScope}</p>
+            </div>
+          ) : (
+            <div>
+              <p className="text-xs font-semibold text-slate-500 uppercase">FX Rate</p>
+              <div className="font-medium text-slate-900 text-xs">
+                {fxEntries.length > 1 ? (
+                  <span className="text-slate-600">Multiple FX rates used</span>
+                ) : fxEntries.length === 1 ? (
+                  <div>{fxEntries[0][0]}: {String(fxEntries[0][1])}</div>
+                ) : (
+                  <span className="text-slate-400 italic">Base (PGK)</span>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Total Weight */}
+          <div>
+            <p className="text-xs font-semibold text-slate-500 uppercase">Total Weight</p>
+            <p className="font-medium text-slate-900">
+              {shipmentMetrics.totalWeightKg > 0
+                ? `${shipmentMetrics.totalWeightKg.toLocaleString()} kg`
+                : "0 kg"}
+            </p>
+          </div>
+
+          {/* Volumetric Weight */}
+          <div>
+            <p className="text-xs font-semibold text-slate-500 uppercase">Volumetric Weight</p>
+            <p className="font-medium text-slate-900">
+              {shipmentMetrics.volumetricWeightKg > 0
+                ? `${shipmentMetrics.volumetricWeightKg.toLocaleString()} kg`
+                : "0 kg"}
+            </p>
+          </div>
+
+          {/* Chargeable Weight (CW) */}
+          <div>
+            <p className="text-xs font-semibold text-slate-500 uppercase">Chargeable Weight (CW)</p>
+            <p className="font-medium text-slate-900">
+              {shipmentMetrics.chargeableWeightKg > 0
+                ? `${shipmentMetrics.chargeableWeightKg.toLocaleString()} kg`
+                : "0 kg"}
+            </p>
+          </div>
+
+          {/* Validity */}
+          <div>
+            <p className="text-xs font-semibold text-slate-500 uppercase">Validity</p>
+            <p className="font-medium text-slate-900">
+              7 Days
+            </p>
+          </div>
+
+          {/* Payment Terms */}
+          <div>
+            <p className="text-xs font-semibold text-slate-500 uppercase">Payment Terms</p>
+            <p className="font-medium text-slate-900">
+              {(() => {
+                const term = (quote.payment_term || "Collect").toLowerCase();
+                return term === 'credit' ? 'Credit (30 Days)' : term.charAt(0).toUpperCase() + term.slice(1);
+              })()}
+            </p>
+          </div>
+        </AlertDescription>
+      </Alert>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Completes Phase 7A.5 by extracting the quote details page "Internal Use Only" inspection alert into a dedicated presentational component.

## Files changed

- `frontend/src/app/quotes/[id]/page.tsx` — replaces the inline inspection alert block with `InternalInspectionAlert`
- `frontend/src/components/quotes/InternalInspectionAlert.tsx` — new presentational component for the internal inspection panel

## Scope guardrails

This PR should be reviewed as a presentational component extraction only.

- No backend changes
- No pricing calculation changes
- No quote lifecycle/status changes
- No SPOT workflow transition changes
- No API call changes
- No PDF/email/customer-facing output changes
- No visual redesign intended

## Verification reported by Gemini/Antigravity

The following commands were run successfully:

- `node scripts/quote-detail-helpers.test.mjs`
- `node scripts/quote-detail-mapping.test.mjs`
- `node scripts/quote-edit-hydration.test.mjs`
- `node scripts/quote-workflow-roundtrip.test.mjs`
- `node --experimental-strip-types --experimental-specifier-resolution=node scripts/quote-store.test.mjs`

Fallow checks were also run:

- `npx fallow health`
- `npx fallow dead-code`
- `npx fallow dupes`

## Manual review notes

Main review focus: confirm the rendered JSX, classes, links, conditional display, and formatting remained equivalent after moving the block into `InternalInspectionAlert.tsx`.