### PR TITLE
refactor(frontend): extract source comparison sheet

### DIFF
--- a/frontend/src/app/quotes/spot/[speId]/page.tsx
+++ b/frontend/src/app/quotes/spot/[speId]/page.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/components/spot";
 import { SpotRateEntryForm } from "@/components/spot/SpotRateEntryForm";
 import { SpotWorkspaceSummary } from "@/components/spot/SpotWorkspaceSummary";
+import { SourceComparisonSheet } from "@/components/spot/SourceComparisonSheet";
 import type { SPEChargeLine, SPECommodity } from "@/lib/spot-types";
 import type { ReplyAnalysisResult } from "@/lib/spot-types";
 import { getSpotStandardCharges } from "@/lib/api";
@@ -1687,70 +1688,15 @@ export default function SpotRateEntryPage() {
                         </SheetContent>
                     </Sheet>
 
-                    <Sheet open={sourceComparisonOpen} onOpenChange={setSourceComparisonOpen}>
-                        <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-5xl">
-                            <div className="space-y-6">
-                                <SheetHeader className="space-y-2 border-b border-slate-200 pb-5">
-                                    <SheetTitle>Source comparison</SheetTitle>
-                                    <SheetDescription>
-                                        Optional audit view. Select a charge to inspect the captured source evidence.
-                                    </SheetDescription>
-                                </SheetHeader>
-                                <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(320px,0.8fr)]">
-                                    <section className="space-y-3">
-                                        <div className="text-sm font-semibold text-slate-950">Source text</div>
-                                        <div className="max-h-[70vh] overflow-auto rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm leading-6 text-slate-800">
-                                            {sourceComparisonText ? (
-                                                <pre className="whitespace-pre-wrap font-sans">{sourceComparisonText}</pre>
-                                            ) : (
-                                                <div className="text-slate-500">No source text captured for this source.</div>
-                                            )}
-                                        </div>
-                                    </section>
-                                    <section className="space-y-3">
-                                        <div className="text-sm font-semibold text-slate-950">Extracted charges</div>
-                                        <div className="space-y-2">
-                                            {sourceComparisonCharges.map((charge) => {
-                                                const key = charge.id || `${charge.bucket}-${charge.description}-${charge.amount}`;
-                                                const isSelected = key === (selectedSourceCharge?.id || `${selectedSourceCharge?.bucket}-${selectedSourceCharge?.description}-${selectedSourceCharge?.amount}`);
-                                                return (
-                                                    <button
-                                                        key={key}
-                                                        type="button"
-                                                        onClick={() => setSelectedSourceChargeKey(key)}
-                                                        className={`w-full rounded-xl border px-4 py-3 text-left text-sm transition-colors ${
-                                                            isSelected
-                                                                ? "border-primary bg-primary/5 text-slate-950"
-                                                                : "border-slate-200 bg-white text-slate-700 hover:border-primary/40"
-                                                        }`}
-                                                    >
-                                                        <div className="font-semibold">{getSpotChargeDisplayLabel(charge, { includeProductCode: true })}</div>
-                                                        <div className="mt-1 text-xs text-slate-500">
-                                                            {formatChargeAmount(charge)} / {chargeUnitLabel(charge.unit)}
-                                                        </div>
-                                                    </button>
-                                                );
-                                            })}
-                                        </div>
-                                        <div className="rounded-xl border border-slate-200 bg-white p-4">
-                                            <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">Source</div>
-                                            {selectedSourceCharge?.source_excerpt ? (
-                                                <div className="mt-3 rounded-md border border-primary/20 bg-primary/5 p-3 text-sm leading-6 text-slate-900">
-                                                    {selectedSourceCharge.source_excerpt}
-                                                </div>
-                                            ) : (
-                                                <div className="mt-3 text-sm text-slate-500">No snippet captured for this charge.</div>
-                                            )}
-                                            <div className="mt-3 space-y-1 text-xs text-slate-500">
-                                                {selectedSourceCharge?.source_line_number ? <div>Line {selectedSourceCharge.source_line_number}</div> : null}
-                                                {selectedSourceCharge?.source_line_identity ? <div className="break-all">{selectedSourceCharge.source_line_identity}</div> : null}
-                                            </div>
-                                        </div>
-                                    </section>
-                                </div>
-                            </div>
-                        </SheetContent>
-                    </Sheet>
+                    <SourceComparisonSheet
+                        open={sourceComparisonOpen}
+                        sourceComparisonText={sourceComparisonText}
+                        sourceComparisonCharges={sourceComparisonCharges}
+                        selectedSourceChargeKey={selectedSourceChargeKey}
+                        selectedSourceCharge={selectedSourceCharge}
+                        onOpenChange={setSourceComparisonOpen}
+                        onSelectSourceChargeKey={setSelectedSourceChargeKey}
+                    />
                 </div>
             )}
 

