### PR TITLE
feat(spot): add template validation review metrics

### DIFF
--- a/backend/quotes/serializers.py
+++ b/backend/quotes/serializers.py
@@ -924,4 +924,13 @@ class SpotTemplateValidationReviewSerializer(serializers.ModelSerializer):
         return instance
 
 
+class SpotTemplateValidationReviewMetricsSerializer(serializers.Serializer):
+    total_reviewed_events = serializers.IntegerField(read_only=True)
+    reviewed_by_finding_code = serializers.DictField(child=serializers.IntegerField(), read_only=True)
+    reviewed_by_canonical_type = serializers.DictField(child=serializers.IntegerField(), read_only=True)
+    reviewed_by_user = serializers.DictField(child=serializers.IntegerField(), read_only=True)
+    latest_events = serializers.ListField(child=serializers.DictField(), read_only=True)
+    top_reviewed_fingerprints = serializers.ListField(child=serializers.DictField(), read_only=True)
+
+
 

--- a/backend/quotes/services/spot_validation_metrics.py
+++ b/backend/quotes/services/spot_validation_metrics.py
@@ -1,0 +1,87 @@
+import logging
+from django.db.models import Count
+from quotes.spot_models import SpotTemplateValidationEvent
+
+logger = logging.getLogger(__name__)
+
+class SpotTemplateValidationMetricsService:
+    @classmethod
+    def get_review_metrics(cls, start_date=None, end_date=None):
+        """
+        Aggregates review metrics strictly from SpotTemplateValidationEvent records
+        where event_type = "finding_reviewed".
+        """
+        # Base queryset
+        queryset = SpotTemplateValidationEvent.objects.filter(event_type="finding_reviewed")
+
+        # Date range filtering
+        if start_date:
+            queryset = queryset.filter(created_at__gte=start_date)
+        if end_date:
+            queryset = queryset.filter(created_at__lte=end_date)
+
+        # 1. total_reviewed_events
+        total_reviewed_events = queryset.count()
+
+        # 2. reviewed_by_finding_code
+        reviewed_by_finding_code = {}
+        for row in queryset.values("finding_code").annotate(count=Count("id")).order_by("-count"):
+            reviewed_by_finding_code[row["finding_code"]] = row["count"]
+
+        # 3. reviewed_by_canonical_type
+        reviewed_by_canonical_type = {}
+        for row in queryset.values("canonical_type").annotate(count=Count("id")).order_by("-count"):
+            c_type = row["canonical_type"] or "Unknown/Unmapped"
+            reviewed_by_canonical_type[c_type] = row["count"]
+
+        # 4. reviewed_by_user
+        reviewed_by_user = {}
+        for row in queryset.values("user__username").annotate(count=Count("id")).order_by("-count"):
+            username = row["user__username"] or "System/Unknown"
+            reviewed_by_user[username] = row["count"]
+
+        # 5. latest_events
+        latest_events = []
+        for event in queryset.select_related("user").order_by("-created_at")[:10]:
+            comment = event.metadata.get("comment") if isinstance(event.metadata, dict) else None
+            latest_events.append({
+                "id": str(event.id),
+                "finding_fingerprint": event.finding_fingerprint,
+                "finding_code": event.finding_code,
+                "canonical_type": event.canonical_type,
+                "user": event.user.username if event.user else "System/Unknown",
+                "comment": comment,
+                "created_at": event.created_at.isoformat()
+            })
+
+        # 6. top_reviewed_fingerprints
+        top_reviewed_fingerprints = []
+        fingerprint_rows = (
+            queryset.values(
+                "finding_fingerprint",
+                "finding_code",
+                "canonical_type",
+                "template_line_id",
+                "charge_line_id"
+            )
+            .annotate(count=Count("id"))
+            .order_by("-count")[:10]
+        )
+        for row in fingerprint_rows:
+            top_reviewed_fingerprints.append({
+                "finding_fingerprint": row["finding_fingerprint"],
+                "finding_code": row["finding_code"],
+                "canonical_type": row["canonical_type"],
+                "template_line_id": row["template_line_id"],
+                "charge_line_id": str(row["charge_line_id"]) if row["charge_line_id"] else None,
+                "count": row["count"]
+            })
+
+        return {
+            "total_reviewed_events": total_reviewed_events,
+            "reviewed_by_finding_code": reviewed_by_finding_code,
+            "reviewed_by_canonical_type": reviewed_by_canonical_type,
+            "reviewed_by_user": reviewed_by_user,
+            "latest_events": latest_events,
+            "top_reviewed_fingerprints": top_reviewed_fingerprints
+        }

