### PR TITLE
feat(spot): add template maintenance insights

### DIFF
--- a/backend/quotes/serializers.py
+++ b/backend/quotes/serializers.py
@@ -957,6 +957,14 @@ class SpotTemplateValidationComparisonMetricsSerializer(serializers.Serializer):
     canonical_type_comparison = serializers.ListField(child=serializers.DictField(), read_only=True)
 
 
+class SpotTemplateValidationMaintenanceInsightsSerializer(serializers.Serializer):
+    period = serializers.DictField(child=serializers.CharField(), read_only=True)
+    filters_applied = serializers.DictField(child=serializers.IntegerField(allow_null=True), read_only=True)
+    score_basis = serializers.DictField(child=serializers.FloatField(), read_only=True)
+    insights = serializers.ListField(child=serializers.DictField(), read_only=True)
+
+
+
 
 
 

--- a/backend/quotes/services/spot_validation_maintenance_insights.py
+++ b/backend/quotes/services/spot_validation_maintenance_insights.py
@@ -1,0 +1,213 @@
+import logging
+from django.db.models import Count
+from quotes.spot_models import (
+    SpotTemplateValidationSnapshot,
+    SpotTemplateValidationEvent,
+    ExpectedChargeTemplate
+)
+
+logger = logging.getLogger(__name__)
+
+class SpotTemplateValidationMaintenanceInsightsService:
+    @classmethod
+    def get_maintenance_insights(cls, start_date, end_date, filters=None, limit=10, min_snapshots=5):
+        """
+        Gathers template validation snapshots, calculates Maintenance Priority Scores,
+        and aggregates pressure signals / finding breakdowns.
+        """
+        if filters is None:
+            filters = {}
+
+        # 1. Base query for snapshots
+        snapshots_qs = SpotTemplateValidationSnapshot.objects.filter(
+            created_at__gte=start_date,
+            created_at__lte=end_date
+        )
+
+        template_id = filters.get("template_id")
+        if template_id is not None:
+            snapshots_qs = snapshots_qs.filter(template_id=template_id)
+
+        # Python-level load
+        snapshots = list(snapshots_qs)
+
+        # Fetch template metadata
+        template_names = {t.id: t.name for t in ExpectedChargeTemplate.objects.all()}
+
+        # Group snapshots by template_id
+        snapshots_by_template = {}
+        for s in snapshots:
+            tid = s.template_id
+            if tid is None:
+                continue
+            snapshots_by_template.setdefault(tid, []).append(s)
+
+        insights_list = []
+
+        # Heuristic constants
+        issue_ratio_weight = 0.4
+        avg_findings_weight = 0.3
+        unreviewed_ratio_weight = 0.3
+        avg_findings_cap = 5.0
+
+        for tid, t_snaps in snapshots_by_template.items():
+            total_snapshots = len(t_snaps)
+
+            # Apply min_snapshots threshold
+            if total_snapshots < min_snapshots:
+                continue
+
+            unique_envelopes_count = len({s.envelope_id for s in t_snaps})
+
+            # Validation status breakdown
+            validation_status_breakdown = {"passed": 0, "warnings": 0, "review": 0}
+            issue_snapshots_count = 0
+            total_findings = 0
+            for s in t_snaps:
+                status_val = s.validation_status
+                validation_status_breakdown[status_val] = validation_status_breakdown.get(status_val, 0) + 1
+                if status_val in ["warnings", "review"]:
+                    issue_snapshots_count += 1
+                total_findings += s.finding_count
+
+            # 1. Issue ratio
+            issue_ratio_percentage = 0.0
+            if total_snapshots > 0:
+                issue_ratio_percentage = round((issue_snapshots_count / total_snapshots) * 100, 2)
+            issue_ratio = issue_ratio_percentage / 100.0
+
+            # 2. Average findings
+            average_findings_per_snapshot = 0.0
+            if total_snapshots > 0:
+                average_findings_per_snapshot = round(total_findings / total_snapshots, 2)
+            
+            avg_findings_normalized = min(average_findings_per_snapshot / avg_findings_cap, 1.0)
+
+            # 3. Review rate & Unreviewed ratio
+            t_envelope_ids = {s.envelope_id for s in t_snaps}
+            envelopes_with_findings_ids = {s.envelope_id for s in t_snaps if s.finding_count > 0}
+            envelopes_with_findings_count = len(envelopes_with_findings_ids)
+
+            # Query matching reviewed events
+            events_qs = SpotTemplateValidationEvent.objects.filter(
+                event_type="finding_reviewed",
+                created_at__gte=start_date,
+                created_at__lte=end_date,
+                envelope_id__in=t_envelope_ids
+            )
+            reviewed_envelope_ids = {e.envelope_id for e in events_qs}
+            envelopes_reviewed_ids = reviewed_envelope_ids.intersection(envelopes_with_findings_ids)
+            envelopes_reviewed_count = len(envelopes_reviewed_ids)
+
+            review_rate_percentage = 100.0
+            if envelopes_with_findings_count > 0:
+                review_rate_percentage = round(
+                    (envelopes_reviewed_count / envelopes_with_findings_count) * 100, 2
+                )
+            
+            unreviewed_ratio_percentage = round(100.0 - review_rate_percentage, 2)
+            unreviewed_ratio = unreviewed_ratio_percentage / 100.0
+
+            # Maintenance Priority Score
+            maintenance_priority_score = round(
+                (issue_ratio_weight * issue_ratio +
+                 avg_findings_weight * avg_findings_normalized +
+                 unreviewed_ratio_weight * unreviewed_ratio) * 100, 2
+            )
+
+            # Pressure flags
+            issue_snaps = [s for s in t_snaps if s.validation_status in ["warnings", "review"]]
+            missing_charge_snapshots_count = sum(
+                1 for s in issue_snaps if "expected_charge_missing" in (s.finding_codes or [])
+            )
+            unexpected_charge_snapshots_count = sum(
+                1 for s in issue_snaps if "unexpected_charge_present" in (s.finding_codes or [])
+            )
+
+            missing_charge_pressure = False
+            unexpected_charge_pressure = False
+            if len(issue_snaps) > 0:
+                missing_charge_pressure = (missing_charge_snapshots_count / len(issue_snaps)) > 0.5
+                unexpected_charge_pressure = (unexpected_charge_snapshots_count / len(issue_snaps)) > 0.5
+
+            high_maintenance_pressure = (
+                maintenance_priority_score > 70.0 or
+                (review_rate_percentage < 15.0 and total_snapshots >= 5)
+            )
+
+            # Summaries
+            finding_code_counts = {}
+            canonical_type_counts = {}
+            for s in t_snaps:
+                for code in (s.finding_codes or []):
+                    finding_code_counts[code] = finding_code_counts.get(code, 0) + 1
+                for c_type in (s.canonical_types or []):
+                    canonical_type_counts[c_type] = canonical_type_counts.get(c_type, 0) + 1
+
+            finding_codes_breakdown = [
+                {"code": k, "snapshot_count": v}
+                for k, v in sorted(finding_code_counts.items(), key=lambda x: x[1], reverse=True)
+            ]
+            canonical_types_breakdown = [
+                {"canonical_type": k, "snapshot_count": v}
+                for k, v in sorted(canonical_type_counts.items(), key=lambda x: x[1], reverse=True)
+            ]
+
+            # Primary template hash (take the latest one in the range)
+            t_snaps_sorted = sorted(t_snaps, key=lambda x: x.created_at, reverse=True)
+            latest_hash = t_snaps_sorted[0].template_hash if t_snaps_sorted else ""
+
+            insights_list.append({
+                "template_id": tid,
+                "template_name": template_names.get(tid, f"Template #{tid}"),
+                "template_hash": latest_hash,
+                "maintenance_priority_score": maintenance_priority_score,
+                "total_snapshots": total_snapshots,
+                "unique_envelopes_count": unique_envelopes_count,
+                "validation_status_breakdown": validation_status_breakdown,
+                "finding_codes_breakdown": finding_codes_breakdown,
+                "canonical_types_breakdown": canonical_types_breakdown,
+                "envelopes_with_findings_count": envelopes_with_findings_count,
+                "envelopes_reviewed_count": envelopes_reviewed_count,
+                "issue_ratio_percentage": issue_ratio_percentage,
+                "unreviewed_ratio_percentage": unreviewed_ratio_percentage,
+                "review_rate_percentage": review_rate_percentage,
+                "average_findings_per_snapshot": average_findings_per_snapshot,
+                "sample_warning": total_snapshots < 5,
+                "maintenance_signals": {
+                    "high_maintenance_pressure": high_maintenance_pressure,
+                    "missing_charge_pressure": missing_charge_pressure,
+                    "unexpected_charge_pressure": unexpected_charge_pressure
+                }
+            })
+
+        # Sort descending by priority_score, then total_snapshots desc, then template_id asc
+        insights_list.sort(
+            key=lambda x: (-x["maintenance_priority_score"], -x["total_snapshots"], x["template_id"])
+        )
+        insights = insights_list[:limit]
+
+        period = {
+            "start_date": start_date.isoformat(),
+            "end_date": end_date.isoformat()
+        }
+
+        filters_applied = {
+            "min_snapshots": min_snapshots
+        }
+        if template_id is not None:
+            filters_applied["template_id"] = template_id
+
+        score_basis = {
+            "issue_ratio_weight": issue_ratio_weight,
+            "avg_findings_weight": avg_findings_weight,
+            "unreviewed_ratio_weight": unreviewed_ratio_weight,
+            "avg_findings_cap": avg_findings_cap
+        }
+
+        return {
+            "period": period,
+            "filters_applied": filters_applied,
+            "score_basis": score_basis,
+            "insights": insights
+        }

