### PR TITLE
feat(quotes): group customer quote lines by ProductCode

### DIFF
--- a/backend/quotes/quote_result_contract.py
+++ b/backend/quotes/quote_result_contract.py
@@ -930,6 +930,88 @@ def line_item_from_quote_line(
     }
 
 
+def _group_canonical_line_items(line_items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Group compatible canonical line items that share the same ProductCode, currency, tax_code, and component."""
+    grouped_map = {}
+    other_items = []
+
+    for item in line_items:
+        pcode = item.get("product_code")
+        if not pcode:
+            other_items.append(item)
+            continue
+
+        currency = item.get("currency")
+        tax_code = item.get("tax_code")
+        component = item.get("component")
+
+        key = (pcode, currency, tax_code, component)
+        if key not in grouped_map:
+            grouped_map[key] = {
+                **item,
+                "_original_items": [item]
+            }
+        else:
+            grouped_map[key]["_original_items"].append(item)
+
+    final_items = []
+    ordered_keys = sorted(grouped_map.keys(), key=lambda k: grouped_map[k]["_original_items"][0]["sort_order"])
+
+    for key in ordered_keys:
+        group_item = grouped_map[key]
+        orig_list = group_item["_original_items"]
+
+        if len(orig_list) == 1:
+            group_item.pop("_original_items")
+            final_items.append(group_item)
+            continue
+
+        # Merge multiple items
+        cost_sum = sum(Decimal(str(x.get("cost_amount") or 0)) for x in orig_list)
+        sell_sum = sum(Decimal(str(x.get("sell_amount") or 0)) for x in orig_list)
+        tax_sum = sum(Decimal(str(x.get("tax_amount") or 0)) for x in orig_list)
+        margin_sum = sum(Decimal(str(x.get("margin_amount") or 0)) for x in orig_list)
+
+        if sell_sum > 0:
+            margin_percent_val = (margin_sum / sell_sum) * 100
+        else:
+            margin_percent_val = Decimal("0.00")
+
+        group_item["cost_amount"] = cost_sum
+        group_item["sell_amount"] = sell_sum
+        group_item["tax_amount"] = tax_sum
+        group_item["margin_amount"] = margin_sum
+        group_item["margin_percent"] = margin_percent_val.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+        all_rates = {str(x.get("rate")) for x in orig_list}
+        all_bases = {str(x.get("basis")) for x in orig_list}
+        all_units = {str(x.get("unit_type")) for x in orig_list}
+
+        if len(all_rates) == 1 and len(all_bases) == 1 and len(all_units) == 1:
+            group_item["quantity"] = sum(Decimal(str(x.get("quantity") or 0)) for x in orig_list)
+        else:
+            group_item["rate"] = None
+            group_item["quantity"] = Decimal("1.00")
+            group_item["basis"] = "Combined"
+            group_item["unit_type"] = "Combined"
+
+        from pricing_v4.models import ProductCode
+        pcode_obj = ProductCode.objects.filter(code=key[0]).first()
+        if pcode_obj and pcode_obj.description:
+            group_item["description"] = pcode_obj.description
+
+        group_item["calculation_notes"] = f"Combined from {len(orig_list)} source charge lines."
+        group_item["is_grouped"] = True
+        group_item["grouped_source_count"] = len(orig_list)
+
+        group_item.pop("_original_items")
+        final_items.append(group_item)
+
+    final_items.extend(other_items)
+    final_items.sort(key=lambda item: item["sort_order"])
+    return final_items
+
+
 def build_quote_result_from_quote(quote: Any, version: Any = None) -> dict[str, Any]:
     active_version = version or getattr(quote, "latest_version", None)
     if active_version is None and hasattr(quote, "versions"):
@@ -959,6 +1041,7 @@ def build_quote_result_from_quote(quote: Any, version: Any = None) -> dict[str, 
         line_item["sort_order"] = (COMPONENT_SORT_ORDER.get(line_item["component"], 9) * 100) + index
         line_items.append(line_item)
     line_items.sort(key=lambda item: item["sort_order"])
+    line_items = _group_canonical_line_items(line_items)
     coverage = evaluate_from_lines(lines, getattr(quote, "shipment_type", None), getattr(quote, "service_scope", None))
 
     warnings: list[str] = []

--- a/backend/quotes/quote_result_contract.py
+++ b/backend/quotes/quote_result_contract.py
@@ -882,6 +882,7 @@ def line_item_from_quote_line(
 
     return {
         "line_id": str(getattr(line, "id", "") or ""),
+        "_grouping_product_code": getattr(line, "product_code", None) or "",
         "product_code": getattr(line, "product_code", None) or getattr(service_component, "code", None) or "",
         "description": (
             getattr(line, "description", None)
@@ -936,8 +937,9 @@ def _group_canonical_line_items(line_items: list[dict[str, Any]]) -> list[dict[s
     other_items = []
 
     for item in line_items:
-        pcode = item.get("product_code")
-        if not pcode:
+        pcode = item.pop("_grouping_product_code", "")
+        included_in_total = item.get("included_in_total", False)
+        if not pcode or not included_in_total:
             other_items.append(item)
             continue
 

--- a/backend/quotes/serializers.py
+++ b/backend/quotes/serializers.py
@@ -314,6 +314,8 @@ class CanonicalQuoteLineItemSerializer(serializers.Serializer):
     fx_applied = serializers.BooleanField(required=False)
     subcategory = serializers.CharField(required=False, allow_null=True, allow_blank=True)
     sort_order = serializers.IntegerField()
+    is_grouped = serializers.BooleanField(required=False, default=False)
+    grouped_source_count = serializers.IntegerField(required=False, default=1)
 
     def to_representation(self, instance):
         data = super().to_representation(instance)

--- a/backend/quotes/tests/test_api_v3.py
+++ b/backend/quotes/tests/test_api_v3.py
@@ -753,6 +753,56 @@ class QuoteCanonicalResultContractAPITest(APITestCase):
             gst_category="GST"
         )
 
+        # Scenario 1: two lines with same service_component.code but no explicit product_code are NOT grouped
+        comp_unmapped = ServiceComponent.objects.create(
+            code="IMP-UNMAPPED-FEE",
+            description="Unmapped Fee",
+            service_code=code,
+            mode="AIR",
+            leg="ORIGIN",
+            category="LOCAL",
+            unit="SHIPMENT",
+        )
+        QuoteLine.objects.create(
+            quote_version=version,
+            service_component=comp_unmapped,
+            product_code=None,
+            sell_pgk=Decimal("15.00"),
+            sell_pgk_incl_gst=Decimal("16.50"),
+            leg="ORIGIN",
+            cost_source="MANUAL",
+            cost_source_description="Unmapped 1",
+            component="ORIGIN_LOCAL",
+            gst_category="GST"
+        )
+        QuoteLine.objects.create(
+            quote_version=version,
+            service_component=comp_unmapped,
+            product_code=None,
+            sell_pgk=Decimal("15.00"),
+            sell_pgk_incl_gst=Decimal("16.50"),
+            leg="ORIGIN",
+            cost_source="MANUAL",
+            cost_source_description="Unmapped 2",
+            component="ORIGIN_LOCAL",
+            gst_category="GST"
+        )
+
+        # Scenario 2: billable line and informational/non-total line with same ProductCode are NOT grouped
+        QuoteLine.objects.create(
+            quote_version=version,
+            service_component=comp,
+            product_code="IMP-AWB-ORIGIN",
+            is_informational=True,
+            sell_pgk=Decimal("20.00"),
+            sell_pgk_incl_gst=Decimal("22.00"),
+            leg="ORIGIN",
+            cost_source="MANUAL",
+            cost_source_description="Informational Line",
+            component="ORIGIN_LOCAL",
+            gst_category="GST"
+        )
+
         url = reverse('quotes:quote-v3-compute-v3', kwargs={'pk': quote.id})
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -760,9 +810,10 @@ class QuoteCanonicalResultContractAPITest(APITestCase):
         quote_result = response.data['quote_result']
         line_items = quote_result['line_items']
 
-        # Verify grouped lines
-        grouped_awb = next((l for l in line_items if l['product_code'] == "IMP-AWB-ORIGIN" and l['currency'] == "PGK"), None)
-        self.assertIsNotNone(grouped_awb)
+        # Verify grouped lines (existing positive test still passes)
+        grouped_awbs = [l for l in line_items if l['product_code'] == "IMP-AWB-ORIGIN" and l['currency'] == "PGK" and l.get('included_in_total')]
+        self.assertEqual(len(grouped_awbs), 1)
+        grouped_awb = grouped_awbs[0]
         self.assertEqual(Decimal(str(grouped_awb['sell_amount'])), Decimal("50.00"))
         self.assertEqual(Decimal(str(grouped_awb['cost_amount'])), Decimal("30.00"))
         self.assertEqual(grouped_awb['description'], "Combined Origin AWB Fee")
@@ -774,3 +825,15 @@ class QuoteCanonicalResultContractAPITest(APITestCase):
         self.assertIsNotNone(usd_awb)
         self.assertEqual(Decimal(str(usd_awb['sell_amount'])), Decimal("10.00"))
         self.assertFalse(usd_awb.get('is_grouped', False))
+
+        # Verify unmapped lines are separate
+        unmapped_items = [l for l in line_items if l['product_code'] == "IMP-UNMAPPED-FEE" and l['currency'] == "PGK"]
+        self.assertEqual(len(unmapped_items), 2)
+        for ui in unmapped_items:
+            self.assertFalse(ui.get('is_grouped', False))
+
+        # Verify informational line is separate
+        info_items = [l for l in line_items if l['product_code'] == "IMP-AWB-ORIGIN" and l['currency'] == "PGK" and not l.get('included_in_total')]
+        self.assertEqual(len(info_items), 1)
+        self.assertEqual(Decimal(str(info_items[0]['sell_amount'])), Decimal("20.00"))
+        self.assertFalse(info_items[0].get('is_grouped', False))

--- a/backend/quotes/tests/test_api_v3.py
+++ b/backend/quotes/tests/test_api_v3.py
@@ -651,3 +651,126 @@ class QuoteCanonicalResultContractAPITest(APITestCase):
         pickup_line = next((l for l in line_items if l['description'] == "Test Pickup"), None)
         self.assertIsNotNone(pickup_line)
         self.assertEqual(pickup_line['subcategory'], "Local Transport / Cartage")
+
+    def test_canonical_line_items_are_grouped(self):
+        # Create quote
+        quote = Quote.objects.create(
+            customer=self.quote.customer,
+            mode="AIR",
+            shipment_type=Quote.ShipmentType.EXPORT,
+            payment_term=Quote.PaymentTerm.PREPAID,
+            origin_location=self.quote.origin_location,
+            destination_location=self.quote.destination_location,
+            status=Quote.Status.DRAFT,
+            created_by=self.user,
+        )
+        version = QuoteVersion.objects.create(
+            quote=quote,
+            version_number=1,
+            created_by=self.user,
+        )
+        QuoteTotal.objects.create(
+            quote_version=version,
+            total_cost_pgk=Decimal("100.00"),
+            total_sell_pgk=Decimal("200.00"),
+            total_sell_pgk_incl_gst=Decimal("220.00"),
+        )
+
+        from services.models import ServiceComponent, ServiceCode
+        from pricing_v4.models import ProductCode
+        
+        code = ServiceCode.objects.create(
+            code="ORG-AWB-FEE",
+            description="Stored Freight Service Code",
+            location_type="ORIGIN",
+            service_category="DOCUMENTATION",
+            pricing_method="PASSTHROUGH",
+        )
+        comp = ServiceComponent.objects.create(
+            code="IMP-AWB-ORIGIN",
+            description="Origin AWB Fee",
+            service_code=code,
+            mode="AIR",
+            leg="ORIGIN",
+            category="LOCAL",
+            unit="SHIPMENT",
+        )
+        ProductCode.objects.create(
+            id=7788,
+            code="IMP-AWB-ORIGIN",
+            description="Combined Origin AWB Fee",
+            domain="IMPORT",
+            category="DOCUMENTATION",
+            is_gst_applicable=True,
+            gst_treatment="STANDARD",
+            gl_revenue_code="REV-1",
+            gl_cost_code="COS-1",
+            default_unit="SHIPMENT"
+        )
+
+        # Create two duplicate lines in the same leg, currency, tax
+        QuoteLine.objects.create(
+            quote_version=version,
+            service_component=comp,
+            product_code="IMP-AWB-ORIGIN",
+            sell_pgk=Decimal("25.00"),
+            sell_pgk_incl_gst=Decimal("27.50"),
+            cost_pgk=Decimal("15.00"),
+            leg="ORIGIN",
+            cost_source="MANUAL",
+            cost_source_description="Line 1",
+            component="ORIGIN_LOCAL",
+            gst_category="GST"
+        )
+        QuoteLine.objects.create(
+            quote_version=version,
+            service_component=comp,
+            product_code="IMP-AWB-ORIGIN",
+            sell_pgk=Decimal("25.00"),
+            sell_pgk_incl_gst=Decimal("27.50"),
+            cost_pgk=Decimal("15.00"),
+            leg="ORIGIN",
+            cost_source="MANUAL",
+            cost_source_description="Line 2",
+            component="ORIGIN_LOCAL",
+            gst_category="GST"
+        )
+
+        # Incompatible line: different currency
+        QuoteLine.objects.create(
+            quote_version=version,
+            service_component=comp,
+            product_code="IMP-AWB-ORIGIN",
+            sell_pgk=Decimal("30.00"),
+            sell_pgk_incl_gst=Decimal("30.00"),
+            sell_fcy=Decimal("10.00"),
+            sell_fcy_incl_gst=Decimal("10.00"),
+            sell_fcy_currency="USD",
+            leg="ORIGIN",
+            cost_source="MANUAL",
+            cost_source_description="Line Currency Mismatch",
+            component="ORIGIN_LOCAL",
+            gst_category="GST"
+        )
+
+        url = reverse('quotes:quote-v3-compute-v3', kwargs={'pk': quote.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        quote_result = response.data['quote_result']
+        line_items = quote_result['line_items']
+
+        # Verify grouped lines
+        grouped_awb = next((l for l in line_items if l['product_code'] == "IMP-AWB-ORIGIN" and l['currency'] == "PGK"), None)
+        self.assertIsNotNone(grouped_awb)
+        self.assertEqual(Decimal(str(grouped_awb['sell_amount'])), Decimal("50.00"))
+        self.assertEqual(Decimal(str(grouped_awb['cost_amount'])), Decimal("30.00"))
+        self.assertEqual(grouped_awb['description'], "Combined Origin AWB Fee")
+        self.assertTrue(grouped_awb['is_grouped'])
+        self.assertEqual(grouped_awb['grouped_source_count'], 2)
+
+        # Verify incompatible USD line is separate
+        usd_awb = next((l for l in line_items if l['product_code'] == "IMP-AWB-ORIGIN" and l['currency'] == "USD"), None)
+        self.assertIsNotNone(usd_awb)
+        self.assertEqual(Decimal(str(usd_awb['sell_amount'])), Decimal("10.00"))
+        self.assertFalse(usd_awb.get('is_grouped', False))

--- a/backend/quotes/tests/test_public_quote_api.py
+++ b/backend/quotes/tests/test_public_quote_api.py
@@ -626,6 +626,56 @@ class QuotePublicDetailAPITest(APITestCase):
             gst_category="GST"
         )
 
+        # Scenario 1: two lines with same service component code but no explicit product code are NOT grouped
+        comp_unmapped = ServiceComponent.objects.create(
+            code="IMP-UNMAPPED-FEE",
+            description="Unmapped Fee",
+            service_code=code,
+            mode="AIR",
+            leg="ORIGIN",
+            category="LOCAL",
+            unit="SHIPMENT",
+        )
+        QuoteLine.objects.create(
+            quote_version=version,
+            service_component=comp_unmapped,
+            product_code=None,
+            sell_pgk=Decimal("15.00"),
+            sell_pgk_incl_gst=Decimal("16.50"),
+            leg="ORIGIN",
+            cost_source="MANUAL",
+            cost_source_description="Unmapped 1",
+            component="ORIGIN_LOCAL",
+            gst_category="GST"
+        )
+        QuoteLine.objects.create(
+            quote_version=version,
+            service_component=comp_unmapped,
+            product_code=None,
+            sell_pgk=Decimal("15.00"),
+            sell_pgk_incl_gst=Decimal("16.50"),
+            leg="ORIGIN",
+            cost_source="MANUAL",
+            cost_source_description="Unmapped 2",
+            component="ORIGIN_LOCAL",
+            gst_category="GST"
+        )
+
+        # Scenario 2: billable line and informational/non-total line with same ProductCode are NOT grouped
+        QuoteLine.objects.create(
+            quote_version=version,
+            service_component=comp,
+            product_code="IMP-AWB-ORIGIN",
+            is_informational=True,
+            sell_pgk=Decimal("20.00"),
+            sell_pgk_incl_gst=Decimal("22.00"),
+            leg="ORIGIN",
+            cost_source="MANUAL",
+            cost_source_description="Informational Line",
+            component="ORIGIN_LOCAL",
+            gst_category="GST"
+        )
+
         token = build_public_quote_token(str(quote.id))
         response = self.client.get(self.url, {"token": token})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -633,17 +683,28 @@ class QuotePublicDetailAPITest(APITestCase):
         payload = response.json()
         origin_bucket = next(b for b in payload["charge_buckets"] if b["name"] == "Origin Charges")
         
-        # Verify IMP-AWB-ORIGIN is grouped (summed to 50.00)
-        awb_line = next((l for l in origin_bucket["lines"] if l["product_code"] == "IMP-AWB-ORIGIN"), None)
-        self.assertIsNotNone(awb_line)
+        # Verify IMP-AWB-ORIGIN is grouped (summed to 50.00, excluding informational line)
+        awb_lines = [l for l in origin_bucket["lines"] if l.get("product_code") == "IMP-AWB-ORIGIN" and not l.get("is_informational")]
+        self.assertEqual(len(awb_lines), 1)
+        awb_line = awb_lines[0]
         self.assertEqual(awb_line["sell"], "50.00")
         self.assertEqual(awb_line["description"], "Combined Origin AWB Fee")
         self.assertTrue(awb_line.get("is_grouped"))
         self.assertEqual(awb_line.get("grouped_source_count"), 2)
 
         # Verify IMP-HANDLING-ORIGIN is not grouped with AWB
-        handling_line = next((l for l in origin_bucket["lines"] if l["product_code"] == "IMP-HANDLING-ORIGIN"), None)
+        handling_line = next((l for l in origin_bucket["lines"] if l.get("product_code") == "IMP-HANDLING-ORIGIN"), None)
         self.assertIsNotNone(handling_line)
         self.assertEqual(handling_line["sell"], "30.00")
         self.assertEqual(handling_line["description"], "Origin Handling Fee")
         self.assertFalse(handling_line.get("is_grouped", False))
+
+        # Verify unmapped lines are separate
+        unmapped_items = [l for l in origin_bucket["lines"] if l.get("product_code") == "IMP-UNMAPPED-FEE"]
+        self.assertEqual(len(unmapped_items), 2)
+        for ui in unmapped_items:
+            self.assertFalse(ui.get('is_grouped', False))
+
+        # Verify informational line is not displayed
+        info_items = [l for l in origin_bucket["lines"] if l.get("product_code") == "IMP-AWB-ORIGIN" and l.get("is_informational")]
+        self.assertEqual(len(info_items), 0)

--- a/backend/quotes/tests/test_public_quote_api.py
+++ b/backend/quotes/tests/test_public_quote_api.py
@@ -535,3 +535,115 @@ class QuotePublicDetailAPITest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         payload = response.json()
         self.assertTrue(payload["branding"]["logo_url"].endswith("/static/images/efm_logo_cropped.png"))
+
+    def test_public_quote_charges_are_grouped(self):
+        # Create a quote
+        quote = self._create_quote(service_scope="D2D")
+        version = quote.versions.first()
+        
+        # Create service component
+        from services.models import ServiceComponent, ServiceCode
+        from pricing_v4.models import ProductCode
+        
+        code = ServiceCode.objects.create(
+            code="ORG-AWB-FEE",
+            description="Stored Freight Service Code",
+            location_type="ORIGIN",
+            service_category="DOCUMENTATION",
+            pricing_method="PASSTHROUGH",
+        )
+        comp = ServiceComponent.objects.create(
+            code="IMP-AWB-ORIGIN",
+            description="Origin AWB Fee",
+            service_code=code,
+            mode="AIR",
+            leg="ORIGIN",
+            category="LOCAL",
+            unit="SHIPMENT",
+        )
+        
+        # Create ProductCode matching code for lookup
+        ProductCode.objects.create(
+            id=7788,
+            code="IMP-AWB-ORIGIN",
+            description="Combined Origin AWB Fee",
+            domain="IMPORT",
+            category="DOCUMENTATION",
+            is_gst_applicable=True,
+            gst_treatment="STANDARD",
+            gl_revenue_code="REV-1",
+            gl_cost_code="COS-1",
+            default_unit="SHIPMENT"
+        )
+
+        # Create two duplicate lines in the same leg, currency, tax
+        QuoteLine.objects.create(
+            quote_version=version,
+            service_component=comp,
+            product_code="IMP-AWB-ORIGIN",
+            sell_pgk=Decimal("25.00"),
+            sell_pgk_incl_gst=Decimal("27.50"),
+            leg="ORIGIN",
+            cost_source="MANUAL",
+            cost_source_description="Line 1",
+            component="ORIGIN_LOCAL",
+            gst_category="GST"
+        )
+        QuoteLine.objects.create(
+            quote_version=version,
+            service_component=comp,
+            product_code="IMP-AWB-ORIGIN",
+            sell_pgk=Decimal("25.00"),
+            sell_pgk_incl_gst=Decimal("27.50"),
+            leg="ORIGIN",
+            cost_source="MANUAL",
+            cost_source_description="Line 2",
+            component="ORIGIN_LOCAL",
+            gst_category="GST"
+        )
+
+        # Incompatible line: different ProductCode
+        comp2 = ServiceComponent.objects.create(
+            code="IMP-HANDLING-ORIGIN",
+            description="Origin Handling Fee",
+            service_code=code,
+            mode="AIR",
+            leg="ORIGIN",
+            category="LOCAL",
+            unit="SHIPMENT",
+        )
+        QuoteLine.objects.create(
+            quote_version=version,
+            service_component=comp2,
+            product_code="IMP-HANDLING-ORIGIN",
+            description="Origin Handling Fee",
+            sell_pgk=Decimal("30.00"),
+            sell_pgk_incl_gst=Decimal("33.00"),
+            leg="ORIGIN",
+            cost_source="MANUAL",
+            cost_source_description="Origin Handling Fee",
+            component="ORIGIN_LOCAL",
+            gst_category="GST"
+        )
+
+        token = build_public_quote_token(str(quote.id))
+        response = self.client.get(self.url, {"token": token})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        payload = response.json()
+        origin_bucket = next(b for b in payload["charge_buckets"] if b["name"] == "Origin Charges")
+        
+        # Verify IMP-AWB-ORIGIN is grouped (summed to 50.00)
+        awb_line = next((l for l in origin_bucket["lines"] if l["product_code"] == "IMP-AWB-ORIGIN"), None)
+        self.assertIsNotNone(awb_line)
+        self.assertEqual(awb_line["sell"], "50.00")
+        self.assertEqual(awb_line["description"], "Combined Origin AWB Fee")
+        self.assertTrue(awb_line.get("is_grouped"))
+        self.assertEqual(awb_line.get("grouped_source_count"), 2)
+
+        # Verify IMP-HANDLING-ORIGIN is not grouped with AWB
+        handling_line = next((l for l in origin_bucket["lines"] if l["product_code"] == "IMP-HANDLING-ORIGIN"), None)
+        self.assertIsNotNone(handling_line)
+        self.assertEqual(handling_line["sell"], "30.00")
+        self.assertEqual(handling_line["description"], "Origin Handling Fee")
+        self.assertFalse(handling_line.get("is_grouped", False))

--- a/backend/quotes/views/public.py
+++ b/backend/quotes/views/public.py
@@ -306,11 +306,18 @@ def _build_public_charge_buckets(lines, currency: str) -> list[dict]:
         if leg not in buckets:
             leg = 'MAIN'
         sell_value = _resolve_line_sell_value(line, currency)
+        
+        pcode = getattr(line, "product_code", None) or (line.service_component.code if line.service_component else None) or ""
+        tax_code = getattr(line, "gst_category", None) or (line.service_component.tax_code if line.service_component else None) or "GST"
         line_data = {
             'description': description,
             'source': source[:20] if source else '-',
             'sell': _format_decimal(sell_value),
             'is_informational': line.is_informational,
+            'product_code': pcode,
+            'currency': (line.sell_fcy_currency or currency or "PGK").upper(),
+            'tax_code': tax_code,
+            '_sell_decimal': sell_value,
         }
         subcategory = classify_quote_line_public_subcategory(line)
         line_data['subcategory'] = subcategory
@@ -330,6 +337,67 @@ def _build_public_charge_buckets(lines, currency: str) -> list[dict]:
                 {'name': subcategory, 'lines': [], 'subtotal': Decimal('0')},
             )
             group['lines'].append(line_data)
+
+    # Perform grouping of compatible lines per subcategory
+    for leg in buckets:
+        for subcategory in buckets[leg]['groups']:
+            group = buckets[leg]['groups'][subcategory]
+            
+            orig_lines = group['lines']
+            grouped_lines_map = {}
+            other_lines = []
+            
+            for ld in orig_lines:
+                pc = ld.get('product_code')
+                if not pc:
+                    other_lines.append(ld)
+                    continue
+                
+                key = (pc, ld.get('currency'), ld.get('tax_code'))
+                if key not in grouped_lines_map:
+                    grouped_lines_map[key] = {
+                        **ld,
+                        '_original': [ld]
+                    }
+                else:
+                    grouped_lines_map[key]['_original'].append(ld)
+            
+            new_lines = []
+            # We preserve the order of the first occurrences
+            for ld in orig_lines:
+                pc = ld.get('product_code')
+                if not pc:
+                    continue
+                key = (pc, ld.get('currency'), ld.get('tax_code'))
+                if key in grouped_lines_map:
+                    g_ld = grouped_lines_map.pop(key)
+                    orig_list = g_ld['_original']
+                    if len(orig_list) == 1:
+                        g_ld.pop('_original')
+                        g_ld.pop('_sell_decimal', None)
+                        new_lines.append(g_ld)
+                        continue
+                    
+                    sell_sum = sum(x['_sell_decimal'] for x in orig_list)
+                    
+                    from pricing_v4.models import ProductCode
+                    pcode_obj = ProductCode.objects.filter(code=key[0]).first()
+                    if pcode_obj and pcode_obj.description:
+                        g_ld['description'] = pcode_obj.description
+                    
+                    g_ld['sell'] = _format_decimal(sell_sum)
+                    g_ld['is_grouped'] = True
+                    g_ld['grouped_source_count'] = len(orig_list)
+                    g_ld.pop('_original')
+                    g_ld.pop('_sell_decimal', None)
+                    new_lines.append(g_ld)
+            
+            # Add back items that didn't have a product code
+            for ld in other_lines:
+                ld.pop('_sell_decimal', None)
+                new_lines.append(ld)
+                
+            group['lines'] = new_lines
 
     response_buckets = []
     for bucket in buckets.values():

--- a/backend/quotes/views/public.py
+++ b/backend/quotes/views/public.py
@@ -318,6 +318,8 @@ def _build_public_charge_buckets(lines, currency: str) -> list[dict]:
             'currency': (line.sell_fcy_currency or currency or "PGK").upper(),
             'tax_code': tax_code,
             '_sell_decimal': sell_value,
+            '_grouping_product_code': getattr(line, "product_code", None) or "",
+            '_include_in_subtotal': should_include_quote_line_in_subtotal(line, currency),
         }
         subcategory = classify_quote_line_public_subcategory(line)
         line_data['subcategory'] = subcategory
@@ -348,8 +350,9 @@ def _build_public_charge_buckets(lines, currency: str) -> list[dict]:
             other_lines = []
             
             for ld in orig_lines:
-                pc = ld.get('product_code')
-                if not pc:
+                pc = ld.get('_grouping_product_code', '')
+                is_subtotal = ld.get('_include_in_subtotal', False)
+                if not pc or not is_subtotal:
                     other_lines.append(ld)
                     continue
                 
@@ -365,8 +368,9 @@ def _build_public_charge_buckets(lines, currency: str) -> list[dict]:
             new_lines = []
             # We preserve the order of the first occurrences
             for ld in orig_lines:
-                pc = ld.get('product_code')
-                if not pc:
+                pc = ld.get('_grouping_product_code', '')
+                is_subtotal = ld.get('_include_in_subtotal', False)
+                if not pc or not is_subtotal:
                     continue
                 key = (pc, ld.get('currency'), ld.get('tax_code'))
                 if key in grouped_lines_map:
@@ -375,6 +379,8 @@ def _build_public_charge_buckets(lines, currency: str) -> list[dict]:
                     if len(orig_list) == 1:
                         g_ld.pop('_original')
                         g_ld.pop('_sell_decimal', None)
+                        g_ld.pop('_grouping_product_code', None)
+                        g_ld.pop('_include_in_subtotal', None)
                         new_lines.append(g_ld)
                         continue
                     
@@ -390,11 +396,15 @@ def _build_public_charge_buckets(lines, currency: str) -> list[dict]:
                     g_ld['grouped_source_count'] = len(orig_list)
                     g_ld.pop('_original')
                     g_ld.pop('_sell_decimal', None)
+                    g_ld.pop('_grouping_product_code', None)
+                    g_ld.pop('_include_in_subtotal', None)
                     new_lines.append(g_ld)
             
-            # Add back items that didn't have a product code
+            # Add back items that didn't have a product code or were excluded
             for ld in other_lines:
                 ld.pop('_sell_decimal', None)
+                ld.pop('_grouping_product_code', None)
+                ld.pop('_include_in_subtotal', None)
                 new_lines.append(ld)
                 
             group['lines'] = new_lines


### PR DESCRIPTION
## Summary
- Groups compatible customer-facing quote line items by ProductCode in the canonical quote result contract.
- Groups compatible public quote charge bucket lines by ProductCode.
- Preserves internal source/audit charge lines; grouping only happens at customer-facing output boundaries.
- Adds grouping metadata such as `is_grouped` and `grouped_source_count`.

## Verification
- `python backend/manage.py test quotes.tests.test_api_v3 quotes.tests.test_public_quote_api`
- `graphify update .`

## Non-goals
- No ProductCode governance changes.
- No database mutations or migrations.
- No Docker/dependency fixes.