### PR TITLE
docs(rbac): standardise financial permission names

### DIFF
--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -546,8 +546,13 @@ sales users may be allowed to see buy cost or margin, and others may not.
 
 Suggested future permission codes:
 
-- `quote.view_buy_cost`
-- `quote.view_margin`
+RateEngine permission codes should use dot-separated namespaces, for example
+`domain.action.scope_or_field`.
+
+- `quote.view.buy_cost`
+- `quote.view.margin`
+- `rate.view.buy`
+- `report.view.financials`
 
 Do not change current COGS or buy-cost visibility in the selector-regression PR.
 Existing tests that assert sales can see COGS should remain as legacy


### PR DESCRIPTION
## Summary

- Standardises future RBAC financial permission examples to dot-separated names.
- Replaces `quote.view_buy_cost` with `quote.view.buy_cost`.
- Replaces `quote.view_margin` with `quote.view.margin`.
- Adds a short naming convention note with examples such as `domain.action.scope_or_field`.

## Scope

- Documentation only.
- No code changes.
- No test changes.
- No migrations.
- No RBAC enforcement changes.

## Checks

- `git diff --check`