### PR TITLE
fix(spot): scope validation metrics by visible envelopes

### DIFF
--- a/backend/quotes/services/spot_validation_comparison_metrics.py
+++ b/backend/quotes/services/spot_validation_comparison_metrics.py
@@ -5,7 +5,7 @@ logger = logging.getLogger(__name__)
 
 class SpotTemplateValidationComparisonMetricsService:
     @classmethod
-    def get_comparison_metrics(cls, start_date, end_date, filters=None, limit=10):
+    def get_comparison_metrics(cls, user, start_date, end_date, filters=None, limit=10):
         """
         Calculates comparison metrics between validation snapshots and reviewed findings.
         Aggregates at the distinct envelope level to prevent updates/lifecycles from skewing metrics.
@@ -13,10 +13,14 @@ class SpotTemplateValidationComparisonMetricsService:
         if filters is None:
             filters = {}
 
+        from quotes.selectors import get_spes_for_user
+        visible_envelopes = get_spes_for_user(user)
+
         # 1. Query snapshots matching date range and filters
         snapshots_qs = SpotTemplateValidationSnapshot.objects.filter(
             created_at__gte=start_date,
-            created_at__lte=end_date
+            created_at__lte=end_date,
+            envelope__in=visible_envelopes
         )
 
         template_id = filters.get("template_id")

--- a/backend/quotes/services/spot_validation_maintenance_insights.py
+++ b/backend/quotes/services/spot_validation_maintenance_insights.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 class SpotTemplateValidationMaintenanceInsightsService:
     @classmethod
-    def get_maintenance_insights(cls, start_date, end_date, filters=None, limit=10, min_snapshots=5):
+    def get_maintenance_insights(cls, user, start_date, end_date, filters=None, limit=10, min_snapshots=5):
         """
         Gathers template validation snapshots, calculates Maintenance Priority Scores,
         and aggregates pressure signals / finding breakdowns.
@@ -18,10 +18,14 @@ class SpotTemplateValidationMaintenanceInsightsService:
         if filters is None:
             filters = {}
 
+        from quotes.selectors import get_spes_for_user
+        visible_envelopes = get_spes_for_user(user)
+
         # 1. Base query for snapshots
         snapshots_qs = SpotTemplateValidationSnapshot.objects.filter(
             created_at__gte=start_date,
-            created_at__lte=end_date
+            created_at__lte=end_date,
+            envelope__in=visible_envelopes
         )
 
         template_id = filters.get("template_id")

--- a/backend/quotes/services/spot_validation_metrics.py
+++ b/backend/quotes/services/spot_validation_metrics.py
@@ -6,13 +6,19 @@ logger = logging.getLogger(__name__)
 
 class SpotTemplateValidationMetricsService:
     @classmethod
-    def get_review_metrics(cls, start_date=None, end_date=None):
+    def get_review_metrics(cls, user, start_date=None, end_date=None):
         """
         Aggregates review metrics strictly from SpotTemplateValidationEvent records
         where event_type = "finding_reviewed".
         """
+        from quotes.selectors import get_spes_for_user
+        visible_envelopes = get_spes_for_user(user)
+
         # Base queryset
-        queryset = SpotTemplateValidationEvent.objects.filter(event_type="finding_reviewed")
+        queryset = SpotTemplateValidationEvent.objects.filter(
+            event_type="finding_reviewed",
+            envelope__in=visible_envelopes
+        )
 
         # Date range filtering
         if start_date:

--- a/backend/quotes/services/spot_validation_snapshot_metrics.py
+++ b/backend/quotes/services/spot_validation_snapshot_metrics.py
@@ -6,17 +6,21 @@ logger = logging.getLogger(__name__)
 
 class SpotTemplateValidationSnapshotMetricsService:
     @classmethod
-    def get_snapshot_metrics(cls, start_date, end_date, filters=None, limit=10):
+    def get_snapshot_metrics(cls, user, start_date, end_date, filters=None, limit=10):
         """
         Aggregates operational validation metrics strictly from SpotTemplateValidationSnapshot records.
         """
         if filters is None:
             filters = {}
 
