### PR TITLE
feat(rbac): add visibility comparison diagnostics

### DIFF
--- a/backend/quotes/management/commands/rbac_compare_visibility.py
+++ b/backend/quotes/management/commands/rbac_compare_visibility.py
@@ -1,0 +1,160 @@
+import json
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db.models import Q
+
+from accounts.models import CustomUser
+from accounts.scope import get_active_memberships
+from quotes.rbac_selector_comparison import (
+    compare_quote_visibility,
+    compare_spe_visibility,
+)
+
+
+class Command(BaseCommand):
+    help = (
+        "Read-only diagnostic comparing legacy quote/SPE selector visibility "
+        "with UserMembership-derived visibility."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--format",
+            choices=["text", "json"],
+            default="text",
+            help="Output format. Defaults to text.",
+        )
+        parser.add_argument(
+            "--user",
+            dest="user_lookup",
+            help="Limit comparison to one user by username or numeric ID.",
+        )
+        parser.add_argument(
+            "--include-inactive",
+            action="store_true",
+            help="Include inactive users. Inactive users are skipped by default.",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            help="Limit the number of users compared.",
+        )
+        parser.add_argument(
+            "--show-details",
+            action="store_true",
+            help="Include record ID lists in output.",
+        )
+
+    def handle(self, *args, **options):
+        users = self._get_users(options)
+        rows = [self._build_user_row(user, show_details=options["show_details"]) for user in users]
+
+        payload = {
+            "summary": self._build_summary(rows),
+            "users": rows,
+        }
+
+        if options["format"] == "json":
+            self.stdout.write(json.dumps(payload, indent=2, sort_keys=True))
+            return
+
+        self._write_text(payload, show_details=options["show_details"])
+
+    def _get_users(self, options):
+        queryset = CustomUser.objects.all().order_by("username", "id")
+
+        if not options["include_inactive"]:
+            queryset = queryset.filter(is_active=True)
+
+        user_lookup = options.get("user_lookup")
+        if user_lookup:
+            lookup = Q(username=user_lookup)
+            if user_lookup.isdigit():
+                lookup |= Q(pk=int(user_lookup))
+            queryset = queryset.filter(lookup)
+
+        limit = options.get("limit")
+        if limit is not None:
+            if limit < 1:
+                raise CommandError("--limit must be a positive integer.")
+            queryset = queryset[:limit]
+
+        users = list(queryset)
+        if user_lookup and not users:
+            raise CommandError(f"No user found for --user={user_lookup!r}.")
+        return users
+
+    def _build_user_row(self, user, *, show_details: bool) -> dict:
+        memberships = list(get_active_memberships(user))
+        quote_comparison = compare_quote_visibility(user)
+        spe_comparison = compare_spe_visibility(user)
+
+        return {
+            "user_id": user.pk,
+            "username": user.username,
+            "is_active": user.is_active,
+            "role": getattr(user, "role", ""),
+            "legacy_department": getattr(user, "department", None),
+            "membership_count": len(memberships),
+            "quotes": quote_comparison.as_dict(show_details=show_details),
+            "spes": spe_comparison.as_dict(show_details=show_details),
+            "has_mismatch": quote_comparison.has_mismatch or spe_comparison.has_mismatch,
+        }
+
+    def _build_summary(self, rows: list[dict]) -> dict:
+        return {
+            "users_compared": len(rows),
+            "users_with_mismatches": sum(1 for row in rows if row["has_mismatch"]),
+            "quote_legacy_only_count": sum(row["quotes"]["legacy_only_count"] for row in rows),
+            "quote_membership_only_count": sum(row["quotes"]["membership_only_count"] for row in rows),
+            "spe_legacy_only_count": sum(row["spes"]["legacy_only_count"] for row in rows),
+            "spe_membership_only_count": sum(row["spes"]["membership_only_count"] for row in rows),
+        }
+
+    def _write_text(self, payload: dict, *, show_details: bool):
+        summary = payload["summary"]
+        self.stdout.write("RBAC visibility comparison")
+        self.stdout.write("==========================")
+        self.stdout.write(f"Users compared: {summary['users_compared']}")
+        self.stdout.write(f"Users with mismatches: {summary['users_with_mismatches']}")
+        self.stdout.write(
+            "Quote mismatches: "
+            f"legacy-only={summary['quote_legacy_only_count']}, "
+            f"membership-only={summary['quote_membership_only_count']}"
+        )
+        self.stdout.write(
+            "SPE mismatches: "
+            f"legacy-only={summary['spe_legacy_only_count']}, "
+            f"membership-only={summary['spe_membership_only_count']}"
+        )
+
+        for row in payload["users"]:
+            self.stdout.write("")
+            self.stdout.write(
+                f"- {row['username']} (id={row['user_id']}, active={row['is_active']}, "
+                f"role={row['role']}, legacy_department={row['legacy_department']}, "
+                f"memberships={row['membership_count']})"
+            )
+            self.stdout.write(
+                self._format_counts("quotes", row["quotes"])
+            )
+            self.stdout.write(
+                self._format_counts("SPEs", row["spes"])
+            )
+            if show_details:
+                self._write_details("quotes", row["quotes"])
+                self._write_details("SPEs", row["spes"])
+
+    def _format_counts(self, label: str, counts: dict) -> str:
+        return (
+            f"  {label}: legacy={counts['legacy_count']}, "
+            f"membership={counts['membership_count']}, "
+            f"matching={counts['matching_count']}, "
+            f"legacy-only={counts['legacy_only_count']}, "
+            f"membership-only={counts['membership_only_count']}, "
+            f"mismatch={counts['has_mismatch']}"
+        )
+
+    def _write_details(self, label: str, counts: dict):
+        self.stdout.write(f"  {label} legacy-only IDs: {counts['legacy_only_ids']}")
+        self.stdout.write(f"  {label} membership-only IDs: {counts['membership_only_ids']}")

