### PR TITLE
feat(rbac): populate customer crm scope on create

### DIFF
--- a/backend/accounts/scope.py
+++ b/backend/accounts/scope.py
@@ -74,6 +74,9 @@ class CreateScope:
     reason: str = "No authenticated active user."
 
 
+SCOPE_FIELD_NAMES = ("organization", "branch", "department")
+
+
 def _is_authenticated_active(user) -> bool:
     return bool(
         user
@@ -140,6 +143,65 @@ def resolve_create_scope_for_user(user) -> CreateScope:
         source="legacy_user_fields",
         reason="No active memberships; using legacy user organization only.",
     )
+
+
+def _membership_create_scope_for_user(user) -> CreateScope:
+    memberships = list(get_active_memberships(user))
+    if len(memberships) == 1:
+        membership = memberships[0]
+        return CreateScope(
+            organization=membership.organization,
+            branch=membership.branch,
+            department=membership.department,
+            owner=user,
+            source="user_membership",
+            reason="Exactly one active membership.",
+        )
+
+    if len(memberships) > 1:
+        return CreateScope(
+            organization=_agreed_membership_value(memberships, "organization", "organization_id"),
+            branch=_agreed_membership_value(memberships, "branch", "branch_id"),
+            department=_agreed_membership_value(memberships, "department", "department_id"),
+            owner=user,
+            source="user_memberships",
+            reason="Multiple active memberships; only agreed scope values resolved.",
+        )
+
+    return CreateScope(reason="No active memberships.")
+
+
+def _scope_value_matches(values: dict, field_name: str, value) -> bool:
+    organization = values.get("organization")
+    if field_name in {"branch", "department"} and organization is not None:
+        if getattr(value, "organization_id", None) != getattr(organization, "id", organization):
+            return False
+
+    branch = values.get("branch")
+    if field_name == "department" and branch is not None:
+        value_branch_id = getattr(value, "branch_id", None)
+        if value_branch_id is not None and value_branch_id != getattr(branch, "id", branch):
+            return False
+
+    return True
+
+
+def populate_missing_scope_values(values: dict, *, user=None, parents=()) -> dict:
+    for field_name in SCOPE_FIELD_NAMES:
+        if values.get(field_name) is not None:
+            continue
+        for parent in parents:
+            if parent is not None and getattr(parent, f"{field_name}_id", None):
+                values[field_name] = getattr(parent, field_name)
+                break
+
+    membership_scope = _membership_create_scope_for_user(user)
+    for field_name in SCOPE_FIELD_NAMES:
+        if values.get(field_name) is None:
+            value = getattr(membership_scope, field_name, None)
+            if value is not None and _scope_value_matches(values, field_name, value):
+                values[field_name] = value
+    return values
 
 
 def _membership_role_codes(membership) -> set[str]:

--- a/backend/crm/serializers.py
+++ b/backend/crm/serializers.py
@@ -1,6 +1,7 @@
 from django.utils import timezone
 from rest_framework import serializers
 
+from accounts.scope import populate_missing_scope_values
 from .models import Interaction, Opportunity, Task
 
 
@@ -54,6 +55,15 @@ class OpportunitySerializer(serializers.ModelSerializer):
             )
         return value
 
+    def create(self, validated_data):
+        request = self.context.get("request")
+        populate_missing_scope_values(
+            validated_data,
+            user=getattr(request, "user", None),
+            parents=(validated_data.get("company"),),
+        )
+        return super().create(validated_data)
+
 
 class InteractionSerializer(serializers.ModelSerializer):
     company_name = serializers.CharField(source="company.name", read_only=True)
@@ -99,6 +109,15 @@ class InteractionSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError({"opportunity": "Selected opportunity does not belong to the selected company."})
         return attrs
 
+    def create(self, validated_data):
+        request = self.context.get("request")
+        populate_missing_scope_values(
+            validated_data,
+            user=getattr(request, "user", None),
+            parents=(validated_data.get("opportunity"), validated_data.get("company")),
+        )
+        return super().create(validated_data)
+
 
 class TaskSerializer(serializers.ModelSerializer):
     owner_username = serializers.CharField(source="owner.username", read_only=True)
@@ -137,8 +156,13 @@ class TaskSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         if validated_data.get("opportunity") and not validated_data.get("company"):
             validated_data["company"] = validated_data["opportunity"].company
