### PR TITLE
test(rbac): add scope foundation and selector visibility regressions

### DIFF
--- a/backend/accounts/scope.py
+++ b/backend/accounts/scope.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .models import CustomUser, UserMembership
+
+
+ORG_WIDE_ROLE_CODES = {
+    CustomUser.ROLE_ADMIN,
+    CustomUser.ROLE_FINANCE,
+}
+
+ORG_WIDE_PERMISSION_CODES = {
+    "quote.view.organization",
+    "report.view.financials",
+    "user.manage",
+    "system.settings",
+}
+
+LEGACY_PERMISSION_CHECKS = {
+    "quote.view.buy_cost": "can_view_buy_charges",
+    "rate.view.buy": "can_view_buy_charges",
+    "quote.view.margin": "can_view_margins",
+    "report.view.financials": "can_view_margins",
+    "quote.create": "can_edit_quotes",
+    "quote.edit": "can_edit_quotes",
+    "quote.clone": "can_edit_quotes",
+    "quote.transition": "can_edit_quotes",
+    "quote.export_pdf": "can_edit_quotes",
+    "quote.finalize": "can_finalize_quotes",
+    "spot.create": "can_use_ai_intake",
+    "spot.analyze": "can_use_ai_intake",
+    "spot.compute": "can_use_ai_intake",
+    "spot.create_quote": "can_use_ai_intake",
+    "spot.acknowledge": "can_use_ai_intake",
+    "rate.edit": "can_edit_rate_cards",
+    "fx.edit": "can_edit_fx_rates",
+    "user.manage": "can_manage_users",
+    "system.settings": "can_access_system_settings",
+    "audit.view": "can_view_audit_logs",
+}
+
+LEGACY_AUTHENTICATED_PERMISSION_CODES = {
+    "quote.view.own",
+    "quote.view.sell",
+    "customer.view",
+    "crm.view",
+    "shipment.view",
+    "report.view.own",
+}
+
+
+@dataclass(frozen=True)
+class EffectiveUserScope:
+    organization_ids: frozenset[Any]
+    branch_ids: frozenset[Any]
+    department_ids: frozenset[Any]
+    department_codes: frozenset[str]
+    role_codes: frozenset[str]
+    permission_codes: frozenset[str]
+    has_active_memberships: bool
+    has_null_branch_scope: bool
+    has_null_department_scope: bool
+
+
+def _is_authenticated_active(user) -> bool:
+    return bool(
+        user
+        and getattr(user, "is_authenticated", False)
+        and getattr(user, "is_active", False)
+    )
+
+
+def _normalize_code(value) -> str:
+    return str(value or "").strip().lower()
+
+
+def _normalize_department_code(value) -> str:
+    return str(value or "").strip().upper()
+
+
+def get_active_memberships(user):
+    if not _is_authenticated_active(user):
+        return UserMembership.objects.none()
+
+    return (
+        UserMembership.objects.filter(user=user, is_active=True)
+        .select_related("organization", "branch", "department", "role")
+        .prefetch_related("role__permissions")
+    )
+
+
+def _membership_role_codes(membership) -> set[str]:
+    role = getattr(membership, "role", None)
+    if not role:
+        return set()
+    return {
+        code
+        for code in {
+            _normalize_code(getattr(role, "code", "")),
+            _normalize_code(getattr(role, "name", "")),
+        }
+        if code
+    }
+
+
+def _membership_permission_codes(membership) -> set[str]:
+    role = getattr(membership, "role", None)
+    if not role or not getattr(role, "is_active", True):
+        return set()
+    return {
+        permission.code
+        for permission in role.permissions.all()
+        if getattr(permission, "is_active", True)
+    }
+
+
+def _membership_is_org_wide(membership) -> bool:
+    role_codes = _membership_role_codes(membership)
+    permission_codes = _membership_permission_codes(membership)
+    return bool(
+        role_codes.intersection(ORG_WIDE_ROLE_CODES)
+        or permission_codes.intersection(ORG_WIDE_PERMISSION_CODES)
+    )
+
+
+def _legacy_permission_codes(user) -> set[str]:
+    permission_codes = set()
+
+    for permission_code in LEGACY_AUTHENTICATED_PERMISSION_CODES:
+        permission_codes.add(permission_code)
+
+    for permission_code, helper_name in LEGACY_PERMISSION_CHECKS.items():
+        if bool(getattr(user, helper_name, False)):
+            permission_codes.add(permission_code)
+
+    return permission_codes
+
+
+def get_effective_user_scope(user) -> EffectiveUserScope:
+    if not _is_authenticated_active(user):
+        return EffectiveUserScope(
+            organization_ids=frozenset(),
+            branch_ids=frozenset(),
+            department_ids=frozenset(),
+            department_codes=frozenset(),
+            role_codes=frozenset(),
+            permission_codes=frozenset(),
+            has_active_memberships=False,
+            has_null_branch_scope=False,
+            has_null_department_scope=False,
+        )
+
+    memberships = list(get_active_memberships(user))
+    if memberships:
+        organization_ids = {
+            membership.organization_id
+            for membership in memberships
+            if membership.organization_id
+        }
+        branch_ids = {
+            membership.branch_id
+            for membership in memberships
+            if membership.branch_id
+        }
+        department_ids = {
+            membership.department_id
+            for membership in memberships
+            if membership.department_id
+        }
+        department_codes = {
+            _normalize_department_code(getattr(membership.department, "code", ""))
+            for membership in memberships
+            if membership.department_id
+        }
+        role_codes = set()
+        permission_codes = set()
+        has_null_branch_scope = False
+        has_null_department_scope = False
+
+        for membership in memberships:
+            role_codes.update(_membership_role_codes(membership))
+            permission_codes.update(_membership_permission_codes(membership))
+            if _membership_is_org_wide(membership):
+                has_null_branch_scope = has_null_branch_scope or membership.branch_id is None
+                has_null_department_scope = (
+                    has_null_department_scope or membership.department_id is None
+                )
+
+        return EffectiveUserScope(
+            organization_ids=frozenset(organization_ids),
+            branch_ids=frozenset(branch_ids),
+            department_ids=frozenset(department_ids),
+            department_codes=frozenset(department_codes),
+            role_codes=frozenset(role_codes),
+            permission_codes=frozenset(permission_codes),
+            has_active_memberships=True,
+            has_null_branch_scope=has_null_branch_scope,
+            has_null_department_scope=has_null_department_scope,
+        )
+
+    role_code = _normalize_code(getattr(user, "role", ""))
+    department_code = _normalize_department_code(getattr(user, "department", ""))
+    organization_id = getattr(user, "organization_id", None)
+
+    return EffectiveUserScope(
+        organization_ids=frozenset({organization_id} if organization_id else set()),
+        branch_ids=frozenset(),
+        department_ids=frozenset(),
+        department_codes=frozenset({department_code} if department_code else set()),
+        role_codes=frozenset({role_code} if role_code else set()),
+        permission_codes=frozenset(_legacy_permission_codes(user)),
+        has_active_memberships=False,
+        has_null_branch_scope=role_code in ORG_WIDE_ROLE_CODES and bool(organization_id),
+        has_null_department_scope=role_code in ORG_WIDE_ROLE_CODES and bool(organization_id),
+    )
+
+
+def user_has_permission(user, permission_code) -> bool:
+    if not _is_authenticated_active(user):
+        return False
+
+    normalized_permission_code = str(permission_code or "").strip()
+    if not normalized_permission_code:
+        return False
+
+    memberships = list(get_active_memberships(user))
+    if memberships:
+        return any(
+            normalized_permission_code in _membership_permission_codes(membership)
+            for membership in memberships
+        )
+
+    if normalized_permission_code in LEGACY_AUTHENTICATED_PERMISSION_CODES:
+        return True
+
+    helper_name = LEGACY_PERMISSION_CHECKS.get(normalized_permission_code)
+    return bool(helper_name and getattr(user, helper_name, False))
+
+
+def user_has_role(user, role_code_or_name) -> bool:
+    if not _is_authenticated_active(user):
+        return False
+
+    normalized_role = _normalize_code(role_code_or_name)
+    if not normalized_role:
+        return False
+
+    return normalized_role in get_effective_user_scope(user).role_codes
+
+
+def user_can_access_organization(user, organization) -> bool:
+    if not _is_authenticated_active(user) or not organization:
+        return False
+
+    if getattr(user, "is_superuser", False):
+        return True
+
+    organization_id = getattr(organization, "id", organization)
+    return organization_id in get_effective_user_scope(user).organization_ids
+
+
+def user_can_access_branch(user, branch) -> bool:
+    if not _is_authenticated_active(user) or not branch:
+        return False
+
+    if getattr(user, "is_superuser", False):
+        return True
+
+    scope = get_effective_user_scope(user)
+    branch_id = getattr(branch, "id", branch)
+    if branch_id in scope.branch_ids:
+        return True
+
+    branch_organization_id = getattr(branch, "organization_id", None)
+    if branch_organization_id not in scope.organization_ids:
+        return False
+
+    if not scope.has_null_branch_scope:
+        return False
+
+    if scope.has_active_memberships:
+        return any(
+            membership.organization_id == branch_organization_id
+            and membership.branch_id is None
+            and _membership_is_org_wide(membership)
+            for membership in get_active_memberships(user)
+        )
+
+    return bool(scope.role_codes.intersection(ORG_WIDE_ROLE_CODES))
+
+
+def user_can_access_department(user, department) -> bool:
+    if not _is_authenticated_active(user) or not department:
+        return False
+
+    if getattr(user, "is_superuser", False):
+        return True
+
+    scope = get_effective_user_scope(user)
+    department_id = getattr(department, "id", department)
+    if department_id in scope.department_ids:
+        return True
+
+    department_organization_id = getattr(department, "organization_id", None)
+    if department_organization_id not in scope.organization_ids:
+        return False
+
+    department_code = _normalize_department_code(getattr(department, "code", ""))
+    if not scope.has_active_memberships and department_code in scope.department_codes:
+        return True
+
+    if not scope.has_null_department_scope:
+        return False
+
+    if scope.has_active_memberships:
+        return any(
+            membership.organization_id == department_organization_id
+            and membership.department_id is None
+            and _membership_is_org_wide(membership)
+            for membership in get_active_memberships(user)
+        )
+
+    return bool(scope.role_codes.intersection(ORG_WIDE_ROLE_CODES))

