### PR TITLE
test(rbac): add selector scope comparison harness

### DIFF
--- a/backend/quotes/tests/rbac_selector_comparison.py
+++ b/backend/quotes/tests/rbac_selector_comparison.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from django.db.models import Q, QuerySet
+
+from accounts.models import CustomUser
+from accounts.scope import get_active_memberships, get_effective_user_scope
+from quotes.models import Quote
+from quotes.selectors import get_quotes_for_user, get_spes_for_user
+from quotes.spot_models import SpotPricingEnvelopeDB
+
+
+@dataclass(frozen=True)
+class SelectorComparison:
+    legacy_ids: frozenset
+    scope_ids: frozenset
+    only_legacy_ids: frozenset
+    only_scope_ids: frozenset
+
+    @property
+    def has_mismatch(self) -> bool:
+        return bool(self.only_legacy_ids or self.only_scope_ids)
+
+
+def compare_quote_visibility(user, queryset: QuerySet | None = None) -> SelectorComparison:
+    if queryset is None:
+        queryset = Quote.objects.all()
+
+    legacy_ids = frozenset(get_quotes_for_user(user, queryset).values_list("id", flat=True))
+    scope_ids = frozenset(
+        _get_records_for_scope(user, queryset, legacy_selector=get_quotes_for_user).values_list(
+            "id",
+            flat=True,
+        )
+    )
+    return _build_comparison(legacy_ids, scope_ids)
+
+
+def compare_spe_visibility(user, queryset: QuerySet | None = None) -> SelectorComparison:
+    if queryset is None:
+        queryset = SpotPricingEnvelopeDB.objects.all()
+
+    legacy_ids = frozenset(get_spes_for_user(user, queryset).values_list("id", flat=True))
+    scope_ids = frozenset(
+        _get_records_for_scope(user, queryset, legacy_selector=get_spes_for_user).values_list(
+            "id",
+            flat=True,
+        )
+    )
+    return _build_comparison(legacy_ids, scope_ids)
+
+
+def _build_comparison(legacy_ids: frozenset, scope_ids: frozenset) -> SelectorComparison:
+    return SelectorComparison(
+        legacy_ids=legacy_ids,
+        scope_ids=scope_ids,
+        only_legacy_ids=frozenset(legacy_ids - scope_ids),
+        only_scope_ids=frozenset(scope_ids - legacy_ids),
+    )
+
+
+def _get_records_for_scope(user, queryset: QuerySet, *, legacy_selector) -> QuerySet:
+    if not user or not getattr(user, "is_authenticated", False):
+        return queryset.none()
+    if not getattr(user, "is_active", False):
+        return queryset.none()
+
+    memberships = list(get_active_memberships(user))
+    if not memberships:
+        return legacy_selector(user, queryset)
+
+    scope = get_effective_user_scope(user)
+    role_codes = scope.role_codes
+
+    if role_codes.intersection({CustomUser.ROLE_ADMIN, CustomUser.ROLE_FINANCE}):
+        return queryset
+
+    if CustomUser.ROLE_MANAGER in role_codes:
+        department_ids = scope.department_ids
+        if department_ids:
+            return queryset.filter(
+                Q(created_by=user)
+                | Q(
+                    created_by__memberships__is_active=True,
+                    created_by__memberships__department_id__in=department_ids,
+                )
+            ).distinct()
+        return queryset.filter(created_by=user)
+
+    return queryset.filter(created_by=user)

--- a/backend/quotes/tests/test_rbac_selector_visibility.py
+++ b/backend/quotes/tests/test_rbac_selector_visibility.py
@@ -9,12 +9,16 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from accounts.models import CustomUser, Role, UserMembership
-from accounts.scope import user_can_access_department
+from accounts.scope import get_active_memberships, user_can_access_department
 from core.models import Currency
 from parties.models import Branch, Company, Department, Organization
 from quotes.models import Quote, QuoteTotal, QuoteVersion
 from quotes.selectors import get_quote_for_user, get_quotes_for_user, get_spes_for_user
 from quotes.spot_models import SpotPricingEnvelopeDB
+from quotes.tests.rbac_selector_comparison import (
+    compare_quote_visibility,
+    compare_spe_visibility,
+)
 
 
 class QuoteAndSpotLegacyVisibilityTests(TestCase):
@@ -288,10 +292,13 @@ class QuoteAndSpotLegacyVisibilityTests(TestCase):
             code="SEA",
             name="Sea Freight",
         )
