### PR TITLE
feat(spot): add snapshot validation metrics

### DIFF
--- a/backend/quotes/serializers.py
+++ b/backend/quotes/serializers.py
@@ -933,4 +933,21 @@ class SpotTemplateValidationReviewMetricsSerializer(serializers.Serializer):
     top_reviewed_fingerprints = serializers.ListField(child=serializers.DictField(), read_only=True)
 
 
+class SpotTemplateValidationSnapshotMetricsSerializer(serializers.Serializer):
+    period = serializers.DictField(child=serializers.CharField(), read_only=True)
+    filters_applied = serializers.DictField(child=serializers.CharField(allow_null=True), read_only=True)
+    total_snapshots = serializers.IntegerField(read_only=True)
+    unique_envelopes_count = serializers.IntegerField(read_only=True)
+    by_validation_status = serializers.DictField(child=serializers.IntegerField(), read_only=True)
+    by_trigger = serializers.DictField(child=serializers.IntegerField(), read_only=True)
+    snapshots_without_template = serializers.IntegerField(read_only=True)
+    review_or_warning_snapshot_count = serializers.IntegerField(read_only=True)
+    review_or_warning_percentage = serializers.FloatField(read_only=True)
+    top_finding_codes = serializers.ListField(child=serializers.DictField(), read_only=True)
+    top_canonical_types = serializers.ListField(child=serializers.DictField(), read_only=True)
+    templates_requiring_attention = serializers.ListField(child=serializers.DictField(), read_only=True)
+    stability_metrics = serializers.DictField(child=serializers.IntegerField(), read_only=True)
+
+
+
 

