### PR TITLE
docs(spot): add template validation admin operations

### DIFF
--- a/backend/quotes/admin.py
+++ b/backend/quotes/admin.py
@@ -5,7 +5,8 @@ from .models import (
     Quote, QuoteVersion, QuoteLine, QuoteTotal, OverrideNote
 )
 from .spot_models import (
-    SpotPricingEnvelopeDB, SPEChargeLineDB, SPEAcknowledgementDB
+    SpotPricingEnvelopeDB, SPEChargeLineDB, SPEAcknowledgementDB,
+    ExpectedChargeTemplate, ExpectedTemplateLine, SpotTemplateValidationReview
 )
 
 class QuoteLineInline(admin.TabularInline):
@@ -116,3 +117,35 @@ class SpotPricingEnvelopeAdmin(admin.ModelAdmin):
 admin.site.register(Quote, QuoteAdmin)
 admin.site.register(QuoteVersion, QuoteVersionAdmin)
 admin.site.register(SpotPricingEnvelopeDB, SpotPricingEnvelopeAdmin)
+
+
+class ExpectedTemplateLineInline(admin.TabularInline):
+    model = ExpectedTemplateLine
+    extra = 1
+
+
+@admin.register(ExpectedChargeTemplate)
+class ExpectedChargeTemplateAdmin(admin.ModelAdmin):
+    list_display = ('name', 'mode', 'transport_mode', 'service_scope', 'origin_country', 'destination_country', 'is_active', 'created_at')
+    list_filter = ('mode', 'transport_mode', 'service_scope', 'is_active')
+    search_fields = ('name', 'origin_code', 'destination_code', 'origin_country', 'destination_country')
+    inlines = [ExpectedTemplateLineInline]
+
+
+@admin.register(ExpectedTemplateLine)
+class ExpectedTemplateLineAdmin(admin.ModelAdmin):
+    list_display = ('template', 'canonical_charge_type', 'requirement_level', 'expected_basis', 'is_active')
+    list_filter = ('requirement_level', 'expected_basis', 'is_active')
+    search_fields = ('template__name', 'canonical_charge_type__code', 'canonical_charge_type__name')
+
+
+@admin.register(SpotTemplateValidationReview)
+class SpotTemplateValidationReviewAdmin(admin.ModelAdmin):
+    list_display = ('envelope', 'finding_code', 'canonical_type', 'reviewed_by', 'reviewed_at')
+    list_filter = ('finding_code', 'canonical_type', 'reviewed_by', 'reviewed_at')
+    search_fields = ('envelope__id', 'finding_code', 'canonical_type', 'finding_fingerprint', 'comment', 'reviewed_by__username')
+    readonly_fields = (
+        'id', 'envelope', 'finding_code', 'canonical_type', 'template_line_id',
+        'charge_line_id', 'finding_fingerprint', 'comment', 'reviewed_by', 'reviewed_at'
+    )
+

--- a/docs/spot-template-validation-operations.md
+++ b/docs/spot-template-validation-operations.md
@@ -1,0 +1,48 @@
+# SPOT Template Validation Operations Runbook
+
+This runbook outlines standard operating procedures for managing, inspecting, and testing the expected charge templates and validation finding reviews in RateEngine.
+
+## 1. Django Admin Operations
+
+Expected charge templates and user reviews are exposed in the Django admin panel under the **Quotes** application.
+
+### Expected Charge Templates
+* **Model**: `ExpectedChargeTemplate`
+* Use this interface to define the expected baseline charges for different shipment contexts.
+* **Fields**: name, mode, transport mode, service scope, origin/destination countries, and active status.
+* **Inline Line Items**: Modify, add, or remove template lines inline using the `ExpectedTemplateLineInline` interface. You can set the requirement level (REQUIRED, OPTIONAL, CONDITIONAL, EXCLUDED) and the expected calculation basis.
+
+### Template Validation Reviews
+* **Model**: `SpotTemplateValidationReview`
+* Use this interface to inspect reviewed validation findings submitted by users on the SPOT review interface.
+* **Fields**: envelope ID, finding code, canonical type, template line ID, charge line ID, fingerprint, comment, reviewer, and review time.
+* **Inspection Only**: This admin dashboard is configured to be **read-only** to preserve the audit trail of operator decisions.
+
+---
+
+## 2. Key Operational Boundaries & Rules
+
+When configuring validation rules or inspecting findings, keep the following architectural guardrails in mind:
+
+1. **Validation is purely diagnostic & non-blocking**: 
+   Template validation findings (missing charges, unexpected charges, etc.) act as a reference guideline for operator visibility. They do **not** block quote calculations, envelope finalisation, or quote generation.
+2. **ProductCode remains authoritative**: 
+   The legacy alias-to-ProductCode mapping remains the sole source of truth for downstream pricing. Validation findings are decoupled from the core pricing engine.
+3. **Expectation-only impact**: 
+   Edits to Expected Charge Templates and Expected Template Lines affect the validation rules/expectations only. They **never** affect quote totals, pricing, or finalisation logic.
+
+---
+
+## 3. QA and Development Seeding
+
+To seed a predictable local/dev environment with stable QA fixtures representing all template validation states, run the following command:
+
+```bash
+python manage.py seed_spot_template_validation_fixtures
+```
+
+This management command creates idempotent test templates and draft SPOT envelopes covering the following states:
+* **Passed**: An envelope with correct required charges.
+* **Warnings**: An envelope containing warnings (missing required charges, unexpected present charges).
+* **Review**: An envelope containing reviews (basis mismatches, duplicate charge families, conditional charges).
+* **Template Not Found**: An envelope matching no criteria to verify the template fallback status.


### PR DESCRIPTION
Summary:
- Registers ExpectedChargeTemplate, ExpectedTemplateLine, and SpotTemplateValidationReview in Django admin.
- Adds admin list/search/filter/read-only visibility for SPOT template validation operations.
- Adds docs for QA fixture seeding, admin inspection, and non-blocking validation rules.

Validation:
- python manage.py check passed.
- 58 targeted backend tests passed.
- graphify update completed.
- npx fallow dead-code completed.

Guardrails:
- Backend/admin/docs only.
- No frontend changes.
- No migrations.
- No pricing/ProductCode/totals changes.
- No finalisation blocking.