--- a/frontend/src/components/spot/SourceComparisonSheet.tsx
+++ b/frontend/src/components/spot/SourceComparisonSheet.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import {
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetHeader,
+    SheetTitle,
+} from "@/components/ui/sheet";
+import type { SPEChargeLine } from "@/lib/spot-types";
+import { getSpotChargeDisplayLabel } from "@/lib/spot-charge-display";
+import {
+    formatChargeAmount,
+    chargeUnitLabel,
+} from "@/lib/spot-workspace-helpers";
+
+export interface SourceComparisonSheetProps {
+    open: boolean;
+    sourceComparisonText: string;
+    sourceComparisonCharges: SPEChargeLine[];
+    selectedSourceChargeKey: string | null;
+    selectedSourceCharge: SPEChargeLine | null;
+    onOpenChange: (open: boolean) => void;
+    onSelectSourceChargeKey: (key: string | null) => void;
+}
+
+export function SourceComparisonSheet({
+    open,
+    sourceComparisonText,
+    sourceComparisonCharges,
+    selectedSourceChargeKey,
+    selectedSourceCharge,
+    onOpenChange,
+    onSelectSourceChargeKey,
+}: SourceComparisonSheetProps) {
+    return (
+        <Sheet open={open} onOpenChange={onOpenChange}>
+            <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-5xl">
+                <div className="space-y-6">
+                    <SheetHeader className="space-y-2 border-b border-slate-200 pb-5">
+                        <SheetTitle>Source comparison</SheetTitle>
+                        <SheetDescription>
+                            Optional audit view. Select a charge to inspect the captured source evidence.
+                        </SheetDescription>
+                    </SheetHeader>
+                    <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(320px,0.8fr)]">
+                        <section className="space-y-3">
+                            <div className="text-sm font-semibold text-slate-950">Source text</div>
+                            <div className="max-h-[70vh] overflow-auto rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm leading-6 text-slate-800">
+                                {sourceComparisonText ? (
+                                    <pre className="whitespace-pre-wrap font-sans">{sourceComparisonText}</pre>
+                                ) : (
+                                    <div className="text-slate-500">No source text captured for this source.</div>
+                                )}
+                            </div>
+                        </section>
+                        <section className="space-y-3">
+                            <div className="text-sm font-semibold text-slate-950">Extracted charges</div>
+                            <div className="space-y-2">
+                                {sourceComparisonCharges.map((charge) => {
+                                    const key = charge.id || `${charge.bucket}-${charge.description}-${charge.amount}`;
+                                    const isSelected = key === (selectedSourceCharge?.id || `${selectedSourceCharge?.bucket}-${selectedSourceCharge?.description}-${selectedSourceCharge?.amount}`);
+                                    return (
+                                        <button
+                                            key={key}
+                                            type="button"
+                                            onClick={() => onSelectSourceChargeKey(key)}
+                                            className={`w-full rounded-xl border px-4 py-3 text-left text-sm transition-colors ${
+                                                isSelected
+                                                    ? "border-primary bg-primary/5 text-slate-950"
+                                                    : "border-slate-200 bg-white text-slate-700 hover:border-primary/40"
+                                            }`}
+                                        >
+                                            <div className="font-semibold">{getSpotChargeDisplayLabel(charge, { includeProductCode: true })}</div>
+                                            <div className="mt-1 text-xs text-slate-500">
+                                                {formatChargeAmount(charge)} / {chargeUnitLabel(charge.unit)}
+                                            </div>
+                                        </button>
+                                    );
+                                })}
+                            </div>
+                            <div className="rounded-xl border border-slate-200 bg-white p-4">
+                                <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">Source</div>
+                                {selectedSourceCharge?.source_excerpt ? (
+                                    <div className="mt-3 rounded-md border border-primary/20 bg-primary/5 p-3 text-sm leading-6 text-slate-900">
+                                        {selectedSourceCharge.source_excerpt}
+                                    </div>
+                                ) : (
+                                    <div className="mt-3 text-sm text-slate-500">No snippet captured for this charge.</div>
+                                )}
+                                <div className="mt-3 space-y-1 text-xs text-slate-500">
+                                    {selectedSourceCharge?.source_line_number ? <div>Line {selectedSourceCharge.source_line_number}</div> : null}
+                                    {selectedSourceCharge?.source_line_identity ? <div className="break-all">{selectedSourceCharge.source_line_identity}</div> : null}
+                                </div>
+                            </div>
+                        </section>
+                    </div>
+                </div>
+            </SheetContent>
+        </Sheet>
+    );
+}