-        manager_role = Role.objects.create(
+        manager_role, _ = Role.objects.get_or_create(
             code=CustomUser.ROLE_MANAGER,
-            name="Manager",
-            is_system=True,
+            organization=None,
+            defaults={
+                "name": "Manager",
+                "is_system": True,
+            },
         )
         UserMembership.objects.create(
             user=self.sea_manager,
@@ -309,3 +316,157 @@ class QuoteAndSpotLegacyVisibilityTests(TestCase):
         )
         self.assertTrue(user_can_access_department(self.sea_manager, air_department))
         self.assertFalse(user_can_access_department(self.sea_manager, sea_department))
+
+
+class QuoteAndSpotScopeComparisonTests(QuoteAndSpotLegacyVisibilityTests):
+    def setUp(self):
+        self.pgk, _ = Currency.objects.get_or_create(
+            code="PGK",
+            defaults={"name": "Papua New Guinean Kina"},
+        )
+        self.organization = Organization.objects.create(
+            name="RBAC Selector Compare Org",
+            slug="rbac-selector-compare",
+            default_currency=self.pgk,
+        )
+        self.branch = Branch.objects.create(
+            organization=self.organization,
+            code="POM",
+            name="Port Moresby",
+        )
+        self.air_department = Department.objects.create(
+            organization=self.organization,
+            branch=self.branch,
+            code="AIR",
+            name="Air Freight",
+        )
+        self.sea_department = Department.objects.create(
+            organization=self.organization,
+            branch=self.branch,
+            code="SEA",
+            name="Sea Freight",
+        )
+        self.sales_role = Role.objects.create(
+            code=CustomUser.ROLE_SALES,
+            name="Sales",
+            is_system=True,
+        )
+        self.manager_role = Role.objects.create(
+            code=CustomUser.ROLE_MANAGER,
+            name="Manager",
+            is_system=True,
+        )
+        self.admin_role = Role.objects.create(
+            code=CustomUser.ROLE_ADMIN,
+            name="Admin",
+            is_system=True,
+        )
+        self.finance_role = Role.objects.create(
+            code=CustomUser.ROLE_FINANCE,
+            name="Finance",
+            is_system=True,
+        )
+
+    def _membership_for(self, user, role, department, *, active=True):
+        return UserMembership.objects.create(
+            user=user,
+            organization=self.organization,
+            branch=self.branch,
+            department=department,
+            role=role,
+            is_active=active,
+        )
+
+    def _assert_no_quote_or_spe_mismatch(self, user):
+        quote_comparison = compare_quote_visibility(user)
+        spe_comparison = compare_spe_visibility(user)
+
+        self.assertFalse(quote_comparison.has_mismatch)
+        self.assertFalse(spe_comparison.has_mismatch)
+        self.assertSetEqual(quote_comparison.legacy_ids, quote_comparison.scope_ids)
+        self.assertSetEqual(spe_comparison.legacy_ids, spe_comparison.scope_ids)
+
+    def test_no_active_memberships_fall_back_to_legacy_behavior(self):
+        self.assertEqual(list(get_active_memberships(self.air_manager)), [])
+
+        self._assert_no_quote_or_spe_mismatch(self.air_manager)
+
+    def test_active_membership_matching_legacy_department_has_no_mismatch(self):
+        self._membership_for(self.air_manager, self.manager_role, self.air_department)
+        self._membership_for(self.air_sales, self.sales_role, self.air_department)
+        self._membership_for(self.inactive_sales, self.sales_role, self.air_department)
+        self._membership_for(self.sea_sales, self.sales_role, self.sea_department)
+
+        self._assert_no_quote_or_spe_mismatch(self.air_manager)
+
+    def test_active_membership_different_from_legacy_department_reports_mismatch(self):
+        self._membership_for(self.sea_manager, self.manager_role, self.air_department)
+        self._membership_for(self.air_sales, self.sales_role, self.air_department)
+        self._membership_for(self.air_manager, self.manager_role, self.air_department)
+        self._membership_for(self.sea_sales, self.sales_role, self.sea_department)
+
+        quote_comparison = compare_quote_visibility(self.sea_manager)
+        spe_comparison = compare_spe_visibility(self.sea_manager)
+
+        self.assertTrue(quote_comparison.has_mismatch)
+        self.assertSetEqual(quote_comparison.legacy_ids, {self.quote_by_sea_sales.id})
+        self.assertSetEqual(
+            quote_comparison.scope_ids,
+            {self.quote_by_air_sales.id, self.quote_by_air_manager.id},
+        )
+        self.assertSetEqual(quote_comparison.only_legacy_ids, {self.quote_by_sea_sales.id})
+        self.assertSetEqual(
+            quote_comparison.only_scope_ids,
+            {self.quote_by_air_sales.id, self.quote_by_air_manager.id},
+        )
+
+        self.assertTrue(spe_comparison.has_mismatch)
+        self.assertSetEqual(spe_comparison.legacy_ids, {self.spe_by_sea_sales.id})
+        self.assertSetEqual(
+            spe_comparison.scope_ids,
+            {self.spe_by_air_sales.id, self.spe_by_air_manager.id},
+        )
+
+    def test_admin_and_finance_organization_wide_comparison_has_no_mismatch(self):
+        self._membership_for(self.admin_user, self.admin_role, None)
+        self._membership_for(self.finance_user, self.finance_role, None)
+
+        self._assert_no_quote_or_spe_mismatch(self.admin_user)
+        self._assert_no_quote_or_spe_mismatch(self.finance_user)
+
+    def test_sales_own_only_comparison_has_no_mismatch(self):
+        self._membership_for(self.air_sales, self.sales_role, self.air_department)
+
+        self._assert_no_quote_or_spe_mismatch(self.air_sales)
+
+    def test_manager_same_department_legacy_comparison_has_no_mismatch(self):
+        self._membership_for(self.air_manager, self.manager_role, self.air_department)
+        self._membership_for(self.air_sales, self.sales_role, self.air_department)
+        self._membership_for(self.inactive_sales, self.sales_role, self.air_department)
+
+        self._assert_no_quote_or_spe_mismatch(self.air_manager)
+
+    def test_anonymous_and_inactive_comparison_documents_current_difference(self):
+        anonymous_quote_comparison = compare_quote_visibility(AnonymousUser())
+        anonymous_spe_comparison = compare_spe_visibility(AnonymousUser())
+
+        self.assertFalse(anonymous_quote_comparison.has_mismatch)
+        self.assertFalse(anonymous_spe_comparison.has_mismatch)
+        self.assertSetEqual(anonymous_quote_comparison.legacy_ids, frozenset())
+        self.assertSetEqual(anonymous_spe_comparison.legacy_ids, frozenset())
+
+        self._membership_for(self.inactive_sales, self.sales_role, self.air_department)
+        inactive_quote_comparison = compare_quote_visibility(self.inactive_sales)
+        inactive_spe_comparison = compare_spe_visibility(self.inactive_sales)
+
+        self.assertTrue(inactive_quote_comparison.has_mismatch)
+        self.assertSetEqual(
+            inactive_quote_comparison.legacy_ids,
+            {self.quote_by_inactive_sales.id},
+        )
+        self.assertSetEqual(inactive_quote_comparison.scope_ids, frozenset())
+        self.assertSetEqual(
+            inactive_spe_comparison.legacy_ids,
+            {self.spe_by_inactive_sales.id},
+        )
+        self.assertSetEqual(inactive_spe_comparison.scope_ids, frozenset())

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -515,6 +515,29 @@ Report inheritance:
   quote selector scope. Regression tests should pin this rather than duplicate
   report-specific RBAC logic.
 
+#### Selector scope comparison harness PR
+
+The selector comparison harness is for tests and migration planning only. It
+compares current legacy selector results with membership-derived scope results
+without changing runtime enforcement.
+
+Rules for this PR:
+
+- Legacy selectors remain authoritative for quote, SPE, and report visibility
+  until an explicit cutover PR changes them.
+- Comparison results must not be used by production API views, serializers, or
+  services.
+- The harness may report mismatches where active `UserMembership.department`
+  differs from legacy `CustomUser.department`.
+- Active users with no active memberships should compare equal to legacy
+  behavior because `accounts.scope` intentionally falls back to legacy fields.
+- Anonymous users should compare as denied on both sides.
+- Inactive users are a known compatibility mismatch: legacy selectors may still
+  return own records if the user is already treated as authenticated, while the
+  scope helper denies inactive users.
+- No enforcement, schema, migration, customer, CRM, shipment, pricing, report,
+  rate, buy-cost, or margin behavior changes are made by the comparison harness.
+
 ### Phase 5: Apply read filters by domain
 
 Apply selectors domain by domain:


### PR DESCRIPTION
## Summary

- Adds a test-only selector comparison harness for quote and SPE visibility.
- Compares current legacy selector IDs with membership-derived scope IDs.
- Adds regression coverage for fallback, matching membership, mismatched membership, org-wide roles, sales own-only behavior, and anonymous/inactive cases.
- Documents that legacy selectors remain authoritative until an explicit cutover.

## Scope

- No production selector enforcement changes.
- No schema changes or migrations.
- No quote, SPOT, customer, CRM, shipment, report, pricing, rate, buy-cost, or margin behavior changes.

## Checks previously run

- `python backend\manage.py test quotes.tests.test_rbac_selector_visibility`
- `python backend\manage.py test accounts`
- `python backend\manage.py test quotes.tests.test_departmental_access`
- `git diff --check`
- Fallow baseline and `graphify update .`