### PR TITLE
feat(frontend): add SPOT validation dashboard

### DIFF
--- a/frontend/e2e/spot-validation.spec.ts
+++ b/frontend/e2e/spot-validation.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect } from "./fixtures";
+
+test.describe("SPOT Validation Dashboard - Access Controls", () => {
+  test("Sales user should be blocked from validation dashboard and sidebar/header", async ({ loginAs, page }) => {
+    await loginAs("sales");
+    
+    // Header More button should either not exist or not contain SPOT Analytics
+    const moreButton = page.getByRole('button', { name: /more/i });
+    const count = await moreButton.count();
+    if (count > 0) {
+      await moreButton.click();
+      const analyticsLink = page.locator('a:has-text("SPOT Analytics")');
+      await expect(analyticsLink).toHaveCount(0);
+    }
+
+    // Direct access should show Access Denied
+    await page.goto("/dashboard/management/spot-validation", { waitUntil: "domcontentloaded" });
+    await expect(page.locator("text=/Access Denied/i")).toBeVisible({ timeout: 10000 });
+  });
+
+  test("Manager user should see sidebar/header link and access validation dashboard", async ({ loginAs, page }) => {
+    // Mock successful API responses to avoid hitting real backend during visual check
+    await page.route("**/api/v3/spot/template-validation/snapshot-metrics/**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          total_snapshots: 45,
+          unique_envelopes_count: 12,
+          validation_status_breakdown: { passed: 20, warnings: 15, review: 10 }
+        })
+      });
+    });
+
+    await page.route("**/api/v3/spot/template-validation/comparison-metrics/**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          summary: {
+            total_envelopes_with_snapshots: 12,
+            total_envelopes_with_reviews: 6,
+            global_review_rate_percentage: 50.0
+          },
+          finding_code_comparison: [
+            { finding_code: "expected_charge_missing", envelopes_with_snapshot_count: 8, envelopes_reviewed_count: 4, review_rate_percentage: 50.0 }
+          ],
+          canonical_type_comparison: [
+            { canonical_type: "AWB", envelopes_with_snapshot_count: 8, envelopes_reviewed_count: 4, review_rate_percentage: 50.0 }
+          ]
+        })
+      });
+    });
+
+    await page.route("**/api/v3/spot/template-validation/maintenance-insights/**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          insights: [
+            {
+              template_id: 1,
+              template_name: "Test Template A",
+              snapshot_count: 5,
+              warnings_count: 3,
+              review_count: 1,
+              issue_ratio_percentage: 60.0,
+              unreviewed_ratio_percentage: 40.0,
+              review_rate_percentage: 60.0,
+              average_findings_per_snapshot: 1.5,
+              maintenance_priority_score: 75.0,
+              high_maintenance_pressure: true,
+              sample_warning: false,
+              finding_codes_breakdown: [],
+              canonical_types_breakdown: []
+            }
+          ]
+        })
+      });
+    });
+
+    await loginAs("manager");
+
+    // Click More button to find SPOT Analytics link
+    await page.getByRole('button', { name: /more/i }).first().click();
+    const analyticsLink = page.locator('a:has-text("SPOT Analytics")').first();
+    await expect(analyticsLink).toBeVisible({ timeout: 10000 });
+    await analyticsLink.click();
+
+    // Verify page title and header
+    await expect(page.locator("h1:has-text('SPOT Validation Intelligence')")).toBeVisible({ timeout: 15000 });
+
+    // Verify statistics cards are populated
+    await expect(page.locator("text=/Total Captured Snapshots/i")).toBeVisible();
+    await expect(page.locator("div.text-indigo-600:has-text('45')").first()).toBeVisible();
+
+    // Verify maintenance Insights table renders data
+    await expect(page.locator("text=Test Template A")).toBeVisible();
+    await expect(page.locator("text=High Pressure")).toBeVisible();
+
+    // Verify comparison table renders data
+    await expect(page.locator("text=expected_charge_missing")).toBeVisible();
+  });
+
+  test("Manager user sees friendly 503 disabled message if backend toggle is disabled", async ({ loginAs, page }) => {
+    // Intercept with 503 Service Unavailable
+    await page.route("**/api/v3/spot/template-validation/**", async (route) => {
+      await route.fulfill({
+        status: 503,
+        contentType: "application/json",
+        body: JSON.stringify({
+          detail: "SPOT validation metrics are temporarily disabled."
+        })
+      });
+    });
+
+    await loginAs("manager");
+
+    await page.goto("/dashboard/management/spot-validation", { waitUntil: "domcontentloaded" });
+
+    // Expect friendly message to be visible
+    await expect(page.locator("text=/Metrics Temporarily Offline/i")).toBeVisible({ timeout: 15000 });
+    await expect(page.locator("text=/SPOT validation metrics are temporarily disabled/i")).toBeVisible();
+  });
+});

