### PR TITLE
feat(spot): request ProductCode from unmapped charge review

### DIFF
--- a/frontend/src/components/spot/SpotChargeLineManualReviewSheet.tsx
+++ b/frontend/src/components/spot/SpotChargeLineManualReviewSheet.tsx
@@ -14,8 +14,11 @@ import {
     SheetTitle,
 } from "@/components/ui/sheet";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
 import type { SPEChargeLine } from "@/lib/spot-types";
-import { getProductCodes, type ProductCodeOption } from "@/lib/api";
+import { getProductCodes, type ProductCodeOption, createProductCodeRequest } from "@/lib/api";
 import { getSpotChargeDisplayLabel } from "@/lib/spot-charge-display";
 import { humanizeEnum } from "@/lib/spot-workspace-helpers";
 
@@ -52,12 +55,53 @@ export function SpotChargeLineManualReviewSheet({
     const [loadError, setLoadError] = useState<string | null>(null);
     const [selectedProductCodeId, setSelectedProductCodeId] = useState<string>("");
 
+    // Request new ProductCode state
+    const [showRequestForm, setShowRequestForm] = useState(false);
+    const [requestSourceLabel, setRequestSourceLabel] = useState("");
+    const [requestSuggestedName, setRequestSuggestedName] = useState("");
+    const [requestSuggestedBucket, setRequestSuggestedBucket] = useState("HANDLING");
+    const [requestSuggestedBasis, setRequestSuggestedBasis] = useState("SHIPMENT");
+    const [requestSuggestedReason, setRequestSuggestedReason] = useState("");
+    const [isSubmittingRequest, setIsSubmittingRequest] = useState(false);
+    const [requestSuccessMessage, setRequestSuccessMessage] = useState<string | null>(null);
+    const [requestErrorMessage, setRequestErrorMessage] = useState<string | null>(null);
+
     useEffect(() => {
-        if (!open || !chargeLine) return;
+        if (!open || !chargeLine) {
+            setSelectedProductCodeId("");
+            setShowRequestForm(false);
+            setRequestSuccessMessage(null);
+            setRequestErrorMessage(null);
+            return;
+        }
 
         const currentManualId = chargeLine.manual_resolved_product_code?.id;
         setSelectedProductCodeId(currentManualId ? String(currentManualId) : "");
+
+        const sourceLabelText = chargeLine.normalized_label || chargeLine.description || "";
+        setRequestSourceLabel(sourceLabelText);
+        setRequestSuggestedName(chargeLine.description || "");
+        
+        if (chargeLine.bucket === "airfreight") {
+            setRequestSuggestedBucket("FREIGHT");
+        } else {
+            setRequestSuggestedBucket("HANDLING");
+        }
+
+        if (chargeLine.unit === "per_kg") {
+            setRequestSuggestedBasis("KG");
+        } else if (chargeLine.unit === "percentage") {
+            setRequestSuggestedBasis("PERCENT");
+        } else {
+            setRequestSuggestedBasis("SHIPMENT");
+        }
+
+        setRequestSuggestedReason("Requested from SPOT review UI");
+        setRequestSuccessMessage(null);
+        setRequestErrorMessage(null);
+        setShowRequestForm(false);
     }, [chargeLine, open]);
+
 
     useEffect(() => {
         if (!open) return;
@@ -96,6 +140,32 @@ export function SpotChargeLineManualReviewSheet({
             })),
         [productCodes]
     );
+
+    const handleSubmitRequest = async () => {
+        setIsSubmittingRequest(true);
+        setRequestErrorMessage(null);
+        setRequestSuccessMessage(null);
+        try {
+            const res = await createProductCodeRequest({
+                source_label: requestSourceLabel,
+                suggested_name: requestSuggestedName,
+                suggested_bucket: requestSuggestedBucket,
+                suggested_basis: requestSuggestedBasis,
+                suggested_reason: requestSuggestedReason,
+            });
+
+            if (res.duplicate_reused) {
+                setRequestSuccessMessage("Reused existing pending request: A matching pending request already exists in the queue.");
+            } else {
+                setRequestSuccessMessage(`Request created successfully! Request ID: ${res.id}`);
+            }
+            setShowRequestForm(false);
+        } catch (error) {
+            setRequestErrorMessage(error instanceof Error ? error.message : "Failed to create product code request");
+        } finally {
+            setIsSubmittingRequest(false);
+        }
+    };
 
     const canSave = Boolean(chargeLine && selectedProductCodeId && !loadingProducts && !isSaving);
 
@@ -196,6 +266,128 @@ export function SpotChargeLineManualReviewSheet({
                                 disabled={loadingProducts || isSaving}
                             />
                         </section>
+
+                        {requestSuccessMessage ? (
+                            <Alert className="border-emerald-200 bg-emerald-50 text-emerald-950">
+                                <AlertCircle className="h-4 w-4 text-emerald-600" />
+                                <AlertDescription>{requestSuccessMessage}</AlertDescription>
+                            </Alert>
+                        ) : null}
+
+                        {requestErrorMessage ? (
+                            <Alert variant="destructive">
+                                <AlertCircle className="h-4 w-4" />
+                                <AlertDescription>{requestErrorMessage}</AlertDescription>
+                            </Alert>
+                        ) : null}
+
+                        {!showRequestForm ? (
+                            <div className="pt-2">
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="sm"
+                                    className="w-full text-slate-700 hover:text-slate-900"
+                                    onClick={() => setShowRequestForm(true)}
+                                    disabled={loadingProducts || isSaving}
+                                >
+                                    Can&apos;t find a matching product code? Create ProductCode Request
+                                </Button>
+                            </div>
+                        ) : (
+                            <section className="space-y-4 rounded-2xl border border-slate-200 bg-slate-50/50 p-4">
+                                <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                                    Request New ProductCode
+                                </div>
+                                <div className="space-y-3">
+                                    <div className="grid gap-1.5">
+                                        <Label htmlFor="req-source-label" className="text-xs font-semibold text-slate-600">Source Label</Label>
+                                        <Input
+                                            id="req-source-label"
+                                            value={requestSourceLabel}
+                                            onChange={(e) => setRequestSourceLabel(e.target.value)}
+                                            placeholder="e.g. Local Handling Fee"
+                                            className="bg-white"
+                                        />
+                                    </div>
+                                    <div className="grid gap-1.5">
+                                        <Label htmlFor="req-suggested-name" className="text-xs font-semibold text-slate-600">Suggested Name</Label>
+                                        <Input
+                                            id="req-suggested-name"
+                                            value={requestSuggestedName}
+                                            onChange={(e) => setRequestSuggestedName(e.target.value)}
+                                            placeholder="e.g. Local Handling"
+                                            className="bg-white"
+                                        />
+                                    </div>
+                                    <div className="grid gap-3 sm:grid-cols-2">
+                                        <div className="grid gap-1.5">
+                                            <Label htmlFor="req-bucket" className="text-xs font-semibold text-slate-600">Category Bucket</Label>
+                                            <select
+                                                id="req-bucket"
+                                                value={requestSuggestedBucket}
+                                                onChange={(e) => setRequestSuggestedBucket(e.target.value)}
+                                                className="flex h-10 w-full rounded-md border border-input bg-white px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                            >
+                                                <option value="FREIGHT">Freight</option>
+                                                <option value="HANDLING">Handling & Terminal</option>
+                                                <option value="CLEARANCE">Customs Clearance</option>
+                                                <option value="DOCUMENTATION">Documentation</option>
+                                                <option value="REGULATORY">Regulatory / Permit</option>
+                                                <option value="CARTAGE">Pickup & Delivery</option>
+                                                <option value="AGENCY">Agency Fees</option>
+                                                <option value="SCREENING">Security & Screening</option>
+                                                <option value="SURCHARGE">Surcharges</option>
+                                            </select>
+                                        </div>
+                                        <div className="grid gap-1.5">
+                                            <Label htmlFor="req-basis" className="text-xs font-semibold text-slate-600">Charge Basis</Label>
+                                            <select
+                                                id="req-basis"
+                                                value={requestSuggestedBasis}
+                                                onChange={(e) => setRequestSuggestedBasis(e.target.value)}
+                                                className="flex h-10 w-full rounded-md border border-input bg-white px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                            >
+                                                <option value="SHIPMENT">Per Shipment</option>
+                                                <option value="KG">Per Kilogram</option>
+                                                <option value="PERCENT">Percentage</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                    <div className="grid gap-1.5">
+                                        <Label htmlFor="req-reason" className="text-xs font-semibold text-slate-600">Reason / Context</Label>
+                                        <Textarea
+                                            id="req-reason"
+                                            value={requestSuggestedReason}
+                                            onChange={(e) => setRequestSuggestedReason(e.target.value)}
+                                            placeholder="Reason for requesting this product code..."
+                                            className="min-h-[60px] bg-white"
+                                        />
+                                    </div>
+                                    <div className="flex gap-2 pt-2">
+                                        <Button
+                                            type="button"
+                                            variant="outline"
+                                            size="sm"
+                                            onClick={() => setShowRequestForm(false)}
+                                            disabled={isSubmittingRequest}
+                                        >
+                                            Cancel
+                                        </Button>
+                                        <Button
+                                            type="button"
+                                            size="sm"
+                                            onClick={handleSubmitRequest}
+                                            loading={isSubmittingRequest}
+                                            loadingText="Submitting..."
+                                            disabled={!requestSourceLabel.trim() || !requestSuggestedName.trim()}
+                                        >
+                                            Submit Request
+                                        </Button>
+                                    </div>
+                                </div>
+                            </section>
+                        )}
                     </div>
                 ) : null}
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1047,6 +1047,7 @@ export {
   deleteCustomerDiscount,
   bulkUpsertCustomerDiscounts,
   getProductCodes,
+  createProductCodeRequest,
 } from './api/customers';
 
 export type {
@@ -1054,6 +1055,8 @@ export type {
   CustomerDiscount,
   CustomerDiscountBulkLine,
   ProductCodeOption,
+  ProductCodeRequestPayload,
+  ProductCodeRequestResponse,
 } from './api/customers';
 
 

--- a/frontend/src/lib/api/customers.ts
+++ b/frontend/src/lib/api/customers.ts
@@ -202,3 +202,42 @@ export async function getProductCodes(params?: {
     throw new Error('Failed to fetch product codes');
   }
 }
+
+export interface ProductCodeRequestPayload {
+  source_label: string;
+  suggested_name: string;
+  suggested_bucket: string;
+  suggested_basis: string;
+  suggested_reason: string;
+}
+
+export interface ProductCodeRequestResponse {
+  id: number;
+  source_label: string;
+  suggested_name: string;
+  suggested_bucket: string;
+  suggested_basis: string;
+  suggested_reason: string;
+  status: string;
+  created_by: number;
+  created_by_username: string;
+  approved_by: number | null;
+  approved_by_username: string | null;
+  approved_at: string | null;
+  rejected_at: string | null;
+  rejection_reason: string | null;
+  created_at: string;
+  updated_at: string;
+  duplicate_reused?: boolean;
+}
+
+export async function createProductCodeRequest(
+  payload: ProductCodeRequestPayload
+): Promise<ProductCodeRequestResponse> {
+  try {
+    return await sendJson(API_BASE_URL + '/api/v4/product-code-requests/', 'POST', payload);
+  } catch (error) {
+    throw new Error(`Failed to submit product code request: ${(error as Error).message}`);
+  }
+}
+


### PR DESCRIPTION
Connects unmapped/unknown SPOT charges in the SPOT review UI to the existing ProductCode request creation API.

Scope:
- Frontend-only SPOT review UI integration.
- Adds ProductCode request API helper/types.
- Exports helper/types.
- Adds Create ProductCode Request action for unmapped SPOT charges.

Validation reported from local run:
- npm run lint passed.
- npm run typecheck passed.

Expected changed files only:
- frontend/src/components/spot/SpotChargeLineManualReviewSheet.tsx
- frontend/src/lib/api.ts
- frontend/src/lib/api/customers.ts