### PR TITLE
refactor(frontend): extract quote detail footer

### DIFF
--- a/frontend/src/app/quotes/[id]/page.tsx
+++ b/frontend/src/app/quotes/[id]/page.tsx
@@ -17,12 +17,13 @@ import {
 } from "@/lib/types";
 import QuoteFinancialBreakdown from "@/components/QuoteFinancialBreakdown";
 import InternalInspectionAlert from "@/components/quotes/InternalInspectionAlert";
+import QuoteDetailFooter from "@/components/quotes/QuoteDetailFooter";
 
 import RoutingWarning from "@/components/RoutingWarning";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Loader2, ArrowLeft, CheckCircle, CheckCircle2, Pencil } from "lucide-react";
+import { Loader2, ArrowLeft, CheckCircle2 } from "lucide-react";
 import { QuoteStatusBadge, QuoteStatusActions } from "@/components/QuoteStatusBadge";
 import { formatServiceScope } from "@/lib/display";
 import { getEffectiveQuoteStatus } from "@/lib/quote-helpers";
@@ -286,6 +287,28 @@ export default function QuoteDetailPage() {
   const isDomesticQuote = (quote.shipment_type || "").toUpperCase() === "DOMESTIC";
   const resolvedServiceScope = formatServiceScope(quote.service_scope);
 
+  const handleDownloadPDF = async () => {
+    if (!quote) return;
+    setPdfDownloading(true);
+    try {
+      await downloadQuotePDF(quote.id, quote.quote_number);
+      if (quote.status?.toUpperCase?.() === "FINALIZED") {
+        const sendResult = await transitionQuoteStatus(quote.id, "send");
+        if (sendResult.success) {
+          const refreshed = await getQuoteV3(id);
+          setQuote(refreshed);
+        } else {
+          console.error("Auto-send failed:", sendResult.error);
+        }
+      }
+    } catch (err) {
+      console.error("PDF download failed:", err);
+      alert(err instanceof Error ? err.message : "Failed to download PDF");
+    } finally {
+      setPdfDownloading(false);
+    }
+  };
+
   if (spotWorkflowHref) {
     return (
       <div className="container mx-auto max-w-3xl p-6">
@@ -445,95 +468,19 @@ export default function QuoteDetailPage() {
       </div>
 
       {/* Sticky Footer Action Bar */}
-      <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-slate-200 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.05)] z-50">
-        <div className="container mx-auto max-w-6xl px-4 py-4 flex items-center justify-between">
-          <div className="flex items-center gap-6">
-            <div>
-              <p className="text-xs text-slate-500 uppercase font-semibold">Total Quote Amount</p>
-              <p className="text-2xl font-bold text-slate-900">
-                {displayCurrency} {displayAmount.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
-              </p>
-              <p className="text-[10px] text-slate-400">
-                Inc. GST
-              </p>
-            </div>
-            {/* Currency Exchange Badge placeholder (future task) */}
-            {quote.latest_version?.totals?.currency !== 'PGK' && (
-              <div className="hidden md:block px-3 py-1 bg-amber-50 rounded border border-amber-100 text-xs text-amber-700">
-                <strong>Note:</strong> Pricing in {quote.latest_version?.totals?.currency}
-              </div>
-            )}
-          </div>
-
-          <div className="flex items-center gap-3">
-            {canDownloadPDF && (
-              <Button
-                variant="outline"
-                className="hidden sm:flex"
-                disabled={pdfDownloading}
-                onClick={async () => {
-                  setPdfDownloading(true);
-                  try {
-                    await downloadQuotePDF(quote.id, quote.quote_number);
-                    if (quote.status?.toUpperCase?.() === "FINALIZED") {
-                      const sendResult = await transitionQuoteStatus(quote.id, "send");
-                      if (sendResult.success) {
-                        const refreshed = await getQuoteV3(id);
-                        setQuote(refreshed);
-                      } else {
-                        console.error("Auto-send failed:", sendResult.error);
-                      }
-                    }
-                  } catch (err) {
-                    console.error("PDF download failed:", err);
-                    alert(err instanceof Error ? err.message : "Failed to download PDF");
-                  } finally {
-                    setPdfDownloading(false);
-                  }
-                }}
-              >
-                {pdfDownloading ? (
-                  <>
-                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                    Generating...
-                  </>
-                ) : (
-                  "Download PDF"
-                )}
-              </Button>
-            )}
-            {/* Only show finalize button for DRAFT quotes, handled by QuoteStatusActions above */}
-            {effectiveStatus === "FINALIZED" || effectiveStatus === "SENT" || effectiveStatus === "EXPIRED" ? (
-              <div className="flex items-center gap-2 text-sm text-slate-500">
-                <CheckCircle className="h-4 w-4 text-emerald-600" />
-                <span>Quote {effectiveStatus.toLowerCase()}</span>
-              </div>
-            ) : effectiveStatus === "DRAFT" ? (
-              <>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="gap-2 mr-2 hidden sm:flex"
-                  onClick={() => router.push(buildQuoteEditHref(quote))}
-                >
-                  <Pencil className="h-4 w-4" />
-                  Edit Quote
-                </Button>
-                <QuoteStatusActions
-                  quoteId={quote.id}
-                  status={quote.status}
-                  validUntil={quote.valid_until}
-                  hasMissingRates={quote.latest_version?.totals?.has_missing_rates || false}
-                  showDelete={false}
-                  onStatusChange={() => {
-                    getQuoteV3(id).then((data) => setQuote(data));
-                  }}
-                />
-              </>
-            ) : null}
-          </div>
-        </div>
-      </div>
+      <QuoteDetailFooter
+        quote={quote}
+        effectiveStatus={effectiveStatus}
+        displayCurrency={displayCurrency}
+        displayAmount={displayAmount}
+        canDownloadPDF={canDownloadPDF}
+        pdfDownloading={pdfDownloading}
+        onDownloadPDF={handleDownloadPDF}
+        onEditQuote={() => router.push(buildQuoteEditHref(quote))}
+        onStatusChange={() => {
+          getQuoteV3(id).then((data) => setQuote(data));
+        }}
+      />
 
     </div >
   );

--- a/frontend/src/components/quotes/QuoteDetailFooter.tsx
+++ b/frontend/src/components/quotes/QuoteDetailFooter.tsx
@@ -1,0 +1,99 @@
+import { Loader2, Pencil, CheckCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { QuoteStatusActions } from "@/components/QuoteStatusBadge";
+import type { V3QuoteComputeResponse } from "@/lib/types";
+
+export interface QuoteDetailFooterProps {
+  quote: V3QuoteComputeResponse;
+  effectiveStatus: string;
+  displayCurrency: string;
+  displayAmount: number;
+  canDownloadPDF: boolean;
+  pdfDownloading: boolean;
+  onDownloadPDF: () => Promise<void>;
+  onEditQuote: () => void;
+  onStatusChange: () => void;
+}
+
+export default function QuoteDetailFooter({
+  quote,
+  effectiveStatus,
+  displayCurrency,
+  displayAmount,
+  canDownloadPDF,
+  pdfDownloading,
+  onDownloadPDF,
+  onEditQuote,
+  onStatusChange,
+}: QuoteDetailFooterProps) {
+  return (
+    <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-slate-200 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.05)] z-50">
+      <div className="container mx-auto max-w-6xl px-4 py-4 flex items-center justify-between">
+        <div className="flex items-center gap-6">
+          <div>
+            <p className="text-xs text-slate-500 uppercase font-semibold">Total Quote Amount</p>
+            <p className="text-2xl font-bold text-slate-900">
+              {displayCurrency} {displayAmount.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+            </p>
+            <p className="text-[10px] text-slate-400">
+              Inc. GST
+            </p>
+          </div>
+          {/* Currency Exchange Badge placeholder (future task) */}
+          {quote.latest_version?.totals?.currency !== 'PGK' && (
+            <div className="hidden md:block px-3 py-1 bg-amber-50 rounded border border-amber-100 text-xs text-amber-700">
+              <strong>Note:</strong> Pricing in {quote.latest_version?.totals?.currency}
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center gap-3">
+          {canDownloadPDF && (
+            <Button
+              variant="outline"
+              className="hidden sm:flex"
+              disabled={pdfDownloading}
+              onClick={onDownloadPDF}
+            >
+              {pdfDownloading ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Generating...
+                </>
+              ) : (
+                "Download PDF"
+              )}
+            </Button>
+          )}
+          {/* Only show finalize button for DRAFT quotes, handled by QuoteStatusActions */}
+          {effectiveStatus === "FINALIZED" || effectiveStatus === "SENT" || effectiveStatus === "EXPIRED" ? (
+            <div className="flex items-center gap-2 text-sm text-slate-500">
+              <CheckCircle className="h-4 w-4 text-emerald-600" />
+              <span>Quote {effectiveStatus.toLowerCase()}</span>
+            </div>
+          ) : effectiveStatus === "DRAFT" ? (
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                className="gap-2 mr-2 hidden sm:flex"
+                onClick={onEditQuote}
+              >
+                <Pencil className="h-4 w-4" />
+                Edit Quote
+              </Button>
+              <QuoteStatusActions
+                quoteId={quote.id}
+                status={quote.status}
+                validUntil={quote.valid_until}
+                hasMissingRates={quote.latest_version?.totals?.has_missing_rates || false}
+                showDelete={false}
+                onStatusChange={onStatusChange}
+              />
+            </>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Completes Phase 7A.7 by extracting the quote details sticky footer/action bar into a dedicated presentational component.

## Files changed

- `frontend/src/app/quotes/[id]/page.tsx` — replaces inline sticky footer markup with `QuoteDetailFooter`, keeps side-effect handlers in the parent page
- `frontend/src/components/quotes/QuoteDetailFooter.tsx` — new presentational component for footer totals/actions

## Scope guardrails

This PR should be reviewed as a presentational component extraction only.

- No backend changes
- No pricing calculation changes
- No quote lifecycle/status behavior changes
- No SPOT workflow transition changes
- No API behavior changes
- No PDF/email behavior changes
- No visual redesign intended

## Verification reported by Gemini/Antigravity

The following commands passed locally:

- `npm run typecheck`
- `node scripts/quote-detail-helpers.test.mjs`
- `node scripts/quote-detail-mapping.test.mjs`
- `node scripts/quote-edit-hydration.test.mjs`
- `node scripts/quote-workflow-roundtrip.test.mjs`
- `node --experimental-strip-types --experimental-specifier-resolution=node scripts/quote-store.test.mjs`

Fallow summary reported:

- Maintainability Index: `88.8` Good
- Dead-code issues: `84`, no new issues introduced
- Duplication: `11.4%`, no increase in density

## Manual review notes

Main review focus: confirm footer rendering and button behavior remained equivalent. `downloadQuotePDF`, `transitionQuoteStatus`, router navigation, and quote state refresh logic should remain in `page.tsx` and be passed into the component as callbacks.