--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -11,6 +11,7 @@ import json
 from io import StringIO
 from io import BytesIO
 
+from django.contrib.auth.models import AnonymousUser
 from django.core.management import call_command
 from django.test import TestCase, override_settings
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -20,6 +21,15 @@ from PIL import Image
 from core.models import Currency
 from parties.models import Branch, Department, Organization, OrganizationBranding
 from .models import CustomUser, Permission, Role, RolePermission, UserMembership
+from .scope import (
+    get_active_memberships,
+    get_effective_user_scope,
+    user_can_access_branch,
+    user_can_access_department,
+    user_can_access_organization,
+    user_has_permission,
+    user_has_role,
+)
 
 
 class LoginTests(TestCase):
@@ -282,6 +292,244 @@ class RBACPermissionTests(TestCase):
         self.assertFalse(self.manager_user.can_access_system_settings)
         self.assertFalse(self.finance_user.can_access_system_settings)
         self.assertTrue(self.admin_user.can_access_system_settings)
+
+
+class RBACScopeHelperTests(TestCase):
+    def setUp(self):
+        self.pgk = Currency.objects.filter(code='PGK').first() or Currency.objects.create(
+            code='PGK',
+            name='Papua New Guinean Kina',
+        )
+        self.org_a = Organization.objects.create(
+            name='Scope Org A',
+            slug='scope-org-a',
+            default_currency=self.pgk,
+            is_active=True,
+        )
+        self.org_b = Organization.objects.create(
+            name='Scope Org B',
+            slug='scope-org-b',
+            default_currency=self.pgk,
+            is_active=True,
+        )
+        self.branch_a = Branch.objects.create(
+            organization=self.org_a,
+            code='POM',
+            name='Port Moresby',
+        )
+        self.branch_b = Branch.objects.create(
+            organization=self.org_b,
+            code='LAE',
+            name='Lae',
+        )
+        self.department_a = Department.objects.create(
+            organization=self.org_a,
+            branch=self.branch_a,
+            code='AIR',
+            name='Air Freight',
+        )
+        self.department_b = Department.objects.create(
+            organization=self.org_b,
+            branch=self.branch_b,
+            code='SEA',
+            name='Sea Freight',
+        )
+        self.department_a_land = Department.objects.create(
+            organization=self.org_a,
+            branch=self.branch_a,
+            code='LAND',
+            name='Land Freight',
+        )
+        self.department_permission = Permission.objects.create(
+            code='quote.view.department',
+            name='View department quotes',
+        )
+        self.organization_permission = Permission.objects.create(
+            code='quote.view.organization',
+            name='View organization quotes',
+        )
+        self.custom_permission = Permission.objects.create(
+            code='custom.scope.permission',
+            name='Custom scope permission',
+        )
+        self.sales_role = Role.objects.create(
+            code=CustomUser.ROLE_SALES,
+            name='Sales',
+            is_system=True,
+        )
+        self.manager_role = Role.objects.create(
+            code=CustomUser.ROLE_MANAGER,
+            name='Manager',
+            is_system=True,
+        )
+        self.admin_role = Role.objects.create(
+            code=CustomUser.ROLE_ADMIN,
+            name='Admin',
+            is_system=True,
+        )
+        RolePermission.objects.create(
+            role=self.manager_role,
+            permission=self.department_permission,
+        )
+        RolePermission.objects.create(
+            role=self.admin_role,
+            permission=self.organization_permission,
+        )
+        RolePermission.objects.create(
+            role=self.sales_role,
+            permission=self.custom_permission,
+        )
+
+    def _create_user(self, username='scope-user', **kwargs):
+        defaults = {
+            'password': 'test12345',
+            'role': CustomUser.ROLE_SALES,
+        }
+        defaults.update(kwargs)
+        return CustomUser.objects.create_user(username=username, **defaults)
+
+    def _create_membership(self, user, role=None, **kwargs):
+        defaults = {
+            'organization': self.org_a,
+            'branch': self.branch_a,
+            'department': self.department_a,
+            'role': role or self.manager_role,
+            'is_active': True,
+        }
+        defaults.update(kwargs)
+        return UserMembership.objects.create(user=user, **defaults)
+
+    def test_active_membership_resolution(self):
+        user = self._create_user()
+        membership = self._create_membership(user)
+
+        memberships = list(get_active_memberships(user))
+        scope = get_effective_user_scope(user)
+
+        self.assertEqual(memberships, [membership])
+        self.assertTrue(scope.has_active_memberships)
+        self.assertIn(self.org_a.id, scope.organization_ids)
+        self.assertIn(self.branch_a.id, scope.branch_ids)
+        self.assertIn(self.department_a.id, scope.department_ids)
+
+    def test_inactive_membership_ignored(self):
+        user = self._create_user()
+        self._create_membership(user, role=self.sales_role, is_active=False)
+
+        self.assertEqual(list(get_active_memberships(user)), [])
+        self.assertFalse(user_has_permission(user, 'custom.scope.permission'))
+
+    def test_fallback_to_legacy_custom_user_fields(self):
+        user = self._create_user(
+            role=CustomUser.ROLE_MANAGER,
+            department='AIR',
+            organization=self.org_a,
+        )
+
+        scope = get_effective_user_scope(user)
+
+        self.assertFalse(scope.has_active_memberships)
+        self.assertIn(self.org_a.id, scope.organization_ids)
+        self.assertIn('AIR', scope.department_codes)
+        self.assertTrue(user_has_role(user, CustomUser.ROLE_MANAGER))
+        self.assertTrue(user_can_access_department(user, self.department_a))
+        self.assertFalse(user_can_access_department(user, self.department_a_land))
+
+    def test_role_and_permission_lookup_through_role_permission(self):
+        user = self._create_user()
+        self._create_membership(user, role=self.manager_role)
+
+        self.assertTrue(user_has_role(user, CustomUser.ROLE_MANAGER))
+        self.assertTrue(user_has_permission(user, 'quote.view.department'))
+        self.assertFalse(user_has_permission(user, 'quote.view.organization'))
+
+    def test_organization_access_uses_membership_organization(self):
+        user = self._create_user()
+        self._create_membership(user)
+
+        self.assertTrue(user_can_access_organization(user, self.org_a))
+        self.assertFalse(user_can_access_organization(user, self.org_b))
+
+    def test_branch_access_uses_explicit_membership_branch(self):
+        user = self._create_user()
+        self._create_membership(user)
+
+        self.assertTrue(user_can_access_branch(user, self.branch_a))
+        self.assertFalse(user_can_access_branch(user, self.branch_b))
+
+    def test_department_access_uses_explicit_membership_department(self):
+        user = self._create_user()
+        self._create_membership(user)
+
+        self.assertTrue(user_can_access_department(user, self.department_a))
+        self.assertFalse(user_can_access_department(user, self.department_b))
+
+    def test_null_branch_and_department_broaden_only_organization_scoped_roles(self):
+        user = self._create_user()
+        self._create_membership(
+            user,
+            role=self.admin_role,
+            branch=None,
+            department=None,
+        )
+
+        scope = get_effective_user_scope(user)
+
+        self.assertTrue(scope.has_null_branch_scope)
+        self.assertTrue(scope.has_null_department_scope)
+        self.assertTrue(user_can_access_branch(user, self.branch_a))
+        self.assertTrue(user_can_access_department(user, self.department_a_land))
+        self.assertFalse(user_can_access_branch(user, self.branch_b))
+        self.assertFalse(user_can_access_department(user, self.department_b))
+
+    def test_null_branch_and_department_do_not_grant_manager_global_scope(self):
+        user = self._create_user()
+        self._create_membership(
+            user,
+            role=self.manager_role,
+            branch=None,
+            department=None,
+        )
+
+        scope = get_effective_user_scope(user)
+
+        self.assertFalse(scope.has_null_branch_scope)
+        self.assertFalse(scope.has_null_department_scope)
+        self.assertTrue(user_can_access_organization(user, self.org_a))
+        self.assertFalse(user_can_access_branch(user, self.branch_a))
+        self.assertFalse(user_can_access_department(user, self.department_a))
+
+    def test_anonymous_and_inactive_user_denied(self):
+        inactive_user = self._create_user(
+            username='inactive-scope-user',
+            organization=self.org_a,
+            is_active=False,
+        )
+
+        for user in (AnonymousUser(), inactive_user):
+            self.assertEqual(list(get_active_memberships(user)), [])
+            self.assertFalse(user_has_role(user, CustomUser.ROLE_SALES))
+            self.assertFalse(user_has_permission(user, 'quote.view.own'))
+            self.assertFalse(user_can_access_organization(user, self.org_a))
+            self.assertFalse(user_can_access_branch(user, self.branch_a))
+            self.assertFalse(user_can_access_department(user, self.department_a))
+
+    def test_no_accidental_global_access_for_ordinary_users(self):
+        member_user = self._create_user(username='ordinary-member')
+        self._create_membership(member_user, role=self.manager_role)
+        legacy_user = self._create_user(
+            username='ordinary-legacy',
+            role=CustomUser.ROLE_SALES,
+            department='AIR',
+            organization=self.org_a,
+        )
+
+        self.assertFalse(user_can_access_organization(member_user, self.org_b))
+        self.assertFalse(user_can_access_branch(member_user, self.branch_b))
+        self.assertFalse(user_can_access_department(member_user, self.department_b))
+        self.assertFalse(user_can_access_branch(legacy_user, self.branch_a))
+        self.assertFalse(user_can_access_branch(legacy_user, self.branch_b))
+        self.assertFalse(user_can_access_department(legacy_user, self.department_b))
 
 
 class UserManagementOrganizationTests(TestCase):

