### PR TITLE
feat(spot): show template validation diagnostics

### DIFF
--- a/frontend/src/app/quotes/spot/[speId]/page.tsx
+++ b/frontend/src/app/quotes/spot/[speId]/page.tsx
@@ -27,6 +27,7 @@ import {
     ExpiredBanner,
     RejectedBanner,
     ReplyPasteCard,
+    SpotTemplateValidationCard,
 } from "@/components/spot";
 import { SpotRateEntryForm } from "@/components/spot/SpotRateEntryForm";
 import { SpotWorkspaceSummary } from "@/components/spot/SpotWorkspaceSummary";
@@ -1036,6 +1037,10 @@ export default function SpotRateEntryPage() {
                     >
                         {"<-"} Back to Intake
                     </Button>
+
+                    {state.spe?.template_validation && (
+                        <SpotTemplateValidationCard validation={state.spe.template_validation} />
+                    )}
 
                     <Card className="overflow-hidden border-slate-200 bg-white shadow-sm">
                         <CardHeader className="border-b border-primary/20 bg-primary pb-5 text-primary-foreground">

--- a/frontend/src/components/spot/SpotTemplateValidationCard.tsx
+++ b/frontend/src/components/spot/SpotTemplateValidationCard.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { CheckCircle2, AlertTriangle, HelpCircle } from "lucide-react";
+import type { TemplateValidation } from "@/lib/spot-types";
+
+export interface SpotTemplateValidationCardProps {
+    validation?: TemplateValidation;
+}
+
+export function SpotTemplateValidationCard({ validation }: SpotTemplateValidationCardProps) {
+    if (!validation) return null;
+
+    const { status, findings = [] } = validation;
+
+    // Subtle/neutral/success for passed
+    if (status === "passed") {
+        return (
+            <Card className="border-emerald-100 bg-emerald-50/30">
+                <CardContent className="flex items-center gap-3 py-3 px-4">
+                    <CheckCircle2 className="h-5 w-5 text-emerald-600 shrink-0" />
+                    <div className="flex flex-wrap items-center gap-2 text-sm text-emerald-800">
+                        <span className="font-semibold text-emerald-950">Template Validation Passed</span>
+                        <span className="opacity-80">All expected charge components are present.</span>
+                        <Badge variant="outline" className="border-emerald-200 bg-emerald-100 text-emerald-800">
+                            Passed
+                        </Badge>
+                    </div>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    // Warnings = amber
+    if (status === "warnings") {
+        return (
+            <Card className="border-amber-200 bg-amber-50/50">
+                <CardContent className="space-y-3 py-4 px-5">
+                    <div className="flex items-center gap-3">
+                        <AlertTriangle className="h-5 w-5 text-amber-600 shrink-0" />
+                        <div className="flex flex-wrap items-center gap-2 text-sm text-amber-800">
+                            <span className="font-semibold text-amber-950">Review Recommended</span>
+                            <span className="opacity-80">Potential discrepancies detected in charge template.</span>
+                            <Badge variant="outline" className="border-amber-300 bg-amber-100 text-amber-800">
+                                Warning
+                            </Badge>
+                        </div>
+                    </div>
+                    {findings.length > 0 && (
+                        <ul className="list-disc pl-5 text-xs text-amber-900 space-y-1">
+                            {findings.map((finding, idx) => (
+                                <li key={idx} className="leading-relaxed">
+                                    {finding.message}
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </CardContent>
+            </Card>
+        );
+    }
+
+    // Review = amber/blue review tone (using blue/slate/sky tones as requested instead of red)
+    if (status === "review") {
+        return (
+            <Card className="border-sky-200 bg-sky-50/50">
+                <CardContent className="space-y-3 py-4 px-5">
+                    <div className="flex items-center gap-3">
+                        <HelpCircle className="h-5 w-5 text-sky-600 shrink-0" />
+                        <div className="flex flex-wrap items-center gap-2 text-sm text-sky-800">
+                            <span className="font-semibold text-sky-950">Review Recommended</span>
+                            <span className="opacity-80">Validation differences require verification.</span>
+                            <Badge variant="outline" className="border-sky-300 bg-sky-100 text-sky-800">
+                                Review
+                            </Badge>
+                        </div>
+                    </div>
+                    {findings.length > 0 && (
+                        <ul className="list-disc pl-5 text-xs text-sky-900 space-y-1">
+                            {findings.map((finding, idx) => (
+                                <li key={idx} className="leading-relaxed">
+                                    {finding.message}
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </CardContent>
+            </Card>
+        );
+    }
+
+    return null;
+}

--- a/frontend/src/components/spot/index.ts
+++ b/frontend/src/components/spot/index.ts
@@ -21,3 +21,5 @@ export { AssertionReviewCard } from './AssertionReviewCard';
 
 export { QuoteVerificationPanel } from './QuoteVerificationPanel';
 
+export { SpotTemplateValidationCard } from './SpotTemplateValidationCard';
+

--- a/frontend/src/lib/spot-types.ts
+++ b/frontend/src/lib/spot-types.ts
@@ -248,6 +248,22 @@ export interface CreateSPERequest {
     validity_hours?: number;
 }
 
+export interface TemplateFinding {
+    code: string;
+    severity: 'warning' | 'review' | 'info' | 'passed';
+    message: string;
+    canonical_type: string | null;
+    template_line_id: number | null;
+    charge_line_id: string | null;
+    metadata: Record<string, unknown>;
+}
+
+export interface TemplateValidation {
+    status: 'passed' | 'warnings' | 'review';
+    template_id: number | null;
+    findings: TemplateFinding[];
+}
+
 /** Full SPE response from API */
 export interface SpotPricingEnvelope {
     id: string;
@@ -269,6 +285,7 @@ export interface SpotPricingEnvelope {
     sources: SPESourceBatch[];
     charges: SPEChargeLine[];
     customer_name?: string; // from backend/quotes/spot_schemas.py
+    template_validation?: TemplateValidation;
 }
 
 /** SPE compute request */


### PR DESCRIPTION
Summary:
- Adds frontend types for the SPOT template_validation API payload.
- Adds a read-only SpotTemplateValidationCard presentational component.
- Displays template validation diagnostics in the SPOT review step.
- Keeps the UI non-blocking and avoids wording that implies validation failure.

Guardrails:
- No backend changes.
- No migrations.
- No persistence.
- No pricing/ProductCode changes.
- No quote total changes.
- No charge creation changes.
- No finalisation blocking.

Validation:
- npm run typecheck: passed.
- npm run test:spot-workspace-helpers: passed.
- graphify update .: passed.
- Existing test:spot-finalization baseline issue left untouched.