### PR DESCRIPTION
## Summary

Completes Phase 7B.6 by extracting the read-only Source Comparison drawer from the SPOT workspace page into a dedicated presentational component.

## Files changed

- `frontend/src/app/quotes/spot/[speId]/page.tsx` — replaces inline Source Comparison drawer markup with `SourceComparisonSheet`
- `frontend/src/components/spot/SourceComparisonSheet.tsx` — new presentational drawer component

## Component props

`SourceComparisonSheet` receives drawer state, read-only comparison data, selection state, and safe callbacks only:

- `open`
- `sourceComparisonText`
- `sourceComparisonCharges`
- `selectedSourceChargeKey`
- `selectedSourceCharge`
- `onOpenChange`
- `onSelectSourceChargeKey`

## Verification reported by Gemini/Antigravity

The following commands passed locally:

- `npm run typecheck`
- `node scripts/spot-workspace-helpers.test.mjs`
- `node scripts/quote-detail-helpers.test.mjs`
- `node scripts/quote-detail-mapping.test.mjs`
- `node scripts/quote-edit-hydration.test.mjs`
- `node scripts/quote-workflow-roundtrip.test.mjs`
- `node --experimental-strip-types --experimental-specifier-resolution=node scripts/quote-store.test.mjs`

Fallow summary reported:

- Maintainability Index: `88.9` Good
- Duplication: `11.2%`, stable
- `SpotRateEntryPage` cyclomatic complexity reduced from `116` to `109`
- `SpotRateEntryPage` cognitive complexity reduced from `90` to `86`
- SPOT page reduced from `1763` to `1715` lines

## Scope guardrails

This PR should be reviewed as a presentational extraction only.

- No backend changes
- No SPOT workflow behavior changes
- No finalisation behavior changes
- No quote creation behavior changes
- No API behavior changes
- No router/navigation behavior changes
- No React state ownership changes
- No IssueDetailsSheet changes
- No manual review logic changes
- No UI redesign intended

## Manual review notes

Main review focus: confirm the drawer layout, selection styling, scroll areas, labels, and read-only comparison display remain equivalent. State ownership for `sourceComparisonOpen`, `selectedSourceChargeKey`, selected source charge derivation, and source comparison data should remain in `page.tsx`.