--- a/backend/quotes/services/spot_validation_snapshot_metrics.py
+++ b/backend/quotes/services/spot_validation_snapshot_metrics.py
@@ -1,0 +1,175 @@
+import logging
+from django.db.models import Count
+from quotes.spot_models import SpotTemplateValidationSnapshot
+
+logger = logging.getLogger(__name__)
+
+class SpotTemplateValidationSnapshotMetricsService:
+    @classmethod
+    def get_snapshot_metrics(cls, start_date, end_date, filters=None, limit=10):
+        """
+        Aggregates operational validation metrics strictly from SpotTemplateValidationSnapshot records.
+        """
+        if filters is None:
+            filters = {}
+
+        # Base query with date range
+        queryset = SpotTemplateValidationSnapshot.objects.filter(
+            created_at__gte=start_date,
+            created_at__lte=end_date
+        )
+
+        # Apply database filters
+        trigger = filters.get("trigger")
+        if trigger:
+            queryset = queryset.filter(trigger=trigger)
+
+        validation_status = filters.get("validation_status")
+        if validation_status:
+            queryset = queryset.filter(validation_status=validation_status)
+
+        template_id = filters.get("template_id")
+        if template_id is not None:
+            queryset = queryset.filter(template_id=template_id)
+
+        # Load snapshots into memory to perform Python-level json-filtering and aggregates.
+        # This bypasses SQLite contains-lookup support limitations.
+        snapshots = list(queryset)
+
+        finding_code = filters.get("finding_code")
+        if finding_code:
+            snapshots = [s for s in snapshots if finding_code in (s.finding_codes or [])]
+
+        canonical_type = filters.get("canonical_type")
+        if canonical_type:
+            snapshots = [s for s in snapshots if canonical_type in (s.canonical_types or [])]
+
+        # 1. total_snapshots
+        total_snapshots = len(snapshots)
+
+        # 2. unique_envelopes_count
+        unique_envelopes_count = len({s.envelope_id for s in snapshots})
+
+        # 3. by_validation_status breakdown
+        by_validation_status = {"passed": 0, "warnings": 0, "review": 0}
+        for s in snapshots:
+            status_val = s.validation_status
+            by_validation_status[status_val] = by_validation_status.get(status_val, 0) + 1
+
+        # 4. by_trigger breakdown
+        by_trigger = {"envelope_created": 0, "envelope_updated": 0, "sales_acknowledged": 0}
+        for s in snapshots:
+            trigger_val = s.trigger
+            by_trigger[trigger_val] = by_trigger.get(trigger_val, 0) + 1
+
+        # 5. snapshots_without_template
+        snapshots_without_template = sum(1 for s in snapshots if s.template_id is None)
+
+        # 6. review_or_warning_snapshot_count & percentage
+        review_or_warning_snapshot_count = sum(
+            1 for s in snapshots if s.validation_status in ["warnings", "review"]
+        )
+        
+        review_or_warning_percentage = 0.0
+        if total_snapshots > 0:
+            review_or_warning_percentage = round(
+                (review_or_warning_snapshot_count / total_snapshots) * 100, 2
+            )
+
+        # 7. Count finding code and canonical type frequencies
+        finding_code_counts = {}
+        canonical_type_counts = {}
+        for s in snapshots:
+            f_codes = s.finding_codes or []
+            for f_code in f_codes:
+                finding_code_counts[f_code] = finding_code_counts.get(f_code, 0) + 1
+            c_types = s.canonical_types or []
+            for c_type in c_types:
+                canonical_type_counts[c_type] = canonical_type_counts.get(c_type, 0) + 1
+
+        top_finding_codes = [
+            {"code": code, "snapshot_count": count}
+            for code, count in sorted(finding_code_counts.items(), key=lambda x: x[1], reverse=True)[:limit]
+        ]
+
+        top_canonical_types = [
+            {"canonical_type": c_type, "snapshot_count": count}
+            for c_type, count in sorted(canonical_type_counts.items(), key=lambda x: x[1], reverse=True)[:limit]
+        ]
+
+        # 8. templates_requiring_attention
+        template_stats = {}
+        for s in snapshots:
+            tid = s.template_id
+            thash = s.template_hash or ""
+            if tid is None:
+                continue
+            key = (tid, thash)
+            if key not in template_stats:
+                template_stats[key] = {"total": 0, "issues": 0}
+            template_stats[key]["total"] += 1
+            if s.validation_status in ["warnings", "review"]:
+                template_stats[key]["issues"] += 1
+
+        templates_req_attention = []
+        for (tid, thash), stats in template_stats.items():
+            total = stats["total"]
+            issues = stats["issues"]
+            pct = round((issues / total) * 100, 2) if total > 0 else 0.0
+            templates_req_attention.append({
+                "template_id": tid,
+                "template_hash": thash,
+                "total_snapshots": total,
+                "review_or_warning_percentage": pct
+            })
+        
+        # Sort by review_or_warning_percentage desc, then total_snapshots desc, then template_id asc
+        templates_req_attention.sort(
+            key=lambda x: (-x["review_or_warning_percentage"], -x["total_snapshots"], x["template_id"])
+        )
+        templates_requiring_attention = templates_req_attention[:limit]
+
+        # 9. stability_metrics
+        envelope_hashes = {}
+        for s in snapshots:
+            env_id = s.envelope_id
+            envelope_hashes.setdefault(env_id, set()).add(s.findings_hash)
+
+        total_envelopes = len(envelope_hashes)
+        stable_envelopes_count = 0
+        unstable_envelopes_count = 0
+        for env_id, hashes in envelope_hashes.items():
+            if len(hashes) <= 1:
+                stable_envelopes_count += 1
+            else:
+                unstable_envelopes_count += 1
+
+        stability_metrics = {
+            "total_envelopes": total_envelopes,
+            "stable_envelopes_count": stable_envelopes_count,
+            "unstable_envelopes_count": unstable_envelopes_count
+        }
+
+        # Format period & applied filters info
+        period = {
+            "start_date": start_date.isoformat(),
+            "end_date": end_date.isoformat()
+        }
+
+        filters_applied = {k: v for k, v in filters.items() if v is not None}
+
+        return {
+            "period": period,
+            "filters_applied": filters_applied,
+            "total_snapshots": total_snapshots,
+            "unique_envelopes_count": unique_envelopes_count,
+            "by_validation_status": by_validation_status,
+            "by_trigger": by_trigger,
+            "snapshots_without_template": snapshots_without_template,
+            "review_or_warning_snapshot_count": review_or_warning_snapshot_count,
+            "review_or_warning_percentage": review_or_warning_percentage,
+            "top_finding_codes": top_finding_codes,
+            "top_canonical_types": top_canonical_types,
+            "templates_requiring_attention": templates_requiring_attention,
+            "stability_metrics": stability_metrics
+        }

