### PR TITLE
feat(pricing_v4): implement ProductCode request creation API

### DIFF
--- a/backend/pricing_v4/serializers.py
+++ b/backend/pricing_v4/serializers.py
@@ -619,5 +619,17 @@ class ProductCodeCreationRequestSerializer(serializers.ModelSerializer):
             'created_at',
             'updated_at',
         ]
-        read_only_fields = fields
+        read_only_fields = [
+            'id',
+            'status',
+            'created_by',
+            'approved_by',
+            'approved_at',
+            'rejected_at',
+            'rejection_reason',
+            'created_at',
+            'updated_at',
+        ]
+
+
 

--- a/backend/pricing_v4/tests/test_product_code_creation_request_api.py
+++ b/backend/pricing_v4/tests/test_product_code_creation_request_api.py
@@ -99,24 +99,138 @@ class ProductCodeCreationRequestTests(APITestCase):
         response = self.client.get(f"/api/v4/product-code-requests/{self.request_1.id}/")
         self.assertEqual(response.status_code, 401)
 
-    def test_no_write_actions_allowed(self):
-        self.client.force_authenticate(user=self.admin_user)
-        
-        # Create not allowed
+    def test_role_creation_permissions(self):
+        # 1. Sales can create request
+        self.client.force_authenticate(user=self.sales_user)
         response = self.client.post(
             "/api/v4/product-code-requests/",
             {
-                "source_label": "New Inbound Fee",
-                "suggested_name": "Inbound Fee",
+                "source_label": "Origin Fee",
+                "suggested_name": "Origin Handling",
+                "suggested_bucket": "HANDLING",
+                "suggested_basis": "SHIPMENT",
+                "suggested_reason": "Sales required",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.data["created_by"], self.sales_user.id)
+        self.assertEqual(response.data["status"], "PENDING")
+
+        # 2. Manager can create request
+        self.client.force_authenticate(user=self.manager_user)
+        response = self.client.post(
+            "/api/v4/product-code-requests/",
+            {
+                "source_label": "Destination Fee",
+                "suggested_name": "Destination Handling",
+                "suggested_bucket": "HANDLING",
+                "suggested_basis": "SHIPMENT",
+                "suggested_reason": "Manager required",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.data["created_by"], self.manager_user.id)
+
+        # 3. Admin can create request
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.post(
+            "/api/v4/product-code-requests/",
+            {
+                "source_label": "Admin Fee",
+                "suggested_name": "Admin Handling",
+                "suggested_bucket": "HANDLING",
+                "suggested_basis": "SHIPMENT",
+                "suggested_reason": "Admin required",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.data["created_by"], self.admin_user.id)
+
+    def test_unauthenticated_create_blocked(self):
+        self.client.force_authenticate(user=None)
+        response = self.client.post(
+            "/api/v4/product-code-requests/",
+            {
+                "source_label": "Unauth Fee",
+                "suggested_name": "Unauth Handling",
                 "suggested_bucket": "HANDLING",
                 "suggested_basis": "SHIPMENT",
             },
             format="json",
         )
-        self.assertEqual(response.status_code, 405)  # Method Not Allowed
+        self.assertEqual(response.status_code, 401)
+
+    def test_client_cannot_override_status_or_created_by(self):
+        self.client.force_authenticate(user=self.sales_user)
+        response = self.client.post(
+            "/api/v4/product-code-requests/",
+            {
+                "source_label": "Fake Fee",
+                "suggested_name": "Fake Handling",
+                "suggested_bucket": "HANDLING",
+                "suggested_basis": "SHIPMENT",
+                "status": "APPROVED",
+                "created_by": self.admin_user.id,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.data["status"], "PENDING")
+        self.assertEqual(response.data["created_by"], self.sales_user.id)
+
+    def test_duplicate_pending_request_handling(self):
+        self.client.force_authenticate(user=self.sales_user)
+        
+        # First creation
+        response1 = self.client.post(
+            "/api/v4/product-code-requests/",
+            {
+                "source_label": "   Duplicate Fee   ",
+                "suggested_name": "Duplicate Handling",
+                "suggested_bucket": "HANDLING",
+                "suggested_basis": "SHIPMENT",
+            },
+            format="json",
+        )
+        self.assertEqual(response1.status_code, 201)
+        initial_id = response1.data["id"]
+
+        # Duplicate creation with trailing space and different casing
+        response2 = self.client.post(
+            "/api/v4/product-code-requests/",
+            {
+                "source_label": "duplicate fee",
+                "suggested_name": "   duplicate handling   ",
+                "suggested_bucket": "HANDLING",
+                "suggested_basis": "SHIPMENT",
+            },
+            format="json",
+        )
+        self.assertEqual(response2.status_code, 200)
+        self.assertEqual(response2.data["id"], initial_id)
+        self.assertTrue(response2.data.get("duplicate_reused"))
+
+        # Verify no new row was actually created
+        self.assertEqual(
+            ProductCodeCreationRequest.objects.filter(suggested_name__icontains="duplicate").count(),
+            1
+        )
+
+    def test_no_put_patch_delete_actions_allowed(self):
+        self.client.force_authenticate(user=self.admin_user)
         
         # Update not allowed
         response = self.client.put(
+            f"/api/v4/product-code-requests/{self.request_1.id}/",
+            {"status": "APPROVED"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 405)
+        
+        response = self.client.patch(
             f"/api/v4/product-code-requests/{self.request_1.id}/",
             {"status": "APPROVED"},
             format="json",

--- a/backend/pricing_v4/views.py
+++ b/backend/pricing_v4/views.py
@@ -1138,13 +1138,68 @@ class LogicalRateCardsView(APIView):
         return {}
 
 
-class ProductCodeCreationRequestViewSet(viewsets.ReadOnlyModelViewSet):
+class IsSalesManagerOrAdmin(permissions.BasePermission):
     """
-    Admin-only endpoint for listing and retrieving ProductCodeCreationRequests.
+    Allows access only to Sales, Manager, or Admin users.
+    """
+    message = "Only Sales, Manager, or Admin users can perform this action."
+    
+    def has_permission(self, request, view):
+        return (
+            request.user.is_authenticated and
+            request.user.role in ['sales', 'manager', 'admin']
+        )
+
+
+from rest_framework import mixins
+
+class ProductCodeCreationRequestViewSet(
+    mixins.CreateModelMixin,
+    mixins.RetrieveModelMixin,
+    mixins.ListModelMixin,
+    viewsets.GenericViewSet
+):
+    """
+    Endpoint for listing, retrieving, and creating ProductCodeCreationRequests.
+    - list/retrieve: Admin only
+    - create: Sales, Manager, Admin
     """
     queryset = ProductCodeCreationRequest.objects.all().order_by('-created_at')
     serializer_class = ProductCodeCreationRequestSerializer
-    permission_classes = [permissions.IsAuthenticated, IsAdmin]
+
+    def get_permissions(self):
+        if self.action == 'create':
+            return [permissions.IsAuthenticated(), IsSalesManagerOrAdmin()]
+        return [permissions.IsAuthenticated(), IsAdmin()]
+
+    def perform_create(self, serializer):
+        serializer.save(created_by=self.request.user)
+
+    def create(self, request, *args, **kwargs):
+        source_label = request.data.get('source_label', '')
+        suggested_name = request.data.get('suggested_name', '')
+        
+        norm_source = str(source_label).strip().lower()
+        norm_suggested = str(suggested_name).strip().lower()
+        
+        existing_requests = ProductCodeCreationRequest.objects.filter(
+            status=ProductCodeCreationRequest.STATUS_PENDING
+        )
+        matched = None
+        for req in existing_requests:
+            if (req.source_label.strip().lower() == norm_source and
+                req.suggested_name.strip().lower() == norm_suggested):
+                matched = req
+                break
+        
+        if matched:
+            serializer = self.get_serializer(matched)
+            data = dict(serializer.data)
+            data['duplicate_reused'] = True
+            return Response(data, status=status.HTTP_200_OK)
+            
+        return super().create(request, *args, **kwargs)
+
 
 
 


### PR DESCRIPTION
Adds the creation workflow for ProductCodeCreationRequest.

Summary:
- Allows sales, manager, and admin users to create ProductCode creation requests.
- Keeps request queue list/retrieve admin-only.
- Automatically assigns created_by from request.user.
- Prevents client override of governance fields such as status and approver fields.
- Adds duplicate protection for pending requests using normalized source_label and suggested_name.
- Returns existing pending request when a duplicate submission is detected.
- Expands test coverage for permissions, duplicate handling, and field protection.

Verification:
- python manage.py test pricing_v4.tests.test_product_code_creation_request_api

Non-goals:
- No ProductCode approval workflow.
- No ProductCode auto-creation.
- No AI suggestions.
- No frontend changes.
- No SPOT drawer integration yet.