+        from quotes.selectors import get_spes_for_user
+        visible_envelopes = get_spes_for_user(user)
+
         # Base query with date range
         queryset = SpotTemplateValidationSnapshot.objects.filter(
             created_at__gte=start_date,
-            created_at__lte=end_date
+            created_at__lte=end_date,
+            envelope__in=visible_envelopes
         )
 
         # Apply database filters

--- a/backend/quotes/spot_views.py
+++ b/backend/quotes/spot_views.py
@@ -3028,7 +3028,7 @@ class SpotTemplateValidationReviewMetricsAPIView(APIView):
             return Response({"error": "The maximum date range allowed is 180 days."}, status=status.HTTP_400_BAD_REQUEST)
 
         from quotes.services.spot_validation_metrics import SpotTemplateValidationMetricsService
-        metrics = SpotTemplateValidationMetricsService.get_review_metrics(start_dt, end_dt)
+        metrics = SpotTemplateValidationMetricsService.get_review_metrics(request.user, start_dt, end_dt)
 
         from quotes.serializers import SpotTemplateValidationReviewMetricsSerializer
         serializer = SpotTemplateValidationReviewMetricsSerializer(metrics)
@@ -3120,6 +3120,7 @@ class SpotTemplateValidationSnapshotMetricsAPIView(APIView):
 
         from quotes.services.spot_validation_snapshot_metrics import SpotTemplateValidationSnapshotMetricsService
         metrics = SpotTemplateValidationSnapshotMetricsService.get_snapshot_metrics(
+            user=request.user,
             start_date=start_dt,
             end_date=end_dt,
             filters=filters,
@@ -3207,6 +3208,7 @@ class SpotTemplateValidationComparisonMetricsAPIView(APIView):
 
         from quotes.services.spot_validation_comparison_metrics import SpotTemplateValidationComparisonMetricsService
         metrics = SpotTemplateValidationComparisonMetricsService.get_comparison_metrics(
+            user=request.user,
             start_date=start_dt,
             end_date=end_dt,
             filters=filters,
@@ -3300,6 +3302,7 @@ class SpotTemplateValidationMaintenanceInsightsAPIView(APIView):
 
         from quotes.services.spot_validation_maintenance_insights import SpotTemplateValidationMaintenanceInsightsService
         insights = SpotTemplateValidationMaintenanceInsightsService.get_maintenance_insights(
+            user=request.user,
             start_date=start_dt,
             end_date=end_dt,
             filters=filters,

--- a/backend/quotes/tests/test_spot_validation_comparison_metrics.py
+++ b/backend/quotes/tests/test_spot_validation_comparison_metrics.py
@@ -33,14 +33,16 @@ class SpotTemplateValidationComparisonMetricsTests(APITestCase):
             shipment_context_json={"origin_country": "SG", "destination_country": "PG"},
             expires_at=timezone.now() + datetime.timedelta(days=2),
             spot_trigger_reason_code="MANUAL",
-            spot_trigger_reason_text="Manual trigger"
+            spot_trigger_reason_text="Manual trigger",
+            created_by=self.manager_user
         )
         self.envelope_2 = SpotPricingEnvelopeDB.objects.create(
             status="draft",
             shipment_context_json={"origin_country": "AU", "destination_country": "NZ"},
             expires_at=timezone.now() + datetime.timedelta(days=2),
             spot_trigger_reason_code="MANUAL",
-            spot_trigger_reason_text="Manual trigger"
+            spot_trigger_reason_text="Manual trigger",
+            created_by=self.manager_user
         )
 
         self.metrics_url = reverse("quotes:spot-validation-comparison-metrics")
@@ -219,7 +221,8 @@ class SpotTemplateValidationComparisonMetricsTests(APITestCase):
                 shipment_context_json={"origin_country": "SG", "destination_country": "PG"},
                 expires_at=timezone.now() + datetime.timedelta(days=2),
                 spot_trigger_reason_code="MANUAL",
-                spot_trigger_reason_text="Manual trigger"
+                spot_trigger_reason_text="Manual trigger",
+                created_by=self.manager_user
             )
             self._create_snapshot(
                 env,
@@ -296,3 +299,74 @@ class SpotTemplateValidationComparisonMetricsTests(APITestCase):
         self.assertEqual(cct_comp[0]["envelopes_generated_count"], 2)
         self.assertEqual(cct_comp[0]["envelopes_reviewed_count"], 1)
         self.assertEqual(cct_comp[0]["review_rate_percentage"], 50.0)
+
+    def test_departmental_rbac_isolation(self):
+        """Verify that a manager can only see comparison metrics for envelopes in their department."""
+        User = get_user_model()
+        
+        manager_air = User.objects.create_user(
+            username="manager_air",
+            password="password123",
+            email="manager_air@example.com",
+            role="manager",
+            department="Air"
+        )
+        manager_ocean = User.objects.create_user(
+            username="manager_ocean",
+            password="password123",
+            email="manager_ocean@example.com",
+            role="manager",
+            department="Ocean"
+        )
+        
+        sales_air = User.objects.create_user(
+            username="sales_air",
+            password="password123",
+            email="sales_air@example.com",
+            role="sales",
+            department="Air"
+        )
+        sales_ocean = User.objects.create_user(
+            username="sales_ocean",
+            password="password123",
+            email="sales_ocean@example.com",
+            role="sales",
+            department="Ocean"
+        )
+        
+        envelope_air = SpotPricingEnvelopeDB.objects.create(
+            status="draft",
+            shipment_context_json={"origin_country": "SG", "destination_country": "PG"},
+            expires_at=timezone.now() + datetime.timedelta(days=2),
+            spot_trigger_reason_code="MANUAL",
+            spot_trigger_reason_text="Manual trigger",
+            created_by=sales_air
+        )
+        envelope_ocean = SpotPricingEnvelopeDB.objects.create(
+            status="draft",
+            shipment_context_json={"origin_country": "SG", "destination_country": "PG"},
+            expires_at=timezone.now() + datetime.timedelta(days=2),
+            spot_trigger_reason_code="MANUAL",
+            spot_trigger_reason_text="Manual trigger",
+            created_by=sales_ocean
+        )
+        
+        self._create_snapshot(envelope_air, finding_codes=["expected_charge_missing"], canonical_types=["AWB"], findings_hash="fp_air")
+        self._create_event(envelope_air, finding_code="expected_charge_missing", canonical_type="AWB")
+        
+        self._create_snapshot(envelope_ocean, finding_codes=["unexpected_charge_present"], canonical_types=["FUEL"], findings_hash="fp_ocean")
+        self._create_event(envelope_ocean, finding_code="unexpected_charge_present", canonical_type="FUEL")
+        
+        self.client.force_authenticate(user=manager_air)
+        response = self.client.get(self.metrics_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["summary"]["total_envelopes_with_snapshots"], 1)
+        self.assertEqual(len(response.data["finding_code_comparison"]), 1)
+        self.assertEqual(response.data["finding_code_comparison"][0]["finding_code"], "expected_charge_missing")
+        
+        self.client.force_authenticate(user=manager_ocean)
+        response = self.client.get(self.metrics_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["summary"]["total_envelopes_with_snapshots"], 1)
+        self.assertEqual(len(response.data["finding_code_comparison"]), 1)
+        self.assertEqual(response.data["finding_code_comparison"][0]["finding_code"], "unexpected_charge_present")

--- a/backend/quotes/tests/test_spot_validation_maintenance_insights.py
+++ b/backend/quotes/tests/test_spot_validation_maintenance_insights.py
@@ -34,7 +34,8 @@ class SpotTemplateValidationMaintenanceInsightsTests(APITestCase):
             shipment_context_json={"origin_country": "SG", "destination_country": "PG"},
             expires_at=timezone.now() + datetime.timedelta(days=2),
             spot_trigger_reason_code="MANUAL",
-            spot_trigger_reason_text="Manual trigger"
+            spot_trigger_reason_text="Manual trigger",
+            created_by=self.manager_user
         )
 
         # Create 2 dummy templates
@@ -255,3 +256,89 @@ class SpotTemplateValidationMaintenanceInsightsTests(APITestCase):
         self.assertEqual(t_insight["finding_codes_breakdown"][0]["snapshot_count"], 5)
         self.assertEqual(t_insight["canonical_types_breakdown"][0]["canonical_type"], "AWB")
         self.assertEqual(t_insight["canonical_types_breakdown"][0]["snapshot_count"], 3)
+
+    def test_departmental_rbac_isolation(self):
+        """Verify that a manager can only see maintenance insights for envelopes in their department."""
+        User = get_user_model()
+        
+        manager_air = User.objects.create_user(
+            username="manager_air",
+            password="password123",
+            email="manager_air@example.com",
+            role="manager",
+            department="Air"
+        )
+        manager_ocean = User.objects.create_user(
+            username="manager_ocean",
+            password="password123",
+            email="manager_ocean@example.com",
+            role="manager",
+            department="Ocean"
+        )
+        
+        sales_air = User.objects.create_user(
+            username="sales_air",
+            password="password123",
+            email="sales_air@example.com",
+            role="sales",
+            department="Air"
+        )
+        sales_ocean = User.objects.create_user(
+            username="sales_ocean",
+            password="password123",
+            email="sales_ocean@example.com",
+            role="sales",
+            department="Ocean"
+        )
+        
+        envelope_air = SpotPricingEnvelopeDB.objects.create(
+            status="draft",
+            shipment_context_json={"origin_country": "SG", "destination_country": "PG"},
+            expires_at=timezone.now() + datetime.timedelta(days=2),
+            spot_trigger_reason_code="MANUAL",
+            spot_trigger_reason_text="Manual trigger",
+            created_by=sales_air
+        )
+        envelope_ocean = SpotPricingEnvelopeDB.objects.create(
+            status="draft",
+            shipment_context_json={"origin_country": "SG", "destination_country": "PG"},
+            expires_at=timezone.now() + datetime.timedelta(days=2),
+            spot_trigger_reason_code="MANUAL",
+            spot_trigger_reason_text="Manual trigger",
+            created_by=sales_ocean
+        )
+        
+        # Create a single snapshot for each department using min_snapshots=1 filter
+        self._create_snapshot(
+            envelope_air,
+            template_id=self.template_1.id,
+            validation_status="warnings",
+            finding_count=1,
+            finding_codes=["expected_charge_missing"],
+            canonical_types=["AWB"],
+            findings_hash="fp_air"
+        )
+        
+        self._create_snapshot(
+            envelope_ocean,
+            template_id=self.template_2.id,
+            validation_status="warnings",
+            finding_count=1,
+            finding_codes=["unexpected_charge_present"],
+            canonical_types=["FUEL"],
+            findings_hash="fp_ocean"
+        )
+        
+        self.client.force_authenticate(user=manager_air)
+        response = self.client.get(f"{self.metrics_url}?min_snapshots=1")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        insights = response.data["insights"]
+        self.assertEqual(len(insights), 1)
+        self.assertEqual(insights[0]["template_id"], self.template_1.id)
+        
+        self.client.force_authenticate(user=manager_ocean)
+        response = self.client.get(f"{self.metrics_url}?min_snapshots=1")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        insights = response.data["insights"]
+        self.assertEqual(len(insights), 1)
+        self.assertEqual(insights[0]["template_id"], self.template_2.id)

--- a/backend/quotes/tests/test_spot_validation_metrics.py
+++ b/backend/quotes/tests/test_spot_validation_metrics.py
@@ -29,7 +29,8 @@ class SpotTemplateValidationReviewMetricsTests(APITestCase):
             shipment_context_json={"origin_country": "SG", "destination_country": "PG"},
             expires_at=timezone.now() + datetime.timedelta(days=2),
             spot_trigger_reason_code="MANUAL",
-            spot_trigger_reason_text="Manual trigger"
+            spot_trigger_reason_text="Manual trigger",
+            created_by=self.manager_user
         )
 
         self.metrics_url = reverse("quotes:spot-validation-review-metrics")
