### PR TITLE
fix(rbac): scope dashboard conversion report

### DIFF
--- a/backend/quotes/reporting_views.py
+++ b/backend/quotes/reporting_views.py
@@ -652,7 +652,7 @@ class ReportsViewSet(viewsets.ViewSet):
         )
 
         # 3. Conversion Rates
-        conversion = Quote.objects.exclude(is_archived=True).aggregate(
+        conversion = quotes_with_latest_total.exclude(is_archived=True).aggregate(
             total=Count('id'),
             drafts=Count('id', filter=Q(status='DRAFT')),
             finalized=Count('id', filter=Q(status__in=['FINALIZED', 'SENT', 'ACCEPTED'])),

--- a/backend/quotes/tests/test_reporting_views.py
+++ b/backend/quotes/tests/test_reporting_views.py
@@ -100,6 +100,79 @@ class TestReportsViewSet:
         assert data['conversion']['finalized'] == 1
         assert data['conversion']['lost'] == 1
 
+    def test_dashboard_conversion_uses_manager_scoped_quote_visibility(
+        self,
+        api_client,
+        manager_user,
+        quote_factory,
+    ):
+        manager_user.department = 'AIR'
+        manager_user.save(update_fields=['department'])
+        air_sales = get_user_model().objects.create_user(
+            username='air-sales-dashboard',
+            password='password',
+            role='sales',
+            department='AIR',
+        )
+        sea_sales = get_user_model().objects.create_user(
+            username='sea-sales-dashboard',
+            password='password',
+            role='sales',
+            department='SEA',
+        )
+
+        api_client.force_authenticate(user=manager_user)
+
+        quote_factory(manager_user, Quote.Status.DRAFT, 500)
+        quote_factory(air_sales, Quote.Status.FINALIZED, 1000)
+        quote_factory(sea_sales, Quote.Status.LOST, 2000)
+
+        response = api_client.get('/api/v3/reports/dashboard/')
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert set(data.keys()) == {'total_revenue', 'volume_by_mode', 'conversion'}
+        assert data['conversion'] == {
+            'total': 2,
+            'drafts': 1,
+            'finalized': 1,
+            'lost': 0,
+        }
+
+    def test_dashboard_conversion_admin_and_finance_keep_broad_visibility(
+        self,
+        api_client,
+        manager_user,
+        sales_user,
+        quote_factory,
+    ):
+        admin_user = get_user_model().objects.create_user(
+            username='admin-dashboard',
+            password='password',
+            role='admin',
+        )
+        finance_user = get_user_model().objects.create_user(
+            username='finance-dashboard',
+            password='password',
+            role='finance',
+        )
+
+        quote_factory(manager_user, Quote.Status.DRAFT, 500)
+        quote_factory(sales_user, Quote.Status.FINALIZED, 1000)
+        quote_factory(sales_user, Quote.Status.LOST, 2000)
+
+        for user in [admin_user, finance_user]:
+            api_client.force_authenticate(user=user)
+            response = api_client.get('/api/v3/reports/dashboard/')
+
+            assert response.status_code == status.HTTP_200_OK
+            assert response.json()['conversion'] == {
+                'total': 3,
+                'drafts': 1,
+                'finalized': 1,
+                'lost': 1,
+            }
+
     def test_dashboard_uses_latest_version_total(self, api_client, manager_user, quote_factory):
         api_client.force_authenticate(user=manager_user)
 

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -800,10 +800,10 @@ Observed visibility by domain:
 - Report outputs expose cost, gross profit, and margin metrics to permitted
   report roles. There is no separate financial-field masking in the reporting
   layer yet.
-- Legacy `dashboard` reporting mostly uses `get_quotes_for_user`, but its
-  `conversion` aggregate still calls `Quote.objects.exclude(is_archived=True)`
-  directly. That aggregate is a report leakage risk because it can count global
-  quote statuses outside the scoped quote queryset.
+- Legacy `dashboard` reporting now uses the scoped quote queryset for
+  `conversion` totals. This fixes the previously audited global
+  `Quote.objects.exclude(is_archived=True)` aggregate while preserving response
+  shape and field names.
 
 Global access risks:
 
@@ -813,8 +813,9 @@ Global access risks:
   another owner or company's CRM data.
 - Reporting financial outputs are role-gated but not permission-code gated, and
   do not mask financial fields independently of endpoint access.
-- Legacy dashboard conversion totals are computed from a global `Quote.objects`
-  aggregate instead of the scoped quote queryset.
+- Reports should continue to derive quote data through `get_quotes_for_user` or
+  an equivalent scoped selector. The legacy dashboard conversion aggregate has
+  been fixed to follow that rule.
 
 Missing scope fields:
 
@@ -861,26 +862,22 @@ Direct ID access risks:
 
 Safe next PR order:
 
-1. Reports-only fix: replace the legacy dashboard `conversion` aggregate with
-   the already scoped quote queryset and add the smallest regression test for a
-   manager seeing only scoped conversion counts. Do not change report permissions
-   or financial masking in that PR.
-2. Customer/Company/Contact read-only diagnostics: add an audit command or tests
+1. Customer/Company/Contact read-only diagnostics: add an audit command or tests
    that count customers, contacts, quotes, shipments, and CRM links by possible
    scope source. Do not add fields or filters yet.
-3. CRM read-only diagnostics: report opportunities, interactions, and tasks by
+2. CRM read-only diagnostics: report opportunities, interactions, and tasks by
    owner, author, linked company, linked quote-derived activity, and missing
    owner/author. Do not enforce owner scope yet.
-4. Shipment branch diagnostics: compare `Shipment.branch` text values to
+3. Shipment branch diagnostics: compare `Shipment.branch` text values to
    `parties.Branch.code` within the shipment organization and report unmapped or
    ambiguous rows. Do not treat text branch as RBAC enforcement yet.
-5. Add nullable customer/CRM/shipment scope fields only after diagnostics prove
+4. Add nullable customer/CRM/shipment scope fields only after diagnostics prove
    the backfill sources are safe. Keep selectors unchanged.
-6. Add create-time scope assignment for customer/CRM/shipment records. Keep old
+5. Add create-time scope assignment for customer/CRM/shipment records. Keep old
    rows on legacy behavior until backfill is approved.
-7. Cut over selectors domain by domain: reports first, then customer/contact,
+6. Cut over selectors domain by domain: reports first, then customer/contact,
    then CRM, then shipment branch filtering.
-8. Add permission-code-based financial report masking after selector boundaries
+7. Add permission-code-based financial report masking after selector boundaries
    are stable.
 
 ### Phase 5: Apply read filters by domain


### PR DESCRIPTION
Fixes the dashboard conversion report so conversion metrics use the existing scoped quote queryset instead of global quote counts.

Summary:
- Dashboard conversion totals now use the scoped quotes_with_latest_total queryset.
- The queryset is built through get_quotes_for_user(request.user).
- Response shape and field names are unchanged.
- Admin/finance broad visibility is preserved.
- Manager/sales visibility remains scoped according to existing selectors.
- Sales endpoint behaviour remains unchanged where dashboard access is denied.
- No schema, migrations, frontend, pricing, ProductCode, customer, CRM, shipment, buy-cost, margin, or permission changes.

Validation:
- python backend\manage.py test quotes.tests.test_rbac_selector_visibility
- pytest backend\quotes\tests\test_reporting_views.py -k dashboard
- python backend\manage.py test accounts
- python backend\manage.py makemigrations --check --dry-run
- git diff --check
- Fallow baseline checked
- graphify update .