### PR TITLE
refactor(frontend): extract lookup api module

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -225,23 +225,7 @@ export async function updateOrganizationBrandingSettings(
 
 // --- Airport Search ---
 
-export async function searchAirports(
-  query: string,
-): Promise<AirportSearchResult[]> {
-  const url =
-    API_BASE_URL + `/api/v3/core/airports/search/?search=${encodeURIComponent(query)}`;
-  const response = await fetch(url, {
-    headers: {
-      Authorization: `Token ${getToken()}`,
-    },
-  });
-
-  if (!response.ok) {
-    throw new Error('Failed to search airports');
-  }
-
-  return response.json();
-}
+export { searchAirports } from './api/lookups';
 
 // --- Quotes V3 ---
 
@@ -403,41 +387,10 @@ export {
   updateCustomer,
 } from './api/customers';
 
-export async function listCountries(query?: string): Promise<CountryOption[]> {
-  const url = new URL(API_BASE_URL + '/api/v3/core/countries/');
-  if (query && query.trim()) {
-    url.searchParams.append('q', query.trim());
-  }
-  const response = await fetch(url.toString(), {
-    headers: {
-      Authorization: `Token ${getToken()}`,
-    },
-  });
-
-  if (!response.ok) {
-    throw new Error('Failed to fetch countries');
-  }
-
-  return response.json();
-}
-
-export async function listCities(params?: {
-  country_code?: string;
-  query?: string;
-}): Promise<CityOption[]> {
-  const url = new URL(API_BASE_URL + '/api/v3/core/cities/');
-  if (params?.country_code) {
-    url.searchParams.append('country', params.country_code);
-  }
-  if (params?.query && params.query.trim()) {
-    url.searchParams.append('q', params.query.trim());
-  }
-  try {
-    return await getJson<CityOption[]>(url.toString());
-  } catch {
-    throw new Error('Failed to fetch cities');
-  }
-}
+export {
+  listCountries,
+  listCities,
+} from './api/lookups';
 
 export {
   deleteCustomer,

--- a/frontend/src/lib/api/lookups.ts
+++ b/frontend/src/lib/api/lookups.ts
@@ -1,0 +1,56 @@
+import { API_BASE_URL, getToken, getJson } from './shared';
+import type { AirportSearchResult, CountryOption, CityOption } from '../types';
+
+export async function searchAirports(
+  query: string,
+): Promise<AirportSearchResult[]> {
+  const url =
+    API_BASE_URL + `/api/v3/core/airports/search/?search=${encodeURIComponent(query)}`;
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Token ${getToken()}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to search airports');
+  }
+
+  return response.json();
+}
+
+export async function listCountries(query?: string): Promise<CountryOption[]> {
+  const url = new URL(API_BASE_URL + '/api/v3/core/countries/');
+  if (query && query.trim()) {
+    url.searchParams.append('q', query.trim());
+  }
+  const response = await fetch(url.toString(), {
+    headers: {
+      Authorization: `Token ${getToken()}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch countries');
+  }
+
+  return response.json();
+}
+
+export async function listCities(params?: {
+  country_code?: string;
+  query?: string;
+}): Promise<CityOption[]> {
+  const url = new URL(API_BASE_URL + '/api/v3/core/cities/');
+  if (params?.country_code) {
+    url.searchParams.append('country', params.country_code);
+  }
+  if (params?.query && params.query.trim()) {
+    url.searchParams.append('q', params.query.trim());
+  }
+  try {
+    return await getJson<CityOption[]>(url.toString());
+  } catch {
+    throw new Error('Failed to fetch cities');
+  }
+}


### PR DESCRIPTION
## Summary

Completes Phase 8.6 by extracting core lookup/search API functions from the monolithic `frontend/src/lib/api.ts` into a dedicated lookup API module.

## Files changed

- `frontend/src/lib/api.ts` — replaces inline lookup implementations with explicit backward-compatible named re-exports
- `frontend/src/lib/api/lookups.ts` — new lookup API module

## Extracted functions

- `searchAirports`
- `listCountries`
- `listCities`

## Extracted types

No new types were moved. Related types already live in `frontend/src/lib/types.ts`:

- `AirportSearchResult`
- `CountryOption`
- `CityOption`

## Compatibility

Existing imports from `@/lib/api` remain supported through explicit named re-exports from `api.ts`.

## Verification reported by Gemini/Antigravity

The following commands passed locally:

- `npm run typecheck`
- `node frontend/scripts/spot-workspace-helpers.test.mjs`
- `node frontend/scripts/quote-detail-helpers.test.mjs`
- `node frontend/scripts/quote-detail-mapping.test.mjs`
- `node frontend/scripts/quote-edit-hydration.test.mjs`
- `node frontend/scripts/quote-workflow-roundtrip.test.mjs`
- `node --experimental-strip-types --experimental-specifier-resolution=node frontend/scripts/quote-store.test.mjs`

Fallow summary reported:

- Circular dependencies: `0`
- Duplication reduced to `11.03%`
- `api.ts` reduced from `1903` to `1851` lines

## Scope guardrails

This PR should be reviewed as airport/country/city lookup API extraction only.

- No backend changes
- No endpoint URL changes
- No HTTP method changes
- No request payload changes
- No response mapping changes
- No auth/header handling changes
- No error behavior changes
- No UI import changes intended
- No quote API changes
- No SPOT API changes
- No customer API changes
- No reporting API changes
- No rate API changes

## Manual review notes

Main review focus: confirm `lookups.ts` imports only shared utilities/types and does not import from `api.ts`, and that `api.ts` preserves explicit backward-compatible exports for current consumers.