--- a/backend/quotes/spot_views.py
+++ b/backend/quotes/spot_views.py
@@ -3218,5 +3218,100 @@ class SpotTemplateValidationComparisonMetricsAPIView(APIView):
         return Response(serializer.data)
 
 
+class SpotTemplateValidationMaintenanceInsightsAPIView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        if not _user_is_manager_or_admin(request.user):
+            raise PermissionDenied("Only managers and admins can view validation metrics.")
+
+        from django.utils.dateparse import parse_date
+        import datetime
+        from django.utils import timezone
+        
+        start_date_str = request.query_params.get("start_date")
+        end_date_str = request.query_params.get("end_date")
+
+        now = timezone.now()
+
+        # Parse start_date
+        if start_date_str:
+            try:
+                start_date = parse_date(start_date_str)
+                if not start_date:
+                    raise ValueError
+                start_dt = timezone.make_aware(datetime.datetime.combine(start_date, datetime.time.min))
+            except ValueError:
+                return Response({"error": "Invalid start_date format. Use YYYY-MM-DD."}, status=status.HTTP_400_BAD_REQUEST)
+        else:
+            start_dt = now - datetime.timedelta(days=30)
+
+        # Parse end_date
+        if end_date_str:
+            try:
+                end_date = parse_date(end_date_str)
+                if not end_date:
+                    raise ValueError
+                end_dt = timezone.make_aware(datetime.datetime.combine(end_date, datetime.time.max))
+            except ValueError:
+                return Response({"error": "Invalid end_date format. Use YYYY-MM-DD."}, status=status.HTTP_400_BAD_REQUEST)
+        else:
+            end_dt = now
+
+        if end_dt < start_dt:
+            return Response({"error": "end_date cannot be before start_date."}, status=status.HTTP_400_BAD_REQUEST)
+
+        if (end_dt - start_dt).days > 180:
+            return Response({"error": "The maximum date range allowed is 180 days."}, status=status.HTTP_400_BAD_REQUEST)
+
+        # Parse limit
+        limit_str = request.query_params.get("limit", "10")
+        try:
+            limit = int(limit_str)
+            if limit <= 0:
+                raise ValueError
+            # Cap at 50
+            if limit > 50:
+                limit = 50
+        except ValueError:
+            return Response({"error": "limit must be a positive integer."}, status=status.HTTP_400_BAD_REQUEST)
+
+        # Parse template_id if provided
+        template_id_str = request.query_params.get("template_id")
+        template_id = None
+        if template_id_str:
+            try:
+                template_id = int(template_id_str)
+            except ValueError:
+                return Response({"error": "template_id must be an integer."}, status=status.HTTP_400_BAD_REQUEST)
+
+        # Parse min_snapshots
+        min_snapshots_str = request.query_params.get("min_snapshots", "5")
+        try:
+            min_snapshots = int(min_snapshots_str)
+            if min_snapshots <= 0:
+                raise ValueError
+        except ValueError:
+            return Response({"error": "min_snapshots must be a positive integer."}, status=status.HTTP_400_BAD_REQUEST)
+
+        filters = {
+            "template_id": template_id,
+        }
+
+        from quotes.services.spot_validation_maintenance_insights import SpotTemplateValidationMaintenanceInsightsService
+        insights = SpotTemplateValidationMaintenanceInsightsService.get_maintenance_insights(
+            start_date=start_dt,
+            end_date=end_dt,
+            filters=filters,
+            limit=limit,
+            min_snapshots=min_snapshots
+        )
+
+        from quotes.serializers import SpotTemplateValidationMaintenanceInsightsSerializer
+        serializer = SpotTemplateValidationMaintenanceInsightsSerializer(insights)
+        return Response(serializer.data)
+
+
+
 
 

