### PR TITLE
feat(spot): add reviewed validation finding UX

### DIFF
--- a/frontend/src/app/quotes/spot/[speId]/page.tsx
+++ b/frontend/src/app/quotes/spot/[speId]/page.tsx
@@ -33,9 +33,9 @@ import { SpotRateEntryForm } from "@/components/spot/SpotRateEntryForm";
 import { SpotWorkspaceSummary } from "@/components/spot/SpotWorkspaceSummary";
 import { SourceComparisonSheet } from "@/components/spot/SourceComparisonSheet";
 import { IssueDetailsSheet } from "@/components/spot/IssueDetailsSheet";
-import type { SPEChargeLine, SPECommodity } from "@/lib/spot-types";
+import type { SPEChargeLine, SPECommodity, TemplateFinding } from "@/lib/spot-types";
 import type { ReplyAnalysisResult } from "@/lib/spot-types";
-import { getSpotStandardCharges } from "@/lib/api";
+import { getSpotStandardCharges, reviewSpotFinding } from "@/lib/api";
 import { getEffectiveProductCode, getSpotChargeDisplayLabel } from "@/lib/spot-charge-display";
 import { getSpotFinalizeDisabledReason } from "@/lib/spot-finalization";
 import {
@@ -178,6 +178,24 @@ export default function SpotRateEntryPage() {
     const { loadSPE } = actions;
     const [currentStep, setCurrentStep] = useState<Step>("intake");
     const [analysisResult, setAnalysisResult] = useState<ReplyAnalysisResult | null>(null);
+
+    const handleReviewFinding = useCallback(async (finding: TemplateFinding, comment: string) => {
+        if (!state.spe) return;
+        try {
+            await reviewSpotFinding(state.spe.id, {
+                finding_code: finding.code,
+                canonical_type: finding.canonical_type,
+                template_line_id: finding.template_line_id,
+                charge_line_id: finding.charge_line_id,
+                comment: comment || undefined
+            });
+            await loadSPE(state.spe.id);
+        } catch (err) {
+            console.error("Failed to review finding:", err);
+            alert(err instanceof Error ? err.message : "Failed to submit review");
+        }
+    }, [state.spe, loadSPE]);
+
     const [primarySourceBatchId, setPrimarySourceBatchId] = useState<string | null>(null);
     const [intakeDirtyMap, setIntakeDirtyMap] = useState<Record<string, boolean>>({});
     const [standardPrefillCharges, setStandardPrefillCharges] = useState<SPEChargeLine[]>([]);
@@ -1039,7 +1057,10 @@ export default function SpotRateEntryPage() {
                     </Button>
 
                     {state.spe?.template_validation && (
-                        <SpotTemplateValidationCard validation={state.spe.template_validation} />
+                        <SpotTemplateValidationCard 
+                            validation={state.spe.template_validation} 
+                            onReviewFinding={handleReviewFinding}
+                        />
                     )}
 
                     <Card className="overflow-hidden border-slate-200 bg-white shadow-sm">

--- a/frontend/src/components/spot/SpotTemplateValidationCard.tsx
+++ b/frontend/src/components/spot/SpotTemplateValidationCard.tsx
@@ -1,17 +1,126 @@
-import React from "react";
+import React, { useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { CheckCircle2, AlertTriangle, HelpCircle } from "lucide-react";
-import type { TemplateValidation } from "@/lib/spot-types";
+import type { TemplateValidation, TemplateFinding } from "@/lib/spot-types";
 
 export interface SpotTemplateValidationCardProps {
     validation?: TemplateValidation;
+    onReviewFinding?: (finding: TemplateFinding, comment: string) => Promise<void>;
 }
 
-export function SpotTemplateValidationCard({ validation }: SpotTemplateValidationCardProps) {
+export function SpotTemplateValidationCard({ validation, onReviewFinding }: SpotTemplateValidationCardProps) {
+    const [activeReviewIdx, setActiveReviewIdx] = useState<number | null>(null);
+    const [comment, setComment] = useState("");
+    const [submitting, setSubmitting] = useState(false);
+
     if (!validation) return null;
 
     const { status, findings = [] } = validation;
+
+    const handleSubmitReview = async (finding: TemplateFinding) => {
+        if (!onReviewFinding) return;
+        setSubmitting(true);
+        try {
+            await onReviewFinding(finding, comment);
+            setActiveReviewIdx(null);
+            setComment("");
+        } catch {
+            // Error is handled by parent or alert
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    const renderFindingsList = (findingsList: TemplateFinding[], isSkyTheme: boolean) => {
+        const borderThemeClass = isSkyTheme ? "border-sky-200/50" : "border-amber-200/50";
+        const textThemeClass = isSkyTheme ? "text-sky-900" : "text-amber-900";
+        const ringThemeClass = isSkyTheme ? "focus:ring-sky-500" : "focus:ring-amber-500";
+        const btnThemeClass = isSkyTheme 
+            ? "text-sky-700 border-sky-300 hover:bg-sky-100/50" 
+            : "text-amber-700 border-amber-300 hover:bg-amber-100/50";
+        const confirmBtnThemeClass = isSkyTheme 
+            ? "bg-sky-600 hover:bg-sky-700 text-white border-sky-600" 
+            : "bg-amber-600 hover:bg-amber-700 text-white border-amber-600";
+
+        return (
+            <div className="mt-3 space-y-2.5">
+                {findingsList.map((finding, idx) => (
+                    <div 
+                        key={idx} 
+                        className={`py-2.5 border-b ${borderThemeClass} last:border-0 flex flex-col sm:flex-row sm:items-center justify-between gap-3`}
+                    >
+                        <div className="space-y-1.5 flex-1">
+                            <div className={`text-xs leading-relaxed ${textThemeClass}`}>
+                                {finding.message}
+                            </div>
+                            {finding.is_reviewed && finding.review && (
+                                <div className="flex flex-wrap items-center gap-1.5 text-[10px] text-emerald-700 bg-emerald-50 border border-emerald-100 rounded px-2 py-0.5 w-fit">
+                                    <CheckCircle2 className="h-3 w-3 shrink-0 text-emerald-600" />
+                                    <span className="font-semibold">Reviewed:</span>
+                                    <span>&ldquo;{finding.review.comment || 'No comment'}&rdquo;</span>
+                                    {finding.review.reviewed_by && (
+                                        <span className="opacity-60">by {finding.review.reviewed_by}</span>
+                                    )}
+                                </div>
+                            )}
+                        </div>
+
+                        {!finding.is_reviewed && onReviewFinding && (
+                            <div className="shrink-0 flex items-center gap-2">
+                                {activeReviewIdx === idx ? (
+                                    <div className="flex items-center gap-1.5">
+                                        <input
+                                            type="text"
+                                            placeholder="Comment (optional)..."
+                                            value={comment}
+                                            onChange={(e) => setComment(e.target.value)}
+                                            className={`text-xs px-2 py-1 border border-slate-300 rounded bg-white text-slate-800 focus:outline-none focus:ring-1 ${ringThemeClass} w-44`}
+                                            disabled={submitting}
+                                        />
+                                        <Button
+                                            size="sm"
+                                            variant="outline"
+                                            onClick={() => handleSubmitReview(finding)}
+                                            disabled={submitting}
+                                            className={`h-7 px-2.5 text-[10px] ${confirmBtnThemeClass}`}
+                                        >
+                                            {submitting ? "..." : "Confirm"}
+                                        </Button>
+                                        <Button
+                                            size="sm"
+                                            variant="ghost"
+                                            onClick={() => {
+                                                setActiveReviewIdx(null);
+                                                setComment("");
+                                            }}
+                                            disabled={submitting}
+                                            className="h-7 px-2 text-[10px] text-slate-500 hover:bg-slate-100"
+                                        >
+                                            Cancel
+                                        </Button>
+                                    </div>
+                                ) : (
+                                    <Button
+                                        size="sm"
+                                        variant="outline"
+                                        onClick={() => {
+                                            setActiveReviewIdx(idx);
+                                            setComment("");
+                                        }}
+                                        className={`h-7 px-2.5 text-[10px] bg-white ${btnThemeClass}`}
+                                    >
+                                        Mark Reviewed
+                                    </Button>
+                                )}
+                            </div>
+                        )}
+                    </div>
+                ))}
+            </div>
+        );
+    };
 
     // Subtle/neutral/success for passed
     if (status === "passed") {
@@ -35,7 +144,7 @@ export function SpotTemplateValidationCard({ validation }: SpotTemplateValidatio
     if (status === "warnings") {
         return (
             <Card className="border-amber-200 bg-amber-50/50">
-                <CardContent className="space-y-3 py-4 px-5">
+                <CardContent className="py-4 px-5">
                     <div className="flex items-center gap-3">
                         <AlertTriangle className="h-5 w-5 text-amber-600 shrink-0" />
                         <div className="flex flex-wrap items-center gap-2 text-sm text-amber-800">
@@ -46,15 +155,7 @@ export function SpotTemplateValidationCard({ validation }: SpotTemplateValidatio
                             </Badge>
                         </div>
                     </div>
-                    {findings.length > 0 && (
-                        <ul className="list-disc pl-5 text-xs text-amber-900 space-y-1">
-                            {findings.map((finding, idx) => (
-                                <li key={idx} className="leading-relaxed">
-                                    {finding.message}
-                                </li>
-                            ))}
-                        </ul>
-                    )}
+                    {findings.length > 0 && renderFindingsList(findings, false)}
                 </CardContent>
             </Card>
         );
@@ -64,7 +165,7 @@ export function SpotTemplateValidationCard({ validation }: SpotTemplateValidatio
     if (status === "review") {
         return (
             <Card className="border-sky-200 bg-sky-50/50">
-                <CardContent className="space-y-3 py-4 px-5">
+                <CardContent className="py-4 px-5">
                     <div className="flex items-center gap-3">
                         <HelpCircle className="h-5 w-5 text-sky-600 shrink-0" />
                         <div className="flex flex-wrap items-center gap-2 text-sm text-sky-800">
@@ -75,15 +176,7 @@ export function SpotTemplateValidationCard({ validation }: SpotTemplateValidatio
                             </Badge>
                         </div>
                     </div>
-                    {findings.length > 0 && (
-                        <ul className="list-disc pl-5 text-xs text-sky-900 space-y-1">
-                            {findings.map((finding, idx) => (
-                                <li key={idx} className="leading-relaxed">
-                                    {finding.message}
-                                </li>
-                            ))}
-                        </ul>
-                    )}
+                    {findings.length > 0 && renderFindingsList(findings, true)}
                 </CardContent>
             </Card>
         );

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1854,3 +1854,34 @@ export async function deleteSpotEnvelopeDraft(id: string): Promise<void> {
     throw new Error(`Failed to delete SPE draft: ${detail}`);
   }
 }
+
+export interface SpotFindingReviewRequest {
+  finding_code: string;
+  canonical_type: string | null;
+  template_line_id: number | null;
+  charge_line_id: string | null;
+  comment?: string | null;
+}
+
+export async function reviewSpotFinding(
+  envelopeId: string,
+  request: SpotFindingReviewRequest
+): Promise<unknown> {
+  const url = API_BASE_URL + `/api/v3/spot/envelopes/${envelopeId}/findings/reviewed/`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Token ${resolveAuthToken()}`,
+    },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    const detail = await parseErrorResponse(response);
+    throw new Error(`Reviewing finding failed: ${detail}`);
+  }
+
+  return response.json();
+}
+

--- a/frontend/src/lib/spot-types.ts
+++ b/frontend/src/lib/spot-types.ts
@@ -250,12 +250,18 @@ export interface CreateSPERequest {
 
 export interface TemplateFinding {
     code: string;
-    severity: 'warning' | 'review' | 'info' | 'passed';
+    severity: 'warning' | 'review' | 'info';
     message: string;
     canonical_type: string | null;
     template_line_id: number | null;
     charge_line_id: string | null;
     metadata: Record<string, unknown>;
+    is_reviewed: boolean;
+    review?: {
+        comment: string | null;
+        reviewed_by: string | null;
+        reviewed_at: string;
+    } | null;
 }
 
 export interface TemplateValidation {


### PR DESCRIPTION
Summary:
- Adds frontend UX for marking SPOT template validation findings as reviewed.
- Adds optional comment capture.
- Posts raw finding identity fields to the reviewed endpoint.
- Refetches the SPOT envelope after review.
- Renders reviewed state on findings.

Validation reported:
- npm run typecheck passed.
- npm run test:spot-workspace-helpers passed.
- npm run lint passed.
- 58 backend tests passed.
- graphify update completed.

Guardrails:
- No backend changes in this PR.
- No migrations.
- No template editing.
- No pricing/ProductCode/totals changes.
- No finalisation blocking.