### PR TITLE
feat(rbac): use scope fields in quote and spot selectors

### DIFF
--- a/backend/quotes/selectors.py
+++ b/backend/quotes/selectors.py
@@ -1,6 +1,42 @@
 from django.core.exceptions import PermissionDenied
 from django.db.models import QuerySet, Q
+from accounts.scope import get_effective_user_scope
 from quotes.models import Quote, SpotPricingEnvelopeDB
+
+
+def _is_global_user(user) -> bool:
+    role = getattr(user, 'role', '')
+    return (
+        getattr(user, 'is_admin', False) or
+        getattr(user, 'is_finance', False) or
+        getattr(user, 'is_superuser', False) or
+        role in ('admin', 'finance')
+    )
+
+
+def _is_manager_user(user) -> bool:
+    return getattr(user, 'is_manager', False) or getattr(user, 'role', '') == 'manager'
+
+
+def _legacy_manager_filter(user) -> Q:
+    dept = getattr(user, 'department', None)
+    if dept:
+        return Q(created_by__department=dept) | Q(created_by=user)
+    return Q(created_by=user)
+
+
+def _manager_scoped_filter(user) -> Q:
+    scope = get_effective_user_scope(user)
+
+    scoped_filter = Q(created_by=user)
+    if scope.department_ids:
+        scoped_filter |= Q(department_id__in=scope.department_ids)
+    if scope.branch_ids:
+        scoped_filter |= Q(department_id__isnull=True, branch_id__in=scope.branch_ids)
+
+    unscoped_filter = Q(branch_id__isnull=True, department_id__isnull=True)
+    return scoped_filter | (unscoped_filter & _legacy_manager_filter(user))
+
 
 def get_spes_for_user(user, queryset: QuerySet | None = None) -> QuerySet:
     """
@@ -8,7 +44,8 @@ def get_spes_for_user(user, queryset: QuerySet | None = None) -> QuerySet:
 
     Rules:
     - Admin/Finance: Global access.
-    - Managers: Own department's SPEs + own SPEs.
+    - Managers: Scoped SPEs by durable branch/department when present.
+      Branch/department-unscoped SPEs keep the legacy creator department fallback.
     - Sales: Own SPEs only.
     """
     if queryset is None:
@@ -17,25 +54,11 @@ def get_spes_for_user(user, queryset: QuerySet | None = None) -> QuerySet:
     if not user or not user.is_authenticated:
         return queryset.none()
 
-    role = getattr(user, 'role', '')
-    is_global = (
-        getattr(user, 'is_admin', False) or
-        getattr(user, 'is_finance', False) or
-        role in ('admin', 'finance')
-    )
-
-    if is_global:
+    if _is_global_user(user):
         return queryset
 
-    # Manager View: Restricted by Department
-    if getattr(user, 'is_manager', False) or role == 'manager':
-        dept = getattr(user, 'department', None)
-        if dept:
-            return queryset.filter(
-                Q(created_by__department=dept) |
-                Q(created_by=user)
-            )
-        return queryset.filter(created_by=user)
+    if _is_manager_user(user):
+        return queryset.filter(_manager_scoped_filter(user))
 
     # Sales / Standard View: Own SPEs only
     return queryset.filter(created_by=user)
@@ -47,7 +70,8 @@ def get_quotes_for_user(user, queryset: QuerySet | None = None) -> QuerySet:
 
     Rules:
     - Admin/Finance: Global access.