@@ -145,3 +146,83 @@ class SpotTemplateValidationReviewMetricsTests(APITestCase):
         response = self.client.get(f"{self.metrics_url}?start_date={start}&end_date={end}")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data["error"], "end_date cannot be before start_date.")
+
+    def test_departmental_rbac_isolation(self):
+        """Verify that a manager can only see review metrics for envelopes in their department."""
+        User = get_user_model()
+        
+        manager_air = User.objects.create_user(
+            username="manager_air",
+            password="password123",
+            email="manager_air@example.com",
+            role="manager",
+            department="Air"
+        )
+        manager_ocean = User.objects.create_user(
+            username="manager_ocean",
+            password="password123",
+            email="manager_ocean@example.com",
+            role="manager",
+            department="Ocean"
+        )
+        
+        sales_air = User.objects.create_user(
+            username="sales_air",
+            password="password123",
+            email="sales_air@example.com",
+            role="sales",
+            department="Air"
+        )
+        sales_ocean = User.objects.create_user(
+            username="sales_ocean",
+            password="password123",
+            email="sales_ocean@example.com",
+            role="sales",
+            department="Ocean"
+        )
+        
+        envelope_air = SpotPricingEnvelopeDB.objects.create(
+            status="draft",
+            shipment_context_json={"origin_country": "SG", "destination_country": "PG"},
+            expires_at=timezone.now() + datetime.timedelta(days=2),
+            spot_trigger_reason_code="MANUAL",
+            spot_trigger_reason_text="Manual trigger",
+            created_by=sales_air
+        )
+        envelope_ocean = SpotPricingEnvelopeDB.objects.create(
+            status="draft",
+            shipment_context_json={"origin_country": "SG", "destination_country": "PG"},
+            expires_at=timezone.now() + datetime.timedelta(days=2),
+            spot_trigger_reason_code="MANUAL",
+            spot_trigger_reason_text="Manual trigger",
+            created_by=sales_ocean
+        )
+        
+        SpotTemplateValidationEvent.objects.create(
+            envelope=envelope_air,
+            event_type="finding_reviewed",
+            finding_code="expected_charge_missing",
+            finding_fingerprint="fp_air",
+            user=sales_air
+        )
+        SpotTemplateValidationEvent.objects.create(
+            envelope=envelope_ocean,
+            event_type="finding_reviewed",
+            finding_code="unexpected_charge_present",
+            finding_fingerprint="fp_ocean",
+            user=sales_ocean
+        )
+        
+        self.client.force_authenticate(user=manager_air)
+        response = self.client.get(self.metrics_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["total_reviewed_events"], 1)
+        self.assertIn("expected_charge_missing", response.data["reviewed_by_finding_code"])
+        self.assertNotIn("unexpected_charge_present", response.data["reviewed_by_finding_code"])
+        
+        self.client.force_authenticate(user=manager_ocean)
+        response = self.client.get(self.metrics_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["total_reviewed_events"], 1)
+        self.assertIn("unexpected_charge_present", response.data["reviewed_by_finding_code"])
+        self.assertNotIn("expected_charge_missing", response.data["reviewed_by_finding_code"])