--- a/backend/quotes/rbac_selector_comparison.py
+++ b/backend/quotes/rbac_selector_comparison.py
@@ -19,8 +19,36 @@ class SelectorComparison:
     only_scope_ids: frozenset
 
     @property
+    def matching_ids(self) -> frozenset:
+        return frozenset(self.legacy_ids.intersection(self.scope_ids))
+
+    @property
     def has_mismatch(self) -> bool:
         return bool(self.only_legacy_ids or self.only_scope_ids)
+
+    def as_counts(self) -> dict:
+        return {
+            "legacy_count": len(self.legacy_ids),
+            "membership_count": len(self.scope_ids),
+            "matching_count": len(self.matching_ids),
+            "legacy_only_count": len(self.only_legacy_ids),
+            "membership_only_count": len(self.only_scope_ids),
+            "has_mismatch": self.has_mismatch,
+        }
+
+    def as_dict(self, *, show_details: bool = False) -> dict:
+        payload = self.as_counts()
+        if show_details:
+            payload.update(
+                {
+                    "legacy_ids": _stringify_ids(self.legacy_ids),
+                    "membership_ids": _stringify_ids(self.scope_ids),
+                    "matching_ids": _stringify_ids(self.matching_ids),
+                    "legacy_only_ids": _stringify_ids(self.only_legacy_ids),
+                    "membership_only_ids": _stringify_ids(self.only_scope_ids),
+                }
+            )
+        return payload
 
 
 def compare_quote_visibility(user, queryset: QuerySet | None = None) -> SelectorComparison:
@@ -89,3 +117,7 @@ def _get_records_for_scope(user, queryset: QuerySet, *, legacy_selector) -> Quer
         return queryset.filter(created_by=user)
 
     return queryset.filter(created_by=user)
+
+
+def _stringify_ids(ids: frozenset) -> list[str]:
+    return sorted(str(item) for item in ids)

