### PR TITLE
feat(spot): add validation comparison metrics

### DIFF
--- a/backend/quotes/serializers.py
+++ b/backend/quotes/serializers.py
@@ -949,5 +949,14 @@ class SpotTemplateValidationSnapshotMetricsSerializer(serializers.Serializer):
     stability_metrics = serializers.DictField(child=serializers.IntegerField(), read_only=True)
 
 
+class SpotTemplateValidationComparisonMetricsSerializer(serializers.Serializer):
+    period = serializers.DictField(child=serializers.CharField(), read_only=True)
+    filters_applied = serializers.DictField(child=serializers.CharField(allow_null=True), read_only=True)
+    summary = serializers.DictField(child=serializers.FloatField(), read_only=True)
+    finding_code_comparison = serializers.ListField(child=serializers.DictField(), read_only=True)
+    canonical_type_comparison = serializers.ListField(child=serializers.DictField(), read_only=True)
+
+
+
 
 

--- a/backend/quotes/services/spot_validation_comparison_metrics.py
+++ b/backend/quotes/services/spot_validation_comparison_metrics.py
@@ -1,0 +1,147 @@
+import logging
+from quotes.spot_models import SpotTemplateValidationSnapshot, SpotTemplateValidationEvent
+
+logger = logging.getLogger(__name__)
+
+class SpotTemplateValidationComparisonMetricsService:
+    @classmethod
+    def get_comparison_metrics(cls, start_date, end_date, filters=None, limit=10):
+        """
+        Calculates comparison metrics between validation snapshots and reviewed findings.
+        Aggregates at the distinct envelope level to prevent updates/lifecycles from skewing metrics.
+        """
+        if filters is None:
+            filters = {}
+
+        # 1. Query snapshots matching date range and filters
+        snapshots_qs = SpotTemplateValidationSnapshot.objects.filter(
+            created_at__gte=start_date,
+            created_at__lte=end_date
+        )
+
+        template_id = filters.get("template_id")
+        if template_id is not None:
+            snapshots_qs = snapshots_qs.filter(template_id=template_id)
+
+        # Python-level filters for json fields to support SQLite
+        snapshots = list(snapshots_qs)
+
+        finding_code = filters.get("finding_code")
+        if finding_code:
+            snapshots = [s for s in snapshots if finding_code in (s.finding_codes or [])]
+
+        canonical_type = filters.get("canonical_type")
+        if canonical_type:
+            snapshots = [s for s in snapshots if canonical_type in (s.canonical_types or [])]
+
+        # Unique envelopes that generated validation snapshots
+        snapshot_envelope_ids = {s.envelope_id for s in snapshots}
+        total_envelopes_with_snapshots = len(snapshot_envelope_ids)
+
+        # 2. Query matching reviewed events (type = 'finding_reviewed')
+        events_qs = SpotTemplateValidationEvent.objects.filter(
+            event_type="finding_reviewed",
+            created_at__gte=start_date,
+            created_at__lte=end_date,
+            envelope_id__in=snapshot_envelope_ids
+        )
+
+        if finding_code:
+            events_qs = events_qs.filter(finding_code=finding_code)
+
+        if canonical_type:
+            events_qs = events_qs.filter(canonical_type=canonical_type)
+
+        events = list(events_qs)
+
+        # Unique envelopes with review actions
+        reviewed_envelope_ids = {e.envelope_id for e in events}
+        total_envelopes_with_reviews = len(reviewed_envelope_ids)
+
+        global_review_rate_percentage = 0.0
+        if total_envelopes_with_snapshots > 0:
+            global_review_rate_percentage = round(
+                (total_envelopes_with_reviews / total_envelopes_with_snapshots) * 100, 2
+            )
+
+        # 3. Finding Code Comparison
+        generated_envs_by_code = {}
+        for s in snapshots:
+            f_codes = s.finding_codes or []
+            for code in f_codes:
+                generated_envs_by_code.setdefault(code, set()).add(s.envelope_id)
+
+        reviewed_envs_by_code = {}
+        for e in events:
+            reviewed_envs_by_code.setdefault(e.finding_code, set()).add(e.envelope_id)
+
+        finding_code_comp_list = []
+        for code, gen_envs in generated_envs_by_code.items():
+            gen_count = len(gen_envs)
+            rev_envs = reviewed_envs_by_code.get(code, set())
+            matched_rev_envs = rev_envs.intersection(gen_envs)
+            rev_count = len(matched_rev_envs)
+            rate = round((rev_count / gen_count) * 100, 2) if gen_count > 0 else 0.0
+            finding_code_comp_list.append({
+                "finding_code": code,
+                "envelopes_generated_count": gen_count,
+                "envelopes_reviewed_count": rev_count,
+                "review_rate_percentage": rate
+            })
+
+        # Sort: envelopes_generated_count desc, then envelopes_reviewed_count desc, then finding_code asc
+        finding_code_comp_list.sort(
+            key=lambda x: (-x["envelopes_generated_count"], -x["envelopes_reviewed_count"], x["finding_code"])
+        )
+        finding_code_comparison = finding_code_comp_list[:limit]
+
+        # 4. Canonical Type Comparison
+        generated_envs_by_cct = {}
+        for s in snapshots:
+            c_types = s.canonical_types or []
+            for c_type in c_types:
+                generated_envs_by_cct.setdefault(c_type, set()).add(s.envelope_id)
+
+        reviewed_envs_by_cct = {}
+        for e in events:
+            if e.canonical_type:
+                reviewed_envs_by_cct.setdefault(e.canonical_type, set()).add(e.envelope_id)
+
+        cct_comp_list = []
+        for cct, gen_envs in generated_envs_by_cct.items():
+            gen_count = len(gen_envs)
+            rev_envs = reviewed_envs_by_cct.get(cct, set())
+            matched_rev_envs = rev_envs.intersection(gen_envs)
+            rev_count = len(matched_rev_envs)
+            rate = round((rev_count / gen_count) * 100, 2) if gen_count > 0 else 0.0
+            cct_comp_list.append({
+                "canonical_type": cct,
+                "envelopes_generated_count": gen_count,
+                "envelopes_reviewed_count": rev_count,
+                "review_rate_percentage": rate
+            })
+
+        cct_comp_list.sort(
+            key=lambda x: (-x["envelopes_generated_count"], -x["envelopes_reviewed_count"], x["canonical_type"])
+        )
+        canonical_type_comparison = cct_comp_list[:limit]
+
+        # Form period & applied filters info
+        period = {
+            "start_date": start_date.isoformat(),
+            "end_date": end_date.isoformat()
+        }
+
+        filters_applied = {k: v for k, v in filters.items() if v is not None}
+
+        return {
+            "period": period,
+            "filters_applied": filters_applied,
+            "summary": {
+                "total_envelopes_with_snapshots": total_envelopes_with_snapshots,
+                "total_envelopes_with_reviews": total_envelopes_with_reviews,
+                "global_review_rate_percentage": global_review_rate_percentage
+            },
+            "finding_code_comparison": finding_code_comparison,
+            "canonical_type_comparison": canonical_type_comparison
+        }

