### PR TITLE
refactor(frontend): extract quote financial helpers

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "test:domestic-service-scope": "node scripts/domestic-service-scope.test.mjs",
     "test:spot-finalization": "node scripts/spot-finalization.test.mjs",
     "test:spot-workspace-helpers": "node scripts/spot-workspace-helpers.test.mjs",
+    "test:quote-financial-helpers": "node scripts/quote-financial-helpers.test.mjs",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",

--- a/frontend/scripts/quote-financial-helpers.test.mjs
+++ b/frontend/scripts/quote-financial-helpers.test.mjs
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import ts from "typescript";
+
+const frontendRoot = path.resolve(process.cwd());
+const helperSourcePath = path.join(frontendRoot, "src", "lib", "quote-financial-helpers.ts");
+
+function transpile(source, fileName) {
+  return ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName,
+  }).outputText;
+}
+
+async function loadModules() {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "quote-financial-helpers-test-"));
+  const libDir = path.join(tempDir, "lib");
+
+  try {
+    await mkdir(libDir, { recursive: true });
+
+    const helperSource = await readFile(helperSourcePath, "utf8");
+
+    const helperModule = transpile(helperSource, helperSourcePath)
+      .replace(/from ['"]\.\/types['"]/g, "from './types.mjs'");
+
+    await writeFile(path.join(libDir, "quote-financial-helpers.mjs"), helperModule, "utf8");
+    await writeFile(path.join(libDir, "types.mjs"), `export {}`, "utf8");
+
+    const helpers = await import(`file://${path.join(libDir, "quote-financial-helpers.mjs")}`);
+    return helpers;
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+const {
+  toMoneyString,
+  mapCanonicalComponentToLeg,
+  mapCanonicalLineItemToBreakdownLine,
+  buildCanonicalTotals,
+  formatAmount,
+  getBucket,
+  calculateBucketTotal,
+  readField,
+  readStringField,
+  getDisplaySellAmount,
+  isAvailable,
+  displayValue,
+  displayApplicable,
+  displayMoney,
+  displayPercent,
+  findRawLine,
+  lineWarnings,
+  sourceLabel,
+} = await loadModules();
+
+// Test: formatting
+assert.equal(toMoneyString(12.3456), "12.35");
+assert.equal(formatAmount("1234.56", "PGK"), "PGK 1,234.56");
+assert.equal(formatAmount(100, "USD"), "USD 100.00");
+
+// Test: display formatting helper
+assert.equal(isAvailable(null), false);
+assert.equal(isAvailable(undefined), false);
+assert.equal(isAvailable(""), false);
+assert.equal(isAvailable("POM"), true);
+
+assert.equal(displayValue("POM"), "POM");
+assert.equal(displayValue(null), "Not available");
+
+assert.equal(displayApplicable("POM", true), "POM");
+assert.equal(displayApplicable("POM", false), "Not applicable");
+
+assert.equal(displayMoney(1234.56, "PGK"), "PGK 1,234.56");
+assert.equal(displayMoney(null, "PGK"), "Not available");
+
+assert.equal(displayPercent(12.345), "12.35%");
+assert.equal(displayPercent("POM"), "POM");
+assert.equal(displayPercent(null), "Not available");
+
+// Test: bucket/leg mapping
+assert.equal(mapCanonicalComponentToLeg("ORIGIN_LOCAL"), "ORIGIN");
+assert.equal(mapCanonicalComponentToLeg("DESTINATION_LOCAL"), "DESTINATION");
+assert.equal(mapCanonicalComponentToLeg("FREIGHT"), "FREIGHT");
+assert.equal(mapCanonicalComponentToLeg("UNKNOWN"), "DESTINATION");
+
+assert.equal(getBucket({ leg: "MAIN" }), "FREIGHT");
+assert.equal(getBucket({ leg: "FREIGHT" }), "FREIGHT");
+assert.equal(getBucket({ leg: "ORIGIN" }), "ORIGIN");
+assert.equal(getBucket({ leg: "DESTINATION" }), "DESTINATION");
+
+// Test: calculateBucketTotal
+const mockLines = [
+  { sell_pgk: "123.45", sell_fcy: "100.00" },
+  { sell_pgk: "20.00", sell_fcy: "15.00" }
+];
+assert.equal(calculateBucketTotal(mockLines, "sell_pgk"), 143.45);
+assert.equal(calculateBucketTotal(mockLines, "sell_fcy"), 115.00);
+
+// Test: findRawLine
+const rawLines = [
+  { id: "line-1", product_code: "POM", description: "Line 1" },
+  { id: "line-2", product_code: "LAE", description: "Line 2" }
+];
+assert.deepEqual(findRawLine(rawLines, { line_id: "line-2" }), rawLines[1]);
+assert.deepEqual(findRawLine(rawLines, { product_code: "POM", description: "Line 1" }), rawLines[0]);
+
+// Test: lineWarnings
+assert.deepEqual(lineWarnings({}, { is_rate_missing: true }), [{ text: "Missing buy rate", level: "critical" }]);
+assert.deepEqual(lineWarnings({ is_manual_override: true }, {}), [{ text: "Manual override", level: "info" }]);
+assert.deepEqual(lineWarnings({ rate_source: "FALLBACK_RULE" }, {}), [{ text: "FX or rate fallback applied", level: "info" }]);
+
+// Test: sourceLabel
+assert.equal(sourceLabel({ is_spot_sourced: true }, {}), "SPOT");
+assert.equal(sourceLabel({}, { is_spot_sourced: true }), "SPOT");
+assert.equal(sourceLabel({ is_manual_override: true }, {}), "Manual entry");
+assert.equal(sourceLabel({ rate_source: "DB_TARIFF" }, {}), "V4 rate card");
+assert.equal(sourceLabel({ rate_source: "FALLBACK_RULE" }, {}), "Fallback rule");
+
+// Test: mapCanonicalLineItemToBreakdownLine
+const canonicalItem = {
+  component: "ORIGIN_LOCAL",
+  product_code: "POM_LOCAL",
+  description: "Port Moresby Handling",
+  cost_amount: "50.00",
+  sell_amount: "100.00",
+  tax_amount: "10.00",
+  margin_percent: "50",
+  cost_currency: "PGK",
+  cost_source: "TARIFF",
+  included_in_total: true,
+};
+const mapped = mapCanonicalLineItemToBreakdownLine(canonicalItem, "PGK");
+assert.equal(mapped.leg, "ORIGIN");
+assert.equal(mapped.sell_pgk, "100.00");
+assert.equal(mapped.sell_pgk_incl_gst, "110.00");
+assert.equal(mapped.gst_amount, "10.00");
+
+// Test: buildCanonicalTotals
+const mockTotalsResult = {
+  currency: "USD",
+  sell_total: "1100.00",
+  tax_breakdown: { gst_amount: "100.00" },
+  total_sell_pgk: "3000.00",
+};
+const totals = buildCanonicalTotals(mockTotalsResult);
+assert.equal(totals.currency, "USD");
+assert.equal(totals.total_quote_amount, "1100.00");
+assert.equal(totals.total_gst, "100.00");
+assert.equal(totals.total_sell_ex_gst, "1000.00");
+
+console.log("quote financial helpers checks passed");

--- a/frontend/src/components/QuoteFinancialBreakdown.tsx
+++ b/frontend/src/components/QuoteFinancialBreakdown.tsx
@@ -21,200 +21,33 @@ interface QuoteFinancialBreakdownProps {
     result: QuoteComputeResult | V3QuoteComputeResponse;
 }
 
-type LooseRecord = Record<string, unknown>;
-
-type RawQuoteLine = V3QuoteLine & Partial<SellLine> & {
-    margin_amount?: string | null;
-};
-
-type BreakdownLine = SellLine & { 
-    sell_fcy_currency?: string;
-    canonical_item?: CanonicalQuoteLineItem;
-    raw_line?: RawQuoteLine;
-    subcategory?: string;
-    margin_amount?: string | null;
-};
-
-type BreakdownDataShape = {
-    status?: string;
-    quote_result?: CanonicalQuoteResult | null;
-    latest_version?: {
-        sell_lines?: BreakdownLine[];
-        lines?: BreakdownLine[];
-        totals?: LooseRecord;
-    };
-    sell_lines?: BreakdownLine[];
-    lines?: BreakdownLine[];
-    totals?: LooseRecord;
-};
-
-function toMoneyString(value: number): string {
-    return value.toFixed(2);
-}
-
-function mapCanonicalComponentToLeg(component: string): SellLine["leg"] {
-    switch ((component || "").toUpperCase()) {
-        case "ORIGIN_LOCAL":
-            return "ORIGIN";
-        case "DESTINATION_LOCAL":
-            return "DESTINATION";
-        case "FREIGHT":
-            return "FREIGHT";
-        default:
-            return "DESTINATION";
-    }
-}
-
-function mapCanonicalLineItemToBreakdownLine(
-    item: CanonicalQuoteLineItem,
-    currency: string,
-    rawLine?: RawQuoteLine
-): BreakdownLine {
-    const sellAmount = parseFloat(item.sell_amount || "0");
-    const taxAmount = parseFloat(item.tax_amount || "0");
-    const sellInclTax = sellAmount + taxAmount;
-
-    return {
-        line_type: "COMPONENT",
-        component: item.product_code || item.component,
-        description: item.description,
-        leg: mapCanonicalComponentToLeg(item.component),
-        cost_pgk: item.cost_amount,
-        sell_pgk: currency === "PGK" ? item.sell_amount : "0.00",
-        sell_pgk_incl_gst: currency === "PGK" ? toMoneyString(sellInclTax) : "0.00",
-        gst_amount: item.tax_amount,
-        sell_fcy: currency !== "PGK" ? item.sell_amount : item.sell_amount,
-        sell_fcy_incl_gst: currency !== "PGK" ? toMoneyString(sellInclTax) : toMoneyString(sellInclTax),
-        sell_currency: currency,
-        sell_fcy_currency: currency !== "PGK" ? currency : undefined,
-        margin_percent: item.margin_percent,
-        exchange_rate: item.rate || "0",
-        subcategory: item.subcategory,
-        source: item.cost_source,
-        is_informational: !item.included_in_total,
-        margin_amount: item.margin_amount,
-        canonical_item: item,
-        raw_line: rawLine,
-    };
-}
-
-function buildCanonicalTotals(result: CanonicalQuoteResult): LooseRecord {
-    const currency = (result.currency || "PGK").toUpperCase();
-    const sellTotal = parseFloat(result.sell_total || "0");
-    const gstAmount = parseFloat(result.tax_breakdown?.gst_amount || "0");
-    const exGst = sellTotal - gstAmount;
-
-    return {
-        currency,
-        total_quote_amount: toMoneyString(sellTotal),
-        total_gst: result.tax_breakdown?.gst_amount || "0.00",
-        gst_amount: result.tax_breakdown?.gst_amount || "0.00",
-        total_sell_pgk: result.total_sell_pgk,
-        total_sell_pgk_incl_gst: currency === "PGK" ? result.sell_total : result.total_sell_pgk,
-        total_sell_ex_gst: toMoneyString(exGst),
-        total_sell_fcy: currency !== "PGK" ? toMoneyString(exGst) : undefined,
-        total_sell_fcy_incl_gst: currency !== "PGK" ? result.sell_total : undefined,
-        total_sell_fcy_currency: currency !== "PGK" ? currency : undefined,
-    };
-}
-
-const formatAmount = (amountStr: string | number | undefined, currency: string) => {
-    const amount = typeof amountStr === 'number' ? amountStr : parseFloat(amountStr || "0");
-    const formatted = new Intl.NumberFormat("en-US", {
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-    }).format(amount);
-    return `${currency} ${formatted}`;
-};
-
-type BucketType = 'ORIGIN' | 'FREIGHT' | 'DESTINATION';
-
-function getBucket(line: SellLine): BucketType {
-    if (line.leg === 'MAIN' || line.leg === 'FREIGHT') return 'FREIGHT';
-    if (line.leg === 'ORIGIN') return 'ORIGIN';
-    return 'DESTINATION';
-}
-
-function calculateBucketTotal(lines: BreakdownLine[], field: string): number {
-    return lines.reduce((sum, line) => {
-        const rawValue = ((line as unknown) as Record<string, unknown>)[field];
-        const value = parseFloat(String(rawValue ?? '0'));
-        return sum + value;
-    }, 0);
-}
-
-function readField(obj: unknown, key: string): unknown {
-    if (!obj || typeof obj !== "object") return undefined;
-    return (obj as Record<string, unknown>)[key];
-}
-
-function readStringField(obj: unknown, key: string): string | undefined {
-    const value = readField(obj, key);
-    return typeof value === "string" ? value : undefined;
-}
-
-function getDisplaySellAmount(line: BreakdownLine, isShowingFCY: boolean): number {
-    const rawValue = isShowingFCY
-        ? (line.sell_fcy || line.sell_pgk)
-        : (line.sell_pgk || line.sell_fcy);
-    return parseFloat(String(rawValue || "0"));
-}
-
-function isAvailable(value: unknown): boolean {
-    return value !== null && value !== undefined && value !== "";
-}
-
-function displayValue(value: unknown): string {
-    return isAvailable(value) ? String(value) : "Not available";
-}
-
-function displayApplicable(value: unknown, applicable: boolean): string {
-    if (!applicable) return "Not applicable";
-    return displayValue(value);
-}
-
-function displayMoney(value: unknown, currency: string): string {
-    if (!isAvailable(value)) return "Not available";
-    return formatAmount(String(value), currency);
-}
-
-function displayPercent(value: unknown): string {
-    if (!isAvailable(value)) return "Not available";
-    const parsed = Number(value);
-    if (!Number.isFinite(parsed)) return String(value);
-    return `${parsed.toFixed(2)}%`;
-}
-
-function findRawLine(rawLines: RawQuoteLine[], canonicalLine: CanonicalQuoteLineItem): RawQuoteLine | undefined {
-    if (canonicalLine.line_id) {
-        const byId = rawLines.find((line) => line.id === canonicalLine.line_id);
-        if (byId) return byId;
-    }
-    return rawLines.find((line) => {
-        const code = line.product_code || line.component || line.service_component?.code;
-        return code === canonicalLine.product_code && line.description === canonicalLine.description;
-    });
-}
-
-type WarningDetails = { text: string; level: 'critical' | 'info' };
-
-function lineWarnings(line: CanonicalQuoteLineItem, rawLine?: Partial<V3QuoteLine>): WarningDetails[] {
-    const warnings: WarningDetails[] = [];
-    if (rawLine?.is_rate_missing) warnings.push({ text: "Missing buy rate", level: 'critical' });
-    if (line.is_manual_override || rawLine?.is_manual_override) warnings.push({ text: "Manual override", level: 'info' });
-    if (line.rate_source === "FALLBACK_RULE") warnings.push({ text: "FX or rate fallback applied", level: 'info' });
-    return warnings;
-}
-
-function sourceLabel(line: CanonicalQuoteLineItem, rawLine?: Partial<V3QuoteLine>): string {
-    if (line.is_spot_sourced || rawLine?.is_spot_sourced) return "SPOT";
-    if (line.is_manual_override || rawLine?.is_manual_override) return "Manual entry";
-    if (line.rate_source === "MANUAL_OVERRIDE") return "Manual entry";
-    if (line.rate_source === "PARTNER_SPOT") return "SPOT";
-    if (line.rate_source === "DB_TARIFF") return "V4 rate card";
-    if (line.rate_source === "FALLBACK_RULE") return "Fallback rule";
-    return displayValue(line.rate_source);
-}
+import {
+    LooseRecord,
+    RawQuoteLine,
+    BreakdownLine,
+    BreakdownDataShape,
+    BucketType,
+    WarningDetails,
+    SUBCATEGORY_ORDER,
+    toMoneyString,
+    mapCanonicalComponentToLeg,
+    mapCanonicalLineItemToBreakdownLine,
+    buildCanonicalTotals,
+    formatAmount,
+    getBucket,
+    calculateBucketTotal,
+    readField,
+    readStringField,
+    getDisplaySellAmount,
+    isAvailable,
+    displayValue,
+    displayApplicable,
+    displayMoney,
+    displayPercent,
+    findRawLine,
+    lineWarnings,
+    sourceLabel,
+} from "@/lib/quote-financial-helpers";
 
 export default function QuoteFinancialBreakdown({ result }: QuoteFinancialBreakdownProps) {
     const normalizedResult = result as unknown as BreakdownDataShape;
@@ -367,16 +200,6 @@ function getSectionStyle() {
     };
 }
 
-const SUBCATEGORY_ORDER = [
-    "Customs / Regulatory",
-    "Documentation",
-    "Local Transport / Cartage",
-    "Handling / Terminal",
-    "Freight / Carrier",
-    "Carrier Surcharges",
-    "Service / Agency Fees",
-    "Other Charges",
-];
 
 function BucketSection({
     title,

--- a/frontend/src/lib/quote-financial-helpers.ts
+++ b/frontend/src/lib/quote-financial-helpers.ts
@@ -1,0 +1,214 @@
+import {
+    CanonicalQuoteLineItem,
+    CanonicalQuoteResult,
+    QuoteComputeResult,
+    SellLine,
+    V3QuoteLine,
+    V3QuoteComputeResponse,
+} from "./types";
+
+export type LooseRecord = Record<string, unknown>;
+
+export type RawQuoteLine = V3QuoteLine & Partial<SellLine> & {
+    margin_amount?: string | null;
+};
+
+export type BreakdownLine = SellLine & { 
+    sell_fcy_currency?: string;
+    canonical_item?: CanonicalQuoteLineItem;
+    raw_line?: RawQuoteLine;
+    subcategory?: string;
+    margin_amount?: string | null;
+};
+
+export type BreakdownDataShape = {
+    status?: string;
+    quote_result?: CanonicalQuoteResult | null;
+    latest_version?: {
+        sell_lines?: BreakdownLine[];
+        lines?: BreakdownLine[];
+        totals?: LooseRecord;
+    };
+    sell_lines?: BreakdownLine[];
+    lines?: BreakdownLine[];
+    totals?: LooseRecord;
+};
+
+export type BucketType = 'ORIGIN' | 'FREIGHT' | 'DESTINATION';
+
+export type WarningDetails = { text: string; level: 'critical' | 'info' };
+
+export const SUBCATEGORY_ORDER = [
+    "Customs / Regulatory",
+    "Documentation",
+    "Local Transport / Cartage",
+    "Handling / Terminal",
+    "Freight / Carrier",
+    "Carrier Surcharges",
+    "Service / Agency Fees",
+    "Other Charges",
+];
+
+export function toMoneyString(value: number): string {
+    return value.toFixed(2);
+}
+
+export function mapCanonicalComponentToLeg(component: string): SellLine["leg"] {
+    switch ((component || "").toUpperCase()) {
+        case "ORIGIN_LOCAL":
+            return "ORIGIN";
+        case "DESTINATION_LOCAL":
+            return "DESTINATION";
+        case "FREIGHT":
+            return "FREIGHT";
+        default:
+            return "DESTINATION";
+    }
+}
+
+export function mapCanonicalLineItemToBreakdownLine(
+    item: CanonicalQuoteLineItem,
+    currency: string,
+    rawLine?: RawQuoteLine
+): BreakdownLine {
+    const sellAmount = parseFloat(item.sell_amount || "0");
+    const taxAmount = parseFloat(item.tax_amount || "0");
+    const sellInclTax = sellAmount + taxAmount;
+
+    return {
+        line_type: "COMPONENT",
+        component: item.product_code || item.component,
+        description: item.description,
+        leg: mapCanonicalComponentToLeg(item.component),
+        cost_pgk: item.cost_amount,
+        sell_pgk: currency === "PGK" ? item.sell_amount : "0.00",
+        sell_pgk_incl_gst: currency === "PGK" ? toMoneyString(sellInclTax) : "0.00",
+        gst_amount: item.tax_amount,
+        sell_fcy: currency !== "PGK" ? item.sell_amount : item.sell_amount,
+        sell_fcy_incl_gst: currency !== "PGK" ? toMoneyString(sellInclTax) : toMoneyString(sellInclTax),
+        sell_currency: currency,
+        sell_fcy_currency: currency !== "PGK" ? currency : undefined,
+        margin_percent: item.margin_percent,
+        exchange_rate: item.rate || "0",
+        subcategory: item.subcategory,
+        source: item.cost_source,
+        is_informational: !item.included_in_total,
+        margin_amount: item.margin_amount,
+        canonical_item: item,
+        raw_line: rawLine,
+    };
+}
+
+export function buildCanonicalTotals(result: CanonicalQuoteResult): LooseRecord {
+    const currency = (result.currency || "PGK").toUpperCase();
+    const sellTotal = parseFloat(result.sell_total || "0");
+    const gstAmount = parseFloat(result.tax_breakdown?.gst_amount || "0");
+    const exGst = sellTotal - gstAmount;
+
+    return {
+        currency,
+        total_quote_amount: toMoneyString(sellTotal),
+        total_gst: result.tax_breakdown?.gst_amount || "0.00",
+        gst_amount: result.tax_breakdown?.gst_amount || "0.00",
+        total_sell_pgk: result.total_sell_pgk,
+        total_sell_pgk_incl_gst: currency === "PGK" ? result.sell_total : result.total_sell_pgk,
+        total_sell_ex_gst: toMoneyString(exGst),
+        total_sell_fcy: currency !== "PGK" ? toMoneyString(exGst) : undefined,
+        total_sell_fcy_incl_gst: currency !== "PGK" ? result.sell_total : undefined,
+        total_sell_fcy_currency: currency !== "PGK" ? currency : undefined,
+    };
+}
+
+export const formatAmount = (amountStr: string | number | undefined, currency: string) => {
+    const amount = typeof amountStr === 'number' ? amountStr : parseFloat(amountStr || "0");
+    const formatted = new Intl.NumberFormat("en-US", {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+    }).format(amount);
+    return `${currency} ${formatted}`;
+};
+
+export function getBucket(line: SellLine): BucketType {
+    if (line.leg === 'MAIN' || line.leg === 'FREIGHT') return 'FREIGHT';
+    if (line.leg === 'ORIGIN') return 'ORIGIN';
+    return 'DESTINATION';
+}
+
+export function calculateBucketTotal(lines: BreakdownLine[], field: string): number {
+    return lines.reduce((sum, line) => {
+        const rawValue = ((line as unknown) as Record<string, unknown>)[field];
+        const value = parseFloat(String(rawValue ?? '0'));
+        return sum + value;
+    }, 0);
+}
+
+export function readField(obj: unknown, key: string): unknown {
+    if (!obj || typeof obj !== "object") return undefined;
+    return (obj as Record<string, unknown>)[key];
+}
+
+export function readStringField(obj: unknown, key: string): string | undefined {
+    const value = readField(obj, key);
+    return typeof value === "string" ? value : undefined;
+}
+
+export function getDisplaySellAmount(line: BreakdownLine, isShowingFCY: boolean): number {
+    const rawValue = isShowingFCY
+        ? (line.sell_fcy || line.sell_pgk)
+        : (line.sell_pgk || line.sell_fcy);
+    return parseFloat(String(rawValue || "0"));
+}
+
+export function isAvailable(value: unknown): boolean {
+    return value !== null && value !== undefined && value !== "";
+}
+
+export function displayValue(value: unknown): string {
+    return isAvailable(value) ? String(value) : "Not available";
+}
+
+export function displayApplicable(value: unknown, applicable: boolean): string {
+    if (!applicable) return "Not applicable";
+    return displayValue(value);
+}
+
+export function displayMoney(value: unknown, currency: string): string {
+    if (!isAvailable(value)) return "Not available";
+    return formatAmount(String(value), currency);
+}
+
+export function displayPercent(value: unknown): string {
+    if (!isAvailable(value)) return "Not available";
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) return String(value);
+    return `${parsed.toFixed(2)}%`;
+}
+
+export function findRawLine(rawLines: RawQuoteLine[], canonicalLine: CanonicalQuoteLineItem): RawQuoteLine | undefined {
+    if (canonicalLine.line_id) {
+        const byId = rawLines.find((line) => line.id === canonicalLine.line_id);
+        if (byId) return byId;
+    }
+    return rawLines.find((line) => {
+        const code = line.product_code || line.component || line.service_component?.code;
+        return code === canonicalLine.product_code && line.description === canonicalLine.description;
+    });
+}
+
+export function lineWarnings(line: CanonicalQuoteLineItem, rawLine?: Partial<V3QuoteLine>): WarningDetails[] {
+    const warnings: WarningDetails[] = [];
+    if (rawLine?.is_rate_missing) warnings.push({ text: "Missing buy rate", level: 'critical' });
+    if (line.is_manual_override || rawLine?.is_manual_override) warnings.push({ text: "Manual override", level: 'info' });
+    if (line.rate_source === "FALLBACK_RULE") warnings.push({ text: "FX or rate fallback applied", level: 'info' });
+    return warnings;
+}
+
+export function sourceLabel(line: CanonicalQuoteLineItem, rawLine?: Partial<V3QuoteLine>): string {
+    if (line.is_spot_sourced || rawLine?.is_spot_sourced) return "SPOT";
+    if (line.is_manual_override || rawLine?.is_manual_override) return "Manual entry";
+    if (line.rate_source === "MANUAL_OVERRIDE") return "Manual entry";
+    if (line.rate_source === "PARTNER_SPOT") return "SPOT";
+    if (line.rate_source === "DB_TARIFF") return "V4 rate card";
+    if (line.rate_source === "FALLBACK_RULE") return "Fallback rule";
+    return displayValue(line.rate_source);
+}


### PR DESCRIPTION
## Summary

Completes Phase 9.2 by extracting pure quote financial helper logic from `QuoteFinancialBreakdown.tsx` into a dedicated helper module with focused unit coverage.

## Files changed

- `frontend/package.json` — adds `test:quote-financial-helpers`
- `frontend/src/components/QuoteFinancialBreakdown.tsx` — imports extracted helpers and removes local pure helper implementations
- `frontend/src/lib/quote-financial-helpers.ts` — new financial helper module
- `frontend/scripts/quote-financial-helpers.test.mjs` — new focused unit tests

## Helpers extracted

- `toMoneyString`
- `formatAmount`
- `displayMoney`
- `displayPercent`
- `displayValue`
- `displayApplicable`
- `mapCanonicalComponentToLeg`
- `mapCanonicalLineItemToBreakdownLine`
- `getBucket`
- `findRawLine`
- `calculateBucketTotal`
- `buildCanonicalTotals`
- `readField`
- `readStringField`
- `getDisplaySellAmount`
- `isAvailable`
- `lineWarnings`
- `sourceLabel`
- `SUBCATEGORY_ORDER`

## Verification reported by Gemini/Antigravity

The following commands passed locally:

- `npm run typecheck`
- `node frontend/scripts/quote-financial-helpers.test.mjs`
- `node frontend/scripts/spot-workspace-helpers.test.mjs`
- `node frontend/scripts/quote-detail-helpers.test.mjs`
- `node frontend/scripts/quote-detail-mapping.test.mjs`
- `node frontend/scripts/quote-edit-hydration.test.mjs`
- `node frontend/scripts/quote-workflow-roundtrip.test.mjs`
- `node --experimental-strip-types --experimental-specifier-resolution=node frontend/scripts/quote-store.test.mjs`

Fallow summary reported:

- Circular dependencies: `0`
- Duplication: `11.06%`
- `QuoteFinancialBreakdown.tsx` reduced from `654` to `476` lines

## Scope guardrails

This PR should be reviewed as pure financial helper extraction only.

- No backend changes
- No quote total calculation changes
- No margin calculation changes
- No GST/tax behavior changes
- No FX/CAF display behavior changes
- No customer-facing display text changes
- No PDF/email behavior changes
- No `ChargeCard` extraction
- No `BucketSection` extraction
- No UI redesign intended

## Manual review notes

Main review focus: confirm the extracted helpers are behavior-preserving and that `QuoteFinancialBreakdown.tsx` only imports the moved pure helpers. Pay special attention to margin fallback behavior, GST fallback behavior, FX/CAF visibility, bucket classification, canonical totals, and warning generation.