### PR TITLE
refactor(spot): harden template validation findings

### DIFF
--- a/backend/quotes/serializers.py
+++ b/backend/quotes/serializers.py
@@ -845,6 +845,8 @@ class SpotPricingEnvelopeSerializer(serializers.ModelSerializer):
 
 
 class SpotTemplateValidationReviewSerializer(serializers.ModelSerializer):
+    comment = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+
     class Meta:
         model = SpotTemplateValidationReview
         fields = [
@@ -853,6 +855,20 @@ class SpotTemplateValidationReviewSerializer(serializers.ModelSerializer):
             'comment', 'reviewed_by', 'reviewed_at'
         ]
         read_only_fields = ['id', 'finding_fingerprint', 'reviewed_by', 'reviewed_at']
+
+    def validate_finding_code(self, value):
+        from quotes.services.spot_template_validation import VALID_FINDING_CODES
+        if value not in VALID_FINDING_CODES:
+            raise serializers.ValidationError(f"Invalid finding code: {value}")
+        return value
+
+    def validate_comment(self, value):
+        if value is None:
+            return None
+        value = value.strip()
+        if len(value) > 2000:
+            raise serializers.ValidationError("Comment cannot exceed 2000 characters.")
+        return value
 
     def create(self, validated_data):
         from quotes.services.spot_template_validation import compute_finding_fingerprint