--- a/backend/quotes/spot_views.py
+++ b/backend/quotes/spot_views.py
@@ -3035,3 +3035,100 @@ class SpotTemplateValidationReviewMetricsAPIView(APIView):
         return Response(serializer.data)
 
 
+class SpotTemplateValidationSnapshotMetricsAPIView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        if not _user_is_manager_or_admin(request.user):
+            raise PermissionDenied("Only managers and admins can view validation metrics.")
+
+        from django.utils.dateparse import parse_date
+        import datetime
+        from django.utils import timezone
+        
+        start_date_str = request.query_params.get("start_date")
+        end_date_str = request.query_params.get("end_date")
+
+        now = timezone.now()
+
+        # Parse start_date
+        if start_date_str:
+            try:
+                start_date = parse_date(start_date_str)
+                if not start_date:
+                    raise ValueError
+                start_dt = timezone.make_aware(datetime.datetime.combine(start_date, datetime.time.min))
+            except ValueError:
+                return Response({"error": "Invalid start_date format. Use YYYY-MM-DD."}, status=status.HTTP_400_BAD_REQUEST)
+        else:
+            start_dt = now - datetime.timedelta(days=30)
+
+        # Parse end_date
+        if end_date_str:
+            try:
+                end_date = parse_date(end_date_str)
+                if not end_date:
+                    raise ValueError
+                end_dt = timezone.make_aware(datetime.datetime.combine(end_date, datetime.time.max))
+            except ValueError:
+                return Response({"error": "Invalid end_date format. Use YYYY-MM-DD."}, status=status.HTTP_400_BAD_REQUEST)
+        else:
+            end_dt = now
+
+        if end_dt < start_dt:
+            return Response({"error": "end_date cannot be before start_date."}, status=status.HTTP_400_BAD_REQUEST)
+
+        if (end_dt - start_dt).days > 180:
+            return Response({"error": "The maximum date range allowed is 180 days."}, status=status.HTTP_400_BAD_REQUEST)
+
+        # Parse limit
+        limit_str = request.query_params.get("limit", "10")
+        try:
+            limit = int(limit_str)
+            if limit <= 0:
+                raise ValueError
+            # Cap at 50
+            if limit > 50:
+                limit = 50
+        except ValueError:
+            return Response({"error": "limit must be a positive integer."}, status=status.HTTP_400_BAD_REQUEST)
+
+        # Parse template_id if provided
+        template_id_str = request.query_params.get("template_id")
+        template_id = None
+        if template_id_str:
+            try:
+                template_id = int(template_id_str)
+            except ValueError:
+                return Response({"error": "template_id must be an integer."}, status=status.HTTP_400_BAD_REQUEST)
+
+        # Gather optional filters
+        filters = {
+            "trigger": request.query_params.get("trigger"),
+            "validation_status": request.query_params.get("validation_status"),
+            "template_id": template_id,
+            "finding_code": request.query_params.get("finding_code"),
+            "canonical_type": request.query_params.get("canonical_type"),
+        }
+
+        # Check filter validity if values are supplied
+        if filters["trigger"] and filters["trigger"] not in ["envelope_created", "envelope_updated", "sales_acknowledged"]:
+            return Response({"error": "Invalid trigger filter value."}, status=status.HTTP_400_BAD_REQUEST)
+
+        if filters["validation_status"] and filters["validation_status"] not in ["passed", "warnings", "review"]:
+            return Response({"error": "Invalid validation_status filter value."}, status=status.HTTP_400_BAD_REQUEST)
+
+        from quotes.services.spot_validation_snapshot_metrics import SpotTemplateValidationSnapshotMetricsService
+        metrics = SpotTemplateValidationSnapshotMetricsService.get_snapshot_metrics(
+            start_date=start_dt,
+            end_date=end_dt,
+            filters=filters,
+            limit=limit
+        )
+
+        from quotes.serializers import SpotTemplateValidationSnapshotMetricsSerializer
+        serializer = SpotTemplateValidationSnapshotMetricsSerializer(metrics)
+        return Response(serializer.data)
+
+
+

