### PR TITLE
chore(rbac): show unknown spot scope details

### DIFF
--- a/backend/quotes/management/commands/rbac_scope_backfill_report.py
+++ b/backend/quotes/management/commands/rbac_scope_backfill_report.py
@@ -99,8 +99,11 @@ class Command(BaseCommand):
             if show_details:
                 for detail in model_payload["details"]:
                     self.stdout.write(
-                        f"  - {detail['id']}: status={detail['status']}, "
-                        f"created_by={detail['created_by_username']}"
+                        f"  - {detail['model']} {detail['reference']} ({detail['id']}): "
+                        f"status={detail['status']}, "
+                        f"reason={detail.get('reason') or '-'}, "
+                        f"created_by={detail['created_by_username'] or '-'}, "
+                        f"created_at={detail['created_at'] or '-'}"
                     )
 
 
@@ -154,9 +157,11 @@ def _inspect_record(record, *, model_name: str, show_details: bool) -> dict:
     base = {
         "id": str(record.pk),
         "model": model_name,
+        "reference": _record_reference(record, model_name=model_name),
         "status": None,
         "created_by_id": getattr(record, "created_by_id", None),
         "created_by_username": getattr(created_by, "username", None),
+        "created_at": _datetime_or_none(getattr(record, "created_at", None)),
     }
 
     if _record_has_scope(record):
@@ -167,7 +172,7 @@ def _inspect_record(record, *, model_name: str, show_details: bool) -> dict:
 
     if not created_by:
         base["status"] = STATUS_UNKNOWN
-        base["reason"] = "missing_created_by"
+        base["reason"] = "no_created_by"
         return base
 
     memberships = list(get_active_memberships(created_by))
@@ -199,8 +204,14 @@ def _inspect_record(record, *, model_name: str, show_details: bool) -> dict:
         return base
 
     base["status"] = STATUS_UNKNOWN
-    base["reason"] = "no_membership_or_legacy_scope"
+    base["reason"] = "no_membership"
     return base
+
+
+def _record_reference(record, *, model_name: str) -> str:
+    if model_name == "quote":
+        return getattr(record, "quote_number", None) or str(record)
+    return str(record)
 
 
 def _record_has_scope(record) -> bool:
@@ -273,3 +284,9 @@ def _string_or_none(value) -> str | None:
     if value is None:
         return None
     return str(value)
+
+
+def _datetime_or_none(value) -> str | None:
+    if value is None:
+        return None
+    return value.isoformat()

--- a/backend/quotes/tests/test_rbac_scope_fields_and_backfill_report.py
+++ b/backend/quotes/tests/test_rbac_scope_fields_and_backfill_report.py
@@ -374,6 +374,33 @@ class RBACScopeFieldsAndBackfillReportTests(TestCase):
         self.assertEqual(self._detail_for(payload, "quote", quote.id)["status"], STATUS_UNKNOWN)
         self.assertEqual(self._detail_for(payload, "spot", spe.id)["status"], STATUS_UNKNOWN)
 
+    def test_unknown_spot_details_identify_no_created_by_record(self):
+        spe = self._create_legacy_unscoped_spe()
+
+        output = self._call_report("--format", "json", "--model", "spot", "--show-details")
+        payload = json.loads(output)
+        detail = self._detail_for(payload, "spot", spe.id)
+
+        self.assertEqual(detail["status"], STATUS_UNKNOWN)
+        self.assertEqual(detail["reason"], "no_created_by")
+        self.assertEqual(detail["model"], "spot")
+        self.assertEqual(detail["reference"], str(spe))
+        self.assertIsNone(detail["created_by_id"])
+        self.assertIsNone(detail["created_by_username"])
+        self.assertIsNotNone(detail["created_at"])
+
+    def test_unknown_spot_details_identify_no_membership_record(self):
+        user = self._create_user("spot-unknown-no-membership")
+        spe = self._create_legacy_unscoped_spe(user)
+
+        output = self._call_report("--model", "spot", "--show-details")
+
+        self.assertIn("spot SPE-", output)
+        self.assertIn(str(spe.id), output)
+        self.assertIn("status=unknown", output)
+        self.assertIn("reason=no_membership", output)
+        self.assertIn("created_by=spot-unknown-no-membership", output)
+
     def test_command_does_not_write_by_default(self):
         user = self._create_user("dry-run-user")
         self._membership_for(user, self.air_department)

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -611,6 +611,12 @@ creator user's explicit RBAC data:
 The command must not infer branch or department from route, origin,
 destination, station code, mode, customer, shipment lane, or pricing lane.
 
+With `--show-details`, unknown Quote and SPE rows include only safe inspection
+fields: model, id, reference, created_by id/username, created_at, and reason
+such as `no_created_by` or `no_membership`. Use this to decide whether unknown
+SPOT rows need a valid creator, manual scope, legacy exemption, or exclusion
+from hard-cutover requirements.
+
 This PR does not change access behavior, buy-cost visibility, margin visibility,
 frontend behavior, selectors, customer access, CRM, shipments, reports, pricing,
 or rates.


### PR DESCRIPTION
Extends the read-only RBAC scope backfill report details so unknown SPOT records can be inspected safely before hard cutover.

Summary:
- Adds safe identifiers to rbac_scope_backfill_report --show-details.
- Normalizes unknown reasons such as no_created_by and no_membership.
- Keeps the command read-only.
- No selector, schema, migration, frontend, pricing, customer, CRM, report, or shipment changes.

Validation:
- python backend\manage.py test quotes.tests.test_rbac_scope_fields_and_backfill_report
- python backend\manage.py test quotes.tests.test_rbac_selector_visibility
- python backend\manage.py test accounts
- python backend\manage.py makemigrations --check --dry-run
- git diff --check
- graphify update .