### PR TITLE
refactor(frontend): extract spot workspace helpers

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "test:crm-quote-prefill": "node scripts/crm-quote-prefill.test.mjs",
     "test:domestic-service-scope": "node scripts/domestic-service-scope.test.mjs",
     "test:spot-finalization": "node scripts/spot-finalization.test.mjs",
+    "test:spot-workspace-helpers": "node scripts/spot-workspace-helpers.test.mjs",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",

--- a/frontend/scripts/spot-workspace-helpers.test.mjs
+++ b/frontend/scripts/spot-workspace-helpers.test.mjs
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import ts from "typescript";
+
+const frontendRoot = path.resolve(process.cwd());
+const helperSourcePath = path.join(frontendRoot, "src", "lib", "spot-workspace-helpers.ts");
+
+function transpile(source, fileName) {
+  return ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName,
+  }).outputText;
+}
+
+async function loadModules() {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "spot-workspace-helpers-test-"));
+  const libDir = path.join(tempDir, "lib");
+
+  try {
+    await mkdir(libDir, { recursive: true });
+
+    const helperSource = await readFile(helperSourcePath, "utf8");
+
+    const helperModule = transpile(helperSource, helperSourcePath);
+
+    await writeFile(path.join(libDir, "spot-workspace-helpers.mjs"), helperModule, "utf8");
+
+    const helpers = await import(`file://${path.join(libDir, "spot-workspace-helpers.mjs")}`);
+    return helpers;
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+const {
+  isBuySideCharge,
+  isStandardRateCharge,
+  componentToBucket,
+  sanitizeSummaryMessage,
+  normalizeSummaryMessage,
+  getAnalysisSignalCount,
+  normalizeIssueLabel,
+  isCountOnlySummaryWarning,
+  parseLineIssueWarning,
+  getPrimaryIssueKind,
+  getIssueProblemMessage,
+  humanizeEnum,
+  formatProductCodeSummary,
+  getChargeStatusLabel,
+  chargeUnitLabel,
+  formatChargeAmount,
+  isActionableAiWarning,
+  getSourceSummaryTitle,
+  getSourceSummarySubtitle,
+  formatMissingComponents,
+  formatListWithAnd,
+} = await loadModules();
+
+// 1. humanizeEnum
+{
+  assert.equal(humanizeEnum("PREPAID"), "Prepaid");
+  assert.equal(humanizeEnum("MANUAL_RESOLUTION"), "Manual Resolution");
+  assert.equal(humanizeEnum(""), "Not recorded");
+  assert.equal(humanizeEnum(null), "Not recorded");
+  assert.equal(humanizeEnum("  "), "Not recorded");
+  assert.equal(humanizeEnum("COLLECT_"), "Collect");
+}
+
+// 2. getPrimaryIssueKind & getIssueProblemMessage
+{
+  assert.equal(getPrimaryIssueKind(["lowConfidence", "unmapped"]), "unmapped");
+  assert.equal(getPrimaryIssueKind(["conditional", "ambiguous"]), "ambiguous");
+  assert.equal(getPrimaryIssueKind(["conditional"]), "conditional");
+
+  assert.equal(getIssueProblemMessage(["unmapped"]), "Choose the correct ProductCode before creating the quote.");
+  assert.equal(getIssueProblemMessage(["ambiguous"]), "Multiple ProductCodes matched. Confirm the correct one.");
+  assert.equal(getIssueProblemMessage(["lowConfidence"]), "Check the normalized charge label before confirming.");
+  assert.equal(getIssueProblemMessage(["conditional"]), "Confirm whether this conditional charge should stay in the quote.");
+}
+
+// 3. normalizeSummaryMessage
+{
+  assert.equal(normalizeSummaryMessage("AI: hello"), "hello");
+  assert.equal(normalizeSummaryMessage("AI critic flagged possible missed charges: cogs"), "Possible missed charges: cogs");
+  assert.equal(normalizeSummaryMessage("AI critic flagged possible hallucinations: cogs"), "Please verify these charges: cogs");
+  assert.equal(normalizeSummaryMessage("AI returned unmapped charges requiring manual review: fuel"), "Some imported charges need manual review: fuel");
+  assert.equal(normalizeSummaryMessage("AI analysis failed: error"), "Import check failed: error");
+  assert.equal(normalizeSummaryMessage("AI analysis is missing required rate or currency fields"), "Some imported lines are missing rate or currency details.");
+  assert.equal(normalizeSummaryMessage("Line 12: Low-confidence normalization for label"), "Line 12: Please verify the charge label for label");
+}
+
+// 4. isCountOnlySummaryWarning
+{
+  assert.equal(isCountOnlySummaryWarning("1 extracted charge(s) could not be mapped cleanly."), true);
+  assert.equal(isCountOnlySummaryWarning("3 extracted charge line(s) were low-confidence."), true);
+  assert.equal(isCountOnlySummaryWarning("Some imported charges need manual review: "), true);
+  assert.equal(isCountOnlySummaryWarning("Line 12: Error occurred"), true);
+  assert.equal(isCountOnlySummaryWarning("This is an actual warning"), false);
+}
+
+// 5. parseLineIssueWarning
+{
+  const lcWarning = "Line 5: Low-confidence normalization for 'Fuel Surcharge'";
+  const lcResult = parseLineIssueWarning(lcWarning);
+  assert.deepEqual(lcResult.labels, ["Fuel Surcharge"]);
+  assert.equal(lcResult.kind, "lowConfidence");
+
+  const unmappedWarning = "Line 7: Unmapped charge 'Security Charge'";
+  const unmappedResult = parseLineIssueWarning(unmappedWarning);
+  assert.deepEqual(unmappedResult.labels, ["Security Charge"]);
+  assert.equal(unmappedResult.kind, "unmapped");
+
+  const manualWarning = "Some imported charges need manual review: Handling Fee, Delivery Charge";
+  const manualResult = parseLineIssueWarning(manualWarning);
+  assert.deepEqual(manualResult.labels, ["Handling Fee", "Delivery Charge"]);
+  assert.equal(manualResult.kind, "unmapped");
+
+  assert.equal(parseLineIssueWarning("Random non-issue message"), null);
+}
+
+// 6. getChargeStatusLabel
+{
+  assert.equal(getChargeStatusLabel({ manual_resolution_status: "RESOLVED" }), "Manually resolved");
+  assert.equal(getChargeStatusLabel({ normalization_status: "MATCHED" }), "Matched");
+  assert.equal(getChargeStatusLabel({ normalization_status: "AMBIGUOUS" }), "Ambiguous");
+  assert.equal(getChargeStatusLabel({ normalization_status: "UNMAPPED" }), "Needs review");
+  assert.equal(getChargeStatusLabel({}), "Not normalized");
+}
+
+// 7. formatChargeAmount
+{
+  assert.equal(formatChargeAmount({ amount: 150, currency: "PGK" }), "150 PGK");
+  assert.equal(formatChargeAmount({ amount: " 250.50 ", currency: "USD" }), "250.50 USD");
+  assert.equal(formatChargeAmount({ currency: "AUD" }), "AUD");
+  assert.equal(formatChargeAmount({}), "");
+}
+
+// 8. getSourceSummaryTitle & getSourceSummarySubtitle
+{
+  assert.equal(getSourceSummaryTitle("Unified Intake", "mixed"), "Uploaded rates");
+  assert.equal(getSourceSummaryTitle("AI Agent Reply", "airfreight"), "Agent Reply");
+  assert.equal(getSourceSummaryTitle("", "origin_charges"), "Origin Charges import");
+
+  assert.equal(getSourceSummarySubtitle("mixed"), "Imported lines are grouped for this quote");
+  assert.equal(getSourceSummarySubtitle("destination_charges"), "Destination Charges lines are grouped for this quote");
+}
+
+// 9. formatMissingComponents & formatListWithAnd
+{
+  assert.deepEqual(formatMissingComponents(["DESTINATION_LOCAL", "FREIGHT"]), ["Destination Charges", "Freight Rate"]);
+  assert.deepEqual(formatMissingComponents([]), null);
+  assert.deepEqual(formatMissingComponents(null), null);
+
+  assert.equal(formatListWithAnd(["One"]), "One");
+  assert.equal(formatListWithAnd(["One", "Two"]), "One and Two");
+  assert.equal(formatListWithAnd(["One", "Two", "Three"]), "One, Two, and Three");
+}
+
+console.log("spot workspace helpers checks passed");

--- a/frontend/src/app/quotes/spot/[speId]/page.tsx
+++ b/frontend/src/app/quotes/spot/[speId]/page.tsx
@@ -57,45 +57,53 @@ const STEPS: { id: DisplayStep; label: string; description: string }[] = [
 
 const EMPTY_COMPONENTS: string[] = [];
 const EMPTY_CHARGES: SPEChargeLine[] = [];
-const BUY_SIDE_SOURCE_MARKERS = ["COGS", "BUY"];
+import {
+    ReviewIssueKind,
+    BUCKET_LABELS,
+    issueKindPriority,
+    isBuySideCharge,
+    isStandardRateCharge,
+    componentToBucket,
+    sanitizeSummaryMessage,
+    normalizeSummaryMessage,
+    getAnalysisSignalCount,
+    normalizeIssueLabel,
+    isCountOnlySummaryWarning,
+    parseLineIssueWarning,
+    getPrimaryIssueKind,
+    getIssueProblemMessage,
+    humanizeEnum,
+    formatProductCodeSummary,
+    getChargeStatusLabel,
+    chargeUnitLabel,
+    formatChargeAmount,
+    isActionableAiWarning,
+    getSourceSummaryTitle,
+    getSourceSummarySubtitle,
+    formatMissingComponents,
+    formatListWithAnd,
+} from "@/lib/spot-workspace-helpers";
 
-const isBuySideCharge = (charge: SPEChargeLine) => {
-    const source = (charge.source_reference || "").toUpperCase();
-    // Standard Rate charges are computed FROM COGS but are sell-side charges, so keep them visible.
-    if (source.startsWith("STANDARD RATE")) return false;
-    // AI/Analysis suggestions are always user-facing
-    if (source.includes("AI") || source.includes("ANALYSIS") || source.includes("AGENT REPLY")) return false;
-    return BUY_SIDE_SOURCE_MARKERS.some((marker) => source.includes(marker));
-};
-
-const isStandardRateCharge = (charge: SPEChargeLine) =>
-    (charge.source_reference || "").toUpperCase().startsWith("STANDARD RATE");
-
-const componentToBucket = (component: string): SPEChargeLine["bucket"] | null => {
-    const normalized = (component || "").toUpperCase();
-    if (normalized === "FREIGHT") return "airfreight";
-    if (normalized === "ORIGIN_LOCAL") return "origin_charges";
-    if (normalized === "DESTINATION_LOCAL") return "destination_charges";
-    return null;
-};
-
-const BUCKET_LABELS: Record<SPEChargeLine["bucket"], string> = {
-    airfreight: "Freight",
-    origin_charges: "Origin Charges",
-    destination_charges: "Destination Charges",
-};
-
-const NON_ACTIONABLE_AI_WARNING_PATTERNS = [
-    "validity not specified - assuming 72 hours",
-    "routing not specified - may involve multiple legs",
-    "space/acceptance not confirmed",
-];
-
-const sanitizeSummaryMessage = (message: string) =>
-    message.replace(/^[^A-Za-z0-9]+/, "").trim();
-
-type ReviewIssueKind = "unmapped" | "ambiguous" | "lowConfidence" | "conditional";
 type ReviewMode = "issues" | "allCharges";
+
+const issueKindMeta: Record<ReviewIssueKind, { label: string; className: string }> = {
+    unmapped: {
+        label: "Needs review",
+        className: "border-amber-200 bg-amber-50 text-amber-800",
+    },
+    ambiguous: {
+        label: "Ambiguous",
+        className: "border-rose-200 bg-rose-50 text-rose-800",
+    },
+    lowConfidence: {
+        label: "Low confidence",
+        className: "border-sky-200 bg-sky-50 text-sky-800",
+    },
+    conditional: {
+        label: "Conditional",
+        className: "border-slate-200 bg-slate-50 text-slate-700",
+    },
+};
 
 type SourceLineIssue = {
     key: string;
@@ -137,198 +145,6 @@ type SourceReviewSummary = {
     };
     lineIssues: SourceLineIssue[];
     generalChecks: string[];
-};
-
-const normalizeSummaryMessage = (message: string) => {
-    const cleaned = sanitizeSummaryMessage(message);
-
-    return cleaned
-        .replace(/^AI:\s*/i, "")
-        .replace(/^AI critic flagged possible missed charges:\s*/i, "Possible missed charges: ")
-        .replace(/^AI critic flagged possible hallucinations:\s*/i, "Please verify these charges: ")
-        .replace(/^AI returned unmapped charges requiring manual review:\s*/i, "Some imported charges need manual review: ")
-        .replace(/^AI analysis failed:\s*/i, "Import check failed: ")
-        .replace(/^AI intake did not produce any charge lines to review\.?$/i, "No charge lines were imported for review.")
-        .replace(/^AI analysis is missing required rate or currency fields\.?$/i, "Some imported lines are missing rate or currency details.")
-        .replace(/^(Line \d+): Low-confidence normalization for /i, "$1: Please verify the charge label for ");
-};
-
-const getAnalysisSignalCount = (source: { analysis_summary_json?: Record<string, unknown> }, key: string) => {
-    const value = source.analysis_summary_json?.[key];
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : 0;
-};
-
-const normalizeIssueLabel = (label: string) => sanitizeSummaryMessage(label).replace(/^['"]|['"]$/g, "").trim();
-
-const LOW_CONFIDENCE_WARNING_PATTERN =
-    /^Line \d+:\s+(?:Please verify the charge label for|Low-confidence normalization for)\s+'([^']+)'/i;
-const UNMAPPED_WARNING_PATTERN = /^Line \d+:\s+Unmapped charge\s+'([^']+)'/i;
-const MANUAL_REVIEW_WARNING_PATTERN = /^Some imported charges need manual review:\s*(.+)$/i;
-const COUNT_ONLY_WARNING_PATTERNS = [
-    /^\d+\s+extracted charge\(s\) could not be mapped cleanly\.?$/i,
-    /^\d+\s+extracted charge line\(s\) were low-confidence\.?$/i,
-    /^\d+\s+extracted charge line\(s\) are conditional\.?$/i,
-    /^Some imported charges need manual review:\s*/i,
-    /^Line \d+:/i,
-];
-
-const isCountOnlySummaryWarning = (warning: string) =>
-    COUNT_ONLY_WARNING_PATTERNS.some((pattern) => pattern.test(warning));
-
-const parseLineIssueWarning = (warning: string) => {
-    const lowConfidenceMatch = warning.match(LOW_CONFIDENCE_WARNING_PATTERN);
-    if (lowConfidenceMatch) {
-        return {
-            labels: [normalizeIssueLabel(lowConfidenceMatch[1] || "")],
-            kind: "lowConfidence" as const,
-            detail: warning,
-        };
-    }
-
-    const unmappedMatch = warning.match(UNMAPPED_WARNING_PATTERN);
-    if (unmappedMatch) {
-        return {
-            labels: [normalizeIssueLabel(unmappedMatch[1] || "")],
-            kind: "unmapped" as const,
-            detail: "Needs manual product mapping.",
-        };
-    }
-
-    const manualReviewMatch = warning.match(MANUAL_REVIEW_WARNING_PATTERN);
-    if (manualReviewMatch) {
-        return {
-            labels: manualReviewMatch[1]
-                .split(",")
-                .map((label) => normalizeIssueLabel(label))
-                .filter(Boolean),
-            kind: "unmapped" as const,
-            detail: "Needs manual product mapping.",
-        };
-    }
-
-    return null;
-};
-
-const issueKindMeta: Record<ReviewIssueKind, { label: string; className: string }> = {
-    unmapped: {
-        label: "Needs review",
-        className: "border-amber-200 bg-amber-50 text-amber-800",
-    },
-    ambiguous: {
-        label: "Ambiguous",
-        className: "border-rose-200 bg-rose-50 text-rose-800",
-    },
-    lowConfidence: {
-        label: "Low confidence",
-        className: "border-sky-200 bg-sky-50 text-sky-800",
-    },
-    conditional: {
-        label: "Conditional",
-        className: "border-slate-200 bg-slate-50 text-slate-700",
-    },
-};
-
-const issueKindPriority: Record<ReviewIssueKind, number> = {
-    unmapped: 0,
-    ambiguous: 1,
-    lowConfidence: 2,
-    conditional: 3,
-};
-
-const getPrimaryIssueKind = (issueKinds: ReviewIssueKind[]) =>
-    [...issueKinds].sort((left, right) => issueKindPriority[left] - issueKindPriority[right])[0] || "conditional";
-
-const getIssueProblemMessage = (issueKinds: ReviewIssueKind[]) => {
-    const primaryIssue = getPrimaryIssueKind(issueKinds);
-    if (primaryIssue === "unmapped") {
-        return "Choose the correct ProductCode before creating the quote.";
-    }
-    if (primaryIssue === "ambiguous") {
-        return "Multiple ProductCodes matched. Confirm the correct one.";
-    }
-    if (primaryIssue === "lowConfidence") {
-        return "Check the normalized charge label before confirming.";
-    }
-    return "Confirm whether this conditional charge should stay in the quote.";
-};
-
-const humanizeEnum = (value?: string | null) => {
-    const normalized = String(value || "").trim();
-    if (!normalized) return "Not recorded";
-    return normalized
-        .split("_")
-        .filter(Boolean)
-        .map((part) => part.charAt(0) + part.slice(1).toLowerCase())
-        .join(" ");
-};
-
-const formatProductCodeSummary = (productCode?: SPEChargeLine["resolved_product_code"] | null) => {
-    if (!productCode?.code) return "Not recorded";
-    return productCode.description ? `${productCode.code} - ${productCode.description}` : productCode.code;
-};
-
-const getChargeStatusLabel = (charge: SPEChargeLine) => {
-    if (charge.manual_resolution_status === "RESOLVED") return "Manually resolved";
-    if (charge.normalization_status === "MATCHED") return "Matched";
-    if (charge.normalization_status === "AMBIGUOUS") return "Ambiguous";
-    if (charge.normalization_status === "UNMAPPED") return "Needs review";
-    return "Not normalized";
-};
-
-const chargeUnitLabel = (unit?: SPEChargeLine["unit"]) => {
-    if (unit === "per_kg") return "Per KG";
-    if (unit === "flat") return "Flat";
-    if (unit === "per_awb") return "Per AWB";
-    if (unit === "per_shipment") return "Per shipment";
-    if (unit === "percentage") return "Percentage";
-    if (unit === "per_trip") return "Per trip";
-    if (unit === "per_set") return "Per set";
-    if (unit === "per_man") return "Per man";
-    if (unit === "min_or_per_kg") return "Min or per KG";
-    return "Unit";
-};
-
-const formatChargeAmount = (charge: SPEChargeLine) => {
-    const amount = String(charge.amount || "").trim();
-    if (!amount) return charge.currency || "";
-    return `${amount} ${charge.currency || ""}`.trim();
-};
-
-const isActionableAiWarning = (warning: string) => {
-    const normalized = normalizeSummaryMessage(warning).toLowerCase();
-    return !NON_ACTIONABLE_AI_WARNING_PATTERNS.some((pattern) => normalized.includes(pattern));
-};
-
-const getSourceSummaryTitle = (label: string, targetBucket: SPEChargeLine["bucket"] | "mixed") => {
-    const cleaned = label.replace(/\bAI\b/gi, "").replace(/\s{2,}/g, " ").trim();
-    if (cleaned.toLowerCase() === "unified intake") return "Uploaded rates";
-    if (cleaned) return cleaned;
-    if (targetBucket === "mixed") return "Uploaded rates";
-    return `${BUCKET_LABELS[targetBucket]} import`;
-};
-
-const getSourceSummarySubtitle = (bucket: SPEChargeLine["bucket"] | "mixed") => {
-    if (bucket === "mixed") return "Imported lines are grouped for this quote";
-    return `${BUCKET_LABELS[bucket]} lines are grouped for this quote`;
-};
-
-const formatMissingComponents = (components?: string[]) => {
-    if (!components || components.length === 0) return null;
-    const friendly = components.map((component) => {
-        const normalized = component.toUpperCase();
-        if (normalized === "DESTINATION_LOCAL") return "Destination Charges";
-        if (normalized === "ORIGIN_LOCAL") return "Origin Charges";
-        if (normalized === "FREIGHT") return "Freight Rate";
-        return component.replace(/_/g, " ");
-    });
-    return Array.from(new Set(friendly));
-};
-
-const formatListWithAnd = (items: string[]) => {
-    if (items.length <= 1) return items[0] || "";
-    if (items.length === 2) return `${items[0]} and ${items[1]}`;
-    return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
 };
 
 export default function SpotRateEntryPage() {

--- a/frontend/src/components/spot/ChargeNormalizationAudit.tsx
+++ b/frontend/src/components/spot/ChargeNormalizationAudit.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
 import type { ChargeNormalizationStatus, SPEProductCodeSummary } from "@/lib/spot-types";
+import { humanizeEnum } from "@/lib/spot-workspace-helpers";
 
 type DisplayNormalizationStatus = ChargeNormalizationStatus | "MANUAL";
 
@@ -62,15 +63,7 @@ const STATUS_STYLES: Record<
     },
 };
 
