### PR TITLE
Potential fix for code scanning alert no. 35: Clear-text logging of sensitive information

### DIFF
--- a/backend/core/secrets.py
+++ b/backend/core/secrets.py
@@ -58,9 +58,9 @@ class SecretResolver:
             resource_name = f"projects/{self._project_id}/secrets/{secret_id}/versions/{version_id}"
 
         try:
-            # We specifically do NOT log the resolved value.
+            # We specifically do NOT log the resolved value or secret identifiers.
             # We only log that we are attempting to resolve a secret.
-            logger.info("Resolving secret from Google Secret Manager: %s", resource_name.split("/versions/")[0])
+            logger.info("Resolving secret from Google Secret Manager")
             
             response = self.client.access_secret_version(request={"name": resource_name})
             return response.payload.data.decode("UTF-8")


### PR DESCRIPTION
Potential fix for [https://github.com/nace-martin/Project-RateEngine/security/code-scanning/35](https://github.com/nace-martin/Project-RateEngine/security/code-scanning/35)

The best fix is to stop logging `resource_name` (or any derivation containing `secret_id`) and replace it with a constant, non-sensitive log message. This preserves functionality (secret resolution still happens exactly the same way) while eliminating leakage of secret metadata.

In `backend/core/secrets.py`, update the logging call in the `resolve` method (around line 63):

- Replace:
  - `logger.info("Resolving secret from Google Secret Manager: %s", resource_name.split("/versions/")[0])`
- With:
  - a message that does not include `resource_name`, `path`, `secret_id`, or version.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
