### PR TITLE
feat(spot): suggest approved ProductCode in manual review

### DIFF
--- a/backend/quotes/serializers.py
+++ b/backend/quotes/serializers.py
@@ -747,7 +747,7 @@ class SPEChargeLineSerializer(serializers.ModelSerializer):
         if domain:
             filters['approved_product_code__domain'] = domain
 
-        req = ProductCodeCreationRequest.objects.filter(**filters).first()
+        req = ProductCodeCreationRequest.objects.filter(**filters).order_by("-approved_at", "-created_at", "-id").first()
         if req:
             return _serialize_spe_product_code_summary(req.approved_product_code)
         return None

--- a/backend/quotes/serializers.py
+++ b/backend/quotes/serializers.py
@@ -656,6 +656,7 @@ class SPEChargeLineSerializer(serializers.ModelSerializer):
     manual_resolved_product_code = serializers.SerializerMethodField()
     manual_resolution_by_user_id = serializers.SerializerMethodField()
     manual_resolution_by_username = serializers.SerializerMethodField()
+    suggested_approved_product_code = serializers.SerializerMethodField()
     
     class Meta:
         model = SPEChargeLineDB
@@ -672,7 +673,7 @@ class SPEChargeLineSerializer(serializers.ModelSerializer):
             'requires_review',
             'manual_resolution_status', 'manual_resolved_product_code',
             'manual_resolution_by_user_id', 'manual_resolution_by_username',
-            'manual_resolution_at',
+            'manual_resolution_at', 'suggested_approved_product_code',
             'source_batch_id', 'source_batch_label',
             'calculation_type', 'unit_type', 'rate', 'min_amount', 'max_amount',
             'percent', 'percent_basis', 'rule_meta', 'rule_display'
@@ -709,6 +710,47 @@ class SPEChargeLineSerializer(serializers.ModelSerializer):
         if not obj.manual_resolution_by_id:
             return None
         return getattr(obj.manual_resolution_by, 'username', None)
+
+    def get_suggested_approved_product_code(self, obj):
+        # Skip if already manually resolved
+        if obj.manual_resolution_status == 'RESOLVED' and obj.manual_resolved_product_code_id:
+            return None
+
+        # The source label that the frontend uses is obj.normalized_label or obj.description or ""
+        label_to_normalize = obj.normalized_label or obj.description or ""
+        if not label_to_normalize:
+            return None
+
+        from pricing_v4.models import ProductCodeCreationRequest
+        norm_label = ProductCodeCreationRequest.normalize_label(label_to_normalize)
+        if not norm_label:
+            return None
+
+        # Optional domain matching based on envelope shipment context
+        domain = None
+        if obj.envelope_id and obj.envelope.shipment_context_json:
+            from core.business_rules import classify_png_shipment
+            ctx = obj.envelope.shipment_context_json or {}
+            org_code = ctx.get("origin_country") or ctx.get("origin_country_code")
+            dest_code = ctx.get("destination_country") or ctx.get("destination_country_code")
+            try:
+                domain = classify_png_shipment(org_code, dest_code)
+            except ValueError:
+                pass
+
+        # Query ProductCodeCreationRequest for latest APPROVED request matching normalized_source_label
+        filters = {
+            'status': ProductCodeCreationRequest.STATUS_APPROVED,
+            'normalized_source_label': norm_label,
+            'approved_product_code__isnull': False
+        }
+        if domain:
+            filters['approved_product_code__domain'] = domain
+
+        req = ProductCodeCreationRequest.objects.filter(**filters).first()
+        if req:
+            return _serialize_spe_product_code_summary(req.approved_product_code)
+        return None
 
     def get_amount(self, obj):
         # Return as string to match original serialization

--- a/backend/quotes/tests/test_spe_charge_line_normalization_metadata.py
+++ b/backend/quotes/tests/test_spe_charge_line_normalization_metadata.py
@@ -200,3 +200,95 @@ class SPEChargeLineNormalizationMetadataTests(TestCase):
             SPEChargeLineDB.ManualResolutionStatus.RESOLVED,
         )
         self.assertFalse(refreshed.requires_review)