--- a/backend/quotes/tests/test_spot_validation_snapshot_metrics.py
+++ b/backend/quotes/tests/test_spot_validation_snapshot_metrics.py
@@ -1,0 +1,275 @@
+import datetime
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from quotes.spot_models import SpotPricingEnvelopeDB, SpotTemplateValidationSnapshot
+
+
+class SpotTemplateValidationSnapshotMetricsTests(APITestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.manager_user = User.objects.create_user(
+            username="manager_test",
+            password="password123",
+            email="manager@example.com",
+            role="manager"
+        )
+        self.sales_user = User.objects.create_user(
+            username="sales_test",
+            password="password123",
+            email="sales@example.com",
+            role="sales"
+        )
+
+        self.envelope_1 = SpotPricingEnvelopeDB.objects.create(
+            status="draft",
+            shipment_context_json={"origin_country": "SG", "destination_country": "PG"},
+            expires_at=timezone.now() + datetime.timedelta(days=2),
+            spot_trigger_reason_code="MANUAL",
+            spot_trigger_reason_text="Manual trigger"
+        )
+        self.envelope_2 = SpotPricingEnvelopeDB.objects.create(
+            status="draft",
+            shipment_context_json={"origin_country": "AU", "destination_country": "NZ"},
+            expires_at=timezone.now() + datetime.timedelta(days=2),
+            spot_trigger_reason_code="MANUAL",
+            spot_trigger_reason_text="Manual trigger"
+        )
+
+        self.metrics_url = reverse("quotes:spot-validation-snapshot-metrics")
+
+    def _create_snapshot(
+        self,
+        envelope,
+        trigger="envelope_created",
+        validation_status="passed",
+        template_id=None,
+        template_hash="thash",
+        findings_hash="fhash",
+        findings_json=None,
+        finding_count=0,
+        finding_codes=None,
+        canonical_types=None,
+        created_at=None
+    ):
+        snap = SpotTemplateValidationSnapshot.objects.create(
+            envelope=envelope,
+            trigger=trigger,
+            validation_status=validation_status,
+            template_id=template_id,
+            template_hash=template_hash,
+            findings_hash=findings_hash,
+            findings_json=findings_json or [],
+            finding_count=finding_count,
+            finding_codes=finding_codes or [],
+            canonical_types=canonical_types or []
+        )
+        if created_at:
+            SpotTemplateValidationSnapshot.objects.filter(id=snap.id).update(created_at=created_at)
+        return snap
+
+    def test_manager_allowed_sales_user_blocked(self):
+        """Verify only manager/admin role can access snapshot metrics."""
+        self.client.force_authenticate(user=self.sales_user)
+        response = self.client.get(self.metrics_url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        self.client.force_authenticate(user=self.manager_user)
+        response = self.client.get(self.metrics_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_default_30_day_date_range(self):
+        """Verify snapshots are filtered by default to the last 30 days."""
+        self.client.force_authenticate(user=self.manager_user)
+        now = timezone.now()
+
+        # In range (10 days ago)
+        self._create_snapshot(self.envelope_1, created_at=now - datetime.timedelta(days=10), findings_hash="hash1")
+        # Out of range (35 days ago)
+        self._create_snapshot(self.envelope_2, created_at=now - datetime.timedelta(days=35), findings_hash="hash2")
+
+        response = self.client.get(self.metrics_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["total_snapshots"], 1)
+
+    def test_invalid_date_range_rejected(self):
+        """Verify invalid date formats and inverted ranges return clear 400s."""
+        self.client.force_authenticate(user=self.manager_user)
+
+        # Inverted range
+        response = self.client.get(f"{self.metrics_url}?start_date=2026-06-12&end_date=2026-06-01")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error"], "end_date cannot be before start_date.")
+
+        # Invalid format
+        response = self.client.get(f"{self.metrics_url}?start_date=invalid-date")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_range_over_180_days_rejected(self):
+        """Verify ranges exceeding 180 days return a 400."""
+        self.client.force_authenticate(user=self.manager_user)
+        response = self.client.get(f"{self.metrics_url}?start_date=2026-01-01&end_date=2026-07-01")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error"], "The maximum date range allowed is 180 days.")
+
+    def test_filters(self):
+        """Verify trigger, status, template, finding_code, and canonical_type filters work."""
+        self.client.force_authenticate(user=self.manager_user)
+        now = timezone.now()
+
+        # Created 3 distinct snapshots for testing filters
+        self._create_snapshot(
+            self.envelope_1,
+            trigger="envelope_created",
+            validation_status="passed",
+            template_id=1,
+            finding_codes=["code_A"],
+            canonical_types=["c_A"],
+            created_at=now - datetime.timedelta(days=2)
+        )
+        self._create_snapshot(
+            self.envelope_1,
+            trigger="envelope_updated",
+            validation_status="warnings",
+            template_id=2,
+            finding_codes=["code_B"],
+            canonical_types=["c_B"],
+            created_at=now - datetime.timedelta(days=3)
+        )
+
+        # Filter by trigger
+        response = self.client.get(f"{self.metrics_url}?trigger=envelope_updated")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["total_snapshots"], 1)
+        self.assertEqual(response.data["filters_applied"]["trigger"], "envelope_updated")
+
+        # Filter by validation_status
+        response = self.client.get(f"{self.metrics_url}?validation_status=passed")
+        self.assertEqual(response.data["total_snapshots"], 1)
+
+        # Filter by template_id
+        response = self.client.get(f"{self.metrics_url}?template_id=2")
+        self.assertEqual(response.data["total_snapshots"], 1)
+
+        # Filter by finding_code
+        response = self.client.get(f"{self.metrics_url}?finding_code=code_A")
+        self.assertEqual(response.data["total_snapshots"], 1)
+
+        # Filter by canonical_type
+        response = self.client.get(f"{self.metrics_url}?canonical_type=c_B")
+        self.assertEqual(response.data["total_snapshots"], 1)
+
+    def test_limit_query_param(self):
+        """Verify limit query param default and max cap of 50."""
+        self.client.force_authenticate(user=self.manager_user)
+        now = timezone.now()
+
+        # Create 15 distinct finding codes using separate snapshots
+        for i in range(15):
+            self._create_snapshot(
+                self.envelope_1,
+                finding_codes=[f"code_{i}"],
+                findings_hash=f"hash_{i}",
+                created_at=now - datetime.timedelta(days=1)
+            )
+
+        # Default limit is 10
+        response = self.client.get(self.metrics_url)
+        self.assertEqual(len(response.data["top_finding_codes"]), 10)
+
+        # Specific limit 5
+        response = self.client.get(f"{self.metrics_url}?limit=5")
+        self.assertEqual(len(response.data["top_finding_codes"]), 5)
+
+        # Max cap 50 (request 60, should cap at 15 since 15 exist)
+        response = self.client.get(f"{self.metrics_url}?limit=60")
+        self.assertEqual(len(response.data["top_finding_codes"]), 15)
+
+    def test_metrics_calculations(self):
+        """Verify total_snapshots, unique_envelopes_count, snapshots_without_template, and warning percentage."""
+        self.client.force_authenticate(user=self.manager_user)
+        now = timezone.now()
+
+        # Snapshot 1: Envelope 1, warning, no template
+        self._create_snapshot(
+            self.envelope_1,
+            validation_status="warnings",
+            template_id=None,
+            findings_hash="h1",
+            created_at=now - datetime.timedelta(days=1)
+        )
+        # Snapshot 2: Envelope 1, review, template 1
+        self._create_snapshot(
+            self.envelope_1,
+            validation_status="review",
+            template_id=1,
+            findings_hash="h2",
+            created_at=now - datetime.timedelta(days=2)
+        )
+        # Snapshot 3: Envelope 2, passed, template 1
+        self._create_snapshot(
+            self.envelope_2,
+            validation_status="passed",
+            template_id=1,
+            findings_hash="h3",
+            created_at=now - datetime.timedelta(days=3)
+        )
+
+        response = self.client.get(self.metrics_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        self.assertEqual(response.data["total_snapshots"], 3)
+        self.assertEqual(response.data["unique_envelopes_count"], 2)
+        self.assertEqual(response.data["snapshots_without_template"], 1)
+        self.assertEqual(response.data["review_or_warning_snapshot_count"], 2)
+        self.assertEqual(response.data["review_or_warning_percentage"], 66.67)
+
+    def test_templates_requiring_attention(self):
+        """Verify templates_requiring_attention aggregation and sorting."""
+        self.client.force_authenticate(user=self.manager_user)
+        now = timezone.now()
+
+        # Template 1: 2 warning snapshots
+        self._create_snapshot(self.envelope_1, template_id=1, template_hash="hash1", validation_status="warnings", findings_hash="ha", created_at=now - datetime.timedelta(days=1))
+        self._create_snapshot(self.envelope_1, template_id=1, template_hash="hash1", validation_status="warnings", findings_hash="hb", created_at=now - datetime.timedelta(days=2))
+
+        # Template 2: 1 warning snapshot, 1 passed snapshot (50% issue rate)
+        self._create_snapshot(self.envelope_1, template_id=2, template_hash="hash2", validation_status="warnings", findings_hash="hc", created_at=now - datetime.timedelta(days=3))
+        self._create_snapshot(self.envelope_1, template_id=2, template_hash="hash2", validation_status="passed", findings_hash="hd", created_at=now - datetime.timedelta(days=4))
+
+        response = self.client.get(self.metrics_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        req_attention = response.data["templates_requiring_attention"]
+        self.assertEqual(len(req_attention), 2)
+        
+        # Sorted by issue percentage desc
+        self.assertEqual(req_attention[0]["template_id"], 1)
+        self.assertEqual(req_attention[0]["review_or_warning_percentage"], 100.0)
+        self.assertEqual(req_attention[1]["template_id"], 2)
+        self.assertEqual(req_attention[1]["review_or_warning_percentage"], 50.0)
+
+    def test_stability_metrics(self):
+        """Verify stability metrics are computed correctly based on distinct findings_hash per envelope."""
+        self.client.force_authenticate(user=self.manager_user)
+        now = timezone.now()
+
+        # Envelope 1: Unstable (2 different findings_hash values)
+        self._create_snapshot(self.envelope_1, findings_hash="hashA", template_hash="thash", created_at=now - datetime.timedelta(days=1))
+        self._create_snapshot(self.envelope_1, findings_hash="hashB", template_hash="thash", created_at=now - datetime.timedelta(days=2))
+
+        # Envelope 2: Stable (1 findings_hash value across multiple snapshots due to template change)
+        self._create_snapshot(self.envelope_2, findings_hash="hashC", template_hash="thash1", created_at=now - datetime.timedelta(days=3))
+        self._create_snapshot(self.envelope_2, findings_hash="hashC", template_hash="thash2", created_at=now - datetime.timedelta(days=4))
+
+
+        response = self.client.get(self.metrics_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        stability = response.data["stability_metrics"]
+        self.assertEqual(stability["total_envelopes"], 2)
+        self.assertEqual(stability["stable_envelopes_count"], 1)
+        self.assertEqual(stability["unstable_envelopes_count"], 1)

--- a/backend/quotes/urls.py
+++ b/backend/quotes/urls.py
@@ -32,6 +32,7 @@ from .spot_views import (
     SpotSourceBatchReviewAPIView,
     SpotTemplateValidationFindingReviewedAPIView,
     SpotTemplateValidationReviewMetricsAPIView,
+    SpotTemplateValidationSnapshotMetricsAPIView,
 )
 
 app_name = 'quotes'
@@ -72,4 +73,5 @@ urlpatterns = [
     path('v3/spot/envelopes/<uuid:envelope_id>/create-quote/', SpotEnvelopeCreateQuoteAPIView.as_view(), name='spot-envelope-create-quote'),
     path('v3/spot/envelopes/<uuid:envelope_id>/findings/reviewed/', SpotTemplateValidationFindingReviewedAPIView.as_view(), name='spot-envelope-finding-reviewed'),
     path('v3/spot/template-validation/review-metrics/', SpotTemplateValidationReviewMetricsAPIView.as_view(), name='spot-validation-review-metrics'),
+    path('v3/spot/template-validation/snapshot-metrics/', SpotTemplateValidationSnapshotMetricsAPIView.as_view(), name='spot-validation-snapshot-metrics'),
 ]


### PR DESCRIPTION
Adds a read-only SPOT snapshot metrics endpoint.

Summary:
- Adds snapshot metrics service over SpotTemplateValidationSnapshot.
- Adds GET /api/v3/spot/template-validation/snapshot-metrics/.
- Restricts access to manager/admin users.
- Supports date range, trigger, validation_status, template_id, finding_code, canonical_type, and limit filters.
- Reports snapshot counts, validation/trigger breakdowns, template attention metrics, and stability metrics.
- Adds focused automated tests.

Non-goals:
- No dynamic revalidation.
- No writes.
- No pricing changes.
- No ProductCode changes.
- No quote total changes.
- No finalisation or approval behaviour changes.