--- a/backend/quotes/spot_views.py
+++ b/backend/quotes/spot_views.py
@@ -2967,3 +2967,55 @@ class SpotTemplateValidationFindingReviewedAPIView(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
+class SpotTemplateValidationReviewMetricsAPIView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        if not _user_is_manager_or_admin(request.user):
+            raise PermissionDenied("Only managers and admins can view validation metrics.")
+
+        from django.utils.dateparse import parse_date
+        import datetime
+        from django.utils import timezone
+        
+        start_date_str = request.query_params.get("start_date")
+        end_date_str = request.query_params.get("end_date")
+
+        now = timezone.now()
+
+        if start_date_str:
+            try:
+                start_date = parse_date(start_date_str)
+                if not start_date:
+                    raise ValueError
+                start_dt = timezone.make_aware(datetime.datetime.combine(start_date, datetime.time.min))
+            except ValueError:
+                return Response({"error": "Invalid start_date format. Use YYYY-MM-DD."}, status=status.HTTP_400_BAD_REQUEST)
+        else:
+            start_dt = now - datetime.timedelta(days=30)
+
+        if end_date_str:
+            try:
+                end_date = parse_date(end_date_str)
+                if not end_date:
+                    raise ValueError
+                end_dt = timezone.make_aware(datetime.datetime.combine(end_date, datetime.time.max))
+            except ValueError:
+                return Response({"error": "Invalid end_date format. Use YYYY-MM-DD."}, status=status.HTTP_400_BAD_REQUEST)
+        else:
+            end_dt = now
+
+        if end_dt < start_dt:
+            return Response({"error": "end_date cannot be before start_date."}, status=status.HTTP_400_BAD_REQUEST)
+
+        if (end_dt - start_dt).days > 180:
+            return Response({"error": "The maximum date range allowed is 180 days."}, status=status.HTTP_400_BAD_REQUEST)
+
+        from quotes.services.spot_validation_metrics import SpotTemplateValidationMetricsService
+        metrics = SpotTemplateValidationMetricsService.get_review_metrics(start_dt, end_dt)
+
+        from quotes.serializers import SpotTemplateValidationReviewMetricsSerializer
+        serializer = SpotTemplateValidationReviewMetricsSerializer(metrics)
+        return Response(serializer.data)
+
+

--- a/backend/quotes/tests/test_spot_validation_metrics.py
+++ b/backend/quotes/tests/test_spot_validation_metrics.py
@@ -1,0 +1,147 @@
+import datetime
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from quotes.spot_models import SpotPricingEnvelopeDB, SpotTemplateValidationEvent
+
+
+class SpotTemplateValidationReviewMetricsTests(APITestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.manager_user = User.objects.create_user(
+            username="manager_test",
+            password="password123",
+            email="manager@example.com",
+            role="manager"
+        )
+        self.sales_user = User.objects.create_user(
+            username="sales_test",
+            password="password123",
+            email="sales@example.com",
+            role="sales"
+        )
+
+        self.envelope = SpotPricingEnvelopeDB.objects.create(
+            status="draft",
+            shipment_context_json={"origin_country": "SG", "destination_country": "PG"},
+            expires_at=timezone.now() + datetime.timedelta(days=2),
+            spot_trigger_reason_code="MANUAL",
+            spot_trigger_reason_text="Manual trigger"
+        )
+
+        self.metrics_url = reverse("quotes:spot-validation-review-metrics")
+
+    def _create_event(self, created_at, event_type="finding_reviewed", finding_code="expected_charge_missing", canonical_type="AWB_DOCUMENTATION", fingerprint="fp1"):
+        event = SpotTemplateValidationEvent.objects.create(
+            envelope=self.envelope,
+            event_type=event_type,
+            finding_code=finding_code,
+            canonical_type=canonical_type,
+            template_line_id=123,
+            charge_line_id=None,
+            finding_fingerprint=fingerprint,
+            validation_status=None,
+            user=self.manager_user,
+            metadata={"comment": "Event comment"}
+        )
+        if created_at:
+            # Override auto_now_add
+            SpotTemplateValidationEvent.objects.filter(id=event.id).update(created_at=created_at)
+        return event
+
+    def test_manager_allowed_sales_user_blocked(self):
+        """Verify only manager/admin role can access validation metrics."""
+        # Authenticate sales user
+        self.client.force_authenticate(user=self.sales_user)
+        response = self.client.get(self.metrics_url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        # Authenticate manager
+        self.client.force_authenticate(user=self.manager_user)
+        response = self.client.get(self.metrics_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_metrics_filtering_and_counts(self):
+        """Verify metrics count only finding_reviewed events and group correctly."""
+        self.client.force_authenticate(user=self.manager_user)
+        now = timezone.now()
+
+        # 1. Create finding_reviewed event (within 30 days)
+        self._create_event(created_at=now - datetime.timedelta(days=2), finding_code="expected_charge_missing", canonical_type="AWB")
+        
+        # 2. Create another finding_reviewed event (within 30 days, different code)
+        self._create_event(created_at=now - datetime.timedelta(days=5), finding_code="unexpected_charge_present", canonical_type="AWB")
+        
+        # 3. Create another event with same code to test count aggregates
+        self._create_event(created_at=now - datetime.timedelta(days=10), finding_code="expected_charge_missing", canonical_type="FUEL")
+
+        # 4. Create non-reviewed event (should not be counted)
+        self._create_event(created_at=now - datetime.timedelta(days=1), event_type="finding_generated")
+
+        # 5. Create event outside default 30-day filter (35 days ago)
+        self._create_event(created_at=now - datetime.timedelta(days=35), finding_code="expected_charge_missing")
+
+        # Run with default 30 day filter
+        response = self.client.get(self.metrics_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.data
+        self.assertEqual(data["total_reviewed_events"], 3)  # Only the 3 reviews within 30 days
+        self.assertEqual(data["reviewed_by_finding_code"]["expected_charge_missing"], 2)
+        self.assertEqual(data["reviewed_by_finding_code"]["unexpected_charge_present"], 1)
+        self.assertEqual(data["reviewed_by_canonical_type"]["AWB"], 2)
+        self.assertEqual(data["reviewed_by_canonical_type"]["FUEL"], 1)
+        self.assertEqual(data["reviewed_by_user"]["manager_test"], 3)
+
+        # Shape assertions
+        self.assertEqual(len(data["latest_events"]), 3)
+        self.assertEqual(data["latest_events"][0]["user"], "manager_test")
+        self.assertEqual(data["latest_events"][0]["comment"], "Event comment")
+        self.assertEqual(len(data["top_reviewed_fingerprints"]), 3)
+
+    def test_explicit_date_filtering(self):
+        """Verify query parameters start_date and end_date filter metrics properly."""
+        self.client.force_authenticate(user=self.manager_user)
+        now = timezone.now()
+
+        # Event 1: 45 days ago
+        self._create_event(created_at=now - datetime.timedelta(days=45), finding_code="code_A")
+        # Event 2: 15 days ago
+        self._create_event(created_at=now - datetime.timedelta(days=15), finding_code="code_B")
+
+        # Query range from 50 days ago to 30 days ago
+        start = (now - datetime.timedelta(days=50)).date().isoformat()
+        end = (now - datetime.timedelta(days=30)).date().isoformat()
+
+        response = self.client.get(f"{self.metrics_url}?start_date={start}&end_date={end}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["total_reviewed_events"], 1)
+        self.assertIn("code_A", response.data["reviewed_by_finding_code"])
+        self.assertNotIn("code_B", response.data["reviewed_by_finding_code"])
+
+    def test_rejects_range_over_180_days(self):
+        """Verify range checks reject queries spanning more than 180 days."""
+        self.client.force_authenticate(user=self.manager_user)
+        now = timezone.now()
+
+        start = (now - datetime.timedelta(days=190)).date().isoformat()
+        end = now.date().isoformat()
+
+        response = self.client.get(f"{self.metrics_url}?start_date={start}&end_date={end}")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error"], "The maximum date range allowed is 180 days.")
+
+    def test_rejects_end_date_before_start_date(self):
+        """Verify rejecting start date that exceeds end date."""
+        self.client.force_authenticate(user=self.manager_user)
+        now = timezone.now()
+
+        start = now.date().isoformat()
+        end = (now - datetime.timedelta(days=10)).date().isoformat()
+
+        response = self.client.get(f"{self.metrics_url}?start_date={start}&end_date={end}")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error"], "end_date cannot be before start_date.")

--- a/backend/quotes/urls.py
+++ b/backend/quotes/urls.py
@@ -31,6 +31,7 @@ from .spot_views import (
     SpotEnvelopeCreateQuoteAPIView,
     SpotSourceBatchReviewAPIView,
     SpotTemplateValidationFindingReviewedAPIView,
+    SpotTemplateValidationReviewMetricsAPIView,
 )
 
 app_name = 'quotes'
@@ -70,4 +71,5 @@ urlpatterns = [
     path('v3/spot/analyze-reply/', SpotReplyAnalysisAPIView.as_view(), name='spot-analyze-reply'),
     path('v3/spot/envelopes/<uuid:envelope_id>/create-quote/', SpotEnvelopeCreateQuoteAPIView.as_view(), name='spot-envelope-create-quote'),
     path('v3/spot/envelopes/<uuid:envelope_id>/findings/reviewed/', SpotTemplateValidationFindingReviewedAPIView.as_view(), name='spot-envelope-finding-reviewed'),
+    path('v3/spot/template-validation/review-metrics/', SpotTemplateValidationReviewMetricsAPIView.as_view(), name='spot-validation-review-metrics'),
 ]


### PR DESCRIPTION
Summary:
- Adds read-only SPOT template validation review metrics from SpotTemplateValidationEvent only.
- Aggregates finding_reviewed events by finding code, canonical type, user, latest events, and top fingerprints.
- Adds default 30-day range and 180-day maximum range safeguard.
- Adds manager/admin-only API endpoint at /api/v3/spot/template-validation/review-metrics/.

Validation:
- python manage.py check passed.
- metrics tests passed.
- broader validation and SPOT flow tests passed.
- graphify update completed.

Guardrails:
- No migrations.
- No frontend changes.
- No generated finding events.
- No validate_envelope_charges loops.
- No pricing/ProductCode/totals changes.
- No finalisation changes.