--- a/backend/quotes/tests/test_spot_validation_snapshot_metrics.py
+++ b/backend/quotes/tests/test_spot_validation_snapshot_metrics.py
@@ -29,14 +29,16 @@ class SpotTemplateValidationSnapshotMetricsTests(APITestCase):
             shipment_context_json={"origin_country": "SG", "destination_country": "PG"},
             expires_at=timezone.now() + datetime.timedelta(days=2),
             spot_trigger_reason_code="MANUAL",
-            spot_trigger_reason_text="Manual trigger"
+            spot_trigger_reason_text="Manual trigger",
+            created_by=self.manager_user
         )
         self.envelope_2 = SpotPricingEnvelopeDB.objects.create(
             status="draft",
             shipment_context_json={"origin_country": "AU", "destination_country": "NZ"},
             expires_at=timezone.now() + datetime.timedelta(days=2),
             spot_trigger_reason_code="MANUAL",
-            spot_trigger_reason_text="Manual trigger"
+            spot_trigger_reason_text="Manual trigger",
+            created_by=self.manager_user
         )
 
         self.metrics_url = reverse("quotes:spot-validation-snapshot-metrics")
@@ -273,3 +275,69 @@ class SpotTemplateValidationSnapshotMetricsTests(APITestCase):
         self.assertEqual(stability["total_envelopes"], 2)
         self.assertEqual(stability["stable_envelopes_count"], 1)
         self.assertEqual(stability["unstable_envelopes_count"], 1)
