### PR TITLE
feat(spot): populate canonical charge metadata

### DIFF
--- a/backend/quotes/spot_views.py
+++ b/backend/quotes/spot_views.py
@@ -294,6 +294,7 @@ def _resolve_spe_charge_normalization_fields(
             "normalization_method": existing_line.normalization_method,
             "matched_alias": existing_line.matched_alias,
             "resolved_product_code": existing_line.resolved_product_code,
+            "canonical_charge_type": existing_line.canonical_charge_type,
             **preserved_manual_resolution,
         }
 
@@ -303,6 +304,13 @@ def _resolve_spe_charge_normalization_fields(
         mode_scope=_charge_mode_scope_for_context(shipment_context),
         direction_scope=_charge_direction_scope_for_bucket(charge.get("bucket")),
     )
+
+    canonical_charge_type = None
+    if normalization_result.resolved_charge_alias and normalization_result.resolved_charge_alias.canonical_charge_type:
+        canonical_charge_type = normalization_result.resolved_charge_alias.canonical_charge_type
+    elif manual_resolution_source is not None:
+        canonical_charge_type = manual_resolution_source.canonical_charge_type
+
     return {
         "source_label": raw_label,
         "normalized_label": normalization_result.normalized_label,
@@ -310,14 +318,13 @@ def _resolve_spe_charge_normalization_fields(
         "normalization_method": normalization_result.normalization_method.value,
         "matched_alias": normalization_result.resolved_charge_alias,
         "resolved_product_code": normalization_result.resolved_product_code,
+        "canonical_charge_type": canonical_charge_type,
         "manual_resolution_status": None,
         "manual_resolved_product_code": None,
         "manual_resolution_by": None,
         "manual_resolution_at": None,
         **preserved_manual_resolution,
     }
-
-
 def _incoming_charge_source_label(charge: dict) -> str:
     return str(charge.get("source_label") or charge.get("description") or "")
 

--- a/backend/quotes/tests/test_spot_canonical_groundwork.py
+++ b/backend/quotes/tests/test_spot_canonical_groundwork.py
@@ -116,3 +116,213 @@ class SpotCanonicalGroundworkTests(TestCase):
         self.assertEqual(result.resolved_product_code, pc)
         self.assertEqual(result.resolved_charge_alias, alias)
         self.assertEqual(result.resolved_charge_alias.canonical_charge_type, ct)
+
+
+class SpotCanonicalAssignmentTests(TestCase):
+    """
+    Test suite for Phase 10.3f — Canonical Assignment Metadata.
+    Verifies that SPEChargeLineDB.canonical_charge_type is populated during normalization and reconciliation.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        from django.contrib.auth import get_user_model
+        User = get_user_model()
+        cls.user = User.objects.create_user(
+            username='assignment_analyst',
+            email='assignment@rateengine.com',
+            password='testpassword',
+            role='sales'
+        )
+        cls.pc = ProductCode.objects.create(
+            id=2991,
+            code='EXP-TEST-FSC',
+            description='Export Fuel Surcharge',
+            domain=ProductCode.DOMAIN_EXPORT,
+            category=ProductCode.CATEGORY_HANDLING,
+            is_gst_applicable=False,
+        )
+        cls.ct = CanonicalChargeType.objects.create(
+            code='AIRLINE_FUEL_TEST',
+            name='Airline Fuel Surcharge (Test)',
+            category='FUEL'
+        )
+        cls.alias_with_ct = ChargeAlias.objects.create(
+            alias_text='fsc label with ct',
+            normalized_alias_text='fsc label with ct',
+            match_type=ChargeAlias.MatchType.EXACT,
+            mode_scope=ChargeAlias.ModeScope.ANY,
+            direction_scope=ChargeAlias.DirectionScope.ANY,
+            product_code=cls.pc,
+            canonical_charge_type=cls.ct,
+            priority=5,
+        )
+        cls.alias_without_ct = ChargeAlias.objects.create(
+            alias_text='fsc label without ct',
+            normalized_alias_text='fsc label without ct',
+            match_type=ChargeAlias.MatchType.EXACT,
+            mode_scope=ChargeAlias.ModeScope.ANY,
+            direction_scope=ChargeAlias.DirectionScope.ANY,
+            product_code=cls.pc,
+            canonical_charge_type=None,
+            priority=5,
+        )
+
+    def _create_spe(self):
+        from django.utils import timezone
+        return SpotPricingEnvelopeDB.objects.create(
+            status='draft',
+            shipment_context_json={
+                'origin_code': 'SIN',
+                'destination_code': 'POM',
+                'origin_country': 'SG',
+                'destination_country': 'PG',
+                'service_scope': 'D2D'
+            },
+            expires_at=timezone.now() + timezone.timedelta(hours=72)
+        )
+
+    def test_matched_alias_with_canonical_type_populates_spe_canonical_charge_type(self):
+        """Verify matched alias with canonical type populates SPEChargeLineDB.canonical_charge_type."""
+        from django.utils import timezone
+        from quotes.spot_views import _create_spe_charge_line
+        spe = self._create_spe()
+        
+        charge_line = _create_spe_charge_line(
+            spe_db=spe,
+            charge={
+                'code': 'FSC_LINE',
+                'description': 'fsc label with ct',
+                'amount': 50.00,
+                'currency': 'SGD',
+                'unit': 'flat',
+                'bucket': 'origin_charges',
+                'source_reference': 'REF-1'
+            },
+            entered_by=self.user,
+            entered_at=timezone.now(),
+            shipment_context=spe.shipment_context_json
+        )
+        self.assertEqual(charge_line.canonical_charge_type, self.ct)
+        self.assertEqual(charge_line.resolved_product_code, self.pc)
+
+    def test_matched_alias_without_canonical_type_leaves_field_null(self):
+        """Verify matched alias without canonical type leaves SPEChargeLineDB.canonical_charge_type null."""
+        from django.utils import timezone
+        from quotes.spot_views import _create_spe_charge_line
+        spe = self._create_spe()
+
+        charge_line = _create_spe_charge_line(
+            spe_db=spe,
+            charge={
+                'code': 'FSC_LINE_NO_CT',
+                'description': 'fsc label without ct',
+                'amount': 50.00,
+                'currency': 'SGD',
+                'unit': 'flat',
+                'bucket': 'origin_charges',
+                'source_reference': 'REF-2'
+            },
+            entered_by=self.user,
+            entered_at=timezone.now(),
+            shipment_context=spe.shipment_context_json
+        )
+        self.assertIsNone(charge_line.canonical_charge_type)
+        self.assertEqual(charge_line.resolved_product_code, self.pc)
+
+    def test_reconciliation_preserves_manual_product_code_resolution(self):
+        """Verify reconciliation preserves manual resolved product code and status."""
+        from django.utils import timezone
+        from quotes.spot_views import _create_spe_charge_line, _build_spe_charge_line_field_values
+        spe = self._create_spe()
+        
+        charge_data = {
+            'code': 'FSC_LINE',
+            'description': 'fsc label with ct',
+            'amount': 50.00,
+            'currency': 'SGD',
+            'unit': 'flat',
+            'bucket': 'origin_charges',
+            'source_reference': 'REF-1'
+        }
+
+        # Create line
+        charge_line = _create_spe_charge_line(
+            spe_db=spe,
+            charge=charge_data,
+            entered_by=self.user,
+            entered_at=timezone.now(),
+            shipment_context=spe.shipment_context_json
+        )
+
+        # Apply manual resolution
+        dummy_pc = ProductCode.objects.create(
+            id=2992,
+            code='EXP-MANUAL-PC',
+            description='Export Manual Product Code',
+            domain=ProductCode.DOMAIN_EXPORT,
+            category=ProductCode.CATEGORY_HANDLING,
+            is_gst_applicable=False,
+        )
+        charge_line.manual_resolved_product_code = dummy_pc
+        charge_line.manual_resolution_status = SPEChargeLineDB.ManualResolutionStatus.RESOLVED
+        charge_line.manual_resolution_by = self.user
+        charge_line.manual_resolution_at = timezone.now()
+        charge_line.save()
+
+        # Reconcile / rebuild fields
+        fields = _build_spe_charge_line_field_values(
+            spe_db=spe,
+            charge=charge_data,
+            entered_by=self.user,
+            entered_at=timezone.now(),
+            shipment_context=spe.shipment_context_json,
+            existing_line=charge_line
+        )
+
+        # Check manual resolution is kept
+        self.assertEqual(fields['manual_resolved_product_code'], dummy_pc)
+        self.assertEqual(fields['manual_resolution_status'], SPEChargeLineDB.ManualResolutionStatus.RESOLVED)
+
+    def test_reconciliation_preserves_existing_canonical_charge_type_if_no_matched_alias(self):
+        """Verify reconciliation preserves existing canonical_charge_type if matched alias has no canonical type."""
+        from django.utils import timezone
+        from quotes.spot_views import _create_spe_charge_line, _build_spe_charge_line_field_values
+        spe = self._create_spe()
+
+        # Line initially created with ct
+        charge_data = {
+            'code': 'FSC_LINE',
+            'description': 'fsc label with ct',
+            'amount': 50.00,
+            'currency': 'SGD',
+            'unit': 'flat',
+            'bucket': 'origin_charges',
+            'source_reference': 'REF-1'
+        }
+
+        charge_line = _create_spe_charge_line(
+            spe_db=spe,
+            charge=charge_data,
+            entered_by=self.user,
+            entered_at=timezone.now(),
+            shipment_context=spe.shipment_context_json
+        )
+        self.assertEqual(charge_line.canonical_charge_type, self.ct)
+
+        # Reconcile with updated description that does not map to any alias with a canonical type
+        updated_charge_data = charge_data.copy()
+        updated_charge_data['description'] = 'fsc label without ct' # maps to alias_without_ct (no canonical type)
+
+        fields = _build_spe_charge_line_field_values(
+            spe_db=spe,
+            charge=updated_charge_data,
+            entered_by=self.user,
+            entered_at=timezone.now(),
+            shipment_context=spe.shipment_context_json,
+            existing_line=charge_line
+        )
+
+        # Ensure the existing canonical type is preserved unchanged
+        self.assertEqual(fields['canonical_charge_type'], self.ct)
+


### PR DESCRIPTION
This populates canonical charge metadata only.

It does not change quote pricing.
It does not change alias or ProductCode resolution behavior.
It does not activate canonical-based mapping.
It preserves manual resolution behavior.

Summary:
- Populates SPEChargeLineDB.canonical_charge_type from matched aliases when available.
- Leaves canonical metadata null when matched aliases do not have canonical types.
- Preserves existing canonical metadata during reconciliation when no stronger matched alias canonical type is available.
- Preserves manual resolution safeguards.

Validation:
- makemigrations --check passed.
- Canonical groundwork tests passed.
- Charge normalization tests passed.
- SPOT charge context tests passed.
- SPOT flow/API tests passed.
- Fallow baseline executed.
- graphify update completed.