### PR TITLE
test(spot): standardize expected charge validation findings

### DIFF
--- a/backend/quotes/services/spot_template_validation.py
+++ b/backend/quotes/services/spot_template_validation.py
@@ -6,6 +6,27 @@ from quotes.spot_models import SpotPricingEnvelopeDB, ExpectedChargeTemplate, Ex
 logger = logging.getLogger(__name__)
 
 
+def _build_finding(
+    code: str,
+    severity: str,
+    message: str,
+    canonical_type: Optional[str] = None,
+    template_line_id: Optional[int] = None,
+    charge_line_id: Optional[str] = None,
+    metadata: Optional[dict] = None
+) -> dict:
+    """Helper to build a standardized finding dictionary with the full key set."""
+    return {
+        "code": code,
+        "severity": severity,
+        "message": message,
+        "canonical_type": canonical_type,
+        "template_line_id": template_line_id,
+        "charge_line_id": charge_line_id,
+        "metadata": metadata or {}
+    }
+
+
 def resolve_expected_charge_template(shipment_context: dict) -> Optional[ExpectedChargeTemplate]:
     """
     Resolves the most specific ExpectedChargeTemplate for a given shipment context.
@@ -93,17 +114,22 @@ def validate_envelope_charges(envelope: SpotPricingEnvelopeDB) -> Dict[str, Any]
     template = resolve_expected_charge_template(context)
     
     if not template:
-        findings.append({
-            "code": "template_not_found",
-            "severity": "Review",
-            "message": "No applicable expectation template resolved for this shipment context.",
-            "canonical_charge_type_code": None
-        })
+        findings.append(
+            _build_finding(
+                code="template_not_found",
+                severity="review",
+                message="No applicable expectation template resolved for this shipment context."
+            )
+        )
+        # Deduce status dynamically to support lowercase 'review' status
+        severities = {f["severity"] for f in findings}
+        status = "review" if "review" in severities else "warnings"
         return {
-            "status": "WARNINGS",
+            "status": status,
             "template_id": None,
             "findings": findings
         }
+
 
     # 2. Gather actual charge lines
     actual_lines = envelope.charge_lines.all()
@@ -125,59 +151,91 @@ def validate_envelope_charges(envelope: SpotPricingEnvelopeDB) -> Dict[str, Any]
         has_actual = canonical_type in actual_by_canonical
         
         if level == ExpectedTemplateLine.RequirementLevel.REQUIRED and not has_actual:
-            findings.append({
-                "code": "expected_charge_missing",
-                "severity": "Warning",
-                "message": f"Expected charge of type '{canonical_type.name}' ({canonical_type.code}) is missing.",
-                "canonical_charge_type_code": canonical_type.code
-            })
+            findings.append(
+                _build_finding(
+                    code="expected_charge_missing",
+                    severity="warning",
+                    message=f"Expected charge of type '{canonical_type.name}' ({canonical_type.code}) is missing.",
+                    canonical_type=canonical_type.code,
+                    template_line_id=t_line.id
+                )
+            )
             
         elif level == ExpectedTemplateLine.RequirementLevel.EXCLUDED and has_actual:
-            findings.append({
-                "code": "unexpected_charge_present",
-                "severity": "Warning",
-                "message": f"Excluded charge of type '{canonical_type.name}' ({canonical_type.code}) was included.",
-                "canonical_charge_type_code": canonical_type.code
-            })
+            for act_line in actual_by_canonical[canonical_type]:
+                findings.append(
+                    _build_finding(
+                        code="unexpected_charge_present",
+                        severity="warning",
+                        message=f"Excluded charge of type '{canonical_type.name}' ({canonical_type.code}) was included.",
+                        canonical_type=canonical_type.code,
+                        template_line_id=t_line.id,
+                        charge_line_id=str(act_line.id)
+                    )
+                )
             
         elif level == ExpectedTemplateLine.RequirementLevel.CONDITIONAL and has_actual:
-            findings.append({
-                "code": "conditional_charge_present",
-                "severity": "Review",
-                "message": f"Conditional charge of type '{canonical_type.name}' ({canonical_type.code}) is present and requires confirmation.",
-                "canonical_charge_type_code": canonical_type.code
-            })
+            for act_line in actual_by_canonical[canonical_type]:
+                findings.append(
+                    _build_finding(
+                        code="conditional_charge_present",
+                        severity="review",
+                        message=f"Conditional charge of type '{canonical_type.name}' ({canonical_type.code}) is present and requires confirmation.",
+                        canonical_type=canonical_type.code,
+                        template_line_id=t_line.id,
+                        charge_line_id=str(act_line.id)
+                    )
+                )
             
         # Check calculation basis mismatch if actual is present
         if has_actual and expected_basis != "any":
             for act_line in actual_by_canonical[canonical_type]:
                 if act_line.calculation_basis != expected_basis:
-                    findings.append({
-                        "code": "expected_basis_mismatch",
-                        "severity": "Review",
-                        "message": (
-                            f"Basis mismatch for '{canonical_type.name}': "
-                            f"Expected basis '{expected_basis}' but actual was '{act_line.calculation_basis}'."
-                        ),
-                        "canonical_charge_type_code": canonical_type.code
-                    })
+                    findings.append(
+                        _build_finding(
+                            code="expected_basis_mismatch",
+                            severity="review",
+                            message=(
+                                f"Basis mismatch for '{canonical_type.name}': "
+                                f"Expected basis '{expected_basis}' but actual was '{act_line.calculation_basis}'."
+                            ),
+                            canonical_type=canonical_type.code,
+                            template_line_id=t_line.id,
+                            charge_line_id=str(act_line.id),
+                            metadata={
+                                "expected_basis": expected_basis,
+                                "actual_basis": act_line.calculation_basis
+                            }
+                        )
+                    )
 
     # 4. Check for duplicates in actual charge lines
     for canonical_type, lines in actual_by_canonical.items():
         if len(lines) > 1:
-            findings.append({
-                "code": "duplicate_charge_family",
-                "severity": "Review",
-                "message": f"Multiple lines detected resolving to canonical charge family '{canonical_type.name}' ({canonical_type.code}).",
-                "canonical_charge_type_code": canonical_type.code
-            })
+            for act_line in lines:
+                findings.append(
+                    _build_finding(
+                        code="duplicate_charge_family",
+                        severity="review",
+                        message=f"Multiple lines detected resolving to canonical charge family '{canonical_type.name}' ({canonical_type.code}).",
+                        canonical_type=canonical_type.code,
+                        charge_line_id=str(act_line.id)
+                    )
+                )
 
     # Deduce final status
-    has_warnings = any(f["severity"] in ("Warning", "Review") for f in findings)
-    status = "WARNINGS" if has_warnings else "PASSED"
+    severities = {f["severity"] for f in findings}
+    if "review" in severities:
+        status = "review"
+    elif "warning" in severities or "info" in severities:
+        status = "warnings"
+    else:
+        status = "passed"
 
     return {
         "status": status,
         "template_id": template.id,
         "findings": findings
     }
+
+

--- a/backend/quotes/tests/test_spot_canonical_groundwork.py
+++ b/backend/quotes/tests/test_spot_canonical_groundwork.py
@@ -776,11 +776,16 @@ class SpotExpectedTemplateValidationTests(TestCase):
         spe = self._create_spe()
         
         result = validate_envelope_charges(spe)
-        self.assertEqual(result["status"], "WARNINGS")
+        self.assertEqual(result["status"], "review")
         self.assertIsNone(result["template_id"])
         self.assertEqual(len(result["findings"]), 1)
-        self.assertEqual(result["findings"][0]["code"], "template_not_found")
-        self.assertEqual(result["findings"][0]["severity"], "Review")
+        finding = result["findings"][0]
+        self.assertEqual(finding["code"], "template_not_found")
+        self.assertEqual(finding["severity"], "review")
+        self.assertIsNone(finding["canonical_type"])
+        self.assertIsNone(finding["template_line_id"])
+        self.assertIsNone(finding["charge_line_id"])
+        self.assertEqual(finding["metadata"], {})
 
     def test_missing_expected_charge(self):
         """Verify validation flags expected_charge_missing if REQUIRED line is absent."""
@@ -794,7 +799,7 @@ class SpotExpectedTemplateValidationTests(TestCase):
             origin_country="PG",
             destination_country="SG"
         )
-        ExpectedTemplateLine.objects.create(
+        t_line = ExpectedTemplateLine.objects.create(
             template=template,
             canonical_charge_type=self.ct_awb,
             requirement_level="REQUIRED"
@@ -802,10 +807,16 @@ class SpotExpectedTemplateValidationTests(TestCase):
         
         spe = self._create_spe()
         result = validate_envelope_charges(spe)
-        self.assertEqual(result["status"], "WARNINGS")
+        self.assertEqual(result["status"], "warnings")
         self.assertEqual(result["template_id"], template.id)
-        findings = {f["code"] for f in result["findings"]}
-        self.assertIn("expected_charge_missing", findings)
+        findings = result["findings"]
+        self.assertEqual(len(findings), 1)
+        finding = findings[0]
+        self.assertEqual(finding["code"], "expected_charge_missing")
+        self.assertEqual(finding["severity"], "warning")
+        self.assertEqual(finding["canonical_type"], self.ct_awb.code)
+        self.assertEqual(finding["template_line_id"], t_line.id)
+        self.assertIsNone(finding["charge_line_id"])
 
     def test_unexpected_charge_present(self):
         """Verify validation flags unexpected_charge_present if EXCLUDED line is present."""
@@ -820,14 +831,14 @@ class SpotExpectedTemplateValidationTests(TestCase):
             origin_country="PG",
             destination_country="SG"
         )
-        ExpectedTemplateLine.objects.create(
+        t_line = ExpectedTemplateLine.objects.create(
             template=template,
             canonical_charge_type=self.ct_delivery,
             requirement_level="EXCLUDED"
         )
         
         spe = self._create_spe()
-        SPEChargeLineDB.objects.create(
+        charge_line = SPEChargeLineDB.objects.create(
             envelope=spe,
             code="EXCLUDED_LINE",
             description="some delivery charge",
@@ -842,9 +853,15 @@ class SpotExpectedTemplateValidationTests(TestCase):
         )
         
         result = validate_envelope_charges(spe)
-        self.assertEqual(result["status"], "WARNINGS")
-        findings = {f["code"] for f in result["findings"]}
-        self.assertIn("unexpected_charge_present", findings)
+        self.assertEqual(result["status"], "warnings")
+        findings = result["findings"]
+        self.assertEqual(len(findings), 1)
+        finding = findings[0]
+        self.assertEqual(finding["code"], "unexpected_charge_present")
+        self.assertEqual(finding["severity"], "warning")
+        self.assertEqual(finding["canonical_type"], self.ct_delivery.code)
+        self.assertEqual(finding["template_line_id"], t_line.id)
+        self.assertEqual(finding["charge_line_id"], str(charge_line.id))
 
     def test_conditional_charge_present(self):
         """Verify validation flags conditional_charge_present if CONDITIONAL line is present."""
@@ -859,14 +876,14 @@ class SpotExpectedTemplateValidationTests(TestCase):
             origin_country="PG",
             destination_country="SG"
         )
-        ExpectedTemplateLine.objects.create(
+        t_line = ExpectedTemplateLine.objects.create(
             template=template,
             canonical_charge_type=self.ct_storage,
             requirement_level="CONDITIONAL"
         )
         
         spe = self._create_spe()
-        SPEChargeLineDB.objects.create(
+        charge_line = SPEChargeLineDB.objects.create(
             envelope=spe,
             code="STORAGE_LINE",
             description="warehouse storage",
@@ -881,9 +898,15 @@ class SpotExpectedTemplateValidationTests(TestCase):
         )
         
         result = validate_envelope_charges(spe)
-        self.assertEqual(result["status"], "WARNINGS")
-        findings = {f["code"] for f in result["findings"]}
-        self.assertIn("conditional_charge_present", findings)
+        self.assertEqual(result["status"], "review")
+        findings = result["findings"]
+        self.assertEqual(len(findings), 1)
+        finding = findings[0]
+        self.assertEqual(finding["code"], "conditional_charge_present")
+        self.assertEqual(finding["severity"], "review")
+        self.assertEqual(finding["canonical_type"], self.ct_storage.code)
+        self.assertEqual(finding["template_line_id"], t_line.id)
+        self.assertEqual(finding["charge_line_id"], str(charge_line.id))
 
     def test_duplicate_charge_family(self):
         """Verify validation flags duplicate_charge_family when actual canonical type is duplicated."""
@@ -905,9 +928,10 @@ class SpotExpectedTemplateValidationTests(TestCase):
         )
         
         spe = self._create_spe()
+        charge_lines = []
         # Add two fuel surcharge lines
         for ref in ["REF-A", "REF-B"]:
-            SPEChargeLineDB.objects.create(
+            cl = SPEChargeLineDB.objects.create(
                 envelope=spe,
                 code="FUEL_LINE",
                 description="airline fuel",
@@ -920,11 +944,18 @@ class SpotExpectedTemplateValidationTests(TestCase):
                 entered_by=self.user,
                 entered_at=timezone.now()
             )
+            charge_lines.append(cl)
             
         result = validate_envelope_charges(spe)
-        self.assertEqual(result["status"], "WARNINGS")
-        findings = {f["code"] for f in result["findings"]}
-        self.assertIn("duplicate_charge_family", findings)
+        self.assertEqual(result["status"], "review")
+        findings = result["findings"]
+        # There should be 2 duplicate charge findings (one for each actual line)
+        self.assertEqual(len(findings), 2)
+        for finding in findings:
+            self.assertEqual(finding["code"], "duplicate_charge_family")
+            self.assertEqual(finding["severity"], "review")
+            self.assertEqual(finding["canonical_type"], self.ct_fuel.code)
+            self.assertIn(finding["charge_line_id"], [str(c.id) for c in charge_lines])
 
     def test_basis_mismatch(self):
         """Verify validation flags expected_basis_mismatch when actual basis differs from expected."""
@@ -939,7 +970,7 @@ class SpotExpectedTemplateValidationTests(TestCase):
             origin_country="PG",
             destination_country="SG"
         )
-        ExpectedTemplateLine.objects.create(
+        t_line = ExpectedTemplateLine.objects.create(
             template=template,
             canonical_charge_type=self.ct_fuel,
             requirement_level="REQUIRED",
@@ -948,7 +979,7 @@ class SpotExpectedTemplateValidationTests(TestCase):
         
         spe = self._create_spe()
         # Add actual line with flat calculation_basis snapshot
-        SPEChargeLineDB.objects.create(
+        charge_line = SPEChargeLineDB.objects.create(
             envelope=spe,
             code="FUEL_LINE",
             description="airline fuel flat",
@@ -964,9 +995,88 @@ class SpotExpectedTemplateValidationTests(TestCase):
         )
         
         result = validate_envelope_charges(spe)
-        self.assertEqual(result["status"], "WARNINGS")
-        findings = {f["code"] for f in result["findings"]}
-        self.assertIn("expected_basis_mismatch", findings)
+        self.assertEqual(result["status"], "review")
+        findings = result["findings"]
+        self.assertEqual(len(findings), 1)
+        finding = findings[0]
+        self.assertEqual(finding["code"], "expected_basis_mismatch")
+        self.assertEqual(finding["severity"], "review")
+        self.assertEqual(finding["canonical_type"], self.ct_fuel.code)
+        self.assertEqual(finding["template_line_id"], t_line.id)
+        self.assertEqual(finding["charge_line_id"], str(charge_line.id))
+        self.assertEqual(finding["metadata"], {"expected_basis": "per_kg", "actual_basis": "flat"})
+
+    def test_standardized_finding_shape_completeness(self):
+        """Verify that every finding includes the full key set with correct types and lowercase statuses."""
+        from quotes.services.spot_template_validation import validate_envelope_charges
+        spe = self._create_spe()
+        
+        result = validate_envelope_charges(spe)
+        self.assertIn("status", result)
+        self.assertIn("template_id", result)
+        self.assertIn("findings", result)
+        
+        self.assertEqual(result["status"], "review")
+        
+        for finding in result["findings"]:
+            # Ensure exact set of expected keys
+            expected_keys = {
+                "code", "severity", "message", "canonical_type", 
+                "template_line_id", "charge_line_id", "metadata"
+            }
+            self.assertEqual(set(finding.keys()), expected_keys)
+            
+            # Severity must be lowercase
+            self.assertIn(finding["severity"], ["info", "warning", "review"])
+            # Types
+            self.assertIsInstance(finding["metadata"], dict)
+            if finding["canonical_type"] is not None:
+                self.assertIsInstance(finding["canonical_type"], str)
+            if finding["template_line_id"] is not None:
+                self.assertIsInstance(finding["template_line_id"], int)
+            if finding["charge_line_id"] is not None:
+                self.assertIsInstance(finding["charge_line_id"], str)
+
+    def test_validation_passed_status(self):
+        """Verify status is 'passed' when a matching template exists and all required charges are present with no anomalies."""
+        from quotes.spot_models import ExpectedChargeTemplate, ExpectedTemplateLine, SPEChargeLineDB
+        from quotes.services.spot_template_validation import validate_envelope_charges
+        from django.utils import timezone
+        template = ExpectedChargeTemplate.objects.create(
+            name="Airfreight Export SG->PG Template",
+            mode="EXPORT",
+            transport_mode="AIR",
+            service_scope="D2D",
+            origin_country="PG",
+            destination_country="SG"
+        )
+        ExpectedTemplateLine.objects.create(
+            template=template,
+            canonical_charge_type=self.ct_awb,
+            requirement_level="REQUIRED",
+            expected_basis="any"
+        )
+        
+        spe = self._create_spe()
+        SPEChargeLineDB.objects.create(
+            envelope=spe,
+            code="AWB_LINE",
+            description="AWB Fee",
+            amount=50.0,
+            currency="SGD",
+            unit="flat",
+            bucket="airfreight",
+            canonical_charge_type=self.ct_awb,
+            source_reference="REF-PASS",
+            entered_by=self.user,
+            entered_at=timezone.now()
+        )
+        
+        result = validate_envelope_charges(spe)
+        self.assertEqual(result["status"], "passed")
+        self.assertEqual(len(result["findings"]), 0)
+
+
 
 
 


### PR DESCRIPTION
Summary:
- Standardizes SPOT expected-vs-actual validation finding schema.
- Adds complete finding key set: code, severity, message, canonical_type, template_line_id, charge_line_id, metadata.
- Replaces canonical_charge_type_code with canonical_type.
- Standardizes lowercase severities and top-level statuses.
- Maps top-level status as passed, warnings, or review.
- Adds tests for finding shape completeness and status mapping.

Guardrails:
- No migrations.
- No persistence.
- No API/frontend/admin changes.
- No pricing/ProductCode/finalisation changes.

Validation:
- 39 targeted tests passed.
- makemigrations --check passed.
- graphify update completed.