+        request = self.context.get("request")
+        populate_missing_scope_values(
+            validated_data,
+            user=getattr(request, "user", None),
+            parents=(validated_data.get("opportunity"), validated_data.get("company")),
+        )
         if validated_data.get("status") == Task.Status.COMPLETED:
-            request = self.context.get("request")
             validated_data["completed_at"] = timezone.now()
             validated_data["completed_by"] = getattr(request, "user", None)
         return super().create(validated_data)

--- a/backend/crm/services.py
+++ b/backend/crm/services.py
@@ -2,6 +2,7 @@ from django.db import transaction
 from django.http import Http404
 from django.utils import timezone
 
+from accounts.scope import populate_missing_scope_values
 from .models import Interaction, Opportunity
 
 
@@ -65,16 +66,21 @@ def _quote_opportunity_title(*, service_type: str, direction: str, origin: str, 
 
 
 def _system_interaction(opportunity, actor, event_type: str, summary: str, outcomes: str = "") -> Interaction:
-    return Interaction.objects.create(
-        company=opportunity.company,
-        opportunity=opportunity,
-        author=actor,
-        interaction_type=Interaction.InteractionType.SYSTEM,
-        summary=summary,
-        outcomes=outcomes,
-        is_system_generated=True,
-        system_event_type=event_type,
+    values = populate_missing_scope_values(
+        {
+            "company": opportunity.company,
+            "opportunity": opportunity,
+            "author": actor,
+            "interaction_type": Interaction.InteractionType.SYSTEM,
+            "summary": summary,
+            "outcomes": outcomes,
+            "is_system_generated": True,
+            "system_event_type": event_type,
+        },
+        user=actor,
+        parents=(opportunity, opportunity.company),
     )
+    return Interaction.objects.create(**values)
 
 
 def create_auto_quote_opportunity_interaction(opportunity, quote, actor=None):
@@ -147,23 +153,28 @@ def resolve_quote_opportunity(
     scope = str(service_scope or "").strip().upper()
     origin = _label_from_location(origin_location)
     destination = _label_from_location(destination_location)
-    opportunity = Opportunity.objects.create(
-        company=customer,
-        title=_quote_opportunity_title(
-            service_type=service_type,
-            direction=direction,
-            origin=origin,
-            destination=destination,
-            customer=customer,
-        ),
-        service_type=service_type,
-        direction=direction,
-        scope=scope,
-        origin=origin,
-        destination=destination,
-        status=_quote_opportunity_status(quote_status),
-        owner=actor if getattr(actor, "is_authenticated", False) else None,
+    values = populate_missing_scope_values(
+        {
+            "company": customer,
+            "title": _quote_opportunity_title(
+                service_type=service_type,
+                direction=direction,
+                origin=origin,
+                destination=destination,
+                customer=customer,
+            ),
+            "service_type": service_type,
+            "direction": direction,
+            "scope": scope,
+            "origin": origin,
+            "destination": destination,
+            "status": _quote_opportunity_status(quote_status),
+            "owner": actor if getattr(actor, "is_authenticated", False) else None,
+        },
+        user=actor,
+        parents=(customer,),
     )
+    opportunity = Opportunity.objects.create(**values)
     return opportunity, True
 
 

--- a/backend/crm/tests/test_crm_foundation.py
+++ b/backend/crm/tests/test_crm_foundation.py
@@ -6,6 +6,7 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from rest_framework.test import APIClient
 
+from accounts.models import Role, UserMembership
 from crm.models import Interaction, Opportunity, Task
 from crm.services import (
     resolve_quote_opportunity,
@@ -13,7 +14,7 @@ from crm.services import (
     mark_opportunity_quoted,
     mark_opportunity_won,
 )
-from parties.models import Company
+from parties.models import Branch, Company, Department, Organization
 from quotes.models import Quote
 from quotes.state_machine import QuoteStateMachine
 
@@ -58,6 +59,26 @@ def create_quote(company, opportunity, user, *, status=Quote.Status.DRAFT, shipm
     )
 
 
+def create_scope_fixture(*, suffix=""):
+    organization = Organization.objects.create(
+        name=f"CRM Scope Org {suffix}".strip(),
+        slug=f"crm-scope-org-{suffix or 'default'}",
+        is_active=True,
+    )
+    branch = Branch.objects.create(organization=organization, code=f"POM{suffix}"[:16], name="Port Moresby")
+    department = Department.objects.create(
+        organization=organization,
+        branch=branch,
+        code=f"AIR{suffix}"[:24],
+        name="Air Freight",
+    )
+    return organization, branch, department
+
+
+def create_role(code="sales"):
+    return Role.objects.create(code=code, name=code.title(), is_system=True)
+
+
 @pytest.mark.django_db
 def test_crm_model_creation(company, user):
     opportunity = Opportunity.objects.create(
@@ -86,6 +107,166 @@ def test_crm_model_creation(company, user):
     assert opportunity.status == Opportunity.Status.NEW
     assert interaction.summary
     assert task.status == Task.Status.PENDING
+
+
+@pytest.mark.django_db
+def test_opportunity_api_create_populates_scope_from_single_active_membership(company, user):
+    organization, branch, department = create_scope_fixture(suffix="1")
+    UserMembership.objects.create(
+        user=user,
+        organization=organization,
+        branch=branch,
+        department=department,
+        role=create_role("sales-1"),
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.post(
+        "/api/v3/crm/opportunities/",
+        {
+            "company": str(company.id),
+            "title": "Scoped CRM opportunity",
+            "service_type": "AIR",
+            "priority": Opportunity.Priority.MEDIUM,
+        },
+        format="json",
+    )
+
+    assert response.status_code == 201
+    opportunity = Opportunity.objects.get(title="Scoped CRM opportunity")
+    assert opportunity.organization == organization
+    assert opportunity.branch == branch
+    assert opportunity.department == department
+
+
+@pytest.mark.django_db
+def test_interaction_and_task_create_inherit_opportunity_scope(company, user):
+    organization, branch, department = create_scope_fixture(suffix="2")
+    opportunity = Opportunity.objects.create(
+        company=company,
+        title="Scoped parent opportunity",
+        service_type="AIR",
+        owner=user,
+        organization=organization,
+        branch=branch,
+        department=department,
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    interaction_response = client.post(
+        "/api/v3/crm/interactions/",
+        {
+            "company": str(company.id),
+            "opportunity": str(opportunity.id),
+            "interaction_type": Interaction.InteractionType.CALL,
+            "summary": "Called customer.",
+        },
+        format="json",
+    )
+    task_response = client.post(
+        "/api/v3/crm/tasks/",
+        {
+            "opportunity": str(opportunity.id),
+            "description": "Follow up.",
+            "due_date": str(date.today() + timedelta(days=1)),
+        },
+        format="json",
+    )
+
+    assert interaction_response.status_code == 201
+    assert task_response.status_code == 201
+    interaction = Interaction.objects.get(summary="Called customer.")
+    task = Task.objects.get(description="Follow up.")
+    assert interaction.organization == organization
+    assert interaction.branch == branch
+    assert interaction.department == department
+    assert task.organization == organization
+    assert task.branch == branch
+    assert task.department == department
+
+
+@pytest.mark.django_db
+def test_opportunity_create_with_multiple_memberships_sets_only_shared_scope(company, user):
+    organization, branch, department = create_scope_fixture(suffix="3")
+    other_branch = Branch.objects.create(organization=organization, code="LAE", name="Lae")
+    other_department = Department.objects.create(
+        organization=organization,
+        branch=other_branch,
+        code="SEA",
+        name="Sea Freight",
+    )
+    role = create_role("sales-3")
+    UserMembership.objects.create(
+        user=user,
+        organization=organization,
+        branch=branch,
+        department=department,
+        role=role,
+        is_primary=True,
+    )
+    UserMembership.objects.create(
+        user=user,
+        organization=organization,
+        branch=other_branch,
+        department=other_department,
+        role=role,
+        is_primary=False,
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.post(
+        "/api/v3/crm/opportunities/",
+        {
+            "company": str(company.id),
+            "title": "Ambiguous CRM opportunity",
+            "service_type": "AIR",
+            "priority": Opportunity.Priority.MEDIUM,
+        },
+        format="json",
+    )
+
+    assert response.status_code == 201
+    opportunity = Opportunity.objects.get(title="Ambiguous CRM opportunity")
+    assert opportunity.organization == organization
+    assert opportunity.branch is None
+    assert opportunity.department is None
+
+
+@pytest.mark.django_db
+def test_membership_fallback_does_not_mix_scope_across_parent_organization(company, user):
+    parent_org = Organization.objects.create(name="Parent Org", slug="parent-org", is_active=True)
+    membership_org, membership_branch, membership_department = create_scope_fixture(suffix="4")
+    company.organization = parent_org
+    company.save(update_fields=["organization", "updated_at"])
+    UserMembership.objects.create(
+        user=user,
+        organization=membership_org,
+        branch=membership_branch,
+        department=membership_department,
+        role=create_role("sales-4"),
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.post(
+        "/api/v3/crm/opportunities/",
+        {
+            "company": str(company.id),
+            "title": "Parent org only opportunity",
+            "service_type": "AIR",
+            "priority": Opportunity.Priority.MEDIUM,
+        },
+        format="json",
+    )
+
+    assert response.status_code == 201
+    opportunity = Opportunity.objects.get(title="Parent org only opportunity")
+    assert opportunity.organization == parent_org
+    assert opportunity.branch is None
+    assert opportunity.department is None
 
 
 @pytest.mark.django_db

--- a/backend/parties/management/commands/import_contacts.py
+++ b/backend/parties/management/commands/import_contacts.py
@@ -4,6 +4,7 @@ from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 from django.db.models.functions import Lower
 
+from accounts.scope import populate_missing_scope_values
 from parties.models import Company, Contact
 
 from ._seed_utils import (
@@ -164,15 +165,19 @@ class Command(BaseCommand):
             )
 
         if not contact:
-            contact = Contact(
-                company=company,
-                email=email,
-                first_name=first_name,
-                last_name=last_name,
-                phone=phone,
-                is_primary=is_primary,
-                is_active=True,
+            contact_values = populate_missing_scope_values(
+                {
+                    "company": company,
+                    "email": email,
+                    "first_name": first_name,
+                    "last_name": last_name,
+                    "phone": phone,
+                    "is_primary": is_primary,
+                    "is_active": True,
+                },
+                parents=(company,),
             )
+            contact = Contact(**contact_values)
             contacts_by_email[email] = contact
             if not dry_run:
                 create_contacts.append(contact)

--- a/backend/parties/tests.py
+++ b/backend/parties/tests.py
@@ -14,10 +14,10 @@ from rest_framework.test import APIClient, APITestCase
 from rest_framework import status
 from PIL import Image
 
-from accounts.models import CustomUser
+from accounts.models import CustomUser, Role, UserMembership
 from core.models import Country, City
 from core.models import Currency
-from parties.models import Company, Contact, Address, Organization, OrganizationBranding
+from parties.models import Branch, Company, Contact, Address, Department, Organization, OrganizationBranding
 from quotes.models import Quote
 from quotes.spot_models import SpotPricingEnvelopeDB
 
@@ -130,6 +130,36 @@ class CustomerSeedCommandTests(TestCase):
         self.assertTrue(new_contact.is_primary)
         self.assertFalse(old_contact.is_primary)
         self.assertTrue(new_contact.is_active)
+
+    def test_import_contacts_inherits_company_scope_for_new_contacts(self):
+        organization = Organization.objects.create(name="Scoped Org", slug="scoped-org", is_active=True)
+        branch = Branch.objects.create(organization=organization, code="POM", name="Port Moresby")
+        department = Department.objects.create(
+            organization=organization,
+            branch=branch,
+            code="AIR",
+            name="Air Freight",
+        )
+        company = Company.objects.create(
+            name="Scoped Customer",
+            is_customer=True,
+            company_type="CUSTOMER",
+            organization=organization,
+            branch=branch,
+            department=department,
+        )
+
+        contacts = self._write_csv(
+            "company_uuid,company_name,email,first_name,last_name,is_primary\n"
+            f"{company.id},Scoped Customer,scoped.contact@example.com,Scoped,Contact,true\n"
+        )
+
+        call_command("import_contacts", file=contacts, stdout=StringIO())
+
+        contact = Contact.objects.get(email="scoped.contact@example.com")
+        self.assertEqual(contact.organization, organization)
+        self.assertEqual(contact.branch, branch)
+        self.assertEqual(contact.department, department)
 
     def test_import_contacts_matches_existing_email_case_insensitively(self):
         company = Company.objects.create(name="Case Customer", is_customer=True, company_type="CUSTOMER")
@@ -433,6 +463,36 @@ class CustomerListAPITests(APITestCase):
         returned_ids = {row["id"] for row in response.data}
         self.assertIn(str(active.id), returned_ids)
         self.assertNotIn(str(archived.id), returned_ids)
+
+    def test_admin_create_populates_scope_from_single_active_membership(self):
+        organization = Organization.objects.create(name="Create Org", slug="create-org", is_active=True)
+        branch = Branch.objects.create(organization=organization, code="POM", name="Port Moresby")
+        department = Department.objects.create(
+            organization=organization,
+            branch=branch,
+            code="AIR",
+            name="Air Freight",
+        )
+        role = Role.objects.create(code="admin", name="Admin", is_system=True)
+        UserMembership.objects.create(
+            user=self.admin,
+            organization=organization,
+            branch=branch,
+            department=department,
+            role=role,
+        )
+
+        response = self.client.post(
+            "/api/v3/customers/",
+            {"name": "Scoped API Customer"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        company = Company.objects.get(name="Scoped API Customer")
+        self.assertEqual(company.organization, organization)
+        self.assertEqual(company.branch, branch)
+        self.assertEqual(company.department, department)
 
 
 class OrganizationBrandingSettingsAPITests(APITestCase):

--- a/backend/parties/views.py
+++ b/backend/parties/views.py
@@ -12,6 +12,7 @@ from rest_framework.permissions import AllowAny, BasePermission
 from rest_framework.views import APIView
 from rest_framework.response import Response
 
+from accounts.scope import populate_missing_scope_values
 from .models import Address, Company, Contact, Organization, OrganizationBranding
 from .serializers import (
     CompanySearchV3Serializer,
@@ -103,7 +104,8 @@ class CustomerV3ViewSet(viewsets.ModelViewSet):
         )
 
     def perform_create(self, serializer):
-        serializer.save(is_customer=True)
+        scope_values = populate_missing_scope_values({}, user=self.request.user)
+        serializer.save(is_customer=True, **scope_values)
 
     def perform_update(self, serializer):
         serializer.save(is_customer=True)

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -1207,6 +1207,37 @@ Next phase:
 4. Keep selectors and enforcement unchanged until comparison diagnostics are
    available.
 
+#### Phase 8D - Create-time Scope Population
+
+Date: 2026-06-20
+
+Branch: `feat/rbac-customer-crm-scope-population`
+
+Scope: additive create-time population for new customer/contact/CRM records
+only. No backfill, selectors, access behavior, frontend behavior, serializer
+field exposure, Quote/SPOT selector changes, or RBAC enforcement changed.
+
+Create-time population added:
+
+- Customer API creates populate missing `organization`, `branch`, and
+  `department` from the authenticated user's active memberships.
+- Contact CSV imports populate missing scope from the linked `Company`.
+- CRM opportunity API creates and quote-driven opportunity creates populate
+  missing scope from linked `Company`, then active user membership.
+- CRM interaction and task API/system creates populate missing scope from
+  linked `Opportunity` first, then linked `Company`, then active user
+  membership.
+
+Ambiguity handling remains conservative: explicit scope values are preserved,
+single active memberships populate all available fields, multiple active
+memberships populate only shared values, and unresolved fields remain null.
+No inference is made from route, lane, origin/destination, customer name,
+department text, quote lane, or free text.
+
+Next phase: add a dry-run customer/CRM backfill candidate report that explains
+candidate source, unresolved fields, and ambiguity reasons before any data
+backfill is proposed.
+
 ### Phase 5: Apply read filters by domain
 
 Apply selectors domain by domain:


### PR DESCRIPTION
## Summary

Phase 8D adds create-time scope population for new Customer/Contact/CRM records using the nullable scope fields added in PR #183.

## Scope

- Populates missing scope for new records only.
- Preserves explicit scope values.
- Inherits scope from linked parent records where safe.
- Uses active user membership fallback only when safe.
- Leaves ambiguous values null.

## Create paths covered

- Customer API create
- Contact CSV import create
- CRM opportunity API create
- Quote-driven CRM opportunity create
- CRM interaction/task API create
- CRM system interactions

## Not included

- No migrations
- No backfill
- No selectors
- No RBAC enforcement
- No frontend changes
- No new serializer/API field exposure
- No Quote/SPOT selector changes

## Checks reported

- `python backend/manage.py makemigrations --check --dry-run`
- `python backend/manage.py check`
- `python backend/manage.py rbac_customer_contact_report`
- `python backend/manage.py rbac_crm_report`
- `pytest backend/parties/tests.py backend/crm/tests -q` → 57 passed
- `git diff --check`
- Fallow baseline
- `graphify update .`

## Follow-up

Existing records remain unscoped by design. Next phase should add a dry-run customer/CRM backfill candidate report with candidate source and ambiguity reasons before any data backfill or enforcement.