--- a/backend/quotes/spot_views.py
+++ b/backend/quotes/spot_views.py
@@ -3131,4 +3131,92 @@ class SpotTemplateValidationSnapshotMetricsAPIView(APIView):
         return Response(serializer.data)
 
 
+class SpotTemplateValidationComparisonMetricsAPIView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        if not _user_is_manager_or_admin(request.user):
+            raise PermissionDenied("Only managers and admins can view validation metrics.")
+
+        from django.utils.dateparse import parse_date
+        import datetime
+        from django.utils import timezone
+        
+        start_date_str = request.query_params.get("start_date")
+        end_date_str = request.query_params.get("end_date")
+
+        now = timezone.now()
+
+        # Parse start_date
+        if start_date_str:
+            try:
+                start_date = parse_date(start_date_str)
+                if not start_date:
+                    raise ValueError
+                start_dt = timezone.make_aware(datetime.datetime.combine(start_date, datetime.time.min))
+            except ValueError:
+                return Response({"error": "Invalid start_date format. Use YYYY-MM-DD."}, status=status.HTTP_400_BAD_REQUEST)
+        else:
+            start_dt = now - datetime.timedelta(days=30)
+
+        # Parse end_date
+        if end_date_str:
+            try:
+                end_date = parse_date(end_date_str)
+                if not end_date:
+                    raise ValueError
+                end_dt = timezone.make_aware(datetime.datetime.combine(end_date, datetime.time.max))
+            except ValueError:
+                return Response({"error": "Invalid end_date format. Use YYYY-MM-DD."}, status=status.HTTP_400_BAD_REQUEST)
+        else:
+            end_dt = now
+
+        if end_dt < start_dt:
+            return Response({"error": "end_date cannot be before start_date."}, status=status.HTTP_400_BAD_REQUEST)
+
+        if (end_dt - start_dt).days > 180:
+            return Response({"error": "The maximum date range allowed is 180 days."}, status=status.HTTP_400_BAD_REQUEST)
+
+        # Parse limit
+        limit_str = request.query_params.get("limit", "10")
+        try:
+            limit = int(limit_str)
+            if limit <= 0:
+                raise ValueError
+            # Cap at 50
+            if limit > 50:
+                limit = 50
+        except ValueError:
+            return Response({"error": "limit must be a positive integer."}, status=status.HTTP_400_BAD_REQUEST)
+
+        # Parse template_id if provided
+        template_id_str = request.query_params.get("template_id")
+        template_id = None
+        if template_id_str:
+            try:
+                template_id = int(template_id_str)
+            except ValueError:
+                return Response({"error": "template_id must be an integer."}, status=status.HTTP_400_BAD_REQUEST)
+
+        # Gather optional filters
+        filters = {
+            "template_id": template_id,
+            "finding_code": request.query_params.get("finding_code"),
+            "canonical_type": request.query_params.get("canonical_type"),
+        }
+
+        from quotes.services.spot_validation_comparison_metrics import SpotTemplateValidationComparisonMetricsService
+        metrics = SpotTemplateValidationComparisonMetricsService.get_comparison_metrics(
+            start_date=start_dt,
+            end_date=end_dt,
+            filters=filters,
+            limit=limit
+        )
+
+        from quotes.serializers import SpotTemplateValidationComparisonMetricsSerializer
+        serializer = SpotTemplateValidationComparisonMetricsSerializer(metrics)
+        return Response(serializer.data)
+
+
+
 