--- a/backend/quotes/tests/test_rbac_selector_visibility.py
+++ b/backend/quotes/tests/test_rbac_selector_visibility.py
@@ -1,0 +1,311 @@
+from decimal import Decimal
+
+from django.contrib.auth.models import AnonymousUser
+from django.core.exceptions import PermissionDenied
+from django.http import Http404
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from accounts.models import CustomUser, Role, UserMembership
+from accounts.scope import user_can_access_department
+from core.models import Currency
+from parties.models import Branch, Company, Department, Organization
+from quotes.models import Quote, QuoteTotal, QuoteVersion
+from quotes.selectors import get_quote_for_user, get_quotes_for_user, get_spes_for_user
+from quotes.spot_models import SpotPricingEnvelopeDB
+
+
+class QuoteAndSpotLegacyVisibilityTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.customer = Company.objects.create(name="RBAC Visibility Customer", is_customer=True)
+        cls.admin_user = cls._create_user("admin-user", CustomUser.ROLE_ADMIN)
+        cls.finance_user = cls._create_user("finance-user", CustomUser.ROLE_FINANCE)
+        cls.air_manager = cls._create_user("air-manager", CustomUser.ROLE_MANAGER, "AIR")
+        cls.sea_manager = cls._create_user("sea-manager", CustomUser.ROLE_MANAGER, "SEA")
+        cls.no_department_manager = cls._create_user("nodept-manager", CustomUser.ROLE_MANAGER)
+        cls.air_sales = cls._create_user("air-sales", CustomUser.ROLE_SALES, "AIR")
+        cls.sea_sales = cls._create_user("sea-sales", CustomUser.ROLE_SALES, "SEA")
+        cls.inactive_sales = cls._create_user(
+            "inactive-sales",
+            CustomUser.ROLE_SALES,
+            "AIR",
+            is_active=False,
+        )
+
+        cls.quote_by_air_sales = cls._create_quote(cls.air_sales, "AIR-SALES", "1000.00")
+        cls.quote_by_air_manager = cls._create_quote(cls.air_manager, "AIR-MANAGER", "2000.00")
+        cls.quote_by_sea_sales = cls._create_quote(cls.sea_sales, "SEA-SALES", "3000.00")
+        cls.quote_by_inactive_sales = cls._create_quote(
+            cls.inactive_sales,
+            "INACTIVE-SALES",
+            "4000.00",
+        )
+
+        cls.spe_by_air_sales = cls._create_spe(cls.air_sales, "AIR_SALES")
+        cls.spe_by_air_manager = cls._create_spe(cls.air_manager, "AIR_MANAGER")
+        cls.spe_by_sea_sales = cls._create_spe(cls.sea_sales, "SEA_SALES")
+        cls.spe_by_inactive_sales = cls._create_spe(cls.inactive_sales, "INACTIVE_SALES")
+
+    @classmethod
+    def _create_user(cls, username, role, department=None, **kwargs):
+        defaults = {
+            "password": "testpass123",
+            "role": role,
+            "department": department,
+        }
+        defaults.update(kwargs)
+        return CustomUser.objects.create_user(username=username, **defaults)
+
+    @classmethod
+    def _create_quote(cls, user, label, total_sell_pgk):
+        quote = Quote.objects.create(
+            quote_number=f"RBAC-{label}",
+            customer=cls.customer,
+            mode="AIR",
+            shipment_type=Quote.ShipmentType.IMPORT,
+            status=Quote.Status.FINALIZED,
+            created_by=user,
+        )
+        version = QuoteVersion.objects.create(
+            quote=quote,
+            version_number=1,
+            status=quote.status,
+            created_by=user,
+        )
+        QuoteTotal.objects.create(
+            quote_version=version,
+            total_cost_pgk=Decimal("100.00"),
+            total_sell_pgk=Decimal(total_sell_pgk),
+            total_sell_pgk_incl_gst=Decimal(total_sell_pgk),
+        )
+        return quote
+
+    @classmethod
+    def _create_spe(cls, user, reason_code):
+        return SpotPricingEnvelopeDB.objects.create(
+            status=SpotPricingEnvelopeDB.Status.DRAFT,
+            shipment_context_json={
+                "origin_country": "PG",
+                "destination_country": "PG",
+                "origin_code": "POM",
+                "destination_code": "LAE",
+                "commodity": "GCR",
+                "total_weight_kg": 10,
+                "pieces": 1,
+                "service_scope": "p2p",
+                "payment_term": "collect",
+            },
+            conditions_json={},
+            spot_trigger_reason_code=reason_code,
+            spot_trigger_reason_text=f"Test {reason_code}",
+            created_by=user,
+            expires_at=timezone.now() + timezone.timedelta(hours=24),
+        )
+
+    def _quote_ids_for_user(self, user):
+        return set(get_quotes_for_user(user).values_list("id", flat=True))
+
+    def _spe_ids_for_user(self, user):
+        return set(get_spes_for_user(user).values_list("id", flat=True))
+
+    def _api_quote_ids_for_user(self, user):
+        client = APIClient()
+        client.force_authenticate(user=user)
+        response = client.get("/api/v3/quotes/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return {row["id"] for row in response.json()["results"]}
+
+    def test_quote_selector_admin_and_finance_see_broadly(self):
+        expected_quote_ids = {
+            self.quote_by_air_sales.id,
+            self.quote_by_air_manager.id,
+            self.quote_by_sea_sales.id,
+            self.quote_by_inactive_sales.id,
+        }
+
+        self.assertSetEqual(self._quote_ids_for_user(self.admin_user), expected_quote_ids)
+        self.assertSetEqual(self._quote_ids_for_user(self.finance_user), expected_quote_ids)
+
+    def test_quote_selector_manager_sees_own_and_same_legacy_department_only(self):
+        self.assertSetEqual(
+            self._quote_ids_for_user(self.air_manager),
+            {
+                self.quote_by_air_sales.id,
+                self.quote_by_air_manager.id,
+                self.quote_by_inactive_sales.id,
+            },
+        )
+        self.assertSetEqual(
+            self._quote_ids_for_user(self.sea_manager),
+            {self.quote_by_sea_sales.id},
+        )
+
+    def test_quote_selector_sales_sees_own_only(self):
+        self.assertSetEqual(
+            self._quote_ids_for_user(self.air_sales),
+            {self.quote_by_air_sales.id},
+        )
+        self.assertSetEqual(
+            self._quote_ids_for_user(self.sea_sales),
+            {self.quote_by_sea_sales.id},
+        )
+
+    def test_quote_selector_anonymous_denied_and_inactive_is_legacy_compatibility(self):
+        self.assertFalse(get_quotes_for_user(AnonymousUser()).exists())
+        with self.assertRaises(PermissionDenied):
+            get_quote_for_user(AnonymousUser(), self.quote_by_air_sales.id)
+
+        # Legacy selector behavior: inactive users are still treated as authenticated.
+        # This is intentionally documented for later cutover rather than changed here.
+        self.assertSetEqual(
+            self._quote_ids_for_user(self.inactive_sales),
+            {self.quote_by_inactive_sales.id},
+        )
+
+    def test_quote_detail_direct_access_follows_backend_selector_rules(self):
+        allowed_response = self.client.get(
+            f"/api/v3/quotes/{self.quote_by_air_sales.id}/",
+            HTTP_AUTHORIZATION="",
+        )
+        self.assertEqual(allowed_response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        client = APIClient()
+        client.force_authenticate(user=self.air_manager)
+
+        allowed_response = client.get(f"/api/v3/quotes/{self.quote_by_air_sales.id}/")
+        denied_response = client.get(f"/api/v3/quotes/{self.quote_by_sea_sales.id}/")
+
+        self.assertEqual(allowed_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(allowed_response.json()["id"], str(self.quote_by_air_sales.id))
+        self.assertEqual(denied_response.status_code, status.HTTP_404_NOT_FOUND)
+
+        self.assertEqual(
+            get_quote_for_user(self.air_manager, self.quote_by_air_sales.id).id,
+            self.quote_by_air_sales.id,
+        )
+        with self.assertRaises(Http404):
+            get_quote_for_user(self.air_manager, self.quote_by_sea_sales.id)
+
+    def test_quote_list_direct_url_uses_backend_selector_not_frontend_state(self):
+        quote_ids = self._api_quote_ids_for_user(self.air_sales)
+
+        self.assertSetEqual(quote_ids, {str(self.quote_by_air_sales.id)})
+        self.assertNotIn(str(self.quote_by_sea_sales.id), quote_ids)
+
+    def test_spot_selector_admin_and_finance_see_broadly(self):
+        expected_spe_ids = {
+            self.spe_by_air_sales.id,
+            self.spe_by_air_manager.id,
+            self.spe_by_sea_sales.id,
+            self.spe_by_inactive_sales.id,
+        }
+
+        self.assertSetEqual(self._spe_ids_for_user(self.admin_user), expected_spe_ids)
+        self.assertSetEqual(self._spe_ids_for_user(self.finance_user), expected_spe_ids)
+
+    def test_spot_selector_manager_same_department_and_sales_own_only(self):
+        self.assertSetEqual(
+            self._spe_ids_for_user(self.air_manager),
+            {
+                self.spe_by_air_sales.id,
+                self.spe_by_air_manager.id,
+                self.spe_by_inactive_sales.id,
+            },
+        )
+        self.assertSetEqual(
+            self._spe_ids_for_user(self.sea_manager),
+            {self.spe_by_sea_sales.id},
+        )
+        self.assertSetEqual(
+            self._spe_ids_for_user(self.air_sales),
+            {self.spe_by_air_sales.id},
+        )
+
+    def test_spot_direct_id_access_denied_when_out_of_scope(self):
+        client = APIClient()
+        client.force_authenticate(user=self.air_manager)
+
+        allowed_response = client.get(f"/api/v3/spot/envelopes/{self.spe_by_air_sales.id}/")
+        denied_response = client.get(f"/api/v3/spot/envelopes/{self.spe_by_sea_sales.id}/")
+
+        self.assertEqual(allowed_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(allowed_response.json()["id"], str(self.spe_by_air_sales.id))
+        self.assertEqual(denied_response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_spot_list_direct_url_uses_backend_selector_not_frontend_state(self):
+        client = APIClient()
+        client.force_authenticate(user=self.air_sales)
+
+        response = client.get("/api/v3/spot/envelopes/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertSetEqual(
+            {row["id"] for row in response.json()},
+            {str(self.spe_by_air_sales.id)},
+        )
+
+    def test_financial_reports_inherit_quote_selector_rules_for_manager_scope(self):
+        client = APIClient()
+        client.force_authenticate(user=self.air_manager)
+
+        response = client.get("/api/v3/reports/revenue_margin/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["total_revenue"], 7000.0)
+        self.assertEqual(
+            {row["count"] for row in data["by_mode"]},
+            {3},
+        )
+
+    def test_membership_helper_scope_can_differ_from_legacy_selector_until_cutover(self):
+        pgk, _ = Currency.objects.get_or_create(
+            code="PGK",
+            defaults={"name": "Papua New Guinean Kina"},
+        )
+        organization = Organization.objects.create(
+            name="RBAC Helper Compare Org",
+            slug="rbac-helper-compare",
+            default_currency=pgk,
+        )
+        branch = Branch.objects.create(
+            organization=organization,
+            code="POM",
+            name="Port Moresby",
+        )
+        air_department = Department.objects.create(
+            organization=organization,
+            branch=branch,
+            code="AIR",
+            name="Air Freight",
+        )
+        sea_department = Department.objects.create(
+            organization=organization,
+            branch=branch,
+            code="SEA",
+            name="Sea Freight",
+        )
+        manager_role = Role.objects.create(
+            code=CustomUser.ROLE_MANAGER,
+            name="Manager",
+            is_system=True,
+        )
+        UserMembership.objects.create(
+            user=self.sea_manager,
+            organization=organization,
+            branch=branch,
+            department=air_department,
+            role=manager_role,
+            is_active=True,
+        )
+
+        # Current selectors still use CustomUser.department, not UserMembership.
+        self.assertSetEqual(
+            self._quote_ids_for_user(self.sea_manager),
+            {self.quote_by_sea_sales.id},
+        )
+        self.assertTrue(user_can_access_department(self.sea_manager, air_department))
+        self.assertFalse(user_can_access_department(self.sea_manager, sea_department))

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -453,6 +453,68 @@ Tests:
 - Managers see only records allowed by explicit membership scope.
 - Finance/admin behavior is explicit and tested.
 
+#### Initial scope foundation helper PR
+
+The first implementation PR for this phase adds central helper functions and
+tests only. It does not enforce new row-level filtering for quotes, SPOT,
+customers, CRM, shipments, reports, pricing, or rate management.
+
+Current model commitments for this PR:
+
+- `accounts.UserMembership` is the target membership model. Do not create a
+  parallel `UserOrgMembership` model.
+- `parties.Organization` remains the tenant/workspace root and branding owner.
+  Do not rename it to `Organisation` in code.
+- `parties.Company` remains for external parties such as customers, suppliers,
+  agents, and carriers. It must not be reused for internal legal entities.
+- `LegalEntity` and `BranchDepartment` are deferred until the business
+  structure and migration rules are confirmed.
+
+Compatibility rules for the helper layer:
+
+- Prefer active `UserMembership` rows when they exist.
+- Fall back to `CustomUser.role`, `CustomUser.department`, and
+  `CustomUser.organization` only when no active membership exists.
+- Treat null branch or department memberships as organization-wide only for
+  roles or permissions that already represent organization-wide access. Normal
+  sales or manager memberships need explicit branch and department membership
+  before branch-aware enforcement begins.
+- Deny anonymous or inactive users, and avoid global access for ordinary users.
+
+#### Selector visibility regression test PR
+
+The next small PR adds read-only regression tests for current quote and SPE
+visibility. It does not change selectors, serializers, permissions, schema, or
+business visibility.
+
+Current legacy selector behavior captured by tests:
+
+- Quote and SPE list/detail access uses `quotes.selectors.get_quotes_for_user`,
+  `get_quote_for_user`, and `get_spes_for_user`.
+- Admin and finance users see broadly.
+- Managers see their own records and records created by users with the same
+  legacy `CustomUser.department`.
+- Managers without a legacy department fall back to own records only.
+- Sales users see own records only.
+- Anonymous users are denied by selectors or DRF authentication.
+- Inactive users are not denied by the legacy selector layer if they are already
+  treated as authenticated. This is a known compatibility/security risk to fix
+  during the permission-service cutover, not in the regression-test PR.
+
+Known mismatch documented for cutover:
+
+- Current quote and SPE selectors ignore `UserMembership` entirely.
+- The new `accounts.scope` helper can derive a different branch or department
+  from active membership than `CustomUser.department`.
+- Until selector cutover, legacy selector behavior remains authoritative for
+  quote, SPE, and report visibility.
+
+Report inheritance:
+
+- Reporting endpoints that call `get_quotes_for_user` inherit the same legacy
+  quote selector scope. Regression tests should pin this rather than duplicate
+  report-specific RBAC logic.
+
 ### Phase 5: Apply read filters by domain
 
 Apply selectors domain by domain:
@@ -478,7 +540,18 @@ Tests:
 
 After selectors are stable, fix the buy-cost and margin visibility mismatch.
 
-This phase should explicitly decide whether sales can view buy costs by default. The current code allows it, while existing comments say they should not. Because changing this is user-visible and workflow-sensitive, do not bury it inside schema work.
+Business decision: sales users should not be controlled by a blanket
+allow/deny rule. Buy cost and margin visibility must be permission-based. Some
+sales users may be allowed to see buy cost or margin, and others may not.
+
+Suggested future permission codes:
+
+- `quote.view_buy_cost`
+- `quote.view_margin`
+
+Do not change current COGS or buy-cost visibility in the selector-regression PR.
+Existing tests that assert sales can see COGS should remain as legacy
+compatibility coverage until the permission-based rollout is implemented.
 
 Tests:
 
@@ -617,4 +690,3 @@ The safest first implementation PR after this report is schema-only and behavior
 7. Do not change quote, SPOT, customer, CRM, shipment, reporting, or rate visibility in that PR.
 
 The second safest slice is central permission resolution and serializer masking tests, still with selectors kept equivalent. The buy-cost visibility mismatch should be fixed only after the expected sales behavior is explicitly confirmed, because current code allows sales buy-cost visibility while existing comments say the opposite.
-


### PR DESCRIPTION
## Summary

- Adds central RBAC/scope helper foundation under `backend/accounts/scope.py`
- Adds focused accounts tests for membership, legacy fallback, permissions, organization, branch, and department access
- Adds quote/SPOT selector regression tests to lock current legacy visibility behaviour before future selector refactors
- Documents that `UserMembership` is the target membership model
- Documents that `Organization` remains the tenant/workspace root
- Documents that `Company` remains external-party-only
- Documents buy-cost/margin visibility direction: permission-based, not blanket sales allow/deny
- Does not change current quote, SPOT, customer, CRM, shipment, report, pricing, or rate visibility enforcement
- Does not add new schema or migrations

## Checks

- `python backend\manage.py test accounts`
- `python backend\manage.py test quotes.tests.test_rbac_selector_visibility`
- `python backend\manage.py test quotes.tests.test_departmental_access accounts`
- `npx fallow --format json`
- `npx fallow dupes --format json`
- `git diff --check`

## Notes

- Fallow dead-code/health findings were observed during the implementation audit phase but are existing findings and not part of this packaging change.
- `git diff --check` passes with the existing Windows LF-to-CRLF warning on edited files.