### PR TITLE
chore(rbac): add customer contact scope diagnostics

### DIFF
--- a/backend/parties/management/commands/rbac_customer_contact_report.py
+++ b/backend/parties/management/commands/rbac_customer_contact_report.py
@@ -1,0 +1,223 @@
+import json
+
+from django.core.management.base import BaseCommand
+from django.db.models import Count, Q
+
+from parties.models import Company, Contact
+from quotes.spot_models import SpotPricingEnvelopeDB
+
+
+COMPANY_SCOPE_FIELDS = [
+    "account_owner",
+    "is_customer",
+    "is_agent",
+    "is_carrier",
+    "audience_type",
+    "company_type",
+    "is_active",
+    "created_at",
+    "updated_at",
+]
+CONTACT_SCOPE_FIELDS = [
+    "company",
+    "is_primary",
+    "is_active",
+]
+
+
+class Command(BaseCommand):
+    help = "Read-only Customer/Contact RBAC scope diagnostic report."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--format",
+            choices=["text", "json"],
+            default="text",
+            help="Output format. Defaults to text.",
+        )
+        parser.add_argument(
+            "--show-details",
+            action="store_true",
+            help="Include safe per-company/contact identifiers.",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=50,
+            help="Maximum detail rows per section. Defaults to 50.",
+        )
+
+    def handle(self, *args, **options):
+        limit = max(options["limit"], 0)
+        payload = build_report(show_details=options["show_details"], limit=limit)
+
+        if options["format"] == "json":
+            self.stdout.write(json.dumps(payload, indent=2, sort_keys=True))
+            return
+
+        self._write_text(payload, show_details=options["show_details"])
+
+    def _write_text(self, payload: dict, *, show_details: bool):
+        summary = payload["summary"]
+        self.stdout.write("Customer/contact RBAC diagnostic report")
+        self.stdout.write("=======================================")
+        self.stdout.write("Mode: read-only")
+        self.stdout.write(
+            "Companies: "
+            f"total={summary['total_companies']}, "
+            f"customers={summary['customer_companies']}, "
+            f"contacts={summary['total_contacts']}, "
+            f"no_account_owner={summary['companies_without_account_owner']}, "
+            f"no_detected_link={summary['companies_without_detected_scope_link']}"
+        )
+        self.stdout.write(
+            "Links: "
+            f"companies_with_quotes={summary['companies_with_quotes']}, "
+            f"companies_with_spot={summary['companies_with_spot']}, "
+            f"contacts_with_company={summary['contacts_with_company']}, "
+            f"contacts_with_customer_company={summary['contacts_linked_to_customer_companies']}, "
+            f"contacts_with_quotes={summary['contacts_with_quotes']}"
+        )
+        self.stdout.write(
+            "Company types: "
+            f"internal={summary['internal_like_companies']}, "
+            f"vendor={summary['vendor_like_companies']}, "
+            f"customer={summary['customer_like_companies']}, "
+            f"carrier={summary['carrier_like_companies']}, "
+            f"agent={summary['agent_like_companies']}"
+        )
+        self.stdout.write("")
+        self.stdout.write("Available future scoping fields:")
+        self.stdout.write(f"  Company: {', '.join(payload['available_scope_fields']['company'])}")
+        self.stdout.write(f"  Contact: {', '.join(payload['available_scope_fields']['contact'])}")
+
+        if not show_details:
+            return
+
+        self.stdout.write("")
+        self.stdout.write("Company details:")
+        for row in payload["details"]["companies"]:
+            self.stdout.write(
+                f"  - {row['id']} {row['name']} "
+                f"type={row['type']} quotes={row['linked_quote_count']} "
+                f"contacts={row['linked_contact_count']} created_at={row['created_at'] or '-'}"
+            )
+        self.stdout.write("Contact details:")
+        for row in payload["details"]["contacts"]:
+            self.stdout.write(
+                f"  - {row['id']} {row['display_name']} "
+                f"company={row['company_id']} quotes={row['linked_quote_count']}"
+            )
+
+
+def build_report(*, show_details: bool = False, limit: int = 50) -> dict:
+    companies = Company.objects.all()
+    contacts = Contact.objects.all()
+    customer_filter = Q(is_customer=True) | Q(company_type="CUSTOMER")
+    spot_company_ids = SpotPricingEnvelopeDB.objects.filter(
+        quote__customer_id__isnull=False
+    ).values("quote__customer_id").distinct()
+
+    payload = {
+        "write_enabled": False,
+        "summary": {
+            "total_companies": companies.count(),
+            "customer_companies": companies.filter(customer_filter).count(),
+            "total_contacts": contacts.count(),
+            "contacts_with_company": contacts.filter(company_id__isnull=False).count(),
+            "contacts_with_quotes": contacts.filter(quotes__isnull=False).distinct().count(),
+            "companies_with_quotes": companies.filter(quotes_as_customer__isnull=False).distinct().count(),
+            "companies_with_spot": companies.filter(id__in=spot_company_ids).count(),
+            "contacts_linked_to_customer_companies": contacts.filter(
+                company__in=companies.filter(customer_filter)
+            ).count(),
+            "companies_without_account_owner": companies.filter(account_owner__isnull=True).count(),
+            "companies_without_detected_scope_link": companies.filter(
+                account_owner__isnull=True,
+                quotes_as_customer__isnull=True,
+                opportunities__isnull=True,
+                interactions__isnull=True,
+                crm_tasks__isnull=True,
+                shipment_address_book_entries__isnull=True,
+            ).distinct().count(),
+            "internal_like_companies": companies.filter(
+                is_customer=False,
+                is_agent=False,
+                is_carrier=False,
+            ).count(),
+            "vendor_like_companies": companies.filter(company_type="SUPPLIER").count(),
+            "customer_like_companies": companies.filter(customer_filter).count(),
+            "carrier_like_companies": companies.filter(is_carrier=True).count(),
+            "agent_like_companies": companies.filter(is_agent=True).count(),
+        },
+        "available_scope_fields": {
+            "company": COMPANY_SCOPE_FIELDS,
+            "contact": CONTACT_SCOPE_FIELDS,
+        },
+        "notes": [
+            "Company and Contact have no durable organization, branch, or department scope fields.",
+            "Customer/contact API reads remain authenticated-global; this command does not enforce access.",
+            "SPOT linkage is counted only where an SPE is linked to a Quote with a customer.",
+        ],
+    }
+
+    if show_details:
+        payload["details"] = {
+            "companies": [_company_detail(company) for company in _company_details(limit)],
+            "contacts": [_contact_detail(contact) for contact in _contact_details(limit)],
+        }
+
+    return payload
+
+
+def _company_details(limit: int):
+    queryset = (
+        Company.objects.annotate(
+            linked_quote_count=Count("quotes_as_customer", distinct=True),
+            linked_contact_count=Count("contacts", distinct=True),
+        )
+        .order_by("name", "id")
+    )
+    return queryset[:limit] if limit else []
+
+
+def _contact_details(limit: int):
+    queryset = (
+        Contact.objects.select_related("company")
+        .annotate(linked_quote_count=Count("quotes", distinct=True))
+        .order_by("company__name", "last_name", "first_name", "id")
+    )
+    return queryset[:limit] if limit else []
+
+
+def _company_detail(company: Company) -> dict:
+    return {
+        "id": str(company.id),
+        "name": company.name,
+        "type": _company_type(company),
+        "linked_quote_count": company.linked_quote_count,
+        "linked_contact_count": company.linked_contact_count,
+        "created_at": company.created_at.isoformat() if company.created_at else None,
+    }
+
+
+def _contact_detail(contact: Contact) -> dict:
+    return {
+        "id": str(contact.id),
+        "display_name": f"{contact.first_name} {contact.last_name}".strip(),
+        "company_id": str(contact.company_id),
+        "linked_quote_count": contact.linked_quote_count,
+    }
+
+
+def _company_type(company: Company) -> str:
+    values = []
+    if company.is_customer or company.company_type == "CUSTOMER":
+        values.append("customer")
+    if company.is_agent:
+        values.append("agent")
+    if company.is_carrier:
+        values.append("carrier")
+    if company.company_type == "SUPPLIER":
+        values.append("vendor")
+    return ",".join(values) or "internal"