-    - Managers: Own department's quotes + own quotes.
+    - Managers: Scoped quotes by durable branch/department when present.
+      Branch/department-unscoped quotes keep the legacy creator department fallback.
     - Sales: Own quotes only.
     """
     if queryset is None:
@@ -56,25 +80,11 @@ def get_quotes_for_user(user, queryset: QuerySet | None = None) -> QuerySet:
     if not user or not user.is_authenticated:
         return queryset.none()
 
-    role = getattr(user, 'role', '')
-    is_global = (
-        getattr(user, 'is_admin', False) or
-        getattr(user, 'is_finance', False) or
-        role in ('admin', 'finance')
-    )
-
-    if is_global:
+    if _is_global_user(user):
         return queryset
 
-    # Manager View: Restricted by Department
-    if getattr(user, 'is_manager', False) or role == 'manager':
-        dept = getattr(user, 'department', None)
-        if dept:
-            return queryset.filter(
-                Q(created_by__department=dept) |
-                Q(created_by=user)
-            )
-        return queryset.filter(created_by=user)
+    if _is_manager_user(user):
+        return queryset.filter(_manager_scoped_filter(user))
 
     # Sales / Standard View: Own quotes only
     return queryset.filter(created_by=user)

--- a/backend/quotes/tests/test_rbac_selector_visibility.py
+++ b/backend/quotes/tests/test_rbac_selector_visibility.py
@@ -64,7 +64,7 @@ class QuoteAndSpotLegacyVisibilityTests(TestCase):
         return CustomUser.objects.create_user(username=username, **defaults)
 
     @classmethod
-    def _create_quote(cls, user, label, total_sell_pgk):
+    def _create_quote(cls, user, label, total_sell_pgk, **kwargs):
         quote = Quote.objects.create(
             quote_number=f"RBAC-{label}",
             customer=cls.customer,
@@ -72,6 +72,7 @@ class QuoteAndSpotLegacyVisibilityTests(TestCase):
             shipment_type=Quote.ShipmentType.IMPORT,
             status=Quote.Status.FINALIZED,
             created_by=user,
+            **kwargs,
         )
         version = QuoteVersion.objects.create(
             quote=quote,
@@ -88,7 +89,7 @@ class QuoteAndSpotLegacyVisibilityTests(TestCase):
         return quote
 
     @classmethod
-    def _create_spe(cls, user, reason_code):
+    def _create_spe(cls, user, reason_code, **kwargs):
         return SpotPricingEnvelopeDB.objects.create(
             status=SpotPricingEnvelopeDB.Status.DRAFT,
             shipment_context_json={
@@ -107,6 +108,7 @@ class QuoteAndSpotLegacyVisibilityTests(TestCase):
             spot_trigger_reason_text=f"Test {reason_code}",
             created_by=user,
             expires_at=timezone.now() + timezone.timedelta(hours=24),
+            **kwargs,
         )
 
     def _quote_ids_for_user(self, user):
@@ -265,14 +267,14 @@ class QuoteAndSpotLegacyVisibilityTests(TestCase):
             {3},
         )
 
-    def test_membership_helper_scope_can_differ_from_legacy_selector_until_cutover(self):
+    def _create_scope_fixture(self, slug):
         pgk, _ = Currency.objects.get_or_create(
             code="PGK",
             defaults={"name": "Papua New Guinean Kina"},
         )
         organization = Organization.objects.create(
-            name="RBAC Helper Compare Org",
-            slug="rbac-helper-compare",
+            name=f"RBAC {slug} Org",
+            slug=slug,
             default_currency=pgk,
         )
         branch = Branch.objects.create(
@@ -292,6 +294,9 @@ class QuoteAndSpotLegacyVisibilityTests(TestCase):
             code="SEA",
             name="Sea Freight",
         )
+        return organization, branch, air_department, sea_department
+
+    def _manager_membership(self, user, organization, branch, department):
         manager_role, _ = Role.objects.get_or_create(
             code=CustomUser.ROLE_MANAGER,
             organization=None,
@@ -300,22 +305,119 @@ class QuoteAndSpotLegacyVisibilityTests(TestCase):
                 "is_system": True,
             },
         )
-        UserMembership.objects.create(
-            user=self.sea_manager,
+        return UserMembership.objects.create(
+            user=user,
             organization=organization,
             branch=branch,
-            department=air_department,
+            department=department,
             role=manager_role,
             is_active=True,
         )
 
-        # Current selectors still use CustomUser.department, not UserMembership.
+    def test_unscoped_records_keep_legacy_fallback_when_membership_differs(self):
+        organization, branch, air_department, sea_department = self._create_scope_fixture(
+            "rbac-helper-compare"
+        )
+        self._manager_membership(self.sea_manager, organization, branch, air_department)
+
+        # Branch/department-null records stay on the legacy fallback until hard cutover.
         self.assertSetEqual(
             self._quote_ids_for_user(self.sea_manager),
             {self.quote_by_sea_sales.id},
         )
         self.assertTrue(user_can_access_department(self.sea_manager, air_department))
         self.assertFalse(user_can_access_department(self.sea_manager, sea_department))
+
+    def test_quote_selector_manager_uses_scoped_department_fields(self):
+        organization, branch, air_department, sea_department = self._create_scope_fixture(
+            "rbac-quote-scoped-selector"
+        )
+        self._manager_membership(self.air_manager, organization, branch, air_department)
+
+        scoped_air_quote = self._create_quote(
+            self.sea_sales,
+            "SCOPED-AIR",
+            "5000.00",
+            organization=organization,
+            branch=branch,
+            department=air_department,
+        )
+        scoped_sea_quote = self._create_quote(
+            self.air_sales,
+            "SCOPED-SEA",
+            "6000.00",
+            organization=organization,
+            branch=branch,
+            department=sea_department,
+        )
+
+        visible_quote_ids = self._quote_ids_for_user(self.air_manager)
+
+        self.assertIn(scoped_air_quote.id, visible_quote_ids)
+        self.assertNotIn(scoped_sea_quote.id, visible_quote_ids)
+
+    def test_quote_scoped_visibility_does_not_follow_creator_legacy_department_changes(self):
+        organization, branch, air_department, _ = self._create_scope_fixture(
+            "rbac-quote-creator-move"
+        )
+        self._manager_membership(self.air_manager, organization, branch, air_department)
+
+        scoped_quote = self._create_quote(
+            self.air_sales,
+            "SCOPED-CREATOR-MOVE",
+            "7000.00",
+            organization=organization,
+            branch=branch,
+            department=air_department,
+        )
+        self.air_sales.department = "SEA"
+        self.air_sales.save(update_fields=["department"])
+
+        self.assertIn(scoped_quote.id, self._quote_ids_for_user(self.air_manager))
+
+    def test_spot_selector_manager_uses_scoped_department_fields(self):
+        organization, branch, air_department, sea_department = self._create_scope_fixture(
+            "rbac-spot-scoped-selector"
+        )
+        self._manager_membership(self.air_manager, organization, branch, air_department)
+
+        scoped_air_spe = self._create_spe(
+            self.sea_sales,
+            "SCOPED_AIR",
+            organization=organization,
+            branch=branch,
+            department=air_department,
+        )
+        scoped_sea_spe = self._create_spe(
+            self.air_sales,
+            "SCOPED_SEA",
+            organization=organization,
+            branch=branch,
+            department=sea_department,
+        )
+
+        visible_spe_ids = self._spe_ids_for_user(self.air_manager)
+
+        self.assertIn(scoped_air_spe.id, visible_spe_ids)
+        self.assertNotIn(scoped_sea_spe.id, visible_spe_ids)
+
+    def test_spot_scoped_visibility_does_not_follow_creator_legacy_department_changes(self):
+        organization, branch, air_department, _ = self._create_scope_fixture(
+            "rbac-spot-creator-move"
+        )
+        self._manager_membership(self.air_manager, organization, branch, air_department)
+
+        scoped_spe = self._create_spe(
+            self.air_sales,
+            "SCOPED_SPE_CREATOR_MOVE",
+            organization=organization,
+            branch=branch,
+            department=air_department,
+        )
+        self.air_sales.department = "SEA"
+        self.air_sales.save(update_fields=["department"])
+
+        self.assertIn(scoped_spe.id, self._spe_ids_for_user(self.air_manager))
 
 
 class QuoteAndSpotScopeComparisonTests(QuoteAndSpotLegacyVisibilityTests):

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -686,6 +686,35 @@ Suggested next step after controlled backfill:
   skipped rows, run `--write` only after approval, then prepare a separate
   selector cutover plan.
 
+#### Transitional Quote and SPE scoped selector PR
+
+Update only `Quote` and `SpotPricingEnvelopeDB` selectors so manager visibility
+prefers durable scope fields where those fields exist:
+
+- Scoped records with `branch` or `department` use the record-owned scope fields,
+  not the creator user's current legacy department.
+- Branch/department-unscoped records keep the existing legacy fallback: own
+  records plus records created by users in the same legacy
+  `CustomUser.department`.
+- Admin, finance, and superuser broad visibility remains unchanged.
+- Sales visibility remains own-records-only.
+- Anonymous users remain denied by selectors/DRF authentication.
+
+This is a transitional selector mode, not the final RBAC hard cutover. It keeps
+old unscoped Quote and SPE rows visible through the documented compatibility
+fallback while allowing backfilled and newly created scoped rows to stop moving
+when a creator's legacy department changes.
+
+This PR must not change customer access, CRM, shipments, reports, pricing,
+rates, buy-cost visibility, margin visibility, ProductCode flows, frontend
+behavior, create-time assignment, or backfill commands.
+
+Suggested next step after transitional selectors:
+
+- Run visibility diagnostics again against development/staging data, clean or
+  manually scope any remaining unscoped rows, then prepare a later PR to remove
+  the legacy fallback only after data cleanup is complete.
+
 ### Phase 5: Apply read filters by domain
 
 Apply selectors domain by domain:


### PR DESCRIPTION
Adds transitional RBAC selector logic for Quote and SPOT/SPE visibility.

Summary:
- Quote and SPE selectors now prefer durable branch/department scope fields for manager visibility when present.
- Branch/department-unscoped records continue to use the legacy creator department fallback.
- Admin, finance, and superuser broad visibility is preserved.
- Sales own-record-only visibility is preserved.
- No schema, migrations, frontend, customer, CRM, shipment, report, pricing, rate, buy-cost, margin, ProductCode, create-time assignment, or backfill command changes.

Validation:
- python backend\manage.py test quotes.tests.test_rbac_selector_visibility
- python backend\manage.py test quotes.tests.test_rbac_scope_fields_and_backfill_report
- python backend\manage.py test accounts
- python backend\manage.py makemigrations --check --dry-run
- git diff --check
- Fallow baseline checked
- graphify update .
- ponytail-review: Lean already. Ship.

Notes:
- This is transitional selector mode, not final hard cutover.
- Legacy fallback remains for unscoped records.
- Hard cutover/removal of fallback should wait until remaining unscoped data is cleaned or explicitly accepted.