+
+    def test_suggested_approved_product_code_in_serializer(self):
+        from quotes.serializers import SPEChargeLineSerializer
+        from pricing_v4.models import ProductCodeCreationRequest
+        from django.contrib.auth import get_user_model
+        
+        User = get_user_model()
+        user = User.objects.create_user(username="testuser", password="password", role="sales")
+
+        # 1. Matching approved request exists -> returns product code details
+        req = ProductCodeCreationRequest.objects.create(
+            source_label="Local Handling Fee",
+            suggested_name="Local Handling",
+            suggested_bucket="HANDLING",
+            suggested_basis="SHIPMENT",
+            created_by=user,
+        )
+        req.status = ProductCodeCreationRequest.STATUS_APPROVED
+        req.approved_product_code = self.product_code
+        req.save()
+
+        line = SPEChargeLineDB.objects.create(
+            envelope=self._create_envelope(),
+            code='ORIGIN_LOCAL_SPOT',
+            description='Local Handling Fee',
+            amount='25.00',
+            currency='PGK',
+            unit=SPEChargeLineDB.Unit.PER_SHIPMENT,
+            bucket=SPEChargeLineDB.Bucket.ORIGIN_CHARGES,
+            source_label='Local Handling Fee',
+            entered_at=timezone.now(),
+        )
+
+        serializer = SPEChargeLineSerializer(instance=line)
+        data = serializer.data
+        self.assertIsNotNone(data['suggested_approved_product_code'])
+        self.assertEqual(data['suggested_approved_product_code']['id'], self.product_code.id)
+        self.assertEqual(data['suggested_approved_product_code']['code'], self.product_code.code)
+
+        # 2. Null when request is pending
+        req.status = ProductCodeCreationRequest.STATUS_PENDING
+        req.approved_product_code = None
+        req.save()
+        serializer = SPEChargeLineSerializer(instance=line)
+        self.assertIsNone(serializer.data['suggested_approved_product_code'])
+
+        # 3. Null when request is rejected
+        req.status = ProductCodeCreationRequest.STATUS_REJECTED
+        req.save()
+        serializer = SPEChargeLineSerializer(instance=line)
+        self.assertIsNone(serializer.data['suggested_approved_product_code'])
+
+        # 4. Null when line is already manually resolved
+        req.status = ProductCodeCreationRequest.STATUS_APPROVED
+        req.approved_product_code = self.product_code
+        req.save()
+        
+        line.manual_resolution_status = SPEChargeLineDB.ManualResolutionStatus.RESOLVED
+        line.manual_resolved_product_code = self.product_code
+        line.save()
+        
+        serializer = SPEChargeLineSerializer(instance=line)
+        self.assertIsNone(serializer.data['suggested_approved_product_code'])
+
+        # 5. Domain mismatch does not suggest
+        import_envelope = SpotPricingEnvelopeDB.objects.create(
+            status=SpotPricingEnvelopeDB.Status.DRAFT,
+            shipment_context_json={
+                'origin_country': 'AU',
+                'destination_country': 'PG',
+            },
+            expires_at=timezone.now() + timedelta(hours=4),
+        )
+        
+        line_import = SPEChargeLineDB.objects.create(
+            envelope=import_envelope,
+            code='ORIGIN_LOCAL_SPOT',
+            description='Local Handling Fee',
+            amount='25.00',
+            currency='PGK',
+            unit=SPEChargeLineDB.Unit.PER_SHIPMENT,
+            bucket=SPEChargeLineDB.Bucket.ORIGIN_CHARGES,
+            source_label='Local Handling Fee',
+            entered_at=timezone.now(),
+        )
+
+        req.status = ProductCodeCreationRequest.STATUS_APPROVED
+        req.approved_product_code = self.product_code  # domain is EXPORT
+        req.save()
+        
+        serializer = SPEChargeLineSerializer(instance=line_import)
+        self.assertIsNone(serializer.data['suggested_approved_product_code'])

--- a/backend/quotes/tests/test_spe_charge_line_normalization_metadata.py
+++ b/backend/quotes/tests/test_spe_charge_line_normalization_metadata.py
@@ -292,3 +292,69 @@ class SPEChargeLineNormalizationMetadataTests(TestCase):
         
         serializer = SPEChargeLineSerializer(instance=line_import)
         self.assertIsNone(serializer.data['suggested_approved_product_code'])
