### PR TITLE
feat(pricing_v4): create ProductCode from request approval

### DIFF
--- a/backend/pricing_v4/serializers.py
+++ b/backend/pricing_v4/serializers.py
@@ -638,4 +638,54 @@ class ProductCodeCreationRequestSerializer(serializers.ModelSerializer):
         ]
 
 
+class ProductCodeCreationDataSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ProductCode
+        fields = [
+            'id',
+            'code',
+            'description',
+            'domain',
+            'category',
+            'is_gst_applicable',
+            'gst_treatment',
+            'gl_revenue_code',
+            'gl_cost_code',
+            'default_unit',
+        ]
+
+    def validate_code(self, value):
+        if value:
+            return value.strip().upper()
+        return value
+
+    def validate(self, data):
+        domain = data.get('domain')
+        pc_id = data.get('id')
+        if domain == ProductCode.DOMAIN_EXPORT and not (1000 <= pc_id < 2000):
+            raise serializers.ValidationError({"id": f"Export ProductCode ID must be 1xxx (1000-1999), got {pc_id}"})
+        elif domain == ProductCode.DOMAIN_IMPORT and not (2000 <= pc_id < 3000):
+            raise serializers.ValidationError({"id": f"Import ProductCode ID must be 2xxx (2000-2999), got {pc_id}"})
+        elif domain == ProductCode.DOMAIN_DOMESTIC and not (3000 <= pc_id < 4000):
+            raise serializers.ValidationError({"id": f"Domestic ProductCode ID must be 3xxx (3000-3999), got {pc_id}"})
+        return data
+
+
+class ProductCodeCreationApprovalSerializer(serializers.Serializer):
+    product_code_id = serializers.IntegerField(required=False, allow_null=True)
+    create_product_code_data = ProductCodeCreationDataSerializer(required=False, allow_null=True)
+
+    def validate(self, data):
+        product_code_id = data.get('product_code_id')
+        create_product_code_data = data.get('create_product_code_data')
+
+        if product_code_id is not None and create_product_code_data is not None:
+            raise serializers.ValidationError("Specify exactly one of product_code_id or create_product_code_data, not both.")
+        if product_code_id is None and create_product_code_data is None:
+            raise serializers.ValidationError("Either product_code_id or create_product_code_data must be specified.")
+        
+        return data
+
+
+
 

--- a/backend/pricing_v4/tests/test_product_code_creation_request_api.py
+++ b/backend/pricing_v4/tests/test_product_code_creation_request_api.py
@@ -414,3 +414,219 @@ class ProductCodeCreationRequestTests(APITestCase):
         )
         self.assertEqual(response.status_code, 400)
 