--- a/frontend/scripts/spot-validation-api.test.mjs
+++ b/frontend/scripts/spot-validation-api.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import ts from "typescript";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const frontendRoot = path.resolve(process.cwd());
+const helperSourcePath = path.join(frontendRoot, "src", "lib", "api", "spot-validation.ts");
+
+function transpile(source, fileName) {
+  return ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName,
+  }).outputText;
+}
+
+// Read and inspect query builder function inside spot-validation.ts
+const source = await readFile(helperSourcePath, "utf8");
+const transpiled = transpile(source, helperSourcePath);
+
+// Test query string building logic statically or through transpiled mock
+// Since fetch is not available globally in node, we mock fetch and test the calls
+globalThis.API_BASE_URL = "http://localhost:8000";
+
+let lastFetchUrl = null;
+let lastFetchOptions = null;
+
+globalThis.fetch = async (url, options) => {
+  lastFetchUrl = url;
+  lastFetchOptions = options;
+  return {
+    ok: true,
+    json: async () => ({})
+  };
+};
+
+// Mock localstorage/authToken resolver
+globalThis.localStorage = {
+  getItem: (key) => "test-token"
+};
+
+// We dynamic import the spot-validation module
+const tempHelperModule = ts.transpileModule(source, {
+  compilerOptions: {
+    module: ts.ModuleKind.CommonJS,
+    target: ts.ScriptTarget.ES2020,
+  }
+}).outputText;
+
+// Simple execution environment
+const moduleObj = { exports: {} };
+const executeFn = new Function("exports", "require", tempHelperModule);
+executeFn(moduleObj.exports, (mod) => {
+  if (mod === "./shared") {
+    return {
+      API_BASE_URL: "http://localhost:8000",
+      getJson: async (url) => {
+        lastFetchUrl = url;
+        return {};
+      }
+    };
+  }
+  return {};
+});
+
+const { getSpotSnapshotMetrics, getSpotComparisonMetrics, getSpotMaintenanceInsights } = moduleObj.exports;
+
+// Test 1: Mappings with empty filters
+{
+  lastFetchUrl = null;
+  await getSpotSnapshotMetrics({});
+  assert.equal(lastFetchUrl, "http://localhost:8000/api/v3/spot/template-validation/snapshot-metrics/");
+}
+
+// Test 2: Date filters mapping
+{
+  lastFetchUrl = null;
+  await getSpotSnapshotMetrics({ start_date: "2026-06-01", end_date: "2026-06-10" });
+  assert.match(lastFetchUrl, /start_date=2026-06-01/);
+  assert.match(lastFetchUrl, /end_date=2026-06-10/);
+}
+
+// Test 3: Limit and min snapshots mapping
+{
+  lastFetchUrl = null;
+  await getSpotMaintenanceInsights({ limit: 20, min_snapshots: 10 });
+  assert.match(lastFetchUrl, /limit=20/);
+  assert.match(lastFetchUrl, /min_snapshots=10/);
+}
+
+console.log("Spot validation API client unit tests passed successfully.");