+
+        # 6. If multiple approved requests match, return the latest approved one
+        from pricing_v4.models import ProductCode
+        older_product_code = ProductCode.objects.create(
+            id=1234,
+            code="OLDCODE",
+            description="Older Product Code",
+            domain="EXPORT",
+            category="HANDLING",
+            is_gst_applicable=True,
+            gst_treatment="STANDARD",
+            gl_revenue_code="REV-OLD",
+            gl_cost_code="COS-OLD",
+            default_unit="flat"
+        )
+        newer_product_code = ProductCode.objects.create(
+            id=5678,
+            code="NEWCODE",
+            description="Newer Product Code",
+            domain="EXPORT",
+            category="HANDLING",
+            is_gst_applicable=True,
+            gst_treatment="STANDARD",
+            gl_revenue_code="REV-NEW",
+            gl_cost_code="COS-NEW",
+            default_unit="flat"
+        )
+        
+        # Clean up older request to avoid interference
+        req.delete()
+        
+        # Create older approved request (approved 2 days ago)
+        req_old = ProductCodeCreationRequest.objects.create(
+            source_label="Local Handling Fee",
+            suggested_name="Local Handling Old",
+            suggested_bucket="HANDLING",
+            suggested_basis="SHIPMENT",
+            created_by=user,
+        )
+        req_old.status = ProductCodeCreationRequest.STATUS_APPROVED
+        req_old.approved_product_code = older_product_code
+        req_old.approved_at = timezone.now() - timedelta(days=2)
+        req_old.save()
+
+        # Create newer approved request (approved 1 hour ago)
+        req_new = ProductCodeCreationRequest.objects.create(
+            source_label="Local Handling Fee",
+            suggested_name="Local Handling New",
+            suggested_bucket="HANDLING",
+            suggested_basis="SHIPMENT",
+            created_by=user,
+        )
+        req_new.status = ProductCodeCreationRequest.STATUS_APPROVED
+        req_new.approved_product_code = newer_product_code
+        req_new.approved_at = timezone.now() - timedelta(hours=1)
+        req_new.save()
+
+        # Reset line back to unresolved
+        line.manual_resolution_status = None
+        line.manual_resolved_product_code = None
+        line.save()
+
+        serializer = SPEChargeLineSerializer(instance=line)
+        self.assertIsNotNone(serializer.data['suggested_approved_product_code'])
+        self.assertEqual(serializer.data['suggested_approved_product_code']['id'], newer_product_code.id)
+        self.assertEqual(serializer.data['suggested_approved_product_code']['code'], newer_product_code.code)

--- a/frontend/src/components/spot/SpotChargeLineManualReviewSheet.tsx
+++ b/frontend/src/components/spot/SpotChargeLineManualReviewSheet.tsx
@@ -266,6 +266,41 @@ export function SpotChargeLineManualReviewSheet({
                             </Alert>
                         ) : null}
 
+                        {chargeLine.suggested_approved_product_code && chargeLine.manual_resolution_status !== "RESOLVED" && (
+                            <section className="rounded-2xl border border-emerald-200 bg-emerald-50/50 p-4 space-y-3">
+                                <div className="flex items-start gap-2.5">
+                                    <div className="mt-0.5 rounded-full bg-emerald-100 p-1 text-emerald-800">
+                                        <Search className="h-4 w-4 text-emerald-600" />
+                                    </div>
+                                    <div className="space-y-1">
+                                        <h4 className="text-sm font-semibold text-emerald-950">
+                                            Approved ProductCode suggestion available
+                                        </h4>
+                                        <p className="text-xs text-emerald-800 leading-normal">
+                                            An approved ProductCode request matches this charge label. Review and apply if correct.
+                                        </p>
+                                    </div>
+                                </div>
+                                <div className="rounded-lg border border-emerald-200/60 bg-white/80 px-3 py-2 text-xs font-mono font-semibold text-emerald-900">
+                                    {chargeLine.suggested_approved_product_code.code} - {chargeLine.suggested_approved_product_code.description}
+                                </div>
+                                <Button
+                                    type="button"
+                                    size="sm"
+                                    className="w-full bg-emerald-600 text-white hover:bg-emerald-700 focus-visible:ring-emerald-500"
+                                    onClick={() => {
+                                        if (chargeLine.suggested_approved_product_code) {
+                                            setSelectedProductCodeId(String(chargeLine.suggested_approved_product_code.id));
+                                            setShowRequestForm(false);
+                                            setShowSelectorAfterSubmit(true);
+                                        }
+                                    }}
+                                >
+                                    Apply to this charge line
+                                </Button>
+                            </section>
+                        )}
+
                         {(!requestSubmitted || showSelectorAfterSubmit) && (
                             <section className="space-y-3">
                                 <div>

--- a/frontend/src/lib/spot-types.ts
+++ b/frontend/src/lib/spot-types.ts
@@ -180,6 +180,7 @@ export interface SPEChargeLine {
     manual_resolution_by_user_id?: string | null;
     manual_resolution_by_username?: string | null;
     manual_resolution_at?: string | null;
+    suggested_approved_product_code?: SPEProductCodeSummary | null;
 }
 
 /** SPE conditions */


### PR DESCRIPTION
## Summary
- Adds suggested_approved_product_code to SPOT charge line serialization.
- Surfaces an approved ProductCode request match in the SPOT manual charge review modal.
- Lets the user explicitly apply the suggested ProductCode before saving manual resolution.
- Keeps behaviour conservative: no silent auto-apply and no permission changes.

## Verification
- python manage.py test quotes.tests.test_spe_charge_line_normalization_metadata
- npm run typecheck
- npm run lint
- graphify update .

## Non-goals
- No database migrations.
- No ProductCode request permission changes.
- No automatic SPOT line resolution.
- No Docker/dependency fixes.