### PR TITLE
refactor(spot): add validation metrics query helper and feature flag

### DIFF
--- a/backend/quotes/spot_views.py
+++ b/backend/quotes/spot_views.py
@@ -22,6 +22,7 @@ from uuid import UUID
 
 from django.utils import timezone
 from django.db import transaction
+from django.conf import settings
 
 from rest_framework import status
 from rest_framework.parsers import MultiPartParser, FormParser, JSONParser
@@ -90,6 +91,72 @@ def _user_is_manager_or_admin(user) -> bool:
     if getattr(user, "is_manager", False) or getattr(user, "is_admin", False):
         return True
     return getattr(user, "role", None) in ("manager", "admin")
+
+
+def _parse_validation_metrics_params(request):
+    """
+    Parses and validates standard parameters for SPOT validation metrics:
+    - start_date and end_date (default 30 days, max 180 days)
+    - limit (default 10, max 50)
+    - min_snapshots (default 5)
+    """
+    from django.utils.dateparse import parse_date
+    import datetime
+    from django.utils import timezone
+    from rest_framework.exceptions import ValidationError
+
+    start_date_str = request.query_params.get("start_date")
+    end_date_str = request.query_params.get("end_date")
+    now = timezone.now()
+
+    if start_date_str:
+        try:
+            start_date = parse_date(start_date_str)
+            if not start_date:
+                raise ValueError
+            start_dt = timezone.make_aware(datetime.datetime.combine(start_date, datetime.time.min))
+        except ValueError:
+            raise ValidationError({"error": "Invalid start_date format. Use YYYY-MM-DD."})
+    else:
+        start_dt = now - datetime.timedelta(days=30)
+
+    if end_date_str:
+        try:
+            end_date = parse_date(end_date_str)
+            if not end_date:
+                raise ValueError
+            end_dt = timezone.make_aware(datetime.datetime.combine(end_date, datetime.time.max))
+        except ValueError:
+            raise ValidationError({"error": "Invalid end_date format. Use YYYY-MM-DD."})
+    else:
+        end_dt = now
+
+    if end_dt < start_dt:
+        raise ValidationError({"error": "end_date cannot be before start_date."})
+
+    if (end_dt - start_dt).days > 180:
+        raise ValidationError({"error": "The maximum date range allowed is 180 days."})
+
+    limit_str = request.query_params.get("limit", "10")
+    try:
+        limit = int(limit_str)
+        if limit <= 0:
+            raise ValueError
+        if limit > 50:
+            limit = 50
+    except ValueError:
+        raise ValidationError({"error": "limit must be a positive integer."})
+
+    min_snapshots_str = request.query_params.get("min_snapshots", "5")
+    try:
+        min_snapshots = int(min_snapshots_str)
+        if min_snapshots <= 0:
+            raise ValueError
+    except ValueError:
+        raise ValidationError({"error": "min_snapshots must be a positive integer."})
+
+    return start_dt, end_dt, limit, min_snapshots
+
 
 
 def _get_spe_or_404(user, envelope_id, queryset=None):
