### PR TITLE
refactor(frontend): extract spot workspace summary

### DIFF
--- a/frontend/src/app/quotes/spot/[speId]/page.tsx
+++ b/frontend/src/app/quotes/spot/[speId]/page.tsx
@@ -29,6 +29,7 @@ import {
     ReplyPasteCard,
 } from "@/components/spot";
 import { SpotRateEntryForm } from "@/components/spot/SpotRateEntryForm";
+import { SpotWorkspaceSummary } from "@/components/spot/SpotWorkspaceSummary";
 import type { SPEChargeLine, SPECommodity } from "@/lib/spot-types";
 import type { ReplyAnalysisResult } from "@/lib/spot-types";
 import { getSpotStandardCharges } from "@/lib/api";
@@ -992,45 +993,16 @@ export default function SpotRateEntryPage() {
             {renderProgress()}
 
             {/* Shipment Summary (Always visible) */}
-            <Card className="mb-6">
-                <CardHeader className="pb-3">
-                    <CardTitle className="text-base font-semibold">Shipment Summary</CardTitle>
-                </CardHeader>
-                <CardContent>
-                    <div className="grid grid-cols-2 gap-4 text-sm md:grid-cols-4 xl:grid-cols-7">
-                        <div className="flex flex-col gap-1">
-                            <span className="text-muted-foreground font-medium">Customer</span>
-                            <span className="font-bold text-slate-900">{displayCustomerName}</span>
-                        </div>
-                        <div className="flex flex-col gap-1">
-                            <span className="text-muted-foreground font-medium">Route</span>
-                            <span className="font-bold text-slate-900">
-                                {originCode || state.spe?.shipment.origin_code} {"->"} {destCode || state.spe?.shipment.destination_code}
-                            </span>
-                        </div>
-                        <div className="flex flex-col gap-1">
-                            <span className="text-muted-foreground font-medium">Commodity</span>
-                            <span className="font-bold text-slate-900">{commodity || state.spe?.shipment.commodity}</span>
-                        </div>
-                        <div className="flex flex-col gap-1">
-                            <span className="text-muted-foreground font-medium">Weight</span>
-                            <span className="font-bold text-slate-900">{weight || state.spe?.shipment.total_weight_kg} kg</span>
-                        </div>
-                        <div className="flex flex-col gap-1">
-                            <span className="text-muted-foreground font-medium">Pieces</span>
-                            <span className="font-bold text-slate-900">{pieces || state.spe?.shipment.pieces}</span>
-                        </div>
-                        <div className="flex flex-col gap-1">
-                            <span className="text-muted-foreground font-medium">Service Scope</span>
-                            <span className="font-bold text-slate-900">{displayServiceScope}</span>
-                        </div>
-                        <div className="flex flex-col gap-1">
-                            <span className="text-muted-foreground font-medium">Payment Terms</span>
-                            <span className="font-bold text-slate-900">{displayPaymentTerm}</span>
-                        </div>
-                    </div>
-                </CardContent>
-            </Card>
+            <SpotWorkspaceSummary
+                customerName={displayCustomerName}
+                originCode={originCode || state.spe?.shipment.origin_code || ""}
+                destinationCode={destCode || state.spe?.shipment.destination_code || ""}
+                commodity={commodity || state.spe?.shipment.commodity || ""}
+                weightKg={weight || state.spe?.shipment.total_weight_kg || 0}
+                pieces={pieces || state.spe?.shipment.pieces || 0}
+                serviceScope={displayServiceScope}
+                paymentTerms={displayPaymentTerm}
+            />
 
             {/* Error display */}
             {(state.error || finalizeError) && (

--- a/frontend/src/components/spot/SpotWorkspaceSummary.tsx
+++ b/frontend/src/components/spot/SpotWorkspaceSummary.tsx
@@ -1,0 +1,65 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export interface SpotWorkspaceSummaryProps {
+    customerName: string;
+    originCode: string;
+    destinationCode: string;
+    commodity: string;
+    weightKg: number;
+    pieces: number;
+    serviceScope: string;
+    paymentTerms: string;
+}
+
+export function SpotWorkspaceSummary({
+    customerName,
+    originCode,
+    destinationCode,
+    commodity,
+    weightKg,
+    pieces,
+    serviceScope,
+    paymentTerms,
+}: SpotWorkspaceSummaryProps) {
+    return (
+        <Card className="mb-6">
+            <CardHeader className="pb-3">
+                <CardTitle className="text-base font-semibold">Shipment Summary</CardTitle>
+            </CardHeader>
+            <CardContent>
+                <div className="grid grid-cols-2 gap-4 text-sm md:grid-cols-4 xl:grid-cols-7">
+                    <div className="flex flex-col gap-1">
+                        <span className="text-muted-foreground font-medium">Customer</span>
+                        <span className="font-bold text-slate-900">{customerName}</span>
+                    </div>
+                    <div className="flex flex-col gap-1">
+                        <span className="text-muted-foreground font-medium">Route</span>
+                        <span className="font-bold text-slate-900">
+                            {originCode} {"->"} {destinationCode}
+                        </span>
+                    </div>
+                    <div className="flex flex-col gap-1">
+                        <span className="text-muted-foreground font-medium">Commodity</span>
+                        <span className="font-bold text-slate-900">{commodity}</span>
+                    </div>
+                    <div className="flex flex-col gap-1">
+                        <span className="text-muted-foreground font-medium">Weight</span>
+                        <span className="font-bold text-slate-900">{weightKg} kg</span>
+                    </div>
+                    <div className="flex flex-col gap-1">
+                        <span className="text-muted-foreground font-medium">Pieces</span>
+                        <span className="font-bold text-slate-900">{pieces}</span>
+                    </div>
+                    <div className="flex flex-col gap-1">
+                        <span className="text-muted-foreground font-medium">Service Scope</span>
+                        <span className="font-bold text-slate-900">{serviceScope}</span>
+                    </div>
+                    <div className="flex flex-col gap-1">
+                        <span className="text-muted-foreground font-medium">Payment Terms</span>
+                        <span className="font-bold text-slate-900">{paymentTerms}</span>
+                    </div>
+                </div>
+            </CardContent>
+        </Card>
+    );
+}


### PR DESCRIPTION
## Summary

Completes Phase 7B.4 by extracting the SPOT workspace shipment/workspace summary card into a dedicated presentational component.

## Files changed

- `frontend/src/app/quotes/spot/[speId]/page.tsx` — replaces the inline summary card with `SpotWorkspaceSummary`
- `frontend/src/components/spot/SpotWorkspaceSummary.tsx` — new presentational summary card component

## Component props

`SpotWorkspaceSummary` receives flat display props only:

- `customerName`
- `originCode`
- `destinationCode`
- `commodity`
- `weightKg`
- `pieces`
- `serviceScope`
- `paymentTerms`

## Verification reported by Gemini/Antigravity

The following commands passed locally:

- `npm run typecheck`
- `node scripts/spot-workspace-helpers.test.mjs`
- `node scripts/quote-detail-helpers.test.mjs`
- `node scripts/quote-detail-mapping.test.mjs`
- `node scripts/quote-edit-hydration.test.mjs`
- `node scripts/quote-workflow-roundtrip.test.mjs`
- `node --experimental-strip-types --experimental-specifier-resolution=node scripts/quote-store.test.mjs`

Fallow summary reported:

- Maintainability Index: `88.9` Good, unchanged
- Duplication: `11.2%`, unchanged
- SPOT page reduced by 27 lines

## Scope guardrails

This PR should be reviewed as a presentational extraction only.

- No backend changes
- No SPOT workflow behavior changes
- No finalisation behavior changes
- No quote creation behavior changes
- No API behavior changes
- No router/navigation behavior changes
- No React state handling changes
- No drawer behavior changes
- No UI redesign intended

## Manual review notes

Main review focus: confirm the summary card layout, classes, labels, copy, and formatting remain equivalent after extraction. No state, API, routing, drawer, or workflow logic should move into `SpotWorkspaceSummary.tsx`.