+
+    def test_departmental_rbac_isolation(self):
+        """Verify that a manager can only see snapshot metrics for envelopes in their department."""
+        User = get_user_model()
+        
+        manager_air = User.objects.create_user(
+            username="manager_air",
+            password="password123",
+            email="manager_air@example.com",
+            role="manager",
+            department="Air"
+        )
+        manager_ocean = User.objects.create_user(
+            username="manager_ocean",
+            password="password123",
+            email="manager_ocean@example.com",
+            role="manager",
+            department="Ocean"
+        )
+        
+        sales_air = User.objects.create_user(
+            username="sales_air",
+            password="password123",
+            email="sales_air@example.com",
+            role="sales",
+            department="Air"
+        )
+        sales_ocean = User.objects.create_user(
+            username="sales_ocean",
+            password="password123",
+            email="sales_ocean@example.com",
+            role="sales",
+            department="Ocean"
+        )
+        
+        envelope_air = SpotPricingEnvelopeDB.objects.create(
+            status="draft",
+            shipment_context_json={"origin_country": "SG", "destination_country": "PG"},
+            expires_at=timezone.now() + datetime.timedelta(days=2),
+            spot_trigger_reason_code="MANUAL",
+            spot_trigger_reason_text="Manual trigger",
+            created_by=sales_air
+        )
+        envelope_ocean = SpotPricingEnvelopeDB.objects.create(
+            status="draft",
+            shipment_context_json={"origin_country": "SG", "destination_country": "PG"},
+            expires_at=timezone.now() + datetime.timedelta(days=2),
+            spot_trigger_reason_code="MANUAL",
+            spot_trigger_reason_text="Manual trigger",
+            created_by=sales_ocean
+        )
+        
+        self._create_snapshot(envelope_air, trigger="envelope_created", validation_status="warnings", findings_hash="fp_air")
+        self._create_snapshot(envelope_ocean, trigger="envelope_created", validation_status="warnings", findings_hash="fp_ocean")
+        
+        self.client.force_authenticate(user=manager_air)
+        response = self.client.get(self.metrics_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["total_snapshots"], 1)
+        self.assertEqual(response.data["unique_envelopes_count"], 1)
+        
+        self.client.force_authenticate(user=manager_ocean)
+        response = self.client.get(self.metrics_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["total_snapshots"], 1)
+        self.assertEqual(response.data["unique_envelopes_count"], 1)


### PR DESCRIPTION
Scopes SPOT validation intelligence metrics to envelopes visible to the requesting user.

Summary:
- Passes request.user into validation metrics service calls.
- Filters review, snapshot, comparison, and maintenance metrics using get_spes_for_user(user).
- Adds departmental RBAC isolation coverage across the relevant metrics tests.

Non-goals:
- No validation rule changes.
- No snapshot trigger changes.
- No pricing changes.
- No ProductCode changes.
- No quote total changes.
- No finalisation or approval-flow changes.