### PR TITLE
feat(rbac): populate scope fields on new quote and spot records

### DIFF
--- a/backend/accounts/scope.py
+++ b/backend/accounts/scope.py
@@ -64,6 +64,16 @@ class EffectiveUserScope:
     has_null_department_scope: bool
 
 
+@dataclass(frozen=True)
+class CreateScope:
+    organization: Any = None
+    branch: Any = None
+    department: Any = None
+    owner: Any = None
+    source: str = "none"
+    reason: str = "No authenticated active user."
+
+
 def _is_authenticated_active(user) -> bool:
     return bool(
         user
@@ -88,6 +98,47 @@ def get_active_memberships(user):
         UserMembership.objects.filter(user=user, is_active=True)
         .select_related("organization", "branch", "department", "role")
         .prefetch_related("role__permissions")
+    )
+
+
+def _agreed_membership_value(memberships, field_name, id_field_name):
+    values = {getattr(membership, id_field_name, None) for membership in memberships}
+    if len(values) == 1 and next(iter(values)) is not None:
+        return getattr(memberships[0], field_name)
+    return None
+
+
+def resolve_create_scope_for_user(user) -> CreateScope:
+    if not _is_authenticated_active(user):
+        return CreateScope()
+
+    memberships = list(get_active_memberships(user))
+    if len(memberships) == 1:
+        membership = memberships[0]
+        return CreateScope(
+            organization=membership.organization,
+            branch=membership.branch,
+            department=membership.department,
+            owner=user,
+            source="user_membership",
+            reason="Exactly one active membership.",
+        )
+
+    if len(memberships) > 1:
+        return CreateScope(
+            organization=_agreed_membership_value(memberships, "organization", "organization_id"),
+            branch=_agreed_membership_value(memberships, "branch", "branch_id"),
+            department=_agreed_membership_value(memberships, "department", "department_id"),
+            owner=user,
+            source="user_memberships",
+            reason="Multiple active memberships; only agreed scope values resolved.",
+        )
+
+    return CreateScope(
+        organization=getattr(user, "organization", None),
+        owner=user,
+        source="legacy_user_fields",
+        reason="No active memberships; using legacy user organization only.",
     )
 
 

--- a/backend/quotes/models.py
+++ b/backend/quotes/models.py
@@ -225,6 +225,20 @@ class Quote(models.Model):
         return self.quote_number or str(self.id)
 
     def save(self, *args, **kwargs):
+        is_create = self._state.adding
+        if is_create and self.created_by_id:
+            from accounts.scope import resolve_create_scope_for_user
+
+            create_scope = resolve_create_scope_for_user(self.created_by)
+            if self.owner_id is None:
+                self.owner = create_scope.owner
+            if self.organization_id is None:
+                self.organization = create_scope.organization
+            if self.branch_id is None:
+                self.branch = create_scope.branch
+            if self.department_id is None:
+                self.department = create_scope.department
+
         # Generate temporary quote_number for drafts if not set
         if not self.quote_number:
             # DRAFT quotes get a temporary identifier

--- a/backend/quotes/spot_models.py
+++ b/backend/quotes/spot_models.py
@@ -127,6 +127,20 @@ class SpotPricingEnvelopeDB(models.Model):
         """Compute hash on save if not set."""
         import hashlib
         import json
+
+        is_create = self._state.adding
+        if is_create and self.created_by_id:
+            from accounts.scope import resolve_create_scope_for_user
+
+            create_scope = resolve_create_scope_for_user(self.created_by)
+            if self.owner_id is None:
+                self.owner = create_scope.owner
+            if self.organization_id is None:
+                self.organization = create_scope.organization
+            if self.branch_id is None:
+                self.branch = create_scope.branch
+            if self.department_id is None:
+                self.department = create_scope.department
         
         if not self.shipment_context_hash:
             normalized = json.dumps(self.shipment_context_json, sort_keys=True)

--- a/backend/quotes/tests/test_rbac_scope_fields_and_backfill_report.py
+++ b/backend/quotes/tests/test_rbac_scope_fields_and_backfill_report.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from io import StringIO
 
 from django.core.management import call_command
@@ -35,6 +36,11 @@ class RBACScopeFieldsAndBackfillReportTests(TestCase):
             code="POM",
             name="Port Moresby",
         )