-const humanizeEnum = (value?: string | null) => {
-    const normalized = String(value || "").trim();
-    if (!normalized) return "Not recorded";
-    return normalized
-        .split("_")
-        .filter(Boolean)
-        .map((part) => part.charAt(0) + part.slice(1).toLowerCase())
-        .join(" ");
-};
+
 
 const productCodeSummary = (productCode?: SPEProductCodeSummary | null) => {
     if (!productCode) return "No product code resolved";

--- a/frontend/src/components/spot/SpotChargeLineManualReviewSheet.tsx
+++ b/frontend/src/components/spot/SpotChargeLineManualReviewSheet.tsx
@@ -17,6 +17,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import type { SPEChargeLine } from "@/lib/spot-types";
 import { getProductCodes, type ProductCodeOption } from "@/lib/api";
 import { getSpotChargeDisplayLabel } from "@/lib/spot-charge-display";
+import { humanizeEnum } from "@/lib/spot-workspace-helpers";
 
 interface SpotChargeLineManualReviewSheetProps {
     open: boolean;
@@ -35,15 +36,7 @@ const formatProductCode = (productCode?: SPEChargeLine["resolved_product_code"] 
         : productCode.code;
 };
 
-const humanizeEnum = (value?: string | null) => {
-    const normalized = String(value || "").trim();
-    if (!normalized) return "Not recorded";
-    return normalized
-        .split("_")
-        .filter(Boolean)
-        .map((part) => part.charAt(0) + part.slice(1).toLowerCase())
-        .join(" ");
-};
+
 
 export function SpotChargeLineManualReviewSheet({
     open,

--- a/frontend/src/lib/spot-workspace-helpers.ts
+++ b/frontend/src/lib/spot-workspace-helpers.ts
@@ -1,0 +1,215 @@
+import type { SPEChargeLine } from "@/lib/spot-types";
+
+export type ReviewIssueKind = "unmapped" | "ambiguous" | "lowConfidence" | "conditional";
+
+export const BUY_SIDE_SOURCE_MARKERS = ["COGS", "BUY"];
+
+export const BUCKET_LABELS: Record<SPEChargeLine["bucket"], string> = {
+    airfreight: "Freight",
+    origin_charges: "Origin Charges",
+    destination_charges: "Destination Charges",
+};
+
+export const NON_ACTIONABLE_AI_WARNING_PATTERNS = [
+    "validity not specified - assuming 72 hours",
+    "routing not specified - may involve multiple legs",
+    "space/acceptance not confirmed",
+];
+
+export const COUNT_ONLY_WARNING_PATTERNS = [
+    /^\d+\s+extracted charge\(s\) could not be mapped cleanly\.?$/i,
+    /^\d+\s+extracted charge line\(s\) were low-confidence\.?$/i,
+    /^\d+\s+extracted charge line\(s\) are conditional\.?$/i,
+    /^Some imported charges need manual review:\s*/i,
+    /^Line \d+:/i,
+];
+
+export const LOW_CONFIDENCE_WARNING_PATTERN =
+    /^Line \d+:\s+(?:Please verify the charge label for|Low-confidence normalization for)\s+'([^']+)'/i;
+export const UNMAPPED_WARNING_PATTERN = /^Line \d+:\s+Unmapped charge\s+'([^']+)'/i;
+export const MANUAL_REVIEW_WARNING_PATTERN = /^Some imported charges need manual review:\s*(.+)$/i;
+
+export const issueKindPriority: Record<ReviewIssueKind, number> = {
+    unmapped: 0,
+    ambiguous: 1,
+    lowConfidence: 2,
+    conditional: 3,
+};
+
+export const isBuySideCharge = (charge: SPEChargeLine): boolean => {
+    const source = (charge.source_reference || "").toUpperCase();
+    // Standard Rate charges are computed FROM COGS but are sell-side charges, so keep them visible.
+    if (source.startsWith("STANDARD RATE")) return false;
+    // AI/Analysis suggestions are always user-facing
+    if (source.includes("AI") || source.includes("ANALYSIS") || source.includes("AGENT REPLY")) return false;
+    return BUY_SIDE_SOURCE_MARKERS.some((marker) => source.includes(marker));
+};
+
+export const isStandardRateCharge = (charge: SPEChargeLine): boolean =>
+    (charge.source_reference || "").toUpperCase().startsWith("STANDARD RATE");
+
+export const componentToBucket = (component: string): SPEChargeLine["bucket"] | null => {
+    const normalized = (component || "").toUpperCase();
+    if (normalized === "FREIGHT") return "airfreight";
+    if (normalized === "ORIGIN_LOCAL") return "origin_charges";
+    if (normalized === "DESTINATION_LOCAL") return "destination_charges";
+    return null;
+};
+
+export const sanitizeSummaryMessage = (message: string): string =>
+    message.replace(/^[^A-Za-z0-9]+/, "").trim();
+
+export const normalizeSummaryMessage = (message: string): string => {
+    const cleaned = sanitizeSummaryMessage(message);
+
+    return cleaned
+        .replace(/^AI:\s*/i, "")
+        .replace(/^AI critic flagged possible missed charges:\s*/i, "Possible missed charges: ")
+        .replace(/^AI critic flagged possible hallucinations:\s*/i, "Please verify these charges: ")
+        .replace(/^AI returned unmapped charges requiring manual review:\s*/i, "Some imported charges need manual review: ")
+        .replace(/^AI analysis failed:\s*/i, "Import check failed: ")
+        .replace(/^AI intake did not produce any charge lines to review\.?$/i, "No charge lines were imported for review.")
+        .replace(/^AI analysis is missing required rate or currency fields\.?$/i, "Some imported lines are missing rate or currency details.")
+        .replace(/^(Line \d+): Low-confidence normalization for /i, "$1: Please verify the charge label for ");
+};
+
+export const getAnalysisSignalCount = (source: { analysis_summary_json?: Record<string, unknown> }, key: string): number => {
+    const value = source.analysis_summary_json?.[key];
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+};
+
+export const normalizeIssueLabel = (label: string): string =>
+    sanitizeSummaryMessage(label).replace(/^['"]|['"]$/g, "").trim();
+
+export const isCountOnlySummaryWarning = (warning: string): boolean =>
+    COUNT_ONLY_WARNING_PATTERNS.some((pattern) => pattern.test(warning));
+
+export const parseLineIssueWarning = (warning: string): { labels: string[]; kind: "unmapped" | "lowConfidence"; detail: string } | null => {
+    const lowConfidenceMatch = warning.match(LOW_CONFIDENCE_WARNING_PATTERN);
+    if (lowConfidenceMatch) {
+        return {
+            labels: [normalizeIssueLabel(lowConfidenceMatch[1] || "")],
+            kind: "lowConfidence" as const,
+            detail: warning,
+        };
+    }
+
+    const unmappedMatch = warning.match(UNMAPPED_WARNING_PATTERN);
+    if (unmappedMatch) {
+        return {
+            labels: [normalizeIssueLabel(unmappedMatch[1] || "")],
+            kind: "unmapped" as const,
+            detail: "Needs manual product mapping.",
+        };
+    }
+
+    const manualReviewMatch = warning.match(MANUAL_REVIEW_WARNING_PATTERN);
+    if (manualReviewMatch) {
+        return {
+            labels: manualReviewMatch[1]
+                .split(",")
+                .map((label) => normalizeIssueLabel(label))
+                .filter(Boolean),
+            kind: "unmapped" as const,
+            detail: "Needs manual product mapping.",
+        };
+    }
+
+    return null;
+};
+
+export const getPrimaryIssueKind = (issueKinds: ReviewIssueKind[]): ReviewIssueKind =>
+    [...issueKinds].sort((left, right) => issueKindPriority[left] - issueKindPriority[right])[0] || "conditional";
+
+export const getIssueProblemMessage = (issueKinds: ReviewIssueKind[]): string => {
+    const primaryIssue = getPrimaryIssueKind(issueKinds);
+    if (primaryIssue === "unmapped") {
+        return "Choose the correct ProductCode before creating the quote.";
+    }
+    if (primaryIssue === "ambiguous") {
+        return "Multiple ProductCodes matched. Confirm the correct one.";
+    }
+    if (primaryIssue === "lowConfidence") {
+        return "Check the normalized charge label before confirming.";
+    }
+    return "Confirm whether this conditional charge should stay in the quote.";
+};
+
+export const humanizeEnum = (value?: string | null): string => {
+    const normalized = String(value || "").trim();
+    if (!normalized) return "Not recorded";
+    return normalized
+        .split("_")
+        .filter(Boolean)
+        .map((part) => part.charAt(0) + part.slice(1).toLowerCase())
+        .join(" ");
+};
+
+export const formatProductCodeSummary = (productCode?: SPEChargeLine["resolved_product_code"] | null): string => {
+    if (!productCode?.code) return "Not recorded";
+    return productCode.description ? `${productCode.code} - ${productCode.description}` : productCode.code;
+};
+
+export const getChargeStatusLabel = (charge: SPEChargeLine): string => {
+    if (charge.manual_resolution_status === "RESOLVED") return "Manually resolved";
+    if (charge.normalization_status === "MATCHED") return "Matched";
+    if (charge.normalization_status === "AMBIGUOUS") return "Ambiguous";
+    if (charge.normalization_status === "UNMAPPED") return "Needs review";
+    return "Not normalized";
+};
+
+export const chargeUnitLabel = (unit?: SPEChargeLine["unit"]): string => {
+    if (unit === "per_kg") return "Per KG";
+    if (unit === "flat") return "Flat";
+    if (unit === "per_awb") return "Per AWB";
+    if (unit === "per_shipment") return "Per shipment";
+    if (unit === "percentage") return "Percentage";
+    if (unit === "per_trip") return "Per trip";
+    if (unit === "per_set") return "Per set";
+    if (unit === "per_man") return "Per man";
+    if (unit === "min_or_per_kg") return "Min or per KG";
+    return "Unit";
+};
+
+export const formatChargeAmount = (charge: SPEChargeLine): string => {
+    const amount = String(charge.amount || "").trim();
+    if (!amount) return charge.currency || "";
+    return `${amount} ${charge.currency || ""}`.trim();
+};
+
+export const isActionableAiWarning = (warning: string): boolean => {
+    const normalized = normalizeSummaryMessage(warning).toLowerCase();
+    return !NON_ACTIONABLE_AI_WARNING_PATTERNS.some((pattern) => normalized.includes(pattern));
+};
+
+export const getSourceSummaryTitle = (label: string, targetBucket: SPEChargeLine["bucket"] | "mixed"): string => {
+    const cleaned = label.replace(/\bAI\b/gi, "").replace(/\s{2,}/g, " ").trim();
+    if (cleaned.toLowerCase() === "unified intake") return "Uploaded rates";
+    if (cleaned) return cleaned;
+    if (targetBucket === "mixed") return "Uploaded rates";
+    return `${BUCKET_LABELS[targetBucket]} import`;
+};
+
+export const getSourceSummarySubtitle = (bucket: SPEChargeLine["bucket"] | "mixed"): string => {
+    if (bucket === "mixed") return "Imported lines are grouped for this quote";
+    return `${BUCKET_LABELS[bucket]} lines are grouped for this quote`;
+};
+
+export const formatMissingComponents = (components?: string[]): string[] | null => {
+    if (!components || components.length === 0) return null;
+    const friendly = components.map((component) => {
+        const normalized = component.toUpperCase();
+        if (normalized === "DESTINATION_LOCAL") return "Destination Charges";
+        if (normalized === "ORIGIN_LOCAL") return "Origin Charges";
+        if (normalized === "FREIGHT") return "Freight Rate";
+        return component.replace(/_/g, " ");
+    });
+    return Array.from(new Set(friendly));
+};
+
+export const formatListWithAnd = (items: string[]): string => {
+    if (items.length <= 1) return items[0] || "";
+    if (items.length === 2) return `${items[0]} and ${items[1]}`;
+    return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
+};


### PR DESCRIPTION
## Summary

Completes Phase 7B.2 by extracting pure SPOT workspace formatting/classification helpers into a shared helper library and replacing duplicated helper definitions across SPOT components.

## Files changed

- `frontend/package.json` — adds `test:spot-workspace-helpers`
- `frontend/src/lib/spot-workspace-helpers.ts` — new shared helper library
- `frontend/scripts/spot-workspace-helpers.test.mjs` — new focused unit coverage
- `frontend/src/app/quotes/spot/[speId]/page.tsx` — imports extracted helpers and removes inline helper definitions
- `frontend/src/components/spot/ChargeNormalizationAudit.tsx` — imports shared `humanizeEnum`
- `frontend/src/components/spot/SpotChargeLineManualReviewSheet.tsx` — imports shared `humanizeEnum`

## Helpers extracted

- `isBuySideCharge`
- `isStandardRateCharge`
- `componentToBucket`
- `sanitizeSummaryMessage`
- `normalizeSummaryMessage`
- `getAnalysisSignalCount`
- `normalizeIssueLabel`
- `isCountOnlySummaryWarning`
- `parseLineIssueWarning`
- `getPrimaryIssueKind`
- `getIssueProblemMessage`
- `humanizeEnum`
- `formatProductCodeSummary`
- `getChargeStatusLabel`
- `chargeUnitLabel`
- `formatChargeAmount`
- `isActionableAiWarning`
- `getSourceSummaryTitle`
- `getSourceSummarySubtitle`
- `formatMissingComponents`
- `formatListWithAnd`

## Verification reported by Gemini/Antigravity

The following commands passed locally:

- `npm run typecheck`
- `node scripts/spot-workspace-helpers.test.mjs`
- `node scripts/quote-detail-helpers.test.mjs`
- `node scripts/quote-detail-mapping.test.mjs`
- `node scripts/quote-edit-hydration.test.mjs`
- `node scripts/quote-workflow-roundtrip.test.mjs`
- `node --experimental-strip-types --experimental-specifier-resolution=node scripts/quote-store.test.mjs`

Fallow summary reported:

- Maintainability Index improved to `88.9`
- Duplication reduced to `11.2%`
- Duplicate clone group `dup:0bb629a5` resolved
- SPOT page reduced by 204 lines

## Scope guardrails

This PR should be reviewed as pure helper extraction only.

- No backend changes
- No SPOT workflow behavior changes
- No finalisation behavior changes
- No quote creation behavior changes
- No API behavior changes
- No router/navigation behavior changes
- No React state handling changes
- No UI layout changes
- No component extraction

## Manual review notes

Main review focus: confirm all extracted helpers are pure and behavior-preserving, and that `ChargeNormalizationAudit.tsx` / `SpotChargeLineManualReviewSheet.tsx` only replace duplicated `humanizeEnum` logic with the shared import.