--- a/backend/quotes/services/spot_template_validation.py
+++ b/backend/quotes/services/spot_template_validation.py
@@ -10,6 +10,45 @@ from quotes.spot_models import (
 
 logger = logging.getLogger(__name__)
 
+# Validation Finding Codes
+FINDING_TEMPLATE_NOT_FOUND = "template_not_found"
+FINDING_EXPECTED_CHARGE_MISSING = "expected_charge_missing"
+FINDING_UNEXPECTED_CHARGE_PRESENT = "unexpected_charge_present"
+FINDING_CONDITIONAL_CHARGE_PRESENT = "conditional_charge_present"
+FINDING_EXPECTED_BASIS_MISMATCH = "expected_basis_mismatch"
+FINDING_DUPLICATE_CHARGE_FAMILY = "duplicate_charge_family"
+
+VALID_FINDING_CODES = {
+    FINDING_TEMPLATE_NOT_FOUND,
+    FINDING_EXPECTED_CHARGE_MISSING,
+    FINDING_UNEXPECTED_CHARGE_PRESENT,
+    FINDING_CONDITIONAL_CHARGE_PRESENT,
+    FINDING_EXPECTED_BASIS_MISMATCH,
+    FINDING_DUPLICATE_CHARGE_FAMILY,
+}
+
+# Validation Severities
+SEVERITY_INFO = "info"
+SEVERITY_WARNING = "warning"
+SEVERITY_REVIEW = "review"
+
+VALID_SEVERITIES = {
+    SEVERITY_INFO,
+    SEVERITY_WARNING,
+    SEVERITY_REVIEW,
+}
+
+# Validation Statuses
+STATUS_PASSED = "passed"
+STATUS_WARNINGS = "warnings"
+STATUS_REVIEW = "review"
+
+VALID_STATUSES = {
+    STATUS_PASSED,
+    STATUS_WARNINGS,
+    STATUS_REVIEW,
+}
+
 
 def compute_finding_fingerprint(
     finding_code: str,
@@ -167,14 +206,14 @@ def validate_envelope_charges(envelope: SpotPricingEnvelopeDB) -> Dict[str, Any]
     if not template:
         findings.append(
             _build_finding(
-                code="template_not_found",
-                severity="review",
+                code=FINDING_TEMPLATE_NOT_FOUND,
+                severity=SEVERITY_REVIEW,
                 message="No applicable expectation template resolved for this shipment context."
             )
         )
         # Deduce status dynamically to support lowercase 'review' status
         severities = {f["severity"] for f in findings}
-        status = "review" if "review" in severities else "warnings"
+        status = STATUS_REVIEW if SEVERITY_REVIEW in severities else STATUS_WARNINGS
         return {
             "status": status,
             "template_id": None,
@@ -205,8 +244,8 @@ def validate_envelope_charges(envelope: SpotPricingEnvelopeDB) -> Dict[str, Any]
         if level == ExpectedTemplateLine.RequirementLevel.REQUIRED and not has_actual:
             findings.append(
                 _build_finding(
-                    code="expected_charge_missing",
-                    severity="warning",
+                    code=FINDING_EXPECTED_CHARGE_MISSING,
+                    severity=SEVERITY_WARNING,
                     message=f"Expected charge of type '{canonical_type.name}' ({canonical_type.code}) is missing.",
                     canonical_type=canonical_type.code,
                     template_line_id=t_line.id
@@ -217,8 +256,8 @@ def validate_envelope_charges(envelope: SpotPricingEnvelopeDB) -> Dict[str, Any]
             for act_line in actual_by_canonical[canonical_type]:
                 findings.append(
                     _build_finding(
-                        code="unexpected_charge_present",
-                        severity="warning",
+                        code=FINDING_UNEXPECTED_CHARGE_PRESENT,
+                        severity=SEVERITY_WARNING,
                         message=f"Excluded charge of type '{canonical_type.name}' ({canonical_type.code}) was included.",
                         canonical_type=canonical_type.code,
                         template_line_id=t_line.id,
@@ -230,8 +269,8 @@ def validate_envelope_charges(envelope: SpotPricingEnvelopeDB) -> Dict[str, Any]
             for act_line in actual_by_canonical[canonical_type]:
                 findings.append(
                     _build_finding(
-                        code="conditional_charge_present",
-                        severity="review",
+                        code=FINDING_CONDITIONAL_CHARGE_PRESENT,
+                        severity=SEVERITY_REVIEW,
                         message=f"Conditional charge of type '{canonical_type.name}' ({canonical_type.code}) is present and requires confirmation.",
                         canonical_type=canonical_type.code,
                         template_line_id=t_line.id,
@@ -245,8 +284,8 @@ def validate_envelope_charges(envelope: SpotPricingEnvelopeDB) -> Dict[str, Any]
                 if act_line.calculation_basis != expected_basis:
                     findings.append(
                         _build_finding(
-                            code="expected_basis_mismatch",
-                            severity="review",
+                            code=FINDING_EXPECTED_BASIS_MISMATCH,
+                            severity=SEVERITY_REVIEW,
                             message=(
                                 f"Basis mismatch for '{canonical_type.name}': "
                                 f"Expected basis '{expected_basis}' but actual was '{act_line.calculation_basis}'."
@@ -267,8 +306,8 @@ def validate_envelope_charges(envelope: SpotPricingEnvelopeDB) -> Dict[str, Any]
             for act_line in lines:
                 findings.append(
                     _build_finding(
-                        code="duplicate_charge_family",
-                        severity="review",
+                        code=FINDING_DUPLICATE_CHARGE_FAMILY,
+                        severity=SEVERITY_REVIEW,
                         message=f"Multiple lines detected resolving to canonical charge family '{canonical_type.name}' ({canonical_type.code}).",
                         canonical_type=canonical_type.code,
                         charge_line_id=str(act_line.id)
@@ -277,12 +316,12 @@ def validate_envelope_charges(envelope: SpotPricingEnvelopeDB) -> Dict[str, Any]
 
     # Deduce final status
     severities = {f["severity"] for f in findings}
-    if "review" in severities:
-        status = "review"
-    elif "warning" in severities or "info" in severities:
-        status = "warnings"
+    if SEVERITY_REVIEW in severities:
+        status = STATUS_REVIEW
+    elif SEVERITY_WARNING in severities or SEVERITY_INFO in severities:
+        status = STATUS_WARNINGS
     else:
-        status = "passed"
+        status = STATUS_PASSED
 
     return {
         "status": status,

--- a/backend/quotes/tests/test_spot_template_validation_review.py
+++ b/backend/quotes/tests/test_spot_template_validation_review.py
@@ -190,3 +190,52 @@ class SpotTemplateValidationReviewAPITest(APITestCase):
         self.assertIsNotNone(finding_after["review"])
         self.assertEqual(finding_after["review"]["comment"], "Reviewed and approved")
         self.assertEqual(finding_after["review"]["reviewed_by"], self.user.username)
+
+    def test_invalid_finding_code_rejected(self):
+        """Verify that validation review endpoint rejects invalid/unknown finding codes."""
+        payload = {
+            "finding_code": "invalid_finding_code_foo",
+            "canonical_type": "AWB_DOCUMENTATION",
+            "template_line_id": self.template_line.id,
+            "charge_line_id": None,
+            "comment": "Nice try"
+        }
+        response = self.client.post(self.review_url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("finding_code", response.data)
+
+    def test_long_comment_rejected(self):
+        """Verify that validation review endpoint rejects comments over 2000 characters."""
+        payload = {
+            "finding_code": "expected_charge_missing",
+            "canonical_type": "AWB_DOCUMENTATION",
+            "template_line_id": self.template_line.id,
+            "charge_line_id": None,
+            "comment": "x" * 2001
+        }
+        response = self.client.post(self.review_url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("comment", response.data)
+
+    def test_whitespace_comment_stripped(self):
+        """Verify that validation review endpoint strips leading/trailing comment whitespace."""
+        payload = {
+            "finding_code": "expected_charge_missing",
+            "canonical_type": "AWB_DOCUMENTATION",
+            "template_line_id": self.template_line.id,
+            "charge_line_id": None,
+            "comment": "   Hello world!  \n "
+        }
+        response = self.client.post(self.review_url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["comment"], "Hello world!")
+
+        review = SpotTemplateValidationReview.objects.get(id=response.data["id"])
+        self.assertEqual(review.comment, "Hello world!")
+
+    def test_fingerprint_remains_stable(self):
+        """Verify compute_finding_fingerprint output format remains stable."""
+        from quotes.services.spot_template_validation import compute_finding_fingerprint
+        fp = compute_finding_fingerprint("expected_charge_missing", "AWB_DOCUMENTATION", 123, "ba259968-f2c4-4725-b264-3da6d5a166ca")
+        self.assertEqual(fp, "expected_charge_missing:AWB_DOCUMENTATION:123:ba259968-f2c4-4725-b264-3da6d5a166ca")
+

--- a/frontend/src/lib/spot-types.ts
+++ b/frontend/src/lib/spot-types.ts
@@ -248,9 +248,21 @@ export interface CreateSPERequest {
     validity_hours?: number;
 }
 
+export type TemplateFindingCode =
+  | 'template_not_found'
+  | 'expected_charge_missing'
+  | 'unexpected_charge_present'
+  | 'conditional_charge_present'
+  | 'expected_basis_mismatch'
+  | 'duplicate_charge_family';
+
+export type TemplateFindingSeverity = 'warning' | 'review' | 'info';
+
+export type TemplateValidationStatus = 'passed' | 'warnings' | 'review';
+
 export interface TemplateFinding {
-    code: string;
-    severity: 'warning' | 'review' | 'info';
+    code: TemplateFindingCode;
+    severity: TemplateFindingSeverity;
     message: string;
     canonical_type: string | null;
     template_line_id: number | null;
@@ -265,7 +277,7 @@ export interface TemplateFinding {
 }
 
 export interface TemplateValidation {
-    status: 'passed' | 'warnings' | 'review';
+    status: TemplateValidationStatus;
     template_id: number | null;
     findings: TemplateFinding[];
 }


### PR DESCRIPTION
Summary:
- Centralizes SPOT template validation finding code, severity, and status constants.
- Replaces duplicated backend literals in the validation service.
- Tightens reviewed-finding serializer validation.
- Adds comment normalization and 2000-character limit.
- Tightens frontend TemplateFinding/TemplateValidation union types.
- Adds tests for invalid codes, long comments, whitespace stripping, and fingerprint stability.

Validation:
- python manage.py check passed.
- 62 targeted backend tests passed.
- npm run typecheck passed.
- graphify update completed.

Guardrails:
- No migrations.
- No new models.
- No broad refactor.
- No pricing/ProductCode/totals changes.
- No finalisation changes.
- Fingerprint output format unchanged.