--- a/backend/quotes/tests/test_rbac_compare_visibility_command.py
+++ b/backend/quotes/tests/test_rbac_compare_visibility_command.py
@@ -1,0 +1,236 @@
+import json
+from decimal import Decimal
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils import timezone
+
+from accounts.models import CustomUser, Role, UserMembership
+from core.models import Currency
+from parties.models import Branch, Company, Department, Organization
+from quotes.models import Quote, QuoteTotal, QuoteVersion
+from quotes.spot_models import SpotPricingEnvelopeDB
+
+
+class RBACCompareVisibilityCommandTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.pgk, _ = Currency.objects.get_or_create(
+            code="PGK",
+            defaults={"name": "Papua New Guinean Kina"},
+        )
+        cls.organization = Organization.objects.create(
+            name="RBAC Compare Command Org",
+            slug="rbac-compare-command",
+            default_currency=cls.pgk,
+        )
+        cls.branch = Branch.objects.create(
+            organization=cls.organization,
+            code="POM",
+            name="Port Moresby",
+        )
+        cls.air_department = Department.objects.create(
+            organization=cls.organization,
+            branch=cls.branch,
+            code="AIR",
+            name="Air Freight",
+        )
+        cls.sea_department = Department.objects.create(
+            organization=cls.organization,
+            branch=cls.branch,
+            code="SEA",
+            name="Sea Freight",
+        )
+        cls.sales_role = Role.objects.create(
+            code=CustomUser.ROLE_SALES,
+            name="Sales",
+            is_system=True,
+        )
+        cls.manager_role = Role.objects.create(
+            code=CustomUser.ROLE_MANAGER,
+            name="Manager",
+            is_system=True,
+        )
+
+        cls.customer = Company.objects.create(
+            name="RBAC Compare Customer",
+            is_customer=True,
+        )
+        cls.air_manager = cls._create_user("compare-air-manager", CustomUser.ROLE_MANAGER, "AIR")
+        cls.sea_manager = cls._create_user("compare-sea-manager", CustomUser.ROLE_MANAGER, "SEA")
+        cls.air_sales = cls._create_user("compare-air-sales", CustomUser.ROLE_SALES, "AIR")
+        cls.sea_sales = cls._create_user("compare-sea-sales", CustomUser.ROLE_SALES, "SEA")
+        cls.inactive_sales = cls._create_user(
+            "compare-inactive-sales",
+            CustomUser.ROLE_SALES,
+            "AIR",
+            is_active=False,
+        )
+
+        cls.air_quote = cls._create_quote(cls.air_sales, "AIR", "1000.00")
+        cls.sea_quote = cls._create_quote(cls.sea_sales, "SEA", "2000.00")
+        cls.air_spe = cls._create_spe(cls.air_sales, "AIR_SPE")
+        cls.sea_spe = cls._create_spe(cls.sea_sales, "SEA_SPE")
+
+    @classmethod
+    def _create_user(cls, username, role, department, **kwargs):
+        defaults = {
+            "password": "testpass123",
+            "role": role,
+            "department": department,
+        }
+        defaults.update(kwargs)
+        return CustomUser.objects.create_user(username=username, **defaults)
+
+    @classmethod
+    def _create_quote(cls, user, label, total_sell_pgk):
+        quote = Quote.objects.create(
+            quote_number=f"RBAC-COMPARE-{label}",
+            customer=cls.customer,
+            mode="AIR",
+            shipment_type=Quote.ShipmentType.IMPORT,
+            status=Quote.Status.FINALIZED,
+            created_by=user,
+        )
+        version = QuoteVersion.objects.create(
+            quote=quote,
+            version_number=1,
+            status=quote.status,
+            created_by=user,
+        )
+        QuoteTotal.objects.create(
+            quote_version=version,
+            total_cost_pgk=Decimal("100.00"),
+            total_sell_pgk=Decimal(total_sell_pgk),
+            total_sell_pgk_incl_gst=Decimal(total_sell_pgk),
+        )
+        return quote
+
+    @classmethod
+    def _create_spe(cls, user, reason_code):
+        return SpotPricingEnvelopeDB.objects.create(
+            status=SpotPricingEnvelopeDB.Status.DRAFT,
+            shipment_context_json={
+                "origin_country": "PG",
+                "destination_country": "PG",
+                "origin_code": "POM",
+                "destination_code": "LAE",
+                "commodity": "GCR",
+                "total_weight_kg": 10,
+                "pieces": 1,
+                "service_scope": "p2p",
+                "payment_term": "collect",
+            },
+            conditions_json={},
+            spot_trigger_reason_code=reason_code,
+            spot_trigger_reason_text=f"Test {reason_code}",
+            created_by=user,
+            expires_at=timezone.now() + timezone.timedelta(hours=24),
+        )
+
+    def _membership_for(self, user, role, department):
+        return UserMembership.objects.create(
+            user=user,
+            organization=self.organization,
+            branch=self.branch,
+            department=department,
+            role=role,
+            is_active=True,
+        )
+
+    def _call_command(self, *args):
+        stdout = StringIO()
+        call_command("rbac_compare_visibility", *args, stdout=stdout)
+        return stdout.getvalue()
+
+    def test_command_runs_successfully_with_text_output(self):
+        output = self._call_command("--user", self.air_sales.username)
+
+        self.assertIn("RBAC visibility comparison", output)
+        self.assertIn(self.air_sales.username, output)
+        self.assertIn("quotes:", output)
+        self.assertIn("SPEs:", output)
+
+    def test_command_runs_successfully_with_json_output(self):
+        output = self._call_command("--format", "json", "--user", self.air_sales.username)
+
+        payload = json.loads(output)
+        self.assertEqual(payload["summary"]["users_compared"], 1)
+        self.assertEqual(payload["users"][0]["username"], self.air_sales.username)
+        self.assertIn("quotes", payload["users"][0])
+        self.assertIn("spes", payload["users"][0])
+
+    def test_command_excludes_inactive_users_by_default(self):
+        output = self._call_command("--format", "json")
+        payload = json.loads(output)
+
+        usernames = {row["username"] for row in payload["users"]}
+        self.assertNotIn(self.inactive_sales.username, usernames)
+
+    def test_command_includes_inactive_users_when_requested(self):
+        output = self._call_command("--format", "json", "--include-inactive")
+        payload = json.loads(output)
+
+        usernames = {row["username"] for row in payload["users"]}
+        self.assertIn(self.inactive_sales.username, usernames)
+
+    def test_command_can_filter_by_user(self):
+        output = self._call_command("--format", "json", "--user", str(self.air_manager.pk))
+        payload = json.loads(output)
+
+        self.assertEqual(payload["summary"]["users_compared"], 1)
+        self.assertEqual(payload["users"][0]["username"], self.air_manager.username)
+
+    def test_command_reports_no_mismatch_when_membership_matches_legacy_department(self):
+        self._membership_for(self.air_manager, self.manager_role, self.air_department)
+        self._membership_for(self.air_sales, self.sales_role, self.air_department)
+
+        output = self._call_command("--format", "json", "--user", self.air_manager.username)
+        row = json.loads(output)["users"][0]
+
+        self.assertFalse(row["has_mismatch"])
+        self.assertFalse(row["quotes"]["has_mismatch"])
+        self.assertFalse(row["spes"]["has_mismatch"])
+
+    def test_command_reports_mismatch_when_membership_differs_from_legacy_department(self):
+        self._membership_for(self.sea_manager, self.manager_role, self.air_department)
+        self._membership_for(self.air_sales, self.sales_role, self.air_department)
+        self._membership_for(self.sea_sales, self.sales_role, self.sea_department)
+
+        output = self._call_command("--format", "json", "--user", self.sea_manager.username)
+        row = json.loads(output)["users"][0]
+
+        self.assertTrue(row["has_mismatch"])
+        self.assertEqual(row["quotes"]["legacy_only_count"], 1)
+        self.assertEqual(row["quotes"]["membership_only_count"], 1)
+        self.assertEqual(row["spes"]["legacy_only_count"], 1)
+        self.assertEqual(row["spes"]["membership_only_count"], 1)
+
+    def test_show_details_includes_ids(self):
+        self._membership_for(self.sea_manager, self.manager_role, self.air_department)
+        self._membership_for(self.air_sales, self.sales_role, self.air_department)
+        self._membership_for(self.sea_sales, self.sales_role, self.sea_department)
+
+        output = self._call_command(
+            "--format",
+            "json",
+            "--user",
+            self.sea_manager.username,
+            "--show-details",
+        )
+        row = json.loads(output)["users"][0]
+
+        self.assertIn(str(self.sea_quote.id), row["quotes"]["legacy_only_ids"])
+        self.assertIn(str(self.air_quote.id), row["quotes"]["membership_only_ids"])
+        self.assertIn(str(self.sea_spe.id), row["spes"]["legacy_only_ids"])
+        self.assertIn(str(self.air_spe.id), row["spes"]["membership_only_ids"])
+
+    def test_default_output_does_not_include_id_lists(self):
+        output = self._call_command("--format", "json", "--user", self.air_sales.username)
+        row = json.loads(output)["users"][0]
+
+        self.assertNotIn("legacy_ids", row["quotes"])
+        self.assertNotIn("membership_ids", row["quotes"])
+        self.assertNotIn("legacy_only_ids", row["spes"])
+        self.assertNotIn(str(self.air_quote.id), output)