--- a/backend/quotes/tests/test_spot_validation_maintenance_insights.py
+++ b/backend/quotes/tests/test_spot_validation_maintenance_insights.py
@@ -1,0 +1,257 @@
+import datetime
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from quotes.spot_models import (
+    SpotPricingEnvelopeDB,
+    SpotTemplateValidationSnapshot,
+    SpotTemplateValidationEvent,
+    ExpectedChargeTemplate
+)
+
+
+class SpotTemplateValidationMaintenanceInsightsTests(APITestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.manager_user = User.objects.create_user(
+            username="manager_test",
+            password="password123",
+            email="manager@example.com",
+            role="manager"
+        )
+        self.sales_user = User.objects.create_user(
+            username="sales_test",
+            password="password123",
+            email="sales@example.com",
+            role="sales"
+        )
+
+        self.envelope = SpotPricingEnvelopeDB.objects.create(
+            status="draft",
+            shipment_context_json={"origin_country": "SG", "destination_country": "PG"},
+            expires_at=timezone.now() + datetime.timedelta(days=2),
+            spot_trigger_reason_code="MANUAL",
+            spot_trigger_reason_text="Manual trigger"
+        )
+
+        # Create 2 dummy templates
+        self.template_1 = ExpectedChargeTemplate.objects.create(
+            name="Template 1",
+            mode="IMPORT",
+            transport_mode="AIR",
+            service_scope="A2D",
+            origin_country="SG",
+            destination_country="PG",
+            is_active=True
+        )
+        self.template_2 = ExpectedChargeTemplate.objects.create(
+            name="Template 2",
+            mode="IMPORT",
+            transport_mode="AIR",
+            service_scope="A2D",
+            origin_country="SG",
+            destination_country="PG",
+            is_active=True
+        )
+
+        self.metrics_url = reverse("quotes:spot-validation-maintenance-insights")
+
+    def _create_snapshot(
+        self,
+        envelope,
+        trigger="envelope_created",
+        validation_status="warnings",
+        template_id=None,
+        template_hash="thash",
+        findings_hash="fhash",
+        finding_count=1,
+        finding_codes=None,
+        canonical_types=None,
+        created_at=None
+    ):
+        snap = SpotTemplateValidationSnapshot.objects.create(
+            envelope=envelope,
+            trigger=trigger,
+            validation_status=validation_status,
+            template_id=template_id,
+            template_hash=template_hash,
+            findings_hash=findings_hash,
+            findings_json=[],
+            finding_count=finding_count,
+            finding_codes=finding_codes or [],
+            canonical_types=canonical_types or []
+        )
+        if created_at:
+            SpotTemplateValidationSnapshot.objects.filter(id=snap.id).update(created_at=created_at)
+        return snap
+
+    def _create_event(
+        self,
+        envelope,
+        event_type="finding_reviewed",
+        finding_code="expected_charge_missing",
+        canonical_type="AWB_DOCUMENTATION",
+        fingerprint="fp1",
+        created_at=None
+    ):
+        event = SpotTemplateValidationEvent.objects.create(
+            envelope=envelope,
+            event_type=event_type,
+            finding_code=finding_code,
+            canonical_type=canonical_type,
+            template_line_id=123,
+            charge_line_id=None,
+            finding_fingerprint=fingerprint,
+            validation_status=None,
+            user=self.manager_user,
+            metadata={"comment": "Comment text"}
+        )
+        if created_at:
+            SpotTemplateValidationEvent.objects.filter(id=event.id).update(created_at=created_at)
+        return event
+
+    def test_manager_allowed_sales_blocked(self):
+        """Verify only manager role is allowed and sales blocked."""
+        self.client.force_authenticate(user=self.sales_user)
+        response = self.client.get(self.metrics_url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        self.client.force_authenticate(user=self.manager_user)
+        response = self.client.get(self.metrics_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_date_validation(self):
+        """Verify invalid date formats, range limits and range inversions are rejected."""
+        self.client.force_authenticate(user=self.manager_user)
+
+        # Inverted date range
+        response = self.client.get(f"{self.metrics_url}?start_date=2026-06-12&end_date=2026-06-01")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error"], "end_date cannot be before start_date.")
+
+        # Range > 180 days
+        response = self.client.get(f"{self.metrics_url}?start_date=2026-01-01&end_date=2026-07-01")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error"], "The maximum date range allowed is 180 days.")
+
+        # Invalid format
+        response = self.client.get(f"{self.metrics_url}?start_date=invalid-date")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_template_id_and_limit_filters(self):
+        """Verify filtering by template_id and applying limits work correctly."""
+        self.client.force_authenticate(user=self.manager_user)
+        now = timezone.now()
+
+        # Create snapshots for template 1 & 2 (using min_snapshots=1 to bypass sample size check)
+        self._create_snapshot(self.envelope, template_id=self.template_1.id, template_hash="hash1", created_at=now - datetime.timedelta(days=2))
+        self._create_snapshot(self.envelope, template_id=self.template_2.id, template_hash="hash2", findings_hash="fhash2", created_at=now - datetime.timedelta(days=2))
+
+        # Filter by template_id
+        response = self.client.get(f"{self.metrics_url}?template_id={self.template_1.id}&min_snapshots=1")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["insights"]), 1)
+        self.assertEqual(response.data["insights"][0]["template_id"], self.template_1.id)
+
+        # Test limit default and max
+        response = self.client.get(f"{self.metrics_url}?limit=1&min_snapshots=1")
+        self.assertEqual(len(response.data["insights"]), 1)
+
+    def test_min_snapshots_default_and_custom(self):
+        """Verify default min_snapshots=5 and custom value exclusions work."""
+        self.client.force_authenticate(user=self.manager_user)
+        now = timezone.now()
+
+        # Create only 3 snapshots for template 1
+        for i in range(3):
+            self._create_snapshot(
+                self.envelope,
+                template_id=self.template_1.id,
+                template_hash="h1",
+                findings_hash=f"fh_{i}",
+                created_at=now - datetime.timedelta(days=1)
+            )
+
+        # Default query (min_snapshots=5): template 1 should be excluded
+        response = self.client.get(self.metrics_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["insights"]), 0)
+
+        # Custom query (min_snapshots=2): template 1 should be included
+        response = self.client.get(f"{self.metrics_url}?min_snapshots=2")
+        self.assertEqual(len(response.data["insights"]), 1)
+        self.assertTrue(response.data["insights"][0]["sample_warning"])  # < 5 snapshots warning should be true
+
+    def test_score_and_metrics_calculation(self):
+        """Verify priority score, ratios, breaks, and pressure signals calculation."""
+        self.client.force_authenticate(user=self.manager_user)
+        now = timezone.now()
+
+        # Create 5 snapshots for template 1:
+        # - 3 warnings, 2 passed (Issue ratio = 60%)
+        # - Average findings = 12 findings total / 5 snapshots = 2.4 avg
+        # - 3 warnings contain code "expected_charge_missing" (missing charge pressure should be True: 3/3 > 50%)
+        # - 0 snapshots contain "unexpected_charge_present" (unexpected charge pressure should be False)
+        # - 1 envelope with findings (envelope_1). We review it -> review rate = 100%, unreviewed ratio = 0%
+        for i in range(3):
+            self._create_snapshot(
+                self.envelope,
+                template_id=self.template_1.id,
+                validation_status="warnings",
+                finding_count=3,
+                finding_codes=["expected_charge_missing"],
+                canonical_types=["AWB"],
+                findings_hash=f"hash_warn_{i}",
+                created_at=now - datetime.timedelta(days=1)
+            )
+        for i in range(2):
+            self._create_snapshot(
+                self.envelope,
+                template_id=self.template_1.id,
+                validation_status="passed",
+                finding_count=1, # Passed snapshots might have some low severity findings (like info), or let's keep it 1/0
+                finding_codes=["expected_charge_missing"],
+                findings_hash=f"hash_pass_{i}",
+                created_at=now - datetime.timedelta(days=2)
+            )
+
+        # Create 1 review event to satisfy unreviewed ratio test
+        self._create_event(
+            self.envelope,
+            finding_code="expected_charge_missing",
+            created_at=now - datetime.timedelta(days=1)
+        )
+
+        response = self.client.get(f"{self.metrics_url}?min_snapshots=5")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        insights = response.data["insights"]
+        self.assertEqual(len(insights), 1)
+
+        t_insight = insights[0]
+        self.assertEqual(t_insight["template_id"], self.template_1.id)
+        self.assertEqual(t_insight["issue_ratio_percentage"], 60.0)
+        self.assertEqual(t_insight["average_findings_per_snapshot"], 2.2)
+        self.assertEqual(t_insight["review_rate_percentage"], 100.0)
+        self.assertEqual(t_insight["unreviewed_ratio_percentage"], 0.0)
+
+        # Score math: 
+        # issue_ratio = 0.60 (weight 0.4 -> 24.0 points)
+        # avg_findings = 2.2 / 5.0 = 0.44 (weight 0.3 -> 13.2 points)
+        # unreviewed_ratio = 0.0 (weight 0.3 -> 0 points)
+        # Expected Priority Score = 24.0 + 13.2 + 0.0 = 37.2
+        self.assertEqual(t_insight["maintenance_priority_score"], 37.20)
+
+        # Signals
+        self.assertFalse(t_insight["maintenance_signals"]["high_maintenance_pressure"])
+        self.assertTrue(t_insight["maintenance_signals"]["missing_charge_pressure"])
+        self.assertFalse(t_insight["maintenance_signals"]["unexpected_charge_pressure"])
+
+        # Ordered breakdowns
+        self.assertEqual(t_insight["finding_codes_breakdown"][0]["code"], "expected_charge_missing")
+        self.assertEqual(t_insight["finding_codes_breakdown"][0]["snapshot_count"], 5)
+        self.assertEqual(t_insight["canonical_types_breakdown"][0]["canonical_type"], "AWB")
+        self.assertEqual(t_insight["canonical_types_breakdown"][0]["snapshot_count"], 3)