+        cls.other_branch = Branch.objects.create(
+            organization=cls.organization,
+            code="LAE",
+            name="Lae",
+        )
         cls.air_department = Department.objects.create(
             organization=cls.organization,
             branch=cls.branch,
@@ -46,6 +52,28 @@ class RBACScopeFieldsAndBackfillReportTests(TestCase):
             branch=cls.branch,
             code="SEA",
             name="Sea Freight",
+        )
+        cls.other_branch_department = Department.objects.create(
+            organization=cls.organization,
+            branch=cls.other_branch,
+            code="LAND",
+            name="Road Freight",
+        )
+        cls.explicit_organization = Organization.objects.create(
+            name="Explicit Scope Org",
+            slug="explicit-scope-org",
+            default_currency=cls.pgk,
+        )
+        cls.explicit_branch = Branch.objects.create(
+            organization=cls.explicit_organization,
+            code="MTK",
+            name="Mount Hagen",
+        )
+        cls.explicit_department = Department.objects.create(
+            organization=cls.explicit_organization,
+            branch=cls.explicit_branch,
+            code="FIN",
+            name="Finance",
         )
         cls.manager_role = Role.objects.create(
             code=CustomUser.ROLE_MANAGER,
@@ -99,11 +127,53 @@ class RBACScopeFieldsAndBackfillReportTests(TestCase):
         defaults.update(kwargs)
         return SpotPricingEnvelopeDB.objects.create(**defaults)
 
-    def _membership_for(self, user, department, *, is_primary=True):
+    def _create_legacy_unscoped_quote(self, user=None, **kwargs):
+        defaults = {
+            "id": uuid.uuid4(),
+            "quote_number": f"LEGACY-{uuid.uuid4().hex[:8].upper()}",
+            "customer": self.customer,
+            "mode": "AIR",
+            "shipment_type": Quote.ShipmentType.IMPORT,
+            "status": Quote.Status.DRAFT,
+            "created_by": user,
+        }
+        defaults.update(kwargs)
+        quote = Quote(**defaults)
+        Quote.objects.bulk_create([quote])
+        return quote
+
+    def _create_legacy_unscoped_spe(self, user=None, **kwargs):
+        defaults = {
+            "id": uuid.uuid4(),
+            "status": SpotPricingEnvelopeDB.Status.DRAFT,
+            "shipment_context_json": {
+                "origin_country": "PG",
+                "destination_country": "PG",
+                "origin_code": "POM",
+                "destination_code": "LAE",
+                "commodity": "GCR",
+                "total_weight_kg": 10,
+                "pieces": 1,
+                "service_scope": "p2p",
+                "payment_term": "collect",
+            },
+            "shipment_context_hash": f"legacy-{uuid.uuid4().hex}",
+            "conditions_json": {},
+            "spot_trigger_reason_code": "TEST",
+            "spot_trigger_reason_text": "Test SPE",
+            "created_by": user,
+            "expires_at": timezone.now() + timezone.timedelta(hours=24),
+        }
+        defaults.update(kwargs)
+        spe = SpotPricingEnvelopeDB(**defaults)
+        SpotPricingEnvelopeDB.objects.bulk_create([spe])
+        return spe
+
+    def _membership_for(self, user, department, *, branch=None, is_primary=True):
         return UserMembership.objects.create(
             user=user,
             organization=self.organization,
-            branch=self.branch,
+            branch=branch or self.branch,
             department=department,
             role=self.manager_role,
             is_primary=is_primary,
@@ -142,6 +212,100 @@ class RBACScopeFieldsAndBackfillReportTests(TestCase):
         self.assertIsNone(spe.department_id)
         self.assertIsNone(spe.owner_id)
 
+    def test_quote_single_membership_populates_scope(self):
+        user = self._create_user("quote-single-membership-user")
+        self._membership_for(user, self.air_department)
+
+        quote = self._create_quote(user)
+
+        self.assertEqual(quote.organization_id, self.organization.id)
+        self.assertEqual(quote.branch_id, self.branch.id)
+        self.assertEqual(quote.department_id, self.air_department.id)
+        self.assertEqual(quote.owner_id, user.id)
+
+    def test_quote_legacy_organization_only_populates_organization_and_owner(self):
+        user = self._create_user("quote-legacy-org-user", organization=self.organization)
+
+        quote = self._create_quote(user)
+
+        self.assertEqual(quote.organization_id, self.organization.id)
+        self.assertEqual(quote.owner_id, user.id)
+        self.assertIsNone(quote.branch_id)
+        self.assertIsNone(quote.department_id)
+
+    def test_quote_multiple_memberships_do_not_guess_branch_or_department(self):
+        user = self._create_user("quote-multi-membership-user")
+        self._membership_for(user, self.air_department)
+        self._membership_for(
+            user,
+            self.other_branch_department,
+            branch=self.other_branch,
+            is_primary=False,
+        )
+
+        quote = self._create_quote(user)
+
+        self.assertEqual(quote.organization_id, self.organization.id)
+        self.assertEqual(quote.owner_id, user.id)
+        self.assertIsNone(quote.branch_id)
+        self.assertIsNone(quote.department_id)
+
+    def test_explicit_quote_scope_values_are_not_overridden(self):
+        user = self._create_user("quote-explicit-scope-user")
+        explicit_owner = self._create_user("quote-explicit-owner")
+        self._membership_for(user, self.air_department)
+
+        quote = self._create_quote(
+            user,
+            organization=self.explicit_organization,
+            branch=self.explicit_branch,
+            department=self.explicit_department,
+            owner=explicit_owner,
+        )
+
+        self.assertEqual(quote.organization_id, self.explicit_organization.id)
+        self.assertEqual(quote.branch_id, self.explicit_branch.id)
+        self.assertEqual(quote.department_id, self.explicit_department.id)
+        self.assertEqual(quote.owner_id, explicit_owner.id)
+
+    def test_spot_single_membership_populates_scope(self):
+        user = self._create_user("spot-single-membership-user")
+        self._membership_for(user, self.air_department)
+
+        spe = self._create_spe(user)
+
+        self.assertEqual(spe.organization_id, self.organization.id)
+        self.assertEqual(spe.branch_id, self.branch.id)
+        self.assertEqual(spe.department_id, self.air_department.id)
+        self.assertEqual(spe.owner_id, user.id)
+
+    def test_spot_legacy_organization_only_populates_organization_and_owner(self):
+        user = self._create_user("spot-legacy-org-user", organization=self.organization)
+
+        spe = self._create_spe(user)
+
+        self.assertEqual(spe.organization_id, self.organization.id)
+        self.assertEqual(spe.owner_id, user.id)
+        self.assertIsNone(spe.branch_id)
+        self.assertIsNone(spe.department_id)
+
+    def test_spot_multiple_memberships_do_not_guess_branch_or_department(self):
+        user = self._create_user("spot-multi-membership-user")
+        self._membership_for(user, self.air_department)
+        self._membership_for(
+            user,
+            self.other_branch_department,
+            branch=self.other_branch,
+            is_primary=False,
+        )
+
+        spe = self._create_spe(user)
+
+        self.assertEqual(spe.organization_id, self.organization.id)
+        self.assertEqual(spe.owner_id, user.id)
+        self.assertIsNone(spe.branch_id)
+        self.assertIsNone(spe.department_id)
+
     def test_dry_run_report_command_runs_for_quotes(self):
         self._create_quote()
 
@@ -161,7 +325,7 @@ class RBACScopeFieldsAndBackfillReportTests(TestCase):
     def test_single_membership_candidate_is_reported(self):
         user = self._create_user("single-membership-user")
         self._membership_for(user, self.air_department)
-        quote = self._create_quote(user)
+        quote = self._create_legacy_unscoped_quote(user)
 
         output = self._call_report("--format", "json", "--model", "quote", "--show-details")
         payload = json.loads(output)
@@ -185,7 +349,7 @@ class RBACScopeFieldsAndBackfillReportTests(TestCase):
         user = self._create_user("ambiguous-membership-user")
         self._membership_for(user, self.air_department)
         self._membership_for(user, self.sea_department, is_primary=False)
-        quote = self._create_quote(user)
+        quote = self._create_legacy_unscoped_quote(user)
 
         output = self._call_report("--format", "json", "--model", "quote", "--show-details")
         payload = json.loads(output)
@@ -208,8 +372,8 @@ class RBACScopeFieldsAndBackfillReportTests(TestCase):
     def test_command_does_not_write_by_default(self):
         user = self._create_user("dry-run-user")
         self._membership_for(user, self.air_department)
-        quote = self._create_quote(user)
-        spe = self._create_spe(user)
+        quote = self._create_legacy_unscoped_quote(user)
+        spe = self._create_legacy_unscoped_spe(user)
 
         self._call_report("--format", "json", "--show-details")
 

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -621,6 +621,32 @@ Suggested next step after nullable fields:
   unknown rows, then prepare a non-destructive data cleanup/backfill plan before
   enabling any scope-based selectors.
 
+#### Create-time Quote and SPE scope assignment PR
+
+Populate nullable RBAC scope fields on newly created `Quote` and
+`SpotPricingEnvelopeDB` records only. Existing rows are not changed and no data
+migration is added.
+
+Create-time rules:
+
+- Anonymous or inactive users do not assign scope.
+- Exactly one active `UserMembership` assigns organization, branch, department,
+  and owner from that membership.
+- Multiple active memberships assign only values all memberships agree on.
+  Ambiguous branch or department values remain null.
+- Users with no active memberships assign legacy `CustomUser.organization` and
+  owner only.
+- Legacy `CustomUser.department` text is not mapped to `parties.Department`.
+- Explicitly supplied scope values are never overwritten.
+
+The create-time assignment must not infer branch or department from route,
+origin, destination, station code, lane, mode, customer, shipment data, or
+pricing data.
+
+This PR does not change quote or SPE visibility, selectors, buy-cost visibility,
+margin visibility, customer access, CRM, shipments, reports, pricing, rates, or
+frontend behavior.
+
 ### Phase 5: Apply read filters by domain
 
 Apply selectors domain by domain:


### PR DESCRIPTION
Adds create-time RBAC scope assignment for new Quote and SPOT records. Populates organization, branch, department, and owner only when safely resolved from user membership or legacy organization fallback. 

Does not change selectors, enforcement, existing records, frontend, migrations, or business visibility.