--- a/backend/quotes/tests/test_rbac_selector_visibility.py
+++ b/backend/quotes/tests/test_rbac_selector_visibility.py
@@ -15,7 +15,7 @@ from parties.models import Branch, Company, Department, Organization
 from quotes.models import Quote, QuoteTotal, QuoteVersion
 from quotes.selectors import get_quote_for_user, get_quotes_for_user, get_spes_for_user
 from quotes.spot_models import SpotPricingEnvelopeDB
-from quotes.tests.rbac_selector_comparison import (
+from quotes.rbac_selector_comparison import (
     compare_quote_visibility,
     compare_spe_visibility,
 )

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -538,6 +538,42 @@ Rules for this PR:
 - No enforcement, schema, migration, customer, CRM, shipment, pricing, report,
   rate, buy-cost, or margin behavior changes are made by the comparison harness.
 
+#### Visibility diagnostics command PR
+
+Add a read-only management command for comparing real-data quote and SPE
+visibility before selector cutover:
+
+```bash
+python backend/manage.py rbac_compare_visibility
+python backend/manage.py rbac_compare_visibility --format json --show-details
+python backend/manage.py rbac_compare_visibility --user USERNAME_OR_ID
+```
+
+The command is a pre-cutover diagnostic tool only. It reports, per user, current
+legacy selector visibility, membership-derived expected visibility, matching
+record counts, legacy-only counts, membership-only counts, and mismatch flags.
+Record ID lists are omitted by default and shown only with `--show-details`.
+
+Rules for the diagnostics command:
+
+- Legacy selectors remain authoritative until a later explicit enforcement PR.
+- The command must not write to the database or modify users, memberships,
+  quotes, SPEs, reports, pricing, or rates.
+- Mismatch output should be used to clean `UserMembership` data before changing
+  production selectors.
+- A common expected mismatch is active `UserMembership.department` differing
+  from legacy `CustomUser.department`.
+- Inactive users are excluded by default and included only with
+  `--include-inactive`.
+- This diagnostic PR does not change access behavior, buy-cost visibility,
+  margin visibility, schema, migrations, or frontend behavior.
+
+Suggested next step after diagnostics:
+
+- Run the command against non-production and production snapshots, review
+  mismatch counts by user, and prepare a data-cleanup/backfill PR before any
+  selector cutover.
+
 ### Phase 5: Apply read filters by domain
 
 Apply selectors domain by domain:


### PR DESCRIPTION
- Adds a read-only management command for RBAC quote/SPOT visibility diagnostics.
- Compares current legacy selector visibility against UserMembership-derived visibility.
- Supports text/json output, user filtering, inactive-user inclusion, limits, and show-details mode.
- Moves reusable comparison logic into backend/quotes/rbac_selector_comparison.py.
- Adds management command tests.
- Updates RBAC documentation.
- Does not change production selector enforcement.
- Does not change quote, SPOT, customer, CRM, shipment, report, pricing, rate, buy-cost, or margin behaviour.
- Does not add schema changes, migrations, or frontend changes.

Report:
- PR link/number
- branch name
- commit hash
- files included
- confirmation that no new changes were made