+    def test_approve_by_inline_creation_works(self):
+        self.client.force_authenticate(user=self.admin_user)
+        creation_data = {
+            "id": 1005,
+            "code": "EXP-FUEL-SUD",
+            "description": "Fuel surcharge Sudan",
+            "domain": "EXPORT",
+            "category": "SURCHARGE",
+            "is_gst_applicable": False,
+            "gst_treatment": "ZERO_RATED",
+            "gl_revenue_code": "4100",
+            "gl_cost_code": "5100",
+            "default_unit": "KG",
+        }
+        response = self.client.post(
+            f"/api/v4/product-code-requests/{self.request_1.id}/approve/",
+            {"create_product_code_data": creation_data},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["status"], "APPROVED")
+        self.assertEqual(response.data["approved_product_code"], 1005)
+        self.assertEqual(response.data["approved_by"], self.admin_user.id)
+        self.assertIsNotNone(response.data["approved_at"])
+
+        # Verify DB ProductCode is created and linked
+        pc = ProductCode.objects.get(id=1005)
+        self.assertEqual(pc.code, "EXP-FUEL-SUD")
+        self.assertEqual(pc.description, "Fuel surcharge Sudan")
+        self.assertEqual(pc.domain, "EXPORT")
+        self.assertEqual(pc.category, "SURCHARGE")
+        self.assertEqual(pc.default_unit, "KG")
+        self.assertEqual(pc.gl_revenue_code, "4100")
+        
+        self.request_1.refresh_from_db()
+        self.assertEqual(self.request_1.status, "APPROVED")
+        self.assertEqual(self.request_1.approved_product_code, pc)
+        self.assertEqual(self.request_1.approved_by, self.admin_user)
+        self.assertIsNotNone(self.request_1.approved_at)
+
+    def test_approve_inline_creation_code_normalization(self):
+        self.client.force_authenticate(user=self.admin_user)
+        creation_data = {
+            "id": 1006,
+            "code": "  exp-fuel-norm  ",
+            "description": "Fuel surcharge Normalized",
+            "domain": "EXPORT",
+            "category": "SURCHARGE",
+            "is_gst_applicable": False,
+            "gst_treatment": "ZERO_RATED",
+            "gl_revenue_code": "4100",
+            "gl_cost_code": "5100",
+            "default_unit": "KG",
+        }
+        response = self.client.post(
+            f"/api/v4/product-code-requests/{self.request_1.id}/approve/",
+            {"create_product_code_data": creation_data},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        pc = ProductCode.objects.get(id=1006)
+        self.assertEqual(pc.code, "EXP-FUEL-NORM")
+
+    def test_approve_inline_creation_invalid_id_range_fails(self):
+        self.client.force_authenticate(user=self.admin_user)
+        # 1. Export domain with Domestic range ID (3xxx)
+        creation_data = {
+            "id": 3005,
+            "code": "EXP-INVALID-RANGE",
+            "description": "Invalid range",
+            "domain": "EXPORT",
+            "category": "SURCHARGE",
+            "is_gst_applicable": False,
+            "gst_treatment": "ZERO_RATED",
+            "gl_revenue_code": "4100",
+            "gl_cost_code": "5100",
+            "default_unit": "KG",
+        }
+        response = self.client.post(
+            f"/api/v4/product-code-requests/{self.request_1.id}/approve/",
+            {"create_product_code_data": creation_data},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("id", response.data.get("create_product_code_data", {}))
+
+    def test_approve_inline_creation_duplicate_code_fails(self):
+        self.client.force_authenticate(user=self.admin_user)
+        # Try to use same code as product_code_1 (EXP-TERM-POM)
+        creation_data = {
+            "id": 1007,
+            "code": "EXP-TERM-POM",
+            "description": "Another POM Term",
+            "domain": "EXPORT",
+            "category": "HANDLING",
+            "is_gst_applicable": True,
+            "gst_treatment": "STANDARD",
+            "gl_revenue_code": "4000",
+            "gl_cost_code": "5000",
+            "default_unit": "SHIPMENT",
+        }
+        response = self.client.post(
+            f"/api/v4/product-code-requests/{self.request_1.id}/approve/",
+            {"create_product_code_data": creation_data},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_approve_inline_creation_duplicate_id_fails(self):
+        self.client.force_authenticate(user=self.admin_user)
+        # Try to use same ID as product_code_1 (1004)
+        creation_data = {
+            "id": 1004,
+            "code": "EXP-DUPLICATE-ID",
+            "description": "Duplicate ID desc",
+            "domain": "EXPORT",
+            "category": "HANDLING",
+            "is_gst_applicable": True,
+            "gst_treatment": "STANDARD",
+            "gl_revenue_code": "4000",
+            "gl_cost_code": "5000",
+            "default_unit": "SHIPMENT",
+        }
+        response = self.client.post(
+            f"/api/v4/product-code-requests/{self.request_1.id}/approve/",
+            {"create_product_code_data": creation_data},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_approve_both_modes_supplied_fails(self):
+        self.client.force_authenticate(user=self.admin_user)
+        creation_data = {
+            "id": 1008,
+            "code": "EXP-BOTH-MODES",
+            "description": "Both modes",
+            "domain": "EXPORT",
+            "category": "HANDLING",
+            "is_gst_applicable": True,
+            "gst_treatment": "STANDARD",
+            "gl_revenue_code": "4000",
+            "gl_cost_code": "5000",
+            "default_unit": "SHIPMENT",
+        }
+        response = self.client.post(
+            f"/api/v4/product-code-requests/{self.request_1.id}/approve/",
+            {
+                "product_code_id": self.product_code_1.id,
+                "create_product_code_data": creation_data
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_approve_neither_mode_supplied_fails(self):
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.post(
+            f"/api/v4/product-code-requests/{self.request_1.id}/approve/",
+            {},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_non_admin_cannot_approve_create(self):
+        self.client.force_authenticate(user=self.sales_user)
+        creation_data = {
+            "id": 1009,
+            "code": "EXP-SALES-CREATE",
+            "description": "Sales create",
+            "domain": "EXPORT",
+            "category": "HANDLING",
+            "is_gst_applicable": True,
+            "gst_treatment": "STANDARD",
+            "gl_revenue_code": "4000",
+            "gl_cost_code": "5000",
+            "default_unit": "SHIPMENT",
+        }
+        response = self.client.post(
+            f"/api/v4/product-code-requests/{self.request_1.id}/approve/",
+            {"create_product_code_data": creation_data},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_transaction_rollback_on_failed_creation(self):
+        self.client.force_authenticate(user=self.admin_user)
+        # Supplying some bad data to trigger a DB-level or serializer validation error.
+        # However, serializer checks ID range. Let's make an ID validation succeed, but code length fail at the database level:
+        # e.g., code length is > max_length (30). ProductCode model code has max_length=30.
+        creation_data = {
+            "id": 1010,
+            "code": "EXP-LONG-CODE-" * 5,  # 70 chars long
+            "description": "Failed creation due to long code",
+            "domain": "EXPORT",
+            "category": "HANDLING",
+            "is_gst_applicable": True,
+            "gst_treatment": "STANDARD",
+            "gl_revenue_code": "4000",
+            "gl_cost_code": "5000",
+            "default_unit": "SHIPMENT",
+        }
+        
+        response = self.client.post(
+            f"/api/v4/product-code-requests/{self.request_1.id}/approve/",
+            {"create_product_code_data": creation_data},
+            format="json",
+        )
+        # Serializer validation might catch it (due to max_length limit from ModelSerializer), 
+        # but the request status must still be PENDING:
+        self.assertEqual(response.status_code, 400)
+        
+        self.request_1.refresh_from_db()
+        self.assertEqual(self.request_1.status, "PENDING")
+        self.assertIsNone(self.request_1.approved_product_code)
+
+

--- a/backend/pricing_v4/tests/test_product_code_creation_request_api.py
+++ b/backend/pricing_v4/tests/test_product_code_creation_request_api.py
@@ -502,10 +502,10 @@ class ProductCodeCreationRequestTests(APITestCase):
 
     def test_approve_inline_creation_duplicate_code_fails(self):
         self.client.force_authenticate(user=self.admin_user)
-        # Try to use same code as product_code_1 (EXP-TERM-POM)
+        # Try to use same code as product_code_1 (EXP-TERM-POM) but in lowercase/mixedcase
         creation_data = {
             "id": 1007,
-            "code": "EXP-TERM-POM",
+            "code": "exp-term-pom",
             "description": "Another POM Term",
             "domain": "EXPORT",
             "category": "HANDLING",
@@ -521,6 +521,7 @@ class ProductCodeCreationRequestTests(APITestCase):
             format="json",
         )
         self.assertEqual(response.status_code, 400)
+        self.assertIn("already exists", response.data.get("detail", ""))
 
     def test_approve_inline_creation_duplicate_id_fails(self):
         self.client.force_authenticate(user=self.admin_user)

--- a/backend/pricing_v4/views.py
+++ b/backend/pricing_v4/views.py
@@ -640,6 +640,7 @@ from .serializers import (
     RateChangeLogSerializer,
     RateRevisionRequestSerializer,
     ProductCodeCreationRequestSerializer,
+    ProductCodeCreationApprovalSerializer,
 )
 
 
@@ -1200,20 +1201,12 @@ class ProductCodeCreationRequestViewSet(
 
     @action(detail=True, methods=['post'])
     def approve(self, request, pk=None):
-        product_code_id = request.data.get('product_code_id')
-        if not product_code_id:
-            return Response(
-                {"detail": "product_code_id is required for approval."},
-                status=status.HTTP_400_BAD_REQUEST
-            )
-
-        try:
-            product_code = ProductCode.objects.get(id=product_code_id)
-        except ProductCode.DoesNotExist:
-            return Response(
-                {"detail": f"ProductCode with id {product_code_id} does not exist."},
-                status=status.HTTP_400_BAD_REQUEST
-            )
+        approval_serializer = ProductCodeCreationApprovalSerializer(data=request.data)
+        if not approval_serializer.is_valid():
+            return Response(approval_serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        
+        product_code_id = approval_serializer.validated_data.get('product_code_id')
+        create_product_code_data = approval_serializer.validated_data.get('create_product_code_data')
 
         with transaction.atomic():
             obj = self.get_queryset().select_for_update().filter(pk=pk).first()
@@ -1228,6 +1221,35 @@ class ProductCodeCreationRequestViewSet(
                     {"detail": f"Only PENDING requests can be approved. Current status: {obj.status}."},
                     status=status.HTTP_400_BAD_REQUEST
                 )
+
+            if product_code_id is not None:
+                try:
+                    product_code = ProductCode.objects.get(id=product_code_id)
+                except ProductCode.DoesNotExist:
+                    return Response(
+                        {"detail": f"ProductCode with id {product_code_id} does not exist."},
+                        status=status.HTTP_400_BAD_REQUEST
+                    )
+            else:
+                # Direct creation path
+                pc_id = create_product_code_data['id']
+                pc_code = create_product_code_data['code']
+                
+                # Check duplicate id
+                if ProductCode.objects.filter(id=pc_id).exists():
+                    return Response(
+                        {"detail": f"ProductCode with id {pc_id} already exists."},
+                        status=status.HTTP_400_BAD_REQUEST
+                    )
+                # Check duplicate normalized code
+                if ProductCode.objects.filter(code=pc_code).exists():
+                    return Response(
+                        {"detail": f"ProductCode with code {pc_code} already exists."},
+                        status=status.HTTP_400_BAD_REQUEST
+                    )
+                
+                # Create the product code
+                product_code = ProductCode.objects.create(**create_product_code_data)
 
             obj.status = ProductCodeCreationRequest.STATUS_APPROVED
             obj.approved_by = request.user

--- a/backend/pricing_v4/views.py
+++ b/backend/pricing_v4/views.py
@@ -1224,7 +1224,7 @@ class ProductCodeCreationRequestViewSet(
 
             if product_code_id is not None:
                 try:
-                    product_code = ProductCode.objects.get(id=product_code_id)
+                    product_code = ProductCode.objects.select_for_update().get(id=product_code_id)
                 except ProductCode.DoesNotExist:
                     return Response(
                         {"detail": f"ProductCode with id {product_code_id} does not exist."},
@@ -1242,7 +1242,7 @@ class ProductCodeCreationRequestViewSet(
                         status=status.HTTP_400_BAD_REQUEST
                     )
                 # Check duplicate normalized code
-                if ProductCode.objects.filter(code=pc_code).exists():
+                if ProductCode.objects.filter(code__iexact=pc_code).exists():
                     return Response(
                         {"detail": f"ProductCode with code {pc_code} already exists."},
                         status=status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
## Summary
- Adds inline ProductCode creation during ProductCodeCreationRequest approval.
- Preserves existing approval by linking to an existing ProductCode.
- Adds serializer validation for mutually exclusive approval modes and ProductCode creation data.
- Enforces domain/id range rules, duplicate code/id checks, code normalization, and transactional approval updates.

## Verification
- python backend/manage.py test pricing_v4.tests.test_product_code_creation_request_api
- graphify update .

## Non-goals
- No frontend changes.
- No AI ProductCode suggestions.
- No Docker/dependency fixes.