--- a/backend/parties/tests.py
+++ b/backend/parties/tests.py
@@ -2,12 +2,14 @@ import os
 import tempfile
 from io import StringIO
 import csv
+import json
 from io import BytesIO
 
 from django.core.management import call_command
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 from django.test import TestCase
+from django.utils import timezone
 from rest_framework.test import APIClient, APITestCase
 from rest_framework import status
 from PIL import Image
@@ -16,6 +18,8 @@ from accounts.models import CustomUser
 from core.models import Country, City
 from core.models import Currency
 from parties.models import Company, Contact, Address, Organization, OrganizationBranding
+from quotes.models import Quote
+from quotes.spot_models import SpotPricingEnvelopeDB
 
 
 class CustomerSeedCommandTests(TestCase):
@@ -293,6 +297,63 @@ class CustomerSeedCommandTests(TestCase):
         self.assertEqual(len(issues), 2)
         self.assertIn("duplicate_email_in_input", reasons)
         self.assertIn("missing_organization_or_email", reasons)
+
+
+class CustomerContactRBACReportTests(TestCase):
+    def _call_report(self, *args):
+        stdout = StringIO()
+        call_command("rbac_customer_contact_report", *args, stdout=stdout)
+        return stdout.getvalue()
+
+    def test_report_counts_safe_customer_contact_scope_signals(self):
+        customer = Company.objects.create(name="Report Customer", is_customer=True, company_type="CUSTOMER")
+        Company.objects.create(name="Report Supplier", company_type="SUPPLIER")
+        contact = Contact.objects.create(
+            company=customer,
+            first_name="Safe",
+            last_name="Contact",
+            email="safe.contact@example.com",
+            phone="+675000",
+        )
+        quote = Quote.objects.create(customer=customer, contact=contact, mode="AIR")
+        SpotPricingEnvelopeDB.objects.create(
+            quote=quote,
+            status=SpotPricingEnvelopeDB.Status.DRAFT,
+            shipment_context_json={"origin_country": "PG", "destination_country": "PG"},
+            conditions_json={},
+            spot_trigger_reason_code="TEST",
+            spot_trigger_reason_text="Test SPE",
+            expires_at=timezone.now() + timezone.timedelta(hours=1),
+        )
+
+        payload = json.loads(self._call_report("--format", "json"))
+
+        summary = payload["summary"]
+        self.assertFalse(payload["write_enabled"])
+        self.assertEqual(summary["total_companies"], 2)
+        self.assertEqual(summary["customer_companies"], 1)
+        self.assertEqual(summary["total_contacts"], 1)
+        self.assertEqual(summary["companies_with_quotes"], 1)
+        self.assertEqual(summary["companies_with_spot"], 1)
+        self.assertEqual(summary["contacts_with_quotes"], 1)
+
+    def test_show_details_omits_contact_email_phone_and_commercial_fields(self):
+        customer = Company.objects.create(name="Detail Customer", is_customer=True, company_type="CUSTOMER")
+        Contact.objects.create(
+            company=customer,
+            first_name="Hidden",
+            last_name="Email",
+            email="hidden.email@example.com",
+            phone="+675111",
+        )
+
+        output = self._call_report("--show-details")
+
+        self.assertIn("Detail Customer", output)
+        self.assertIn("Hidden Email", output)
+        self.assertNotIn("hidden.email@example.com", output)
+        self.assertNotIn("+675111", output)
+        self.assertNotIn("margin", output.lower())
 
 
 class CustomerListAPITests(APITestCase):

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -862,9 +862,9 @@ Direct ID access risks:
 
 Safe next PR order:
 