--- a/frontend/src/app/dashboard/management/spot-validation/page.tsx
+++ b/frontend/src/app/dashboard/management/spot-validation/page.tsx
@@ -1,0 +1,530 @@
+"use client";
+
+import { useState, useEffect, useMemo } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/context/auth-context";
+import { usePermissions } from "@/hooks/usePermissions";
+import {
+  getSpotSnapshotMetrics,
+  getSpotComparisonMetrics,
+  getSpotMaintenanceInsights,
+  SpotSnapshotMetricsSummary,
+  SpotComparisonMetricsData,
+  SpotMaintenanceInsightsData
+} from "@/lib/api";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Loader2,
+  ArrowLeft,
+  RefreshCw,
+  AlertTriangle,
+  AlertCircle,
+  CheckCircle,
+  BarChart3,
+  AlertOctagon,
+  FileCheck
+} from "lucide-react";
+
+export default function SpotValidationDashboardPage() {
+  const { user } = useAuth();
+  const { isManager, isAdmin } = usePermissions();
+  const router = useRouter();
+
+  // Filters
+  const [timeframe, setTimeframe] = useState<"7" | "30" | "90">("30");
+  const [limit, setLimit] = useState<number>(10);
+  const [minSnapshots, setMinSnapshots] = useState<number>(5);
+
+  // Data
+  const [snapshotMetrics, setSnapshotMetrics] = useState<SpotSnapshotMetricsSummary | null>(null);
+  const [comparisonMetrics, setComparisonMetrics] = useState<SpotComparisonMetricsData | null>(null);
+  const [maintenanceInsights, setMaintenanceInsights] = useState<SpotMaintenanceInsightsData | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const hasAccess = isManager || isAdmin;
+
+  // Derive date range from timeframe
+  const queryFilters = useMemo(() => {
+    const end = new Date();
+    const start = new Date();
+    start.setDate(end.getDate() - parseInt(timeframe));
+    return {
+      start_date: start.toISOString().split("T")[0],
+      end_date: end.toISOString().split("T")[0],
+      limit,
+      min_snapshots: minSnapshots
+    };
+  }, [timeframe, limit, minSnapshots]);
+
+  const fetchData = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [snapshots, comparisons, insights] = await Promise.all([
+        getSpotSnapshotMetrics(queryFilters),
+        getSpotComparisonMetrics(queryFilters),
+        getSpotMaintenanceInsights(queryFilters)
+      ]);
+      setSnapshotMetrics(snapshots);
+      setComparisonMetrics(comparisons);
+      setMaintenanceInsights(insights);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Failed to load validation metrics.";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!user || !hasAccess) return;
+    fetchData();
+  }, [user, hasAccess, queryFilters]);
+
+  // Auth block
+  if (!user) return null;
+
+  if (!hasAccess) {
+    return (
+      <div className="container mx-auto p-8 max-w-xl text-center space-y-6">
+        <div className="flex flex-col items-center justify-center space-y-4">
+          <AlertOctagon className="h-16 w-16 text-destructive animate-bounce" />
+          <h2 className="text-2xl font-bold tracking-tight text-foreground">Access Denied</h2>
+          <p className="text-muted-foreground text-sm">
+            Only managers and admins can view SPOT template validation metrics.
+          </p>
+        </div>
+        <Button onClick={() => router.push("/dashboard")} className="mt-4 shadow-sm hover:scale-[1.02] active:scale-[0.98] transition">
+          Back to Dashboard
+        </Button>
+      </div>
+    );
+  }
+
+  // Service Unavailable (503) state
+  const isServiceDisabled = error === "SPOT validation metrics are temporarily disabled.";
+
+  if (isServiceDisabled) {
+    return (
+      <div className="container mx-auto p-8 max-w-lg text-center space-y-6">
+        <div className="flex flex-col items-center justify-center p-8 bg-card border rounded-2xl shadow-xl space-y-4">
+          <AlertTriangle className="h-16 w-16 text-amber-500 animate-pulse" />
+          <h2 className="text-2xl font-bold tracking-tight text-foreground">Metrics Temporarily Offline</h2>
+          <p className="text-muted-foreground text-sm">
+            SPOT validation metrics are temporarily disabled.
+          </p>
+          <Button variant="outline" size="sm" onClick={fetchData} className="mt-4 gap-2">
+            <RefreshCw className="h-4 w-4" /> Try Reconnecting
+          </Button>
+        </div>
+        <Button variant="ghost" onClick={() => router.push("/dashboard")}>
+          Back to Dashboard
+        </Button>
+      </div>
+    );
+  }
+
+  // General error layout
+  if (error) {
+    return (
+      <div className="container mx-auto p-8 max-w-2xl space-y-6">
+        <Alert variant="destructive" className="border-destructive/30 bg-destructive/10">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Error Loading Dashboard</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+        <div className="flex items-center gap-4">
+          <Button variant="outline" onClick={fetchData} className="gap-2">
+            <RefreshCw className="h-4 w-4" /> Retry
+          </Button>
+          <Button variant="ghost" onClick={() => router.push("/dashboard")}>
+            Back to Dashboard
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // Summary Metrics calculations
+  const totalSnapshots = snapshotMetrics?.total_snapshots ?? 0;
+  
+  const statusBreakdown = snapshotMetrics?.validation_status_breakdown || { passed: 0, warnings: 0, review: 0 };
+  const issuesCount = statusBreakdown.warnings + statusBreakdown.review;
+  const issuesPercentage = totalSnapshots > 0 ? Math.round((issuesCount / totalSnapshots) * 100) : 0;
+  
+  const globalReviewRate = comparisonMetrics?.summary?.global_review_rate_percentage ?? 0;
+  
+  const templatesRequiringAttention = maintenanceInsights?.insights?.filter(i => i.high_maintenance_pressure).length ?? 0;
+
+  return (
+    <div className="container mx-auto p-4 max-w-7xl space-y-6">
+      {/* Header */}
+      <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight bg-gradient-to-r from-violet-600 to-indigo-600 bg-clip-text text-transparent">
+            SPOT Validation Intelligence
+          </h1>
+          <p className="text-muted-foreground text-sm">
+            Template health audits, validation quality review ratios, and snapshot insights.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={fetchData} disabled={loading} className="gap-2">
+            {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+            Reload
+          </Button>
+          <Button variant="ghost" size="sm" onClick={() => router.push("/dashboard")} className="gap-2">
+            <ArrowLeft className="h-4 w-4" />
+            Back
+          </Button>
+        </div>
+      </div>
+
+      {/* Filters Card */}
+      <div className="p-4 bg-card/60 backdrop-blur-md rounded-xl border shadow-sm flex flex-wrap items-center gap-6">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-muted-foreground">Date Horizon:</span>
+          <Select value={timeframe} onValueChange={(v) => setTimeframe(v as "7" | "30" | "90")}>
+            <SelectTrigger className="w-[140px] bg-background">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="7">Last 7 Days</SelectItem>
+              <SelectItem value="30">Last 30 Days</SelectItem>
+              <SelectItem value="90">Last 90 Days</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-muted-foreground">Min Snapshots:</span>
+          <Select value={String(minSnapshots)} onValueChange={(v) => setMinSnapshots(parseInt(v))}>
+            <SelectTrigger className="w-[120px] bg-background">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="1">1 snapshot</SelectItem>
+              <SelectItem value="3">3 snapshots</SelectItem>
+              <SelectItem value="5">5 snapshots</SelectItem>
+              <SelectItem value="10">10 snapshots</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-muted-foreground">View Limit:</span>
+          <Select value={String(limit)} onValueChange={(v) => setLimit(parseInt(v))}>
+            <SelectTrigger className="w-[120px] bg-background">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="10">Top 10</SelectItem>
+              <SelectItem value="20">Top 20</SelectItem>
+              <SelectItem value="50">Top 50</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 animate-pulse">
+          {[1, 2, 3, 4].map(i => (
+            <Card key={i} className="bg-card">
+              <CardHeader className="h-24 bg-muted/30 rounded-t-xl" />
+              <CardContent className="h-16 bg-muted/10 rounded-b-xl" />
+            </Card>
+          ))}
+        </div>
+      ) : (
+        <>
+          {/* Summary Stat Cards */}
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+            <Card className="shadow-sm border border-border/80">
+              <CardHeader className="pb-2">
+                <CardDescription className="font-semibold text-xs uppercase tracking-wider text-muted-foreground">
+                  Total Captured Snapshots
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="text-3xl font-extrabold text-indigo-600">{totalSnapshots}</div>
+                <p className="text-[11px] text-muted-foreground mt-1">
+                  Generated across active user-facing transactions.
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card className="shadow-sm border border-border/80">
+              <CardHeader className="pb-2">
+                <CardDescription className="font-semibold text-xs uppercase tracking-wider text-muted-foreground">
+                  Failure/Warning Rate
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="text-3xl font-extrabold text-rose-500">{issuesPercentage}%</div>
+                <div className="w-full bg-muted h-1.5 rounded-full mt-2 overflow-hidden">
+                  <div
+                    className="bg-rose-500 h-1.5 rounded-full transition-all duration-500"
+                    style={{ width: `${issuesPercentage}%` }}
+                  />
+                </div>
+                <p className="text-[11px] text-muted-foreground mt-2">
+                  Snapshots requiring review or raising warnings.
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card className="shadow-sm border border-border/80">
+              <CardHeader className="pb-2">
+                <CardDescription className="font-semibold text-xs uppercase tracking-wider text-muted-foreground">
+                  Global Review Rate
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="text-3xl font-extrabold text-emerald-500">{Math.round(globalReviewRate)}%</div>
+                <div className="w-full bg-muted h-1.5 rounded-full mt-2 overflow-hidden">
+                  <div
+                    className="bg-emerald-500 h-1.5 rounded-full transition-all duration-500"
+                    style={{ width: `${globalReviewRate}%` }}
+                  />
+                </div>
+                <p className="text-[11px] text-muted-foreground mt-2">
+                  Ratio of generated discrepancies resolved.
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card className="shadow-sm border border-border/80">
+              <CardHeader className="pb-2">
+                <CardDescription className="font-semibold text-xs uppercase tracking-wider text-muted-foreground">
+                  Hotspot Templates
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="text-3xl font-extrabold text-amber-500">{templatesRequiringAttention}</div>
+                <p className="text-[11px] text-muted-foreground mt-1">
+                  Expected charge templates displaying high maintenance pressure.
+                </p>
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Maintenance Insights Grid */}
+          <Card className="shadow-sm">
+            <CardHeader className="border-b bg-muted/10">
+              <CardTitle className="text-lg font-bold flex items-center gap-2">
+                <AlertTriangle className="h-5 w-5 text-amber-500" />
+                Template Maintenance Insights
+              </CardTitle>
+              <CardDescription>
+                Identifies which Expected Charge Templates repeatedly trigger validation failures, warnings, or review prompts.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="p-0">
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader className="bg-muted/30">
+                    <TableRow>
+                      <TableHead className="font-semibold">Template</TableHead>
+                      <TableHead className="font-semibold text-center">Snapshots</TableHead>
+                      <TableHead className="font-semibold text-center">Issue Ratio</TableHead>
+                      <TableHead className="font-semibold text-center">Avg Findings</TableHead>
+                      <TableHead className="font-semibold text-center">Review Rate</TableHead>
+                      <TableHead className="font-semibold text-center">Priority Score</TableHead>
+                      <TableHead className="font-semibold text-right pr-4">Health</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {maintenanceInsights?.insights && maintenanceInsights.insights.length > 0 ? (
+                      maintenanceInsights.insights.map((item) => (
+                        <TableRow key={item.template_id} className="hover:bg-muted/10 transition-colors">
+                          <TableCell className="font-medium">
+                            <div>
+                              <span className="text-sm font-semibold">{item.template_name}</span>
+                              <div className="text-[10px] text-muted-foreground">ID: {item.template_id}</div>
+                            </div>
+                          </TableCell>
+                          <TableCell className="text-center font-medium">{item.snapshot_count}</TableCell>
+                          <TableCell className="text-center">
+                            <span className={`font-semibold ${item.issue_ratio_percentage > 50 ? "text-rose-500" : "text-amber-500"}`}>
+                              {Math.round(item.issue_ratio_percentage)}%
+                            </span>
+                          </TableCell>
+                          <TableCell className="text-center font-medium">
+                            {item.average_findings_per_snapshot.toFixed(1)}
+                          </TableCell>
+                          <TableCell className="text-center">
+                            <span className="font-semibold text-emerald-600">
+                              {Math.round(item.review_rate_percentage)}%
+                            </span>
+                          </TableCell>
+                          <TableCell className="text-center">
+                            <div className="inline-flex items-center justify-center px-2 py-1 bg-indigo-50 border border-indigo-100 rounded text-indigo-700 font-extrabold text-xs">
+                              {Math.round(item.maintenance_priority_score)}
+                            </div>
+                          </TableCell>
+                          <TableCell className="text-right pr-4">
+                            {item.high_maintenance_pressure ? (
+                              <Badge variant="destructive" className="bg-rose-500 animate-pulse">
+                                High Pressure
+                              </Badge>
+                            ) : (
+                              <Badge variant="secondary" className="bg-emerald-50 text-emerald-700 border-emerald-200">
+                                Stable
+                              </Badge>
+                            )}
+                          </TableCell>
+                        </TableRow>
+                      ))
+                    ) : (
+                      <TableRow>
+                        <TableCell colSpan={7} className="text-center p-8 text-muted-foreground">
+                          No template insights matches the selected filters.
+                        </TableCell>
+                      </TableRow>
+                    )}
+                  </TableBody>
+                </Table>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Comparison breakdown */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            {/* Finding Code Comparison */}
+            <Card className="shadow-sm">
+              <CardHeader className="border-b bg-muted/10">
+                <CardTitle className="text-sm font-bold flex items-center gap-2">
+                  <BarChart3 className="h-4 w-4 text-violet-500" />
+                  Discrepancy Breakdown by Code
+                </CardTitle>
+                <CardDescription>
+                  Ratios of manual reviews to captured discrepancies grouping by finding type.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="p-0">
+                <div className="overflow-x-auto">
+                  <Table>
+                    <TableHeader className="bg-muted/30">
+                      <TableRow>
+                        <TableHead className="font-semibold text-xs">Finding Code</TableHead>
+                        <TableHead className="font-semibold text-xs text-center">Envelopes Affected</TableHead>
+                        <TableHead className="font-semibold text-xs text-center">Envelopes Reviewed</TableHead>
+                        <TableHead className="font-semibold text-xs text-right pr-4">Review Rate</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {comparisonMetrics?.finding_code_comparison && comparisonMetrics.finding_code_comparison.length > 0 ? (
+                        comparisonMetrics.finding_code_comparison.map((item) => (
+                          <TableRow key={item.finding_code} className="hover:bg-muted/10 transition-colors">
+                            <TableCell className="font-medium text-xs">
+                              <code className="px-1.5 py-0.5 bg-muted rounded font-mono text-foreground">
+                                {item.finding_code}
+                              </code>
+                            </TableCell>
+                            <TableCell className="text-center font-medium text-xs">
+                              {item.envelopes_with_snapshot_count}
+                            </TableCell>
+                            <TableCell className="text-center font-medium text-xs">
+                              {item.envelopes_reviewed_count}
+                            </TableCell>
+                            <TableCell className="text-right pr-4 text-xs font-bold text-emerald-600">
+                              {Math.round(item.review_rate_percentage)}%
+                            </TableCell>
+                          </TableRow>
+                        ))
+                      ) : (
+                        <TableRow>
+                          <TableCell colSpan={4} className="text-center p-6 text-muted-foreground text-xs">
+                            No finding codes recorded.
+                          </TableCell>
+                        </TableRow>
+                      )}
+                    </TableBody>
+                  </Table>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Canonical Type Comparison */}
+            <Card className="shadow-sm">
+              <CardHeader className="border-b bg-muted/10">
+                <CardTitle className="text-sm font-bold flex items-center gap-2">
+                  <FileCheck className="h-4 w-4 text-indigo-500" />
+                  Discrepancy Breakdown by Canonical Type
+                </CardTitle>
+                <CardDescription>
+                  Ratios of manual reviews to captured discrepancies grouping by business charges category.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="p-0">
+                <div className="overflow-x-auto">
+                  <Table>
+                    <TableHeader className="bg-muted/30">
+                      <TableRow>
+                        <TableHead className="font-semibold text-xs">Canonical Category</TableHead>
+                        <TableHead className="font-semibold text-xs text-center">Envelopes Affected</TableHead>
+                        <TableHead className="font-semibold text-xs text-center">Envelopes Reviewed</TableHead>
+                        <TableHead className="font-semibold text-xs text-right pr-4">Review Rate</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {comparisonMetrics?.canonical_type_comparison && comparisonMetrics.canonical_type_comparison.length > 0 ? (
+                        comparisonMetrics.canonical_type_comparison.map((item) => (
+                          <TableRow key={item.canonical_type} className="hover:bg-muted/10 transition-colors">
+                            <TableCell className="font-medium text-xs">
+                              <span className="font-medium text-foreground">{item.canonical_type}</span>
+                            </TableCell>
+                            <TableCell className="text-center font-medium text-xs">
+                              {item.envelopes_with_snapshot_count}
+                            </TableCell>
+                            <TableCell className="text-center font-medium text-xs">
+                              {item.envelopes_reviewed_count}
+                            </TableCell>
+                            <TableCell className="text-right pr-4 text-xs font-bold text-emerald-600">
+                              {Math.round(item.review_rate_percentage)}%
+                            </TableCell>
+                          </TableRow>
+                        ))
+                      ) : (
+                        <TableRow>
+                          <TableCell colSpan={4} className="text-center p-6 text-muted-foreground text-xs">
+                            No canonical types recorded.
+                          </TableCell>
+                        </TableRow>
+                      )}
+                    </TableBody>
+                  </Table>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/app-header.tsx
+++ b/frontend/src/components/app-header.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import { Home, FileText, Users, Database, Plus, Settings, LogOut, User, ChevronDown, Menu, Building2, Settings2 } from 'lucide-react';
+import { Home, FileText, Users, Database, Plus, Settings, LogOut, User, ChevronDown, Menu, Building2, Settings2, BarChart3 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { useAuth } from '@/context/auth-context';
 import { usePermissions } from '@/hooks/usePermissions';
@@ -78,6 +78,11 @@ export default function AppHeader() {
   // User Management (Manager/Admin only)
   if (isManager || isAdmin) {
     moreItems.push({ href: '/settings/users', label: 'Users', icon: Users });
+  }
+
+  // SPOT Analytics (Manager/Admin only)
+  if (isManager || isAdmin) {
+    moreItems.push({ href: '/dashboard/management/spot-validation', label: 'SPOT Analytics', icon: BarChart3 });
   }
 
   // Role badge styling

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -16,6 +16,7 @@ import {
     Plane,
     ChevronLeft,
     PackageCheck,
+    BarChart3,
 } from 'lucide-react';
 import { useState } from 'react';
 
@@ -65,6 +66,13 @@ export function AppSidebar() {
             color: 'text-slate-600',
             role: ['sales', 'manager', 'admin'],
             badge: 'CRM'
+        },
+        {
+            label: 'SPOT Analytics',
+            icon: BarChart3,
+            href: '/dashboard/management/spot-validation',
+            color: 'text-indigo-600',
+            role: ['manager', 'admin']
         },
         {
             label: 'Settings',

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1885,3 +1885,6 @@ export async function reviewSpotFinding(
   return response.json();
 }
 
+export * from './api/spot-validation';
+
+

--- a/frontend/src/lib/api/spot-validation.ts
+++ b/frontend/src/lib/api/spot-validation.ts
@@ -1,0 +1,91 @@
+import { API_BASE_URL, getJson } from "./shared";
+
+export interface SpotValidationFilters {
+  start_date?: string;
+  end_date?: string;
+  limit?: number;
+  min_snapshots?: number;
+}
+
+export interface SpotSnapshotMetricsSummary {
+  total_snapshots: number;
+  unique_envelopes_count: number;
+  validation_status_breakdown: {
+    passed: number;
+    warnings: number;
+    review: number;
+  };
+}
+
+export interface FindingCodeComparisonItem {
+  finding_code: string;
+  envelopes_with_snapshot_count: number;
+  envelopes_reviewed_count: number;
+  review_rate_percentage: number;
+}
+
+export interface CanonicalTypeComparisonItem {
+  canonical_type: string;
+  envelopes_with_snapshot_count: number;
+  envelopes_reviewed_count: number;
+  review_rate_percentage: number;
+}
+
+export interface SpotComparisonMetricsData {
+  summary: {
+    total_envelopes_with_snapshots: number;
+    total_envelopes_with_reviews: number;
+    global_review_rate_percentage: number;
+  };
+  finding_code_comparison: FindingCodeComparisonItem[];
+  canonical_type_comparison: CanonicalTypeComparisonItem[];
+}
+
+export interface SpotMaintenanceInsightItem {
+  template_id: number;
+  template_name: string;
+  snapshot_count: number;
+  warnings_count: number;
+  review_count: number;
+  issue_ratio_percentage: number;
+  unreviewed_ratio_percentage: number;
+  review_rate_percentage: number;
+  average_findings_per_snapshot: number;
+  maintenance_priority_score: number;
+  high_maintenance_pressure: boolean;
+  sample_warning: boolean;
+  finding_codes_breakdown: Array<{ code: string; count: number }>;
+  canonical_types_breakdown: Array<{ type: string; count: number }>;
+}
+
+export interface SpotMaintenanceInsightsData {
+  insights: SpotMaintenanceInsightItem[];
+}
+
+function buildSpotQueryParams(filters: SpotValidationFilters): string {
+  const params = new URLSearchParams();
+  if (filters.start_date) params.append("start_date", filters.start_date);
+  if (filters.end_date) params.append("end_date", filters.end_date);
+  if (filters.limit !== undefined) params.append("limit", String(filters.limit));
+  if (filters.min_snapshots !== undefined) params.append("min_snapshots", String(filters.min_snapshots));
+  const query = params.toString();
+  return query ? `?${query}` : "";
+}
+
+export async function getSpotSnapshotMetrics(filters: SpotValidationFilters = {}): Promise<SpotSnapshotMetricsSummary> {
+  const query = buildSpotQueryParams(filters);
+  const url = `${API_BASE_URL}/api/v3/spot/template-validation/snapshot-metrics/${query}`;
+  return getJson<SpotSnapshotMetricsSummary>(url);
+}
+
+export async function getSpotComparisonMetrics(filters: SpotValidationFilters = {}): Promise<SpotComparisonMetricsData> {
+  const query = buildSpotQueryParams(filters);
+  const url = `${API_BASE_URL}/api/v3/spot/template-validation/comparison-metrics/${query}`;
+  return getJson<SpotComparisonMetricsData>(url);
+}
+
+export async function getSpotMaintenanceInsights(filters: SpotValidationFilters = {}): Promise<SpotMaintenanceInsightsData> {
+  const query = buildSpotQueryParams(filters);
+  const url = `${API_BASE_URL}/api/v3/spot/template-validation/maintenance-insights/${query}`;
+  return getJson<SpotMaintenanceInsightsData>(url);
+}


### PR DESCRIPTION
## Summary

Adds the first manager/admin frontend dashboard for SPOT Validation Intelligence.

Includes:
- New typed SPOT validation API client
- Dashboard route at `/dashboard/management/spot-validation`
- Summary cards, maintenance insights table, and generated-vs-reviewed comparison views
- Friendly 503 disabled-state handling for the backend metrics kill switch
- Manager/admin navigation links in header/sidebar
- Frontend API unit test and Playwright coverage

## Non-goals

- No backend endpoint changes
- No backend response shape changes
- No pricing/ProductCode/totals/finalisation changes
- No template mutation or auto-fix workflow
- No buy-cost or margin exposure

## Verification

- `npm run typecheck`
- `node scripts/spot-validation-api.test.mjs`
- `npx playwright test e2e/spot-validation.spec.ts`
- `graphify update .`