--- a/backend/quotes/urls.py
+++ b/backend/quotes/urls.py
@@ -34,6 +34,7 @@ from .spot_views import (
     SpotTemplateValidationReviewMetricsAPIView,
     SpotTemplateValidationSnapshotMetricsAPIView,
     SpotTemplateValidationComparisonMetricsAPIView,
+    SpotTemplateValidationMaintenanceInsightsAPIView,
 )
 
 app_name = 'quotes'
@@ -76,4 +77,5 @@ urlpatterns = [
     path('v3/spot/template-validation/review-metrics/', SpotTemplateValidationReviewMetricsAPIView.as_view(), name='spot-validation-review-metrics'),
     path('v3/spot/template-validation/snapshot-metrics/', SpotTemplateValidationSnapshotMetricsAPIView.as_view(), name='spot-validation-snapshot-metrics'),
     path('v3/spot/template-validation/comparison-metrics/', SpotTemplateValidationComparisonMetricsAPIView.as_view(), name='spot-validation-comparison-metrics'),
+    path('v3/spot/template-validation/maintenance-insights/', SpotTemplateValidationMaintenanceInsightsAPIView.as_view(), name='spot-validation-maintenance-insights'),
 ]


### PR DESCRIPTION
Adds a read-only SPOT template maintenance insights endpoint.

Summary:
- Adds maintenance insights service over existing validation snapshots and review events.
- Adds dedicated manager/admin-only endpoint at /api/v3/spot/template-validation/maintenance-insights/.
- Computes heuristic maintenance priority score, issue/review ratios, sample warning, and pressure signals.
- Returns ordered finding-code and canonical-type breakdowns.
- Adds tests for permissions, date validation, filters, scoring, ratio math, and signals.

Non-goals:
- No dynamic revalidation.
- No template mutation.
- No validation rule changes.
- No snapshot trigger changes.
- No pricing, ProductCode, quote total, finalisation, or approval-flow changes.