@@ -2987,45 +3054,16 @@ class SpotTemplateValidationReviewMetricsAPIView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
+        if not getattr(settings, "SPOT_VALIDATION_METRICS_ENABLED", True):
+            return Response(
+                {"detail": "SPOT validation metrics are temporarily disabled."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE
+            )
+
         if not _user_is_manager_or_admin(request.user):
             raise PermissionDenied("Only managers and admins can view validation metrics.")
 
-        from django.utils.dateparse import parse_date
-        import datetime
-        from django.utils import timezone
-        
-        start_date_str = request.query_params.get("start_date")
-        end_date_str = request.query_params.get("end_date")
-
-        now = timezone.now()
-
-        if start_date_str:
-            try:
-                start_date = parse_date(start_date_str)
-                if not start_date:
-                    raise ValueError
-                start_dt = timezone.make_aware(datetime.datetime.combine(start_date, datetime.time.min))
-            except ValueError:
-                return Response({"error": "Invalid start_date format. Use YYYY-MM-DD."}, status=status.HTTP_400_BAD_REQUEST)
-        else:
-            start_dt = now - datetime.timedelta(days=30)
-
-        if end_date_str:
-            try:
-                end_date = parse_date(end_date_str)
-                if not end_date:
-                    raise ValueError
-                end_dt = timezone.make_aware(datetime.datetime.combine(end_date, datetime.time.max))
-            except ValueError:
-                return Response({"error": "Invalid end_date format. Use YYYY-MM-DD."}, status=status.HTTP_400_BAD_REQUEST)
-        else:
-            end_dt = now
-
-        if end_dt < start_dt:
-            return Response({"error": "end_date cannot be before start_date."}, status=status.HTTP_400_BAD_REQUEST)
-
-        if (end_dt - start_dt).days > 180:
-            return Response({"error": "The maximum date range allowed is 180 days."}, status=status.HTTP_400_BAD_REQUEST)
+        start_dt, end_dt, limit, min_snapshots = _parse_validation_metrics_params(request)
 
         from quotes.services.spot_validation_metrics import SpotTemplateValidationMetricsService
         metrics = SpotTemplateValidationMetricsService.get_review_metrics(request.user, start_dt, end_dt)
@@ -3039,59 +3077,16 @@ class SpotTemplateValidationSnapshotMetricsAPIView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
+        if not getattr(settings, "SPOT_VALIDATION_METRICS_ENABLED", True):
+            return Response(
+                {"detail": "SPOT validation metrics are temporarily disabled."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE
+            )
+
         if not _user_is_manager_or_admin(request.user):
             raise PermissionDenied("Only managers and admins can view validation metrics.")
 
-        from django.utils.dateparse import parse_date
-        import datetime
-        from django.utils import timezone
-        
-        start_date_str = request.query_params.get("start_date")
-        end_date_str = request.query_params.get("end_date")
-
-        now = timezone.now()
-
-        # Parse start_date
-        if start_date_str:
-            try:
-                start_date = parse_date(start_date_str)
-                if not start_date:
-                    raise ValueError
-                start_dt = timezone.make_aware(datetime.datetime.combine(start_date, datetime.time.min))
-            except ValueError:
-                return Response({"error": "Invalid start_date format. Use YYYY-MM-DD."}, status=status.HTTP_400_BAD_REQUEST)
-        else:
-            start_dt = now - datetime.timedelta(days=30)
-
-        # Parse end_date
-        if end_date_str:
-            try:
-                end_date = parse_date(end_date_str)
-                if not end_date:
-                    raise ValueError
-                end_dt = timezone.make_aware(datetime.datetime.combine(end_date, datetime.time.max))
-            except ValueError:
-                return Response({"error": "Invalid end_date format. Use YYYY-MM-DD."}, status=status.HTTP_400_BAD_REQUEST)
-        else:
-            end_dt = now
-
-        if end_dt < start_dt:
-            return Response({"error": "end_date cannot be before start_date."}, status=status.HTTP_400_BAD_REQUEST)
-
-        if (end_dt - start_dt).days > 180:
-            return Response({"error": "The maximum date range allowed is 180 days."}, status=status.HTTP_400_BAD_REQUEST)
-
-        # Parse limit
-        limit_str = request.query_params.get("limit", "10")
-        try:
-            limit = int(limit_str)
-            if limit <= 0:
-                raise ValueError
-            # Cap at 50
-            if limit > 50:
-                limit = 50
-        except ValueError:
-            return Response({"error": "limit must be a positive integer."}, status=status.HTTP_400_BAD_REQUEST)
+        start_dt, end_dt, limit, min_snapshots = _parse_validation_metrics_params(request)
 
         # Parse template_id if provided
         template_id_str = request.query_params.get("template_id")
@@ -3136,59 +3131,16 @@ class SpotTemplateValidationComparisonMetricsAPIView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
+        if not getattr(settings, "SPOT_VALIDATION_METRICS_ENABLED", True):
+            return Response(
+                {"detail": "SPOT validation metrics are temporarily disabled."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE
+            )
+
         if not _user_is_manager_or_admin(request.user):
             raise PermissionDenied("Only managers and admins can view validation metrics.")
 
-        from django.utils.dateparse import parse_date
-        import datetime
-        from django.utils import timezone
-        
-        start_date_str = request.query_params.get("start_date")
-        end_date_str = request.query_params.get("end_date")
-
-        now = timezone.now()
-
-        # Parse start_date
-        if start_date_str:
-            try:
-                start_date = parse_date(start_date_str)
-                if not start_date:
-                    raise ValueError
-                start_dt = timezone.make_aware(datetime.datetime.combine(start_date, datetime.time.min))
-            except ValueError:
-                return Response({"error": "Invalid start_date format. Use YYYY-MM-DD."}, status=status.HTTP_400_BAD_REQUEST)
-        else:
-            start_dt = now - datetime.timedelta(days=30)
-
-        # Parse end_date
-        if end_date_str:
-            try:
-                end_date = parse_date(end_date_str)
-                if not end_date:
-                    raise ValueError
-                end_dt = timezone.make_aware(datetime.datetime.combine(end_date, datetime.time.max))
-            except ValueError:
-                return Response({"error": "Invalid end_date format. Use YYYY-MM-DD."}, status=status.HTTP_400_BAD_REQUEST)
-        else:
-            end_dt = now
-
-        if end_dt < start_dt:
-            return Response({"error": "end_date cannot be before start_date."}, status=status.HTTP_400_BAD_REQUEST)
-
-        if (end_dt - start_dt).days > 180:
-            return Response({"error": "The maximum date range allowed is 180 days."}, status=status.HTTP_400_BAD_REQUEST)
-
-        # Parse limit
-        limit_str = request.query_params.get("limit", "10")
-        try:
-            limit = int(limit_str)
-            if limit <= 0:
-                raise ValueError
-            # Cap at 50
-            if limit > 50:
-                limit = 50
-        except ValueError:
-            return Response({"error": "limit must be a positive integer."}, status=status.HTTP_400_BAD_REQUEST)
+        start_dt, end_dt, limit, min_snapshots = _parse_validation_metrics_params(request)
 
         # Parse template_id if provided
         template_id_str = request.query_params.get("template_id")
@@ -3224,59 +3176,16 @@ class SpotTemplateValidationMaintenanceInsightsAPIView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
+        if not getattr(settings, "SPOT_VALIDATION_METRICS_ENABLED", True):
+            return Response(
+                {"detail": "SPOT validation metrics are temporarily disabled."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE
+            )
+
         if not _user_is_manager_or_admin(request.user):
             raise PermissionDenied("Only managers and admins can view validation metrics.")
 
-        from django.utils.dateparse import parse_date
-        import datetime
-        from django.utils import timezone
-        
-        start_date_str = request.query_params.get("start_date")
-        end_date_str = request.query_params.get("end_date")
-
-        now = timezone.now()
-
-        # Parse start_date
-        if start_date_str:
-            try:
-                start_date = parse_date(start_date_str)
-                if not start_date:
-                    raise ValueError
-                start_dt = timezone.make_aware(datetime.datetime.combine(start_date, datetime.time.min))
-            except ValueError:
-                return Response({"error": "Invalid start_date format. Use YYYY-MM-DD."}, status=status.HTTP_400_BAD_REQUEST)
-        else:
-            start_dt = now - datetime.timedelta(days=30)
-
-        # Parse end_date
-        if end_date_str:
-            try:
-                end_date = parse_date(end_date_str)
-                if not end_date:
-                    raise ValueError
-                end_dt = timezone.make_aware(datetime.datetime.combine(end_date, datetime.time.max))
-            except ValueError:
-                return Response({"error": "Invalid end_date format. Use YYYY-MM-DD."}, status=status.HTTP_400_BAD_REQUEST)
-        else:
-            end_dt = now
-
-        if end_dt < start_dt:
-            return Response({"error": "end_date cannot be before start_date."}, status=status.HTTP_400_BAD_REQUEST)
-
-        if (end_dt - start_dt).days > 180:
-            return Response({"error": "The maximum date range allowed is 180 days."}, status=status.HTTP_400_BAD_REQUEST)
-
-        # Parse limit
-        limit_str = request.query_params.get("limit", "10")
-        try:
-            limit = int(limit_str)
-            if limit <= 0:
-                raise ValueError
-            # Cap at 50
-            if limit > 50:
-                limit = 50
-        except ValueError:
-            return Response({"error": "limit must be a positive integer."}, status=status.HTTP_400_BAD_REQUEST)
+        start_dt, end_dt, limit, min_snapshots = _parse_validation_metrics_params(request)
 
         # Parse template_id if provided
         template_id_str = request.query_params.get("template_id")
@@ -3286,15 +3195,6 @@ class SpotTemplateValidationMaintenanceInsightsAPIView(APIView):
                 template_id = int(template_id_str)
             except ValueError:
                 return Response({"error": "template_id must be an integer."}, status=status.HTTP_400_BAD_REQUEST)
-
-        # Parse min_snapshots
-        min_snapshots_str = request.query_params.get("min_snapshots", "5")
-        try:
-            min_snapshots = int(min_snapshots_str)
-            if min_snapshots <= 0:
-                raise ValueError
-        except ValueError:
-            return Response({"error": "min_snapshots must be a positive integer."}, status=status.HTTP_400_BAD_REQUEST)
 
         filters = {
             "template_id": template_id,

--- a/backend/quotes/tests/test_spot_validation_comparison_metrics.py
+++ b/backend/quotes/tests/test_spot_validation_comparison_metrics.py
@@ -370,3 +370,20 @@ class SpotTemplateValidationComparisonMetricsTests(APITestCase):
         self.assertEqual(response.data["summary"]["total_envelopes_with_snapshots"], 1)
         self.assertEqual(len(response.data["finding_code_comparison"]), 1)
         self.assertEqual(response.data["finding_code_comparison"][0]["finding_code"], "unexpected_charge_present")
+
+    def test_disabled_flag_returns_503(self):
+        """Verify the endpoint returns HTTP 503 if the operational toggle is disabled."""
+        from django.test import override_settings
+        self.client.force_authenticate(user=self.manager_user)
+        with override_settings(SPOT_VALIDATION_METRICS_ENABLED=False):
+            response = self.client.get(self.metrics_url)
+            self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+            self.assertEqual(response.data, {"detail": "SPOT validation metrics are temporarily disabled."})
+
+    def test_invalid_limit(self):
+        """Verify invalid limit values are rejected with 400."""
+        self.client.force_authenticate(user=self.manager_user)
+        response = self.client.get(f"{self.metrics_url}?limit=-5")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error"], "limit must be a positive integer.")
+

--- a/backend/quotes/tests/test_spot_validation_maintenance_insights.py
+++ b/backend/quotes/tests/test_spot_validation_maintenance_insights.py
@@ -342,3 +342,27 @@ class SpotTemplateValidationMaintenanceInsightsTests(APITestCase):
         insights = response.data["insights"]
         self.assertEqual(len(insights), 1)
         self.assertEqual(insights[0]["template_id"], self.template_2.id)
+
+    def test_disabled_flag_returns_503(self):
+        """Verify the endpoint returns HTTP 503 if the operational toggle is disabled."""
+        from django.test import override_settings
+        self.client.force_authenticate(user=self.manager_user)
+        with override_settings(SPOT_VALIDATION_METRICS_ENABLED=False):
+            response = self.client.get(self.metrics_url)
+            self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+            self.assertEqual(response.data, {"detail": "SPOT validation metrics are temporarily disabled."})
+
+    def test_invalid_limit(self):
+        """Verify invalid limit values are rejected with 400."""
+        self.client.force_authenticate(user=self.manager_user)
+        response = self.client.get(f"{self.metrics_url}?limit=-5")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error"], "limit must be a positive integer.")
+
+    def test_invalid_min_snapshots(self):
+        """Verify invalid min_snapshots values are rejected with 400."""
+        self.client.force_authenticate(user=self.manager_user)
+        response = self.client.get(f"{self.metrics_url}?min_snapshots=-2")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error"], "min_snapshots must be a positive integer.")
+

--- a/backend/quotes/tests/test_spot_validation_metrics.py
+++ b/backend/quotes/tests/test_spot_validation_metrics.py
@@ -226,3 +226,20 @@ class SpotTemplateValidationReviewMetricsTests(APITestCase):
         self.assertEqual(response.data["total_reviewed_events"], 1)
         self.assertIn("unexpected_charge_present", response.data["reviewed_by_finding_code"])
         self.assertNotIn("expected_charge_missing", response.data["reviewed_by_finding_code"])
+
+    def test_disabled_flag_returns_503(self):
+        """Verify the endpoint returns HTTP 503 if the operational toggle is disabled."""
+        from django.test import override_settings
+        self.client.force_authenticate(user=self.manager_user)
+        with override_settings(SPOT_VALIDATION_METRICS_ENABLED=False):
+            response = self.client.get(self.metrics_url)
+            self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+            self.assertEqual(response.data, {"detail": "SPOT validation metrics are temporarily disabled."})
+
+    def test_invalid_limit(self):
+        """Verify invalid limit values are rejected with 400."""
+        self.client.force_authenticate(user=self.manager_user)
+        response = self.client.get(f"{self.metrics_url}?limit=-5")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error"], "limit must be a positive integer.")
+

--- a/backend/quotes/tests/test_spot_validation_snapshot_metrics.py
+++ b/backend/quotes/tests/test_spot_validation_snapshot_metrics.py
@@ -341,3 +341,20 @@ class SpotTemplateValidationSnapshotMetricsTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["total_snapshots"], 1)
         self.assertEqual(response.data["unique_envelopes_count"], 1)
+
+    def test_disabled_flag_returns_503(self):
+        """Verify the endpoint returns HTTP 503 if the operational toggle is disabled."""
+        from django.test import override_settings
+        self.client.force_authenticate(user=self.manager_user)
+        with override_settings(SPOT_VALIDATION_METRICS_ENABLED=False):
+            response = self.client.get(self.metrics_url)
+            self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+            self.assertEqual(response.data, {"detail": "SPOT validation metrics are temporarily disabled."})
+
+    def test_invalid_limit(self):
+        """Verify invalid limit values are rejected with 400."""
+        self.client.force_authenticate(user=self.manager_user)
+        response = self.client.get(f"{self.metrics_url}?limit=-5")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error"], "limit must be a positive integer.")
+

--- a/backend/rate_engine/settings.py
+++ b/backend/rate_engine/settings.py
@@ -493,3 +493,6 @@ LOGGING = {
         'level': os.environ.get('LOG_LEVEL', 'INFO'),
     },
 }
+
+SPOT_VALIDATION_METRICS_ENABLED = True
+


### PR DESCRIPTION
Adds shared query parsing and an operational feature flag for SPOT validation metrics endpoints.

Summary:
- Adds shared metrics query parameter parsing for date range, limit, and min_snapshots.
- Adds SPOT_VALIDATION_METRICS_ENABLED default setting.
- Returns HTTP 503 when validation metrics are disabled.
- Applies the helper to review metrics, snapshot metrics, comparison metrics, and maintenance insights endpoints.
- Adds focused tests for disabled-flag behavior and invalid parameter handling.

Non-goals:
- No response shape changes when enabled.
- No endpoint URL changes.
- No RBAC logic changes.
- No validation rule changes.
- No snapshot trigger changes.
- No pricing, ProductCode, quote total, finalisation, or approval-flow changes.