### PR TITLE
feat(spot): expose expected charge validation findings

### DIFF
--- a/backend/quotes/serializers.py
+++ b/backend/quotes/serializers.py
@@ -777,11 +777,12 @@ class SpotPricingEnvelopeSerializer(serializers.ModelSerializer):
     sources = SPESourceBatchSerializer(source='source_batches', many=True, read_only=True)
     acknowledgement = SPEAcknowledgementSerializer(read_only=True)
     
-    missing_mandatory_fields = serializers.SerializerMethodField()
-    can_proceed = serializers.SerializerMethodField()
     has_acknowledgement = serializers.SerializerMethodField()
     context_integrity_valid = serializers.SerializerMethodField()
     intake_safety = serializers.SerializerMethodField()
+    template_validation = serializers.SerializerMethodField(read_only=True)
+    missing_mandatory_fields = serializers.SerializerMethodField(read_only=True)
+    can_proceed = serializers.SerializerMethodField(read_only=True)
     
     class Meta:
         model = SpotPricingEnvelopeDB
@@ -792,9 +793,10 @@ class SpotPricingEnvelopeSerializer(serializers.ModelSerializer):
             'shipment_context_hash', 'context_integrity_valid',
             'has_acknowledgement', 'acknowledgement',
             'missing_mandatory_fields', 'can_proceed', 'intake_safety',
-            'sources', 'charges'
+            'template_validation', 'sources', 'charges'
         )
         read_only_fields = fields
+
 
     def get_customer_name(self, obj):
         if obj.quote and obj.quote.customer:
@@ -835,4 +837,9 @@ class SpotPricingEnvelopeSerializer(serializers.ModelSerializer):
 
     def get_intake_safety(self, obj):
         return evaluate_envelope_intake_safety(obj.source_batches.all())
+
+    def get_template_validation(self, obj):
+        from quotes.services.spot_template_validation import validate_envelope_charges
+        return validate_envelope_charges(obj)
+
 

--- a/backend/quotes/tests/test_spot_canonical_groundwork.py
+++ b/backend/quotes/tests/test_spot_canonical_groundwork.py
@@ -1076,6 +1076,76 @@ class SpotExpectedTemplateValidationTests(TestCase):
         self.assertEqual(result["status"], "passed")
         self.assertEqual(len(result["findings"]), 0)
 
+    def test_serializer_includes_template_validation_passed(self):
+        """Verify SpotPricingEnvelopeSerializer includes template_validation with passed status and clean schema structure."""
+        from quotes.serializers import SpotPricingEnvelopeSerializer
+        spe = self._create_spe()
+        
+        # We don't have a template seeded so template_not_found is expected, which resolves to review status.
+        # Let's seed a matching template and charge to achieve passed status.
+        from quotes.spot_models import ExpectedChargeTemplate, ExpectedTemplateLine, SPEChargeLineDB
+        from django.utils import timezone
+        template = ExpectedChargeTemplate.objects.create(
+            name="Airfreight Export SG->PG Template",
+            mode="EXPORT",
+            transport_mode="AIR",
+            service_scope="D2D",
+            origin_country="PG",
+            destination_country="SG"
+        )
+        ExpectedTemplateLine.objects.create(
+            template=template,
+            canonical_charge_type=self.ct_awb,
+            requirement_level="REQUIRED",
+            expected_basis="any"
+        )
+        
+        SPEChargeLineDB.objects.create(
+            envelope=spe,
+            code="AWB_LINE",
+            description="AWB Fee",
+            amount=50.0,
+            currency="SGD",
+            unit="flat",
+            bucket="airfreight",
+            canonical_charge_type=self.ct_awb,
+            source_reference="REF-PASS",
+            entered_by=self.user,
+            entered_at=timezone.now()
+        )
+        
+        serializer = SpotPricingEnvelopeSerializer(spe)
+        data = serializer.data
+        self.assertIn("template_validation", data)
+        validation = data["template_validation"]
+        self.assertEqual(validation["status"], "passed")
+        self.assertEqual(validation["template_id"], template.id)
+        self.assertEqual(len(validation["findings"]), 0)
+
+    def test_serializer_includes_template_validation_review(self):
+        """Verify SpotPricingEnvelopeSerializer includes template_validation with review/warning status and correct finding structures."""
+        from quotes.serializers import SpotPricingEnvelopeSerializer
+        spe = self._create_spe()
+        
+        # template_not_found is triggered (review severity)
+        serializer = SpotPricingEnvelopeSerializer(spe)
+        data = serializer.data
+        self.assertIn("template_validation", data)
+        validation = data["template_validation"]
+        self.assertEqual(validation["status"], "review")
+        self.assertIsNone(validation["template_id"])
+        self.assertEqual(len(validation["findings"]), 1)
+        
+        finding = validation["findings"][0]
+        self.assertEqual(finding["code"], "template_not_found")
+        self.assertEqual(finding["severity"], "review")
+        self.assertIn("message", finding)
+        self.assertIsNone(finding["canonical_type"])
+        self.assertIsNone(finding["template_line_id"])
+        self.assertIsNone(finding["charge_line_id"])
+        self.assertEqual(finding["metadata"], {})
+
+
 
 
 


### PR DESCRIPTION
Summary:
- Exposes standardized SPOT expected-charge validation findings through SpotPricingEnvelopeSerializer.
- Adds read-only template_validation diagnostics to serialized SPOT envelope payloads.
- Adds integration coverage proving the serialized payload includes status, template_id, and standardized finding keys.

Guardrails:
- No migrations.
- No persistence.
- No admin changes.
- No frontend changes.
- No pricing/ProductCode changes.
- No quote total changes.
- No charge creation changes.
- No finalisation blocking.

Validation reported:
- quotes.tests.test_spot_canonical_groundwork passed.
- quotes.tests.test_spot_flow_api passed.
- makemigrations --check: no changes detected.
- graphify update completed.