--- a/backend/quotes/tests/test_spot_validation_comparison_metrics.py
+++ b/backend/quotes/tests/test_spot_validation_comparison_metrics.py
@@ -1,0 +1,298 @@
+import datetime
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from quotes.spot_models import (
+    SpotPricingEnvelopeDB,
+    SpotTemplateValidationSnapshot,
+    SpotTemplateValidationEvent
+)
+
+
+class SpotTemplateValidationComparisonMetricsTests(APITestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.manager_user = User.objects.create_user(
+            username="manager_test",
+            password="password123",
+            email="manager@example.com",
+            role="manager"
+        )
+        self.sales_user = User.objects.create_user(
+            username="sales_test",
+            password="password123",
+            email="sales@example.com",
+            role="sales"
+        )
+
+        self.envelope_1 = SpotPricingEnvelopeDB.objects.create(
+            status="draft",
+            shipment_context_json={"origin_country": "SG", "destination_country": "PG"},
+            expires_at=timezone.now() + datetime.timedelta(days=2),
+            spot_trigger_reason_code="MANUAL",
+            spot_trigger_reason_text="Manual trigger"
+        )
+        self.envelope_2 = SpotPricingEnvelopeDB.objects.create(
+            status="draft",
+            shipment_context_json={"origin_country": "AU", "destination_country": "NZ"},
+            expires_at=timezone.now() + datetime.timedelta(days=2),
+            spot_trigger_reason_code="MANUAL",
+            spot_trigger_reason_text="Manual trigger"
+        )
+
+        self.metrics_url = reverse("quotes:spot-validation-comparison-metrics")
+
+    def _create_snapshot(
+        self,
+        envelope,
+        trigger="envelope_created",
+        validation_status="warnings",
+        template_id=None,
+        template_hash="thash",
+        findings_hash="fhash",
+        findings_json=None,
+        finding_count=1,
+        finding_codes=None,
+        canonical_types=None,
+        created_at=None
+    ):
+        snap = SpotTemplateValidationSnapshot.objects.create(
+            envelope=envelope,
+            trigger=trigger,
+            validation_status=validation_status,
+            template_id=template_id,
+            template_hash=template_hash,
+            findings_hash=findings_hash,
+            findings_json=findings_json or [],
+            finding_count=finding_count,
+            finding_codes=finding_codes or [],
+            canonical_types=canonical_types or []
+        )
+        if created_at:
+            SpotTemplateValidationSnapshot.objects.filter(id=snap.id).update(created_at=created_at)
+        return snap
+
+    def _create_event(
+        self,
+        envelope,
+        event_type="finding_reviewed",
+        finding_code="expected_charge_missing",
+        canonical_type="AWB_DOCUMENTATION",
+        fingerprint="fp1",
+        created_at=None
+    ):
+        event = SpotTemplateValidationEvent.objects.create(
+            envelope=envelope,
+            event_type=event_type,
+            finding_code=finding_code,
+            canonical_type=canonical_type,
+            template_line_id=123,
+            charge_line_id=None,
+            finding_fingerprint=fingerprint,
+            validation_status=None,
+            user=self.manager_user,
+            metadata={"comment": "Comment text"}
+        )
+        if created_at:
+            SpotTemplateValidationEvent.objects.filter(id=event.id).update(created_at=created_at)
+        return event
+
+    def test_manager_allowed_sales_blocked(self):
+        """Verify sales role is blocked and manager/admin role is allowed."""
+        self.client.force_authenticate(user=self.sales_user)
+        response = self.client.get(self.metrics_url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        self.client.force_authenticate(user=self.manager_user)
+        response = self.client.get(self.metrics_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_default_30_day_date_range(self):
+        """Verify comparison counts filter records within default 30 days range."""
+        self.client.force_authenticate(user=self.manager_user)
+        now = timezone.now()
+
+        # In range snapshot and event
+        self._create_snapshot(
+            self.envelope_1,
+            finding_codes=["expected_charge_missing"],
+            created_at=now - datetime.timedelta(days=10)
+        )
+        self._create_event(
+            self.envelope_1,
+            finding_code="expected_charge_missing",
+            created_at=now - datetime.timedelta(days=10)
+        )
+
+        # Out of range snapshot and event (35 days ago)
+        self._create_snapshot(
+            self.envelope_2,
+            finding_codes=["expected_charge_missing"],
+            findings_hash="fhash_out",
+            created_at=now - datetime.timedelta(days=35)
+        )
+        self._create_event(
+            self.envelope_2,
+            finding_code="expected_charge_missing",
+            created_at=now - datetime.timedelta(days=35)
+        )
+
+        response = self.client.get(self.metrics_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        # Summary counts
+        self.assertEqual(response.data["summary"]["total_envelopes_with_snapshots"], 1)
+        self.assertEqual(response.data["summary"]["total_envelopes_with_reviews"], 1)
+        self.assertEqual(response.data["summary"]["global_review_rate_percentage"], 100.0)
+
+    def test_invalid_date_range_rejected(self):
+        """Verify invalid formats and range inversions return 400."""
+        self.client.force_authenticate(user=self.manager_user)
+
+        # Inverted range
+        response = self.client.get(f"{self.metrics_url}?start_date=2026-06-12&end_date=2026-06-01")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error"], "end_date cannot be before start_date.")
+
+        # Invalid format
+        response = self.client.get(f"{self.metrics_url}?start_date=invalid-date")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_range_over_180_days_rejected(self):
+        """Verify range exceeds limits check returns 400."""
+        self.client.force_authenticate(user=self.manager_user)
+        response = self.client.get(f"{self.metrics_url}?start_date=2026-01-01&end_date=2026-07-01")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error"], "The maximum date range allowed is 180 days.")
+
+    def test_filters(self):
+        """Verify template_id, finding_code, canonical_type, and limit filters work."""
+        self.client.force_authenticate(user=self.manager_user)
+        now = timezone.now()
+
+        # Envelope 1: template 1, code_A, cct_A
+        self._create_snapshot(
+            self.envelope_1,
+            template_id=1,
+            finding_codes=["code_A"],
+            canonical_types=["cct_A"],
+            created_at=now - datetime.timedelta(days=2)
+        )
+        self._create_event(
+            self.envelope_1,
+            finding_code="code_A",
+            canonical_type="cct_A",
+            created_at=now - datetime.timedelta(days=2)
+        )
+
+        # Envelope 2: template 2, code_B, cct_B
+        self._create_snapshot(
+            self.envelope_2,
+            template_id=2,
+            finding_codes=["code_B"],
+            findings_hash="fhash_env2",
+            canonical_types=["cct_B"],
+            created_at=now - datetime.timedelta(days=2)
+        )
+
+        # Filter template_id=1
+        response = self.client.get(f"{self.metrics_url}?template_id=1")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["summary"]["total_envelopes_with_snapshots"], 1)
+
+        # Filter finding_code=code_B
+        response = self.client.get(f"{self.metrics_url}?finding_code=code_B")
+        self.assertEqual(response.data["summary"]["total_envelopes_with_snapshots"], 1)
+
+        # Filter canonical_type=cct_A
+        response = self.client.get(f"{self.metrics_url}?canonical_type=cct_A")
+        self.assertEqual(response.data["summary"]["total_envelopes_with_snapshots"], 1)
+
+        # Test limit filter
+        # Create many comparison items
+        for i in range(15):
+            env = SpotPricingEnvelopeDB.objects.create(
+                status="draft",
+                shipment_context_json={"origin_country": "SG", "destination_country": "PG"},
+                expires_at=timezone.now() + datetime.timedelta(days=2),
+                spot_trigger_reason_code="MANUAL",
+                spot_trigger_reason_text="Manual trigger"
+            )
+            self._create_snapshot(
+                env,
+                finding_codes=[f"code_{i}"],
+                findings_hash=f"hash_{i}",
+                created_at=now - datetime.timedelta(days=1)
+            )
+
+        response = self.client.get(f"{self.metrics_url}?limit=5")
+        self.assertEqual(len(response.data["finding_code_comparison"]), 5)
+
+    def test_aggregation_and_deduplication(self):
+        """Verify envelope deduplication and accurate rate math calculation."""
+        self.client.force_authenticate(user=self.manager_user)
+        now = timezone.now()
+
+        # Envelope 1 has multiple snapshots but identical finding code (deduplication check!)
+        self._create_snapshot(
+            self.envelope_1,
+            template_id=1,
+            finding_codes=["expected_charge_missing"],
+            canonical_types=["AWB"],
+            findings_hash="h1",
+            created_at=now - datetime.timedelta(days=1)
+        )
+        self._create_snapshot(
+            self.envelope_1,
+            template_id=1,
+            finding_codes=["expected_charge_missing"],
+            canonical_types=["AWB"],
+            findings_hash="h2", # Different findings_hash to bypass DB unique check
+            template_hash="thash_diff",
+            created_at=now - datetime.timedelta(days=2)
+        )
+
+        # Envelope 1 reviewed
+        self._create_event(
+            self.envelope_1,
+            finding_code="expected_charge_missing",
+            canonical_type="AWB",
+            created_at=now - datetime.timedelta(days=1)
+        )
+
+        # Envelope 2 has snapshot with same finding but not reviewed
+        self._create_snapshot(
+            self.envelope_2,
+            template_id=1,
+            finding_codes=["expected_charge_missing"],
+            canonical_types=["AWB"],
+            findings_hash="h3",
+            created_at=now - datetime.timedelta(days=3)
+        )
+
+        response = self.client.get(self.metrics_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Total unique envelopes should be 2, not 3 (even though envelope 1 had 2 snapshots)
+        self.assertEqual(response.data["summary"]["total_envelopes_with_snapshots"], 2)
+        self.assertEqual(response.data["summary"]["total_envelopes_with_reviews"], 1)
+        self.assertEqual(response.data["summary"]["global_review_rate_percentage"], 50.0)
+
+        # Finding code comparison
+        finding_comp = response.data["finding_code_comparison"]
+        self.assertEqual(len(finding_comp), 1)
+        self.assertEqual(finding_comp[0]["finding_code"], "expected_charge_missing")
+        self.assertEqual(finding_comp[0]["envelopes_generated_count"], 2)
+        self.assertEqual(finding_comp[0]["envelopes_reviewed_count"], 1)
+        self.assertEqual(finding_comp[0]["review_rate_percentage"], 50.0)
+
+        # Canonical type comparison
+        cct_comp = response.data["canonical_type_comparison"]
+        self.assertEqual(len(cct_comp), 1)
+        self.assertEqual(cct_comp[0]["canonical_type"], "AWB")
+        self.assertEqual(cct_comp[0]["envelopes_generated_count"], 2)
+        self.assertEqual(cct_comp[0]["envelopes_reviewed_count"], 1)
+        self.assertEqual(cct_comp[0]["review_rate_percentage"], 50.0)

--- a/backend/quotes/urls.py
+++ b/backend/quotes/urls.py
@@ -33,6 +33,7 @@ from .spot_views import (
     SpotTemplateValidationFindingReviewedAPIView,
     SpotTemplateValidationReviewMetricsAPIView,
     SpotTemplateValidationSnapshotMetricsAPIView,
+    SpotTemplateValidationComparisonMetricsAPIView,
 )
 
 app_name = 'quotes'
@@ -74,4 +75,5 @@ urlpatterns = [
     path('v3/spot/envelopes/<uuid:envelope_id>/findings/reviewed/', SpotTemplateValidationFindingReviewedAPIView.as_view(), name='spot-envelope-finding-reviewed'),
     path('v3/spot/template-validation/review-metrics/', SpotTemplateValidationReviewMetricsAPIView.as_view(), name='spot-validation-review-metrics'),
     path('v3/spot/template-validation/snapshot-metrics/', SpotTemplateValidationSnapshotMetricsAPIView.as_view(), name='spot-validation-snapshot-metrics'),
+    path('v3/spot/template-validation/comparison-metrics/', SpotTemplateValidationComparisonMetricsAPIView.as_view(), name='spot-validation-comparison-metrics'),
 ]


### PR DESCRIPTION
Adds a read-only SPOT validation comparison metrics API.

Summary:
- Adds comparison metrics service for generated snapshots vs reviewed events.
- Adds endpoint: GET /api/v3/spot/template-validation/comparison-metrics/.
- Deduplicates at unique envelope level to reduce lifecycle snapshot distortion.
- Supports date range, template, finding code, canonical type, and limit filters.
- Restricts access to manager/admin users.
- Adds automated tests for authorization, date validation, filters, limits, envelope dedupe, and math accuracy.

Non-goals:
- No dynamic revalidation.
- No writes.
- No template mutation.
- No snapshot trigger changes.
- No pricing/ProductCode/totals/finalisation/approval changes.