-1. Customer/Company/Contact read-only diagnostics: add an audit command or tests
-   that count customers, contacts, quotes, shipments, and CRM links by possible
-   scope source. Do not add fields or filters yet.
+1. Customer/Company/Contact read-only diagnostics: added
+   `python backend\manage.py rbac_customer_contact_report`. Do not add fields or
+   filters yet.
 2. CRM read-only diagnostics: report opportunities, interactions, and tasks by
    owner, author, linked company, linked quote-derived activity, and missing
    owner/author. Do not enforce owner scope yet.
@@ -879,6 +879,34 @@ Safe next PR order:
    then CRM, then shipment branch filtering.
 7. Add permission-code-based financial report masking after selector boundaries
    are stable.
+
+Customer/contact diagnostics added on 2026-06-19:
+
+```text
+Customer/contact RBAC diagnostic report
+=======================================
+Mode: read-only
+Companies: total=236, customers=227, contacts=298, no_account_owner=235, no_detected_link=214
+Links: companies_with_quotes=20, companies_with_spot=11, contacts_with_company=298, contacts_with_customer_company=297, contacts_with_quotes=21
+Company types: internal=6, vendor=7, customer=227, carrier=1, agent=10
+
+Available future scoping fields:
+  Company: account_owner, is_customer, is_agent, is_carrier, audience_type, company_type, is_active, created_at, updated_at
+  Contact: company, is_primary, is_active
+```
+
+Recommended next steps:
+
+- Do not enforce customer/contact RBAC from the current data alone. `Company`
+  and `Contact` still lack durable organization, branch, and department scope.
+- Treat `Company.account_owner` as a weak candidate only; it is missing on most
+  current rows and does not model shared customer visibility.
+- Use quote, SPOT-through-quote, CRM, and shipment address-book links as
+  backfill evidence, not as runtime selectors, until a separate schema/backfill
+  PR defines ownership rules.
+- Run CRM diagnostics next before choosing whether customer scope follows
+  account owner, quote ownership, CRM owner, organization, branch, department,
+  or an explicit access table.
 
 ### Phase 5: Apply read filters by domain
 


### PR DESCRIPTION
Adds a read-only customer/contact RBAC diagnostic command.

Summary:
- Adds rbac_customer_contact_report.
- Reports customer/company/contact counts and detectable links.
- Shows Company.account_owner is too sparse for enforcement.
- Lists available future scoping fields.
- Adds focused tests and documentation.
- No access behaviour, selectors, schema, migrations, frontend, pricing, ProductCode, reports, shipments, Quote/SPOT selector logic, buy-cost, or margin changes.

Validation:
- python backend\manage.py rbac_customer_contact_report
- python backend\manage.py test parties.tests.CustomerContactRBACReportTests
- python backend\manage.py makemigrations --check --dry-run
- git diff --check
- Fallow baseline checked
- graphify update .