### PR TITLE
chore(rbac): add master data seed membership alignment

### DIFF
--- a/backend/parties/management/commands/rbac_master_data_alignment_plan.py
+++ b/backend/parties/management/commands/rbac_master_data_alignment_plan.py
@@ -8,26 +8,26 @@ from parties.models import Branch, Department, Organization
 
 
 TARGET_ORGANIZATIONS = ("EFM PNG", "EFM Australia", "EFM Fiji", "EFM Solomon Islands")
-PENDING_ORGANIZATIONS = ("EFM Express Air Cargo",)
+PENDING_ORGANIZATIONS = ()
 TARGET_BRANCHES = {
     "EFM PNG": ("Port Moresby", "Lae"),
     "EFM Australia": ("Brisbane",),
     "EFM Fiji": ("Suva",),
     "EFM Solomon Islands": ("Honiara",),
 }
-TARGET_DEPARTMENTS = ("Air Freight", "Sea Freight", "Customs", "Transport", "Warehousing")
-PENDING_DEPARTMENTS = ("EAC",)
+TARGET_DEPARTMENTS = ("Air Freight", "Sea Freight", "Customs", "Transport")
+PENDING_DEPARTMENTS = ()
 LEGACY_ORG_ACTIONS = {
     "Express Freight Management": "RENAME_CANDIDATE",
-    "EFM Express Air Cargo": "RETAIN_PENDING_DECISION",
+    "EFM Express Air Cargo": "DEFER",
     "Test Org": "EXCLUDE_TEST",
 }
 BLOCKERS = (
-    "EAC placement unresolved",
     "AU second office unresolved",
     "Fiji second office unresolved",
     "Express Freight Management handling unresolved",
     "Test Org dependency check unresolved",
+    "EFM Express Air Cargo legacy wording review unresolved",
 )
 
 
@@ -206,8 +206,6 @@ def branch_report_for(branches):
             else:
                 actions.append(branch_action(org_name, branch_name, "CREATE"))
                 missing.setdefault(org_name, []).append(branch_name)
-    actions.append(branch_action("EFM Express Air Cargo", "EAC branch pending", "DEFER"))
-
     expected_branch_names = {name for names in TARGET_BRANCHES.values() for name in names}
     unexpected = [
         branch_row(branch, "MOVE_CANDIDATE")
@@ -247,7 +245,6 @@ def department_report_for(departments):
                     "action": "KEEP" if department_name in org_department_names else "CREATE",
                 }
             )
-    actions.append({"type": "department", "organization": "EAC pending", "name": "EAC", "action": "DEFER"})
     unexpected = sorted(all_current_names - set(TARGET_DEPARTMENTS) - set(PENDING_DEPARTMENTS))
     return {
         "current_by_organization": dict(sorted(current_by_org.items())),

--- a/backend/parties/management/commands/rbac_master_data_seed_alignment.py
+++ b/backend/parties/management/commands/rbac_master_data_seed_alignment.py
@@ -1,0 +1,143 @@
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from accounts.models import UserMembership
+from parties.models import Branch, Department, Organization
+
+
+ORGANIZATIONS = ("EFM PNG", "EFM Australia", "EFM Fiji", "EFM Solomon Islands")
+BRANCHES = {
+    "EFM PNG": (("POM", "Port Moresby"), ("LAE", "Lae")),
+    "EFM Australia": (("BNE", "Brisbane"),),
+    "EFM Fiji": (("SUV", "Suva"),),
+    "EFM Solomon Islands": (("HIR", "Honiara"),),
+}
+DEPARTMENTS = (("AIR", "Air Freight"), ("SEA", "Sea Freight"), ("CUS", "Customs"), ("TRN", "Transport"))
+
+
+class Command(BaseCommand):
+    help = "Additively align RBAC master data and deterministic active memberships."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--apply", action="store_true", help="Write additive changes. Defaults to dry-run.")
+
+    def handle(self, *args, **options):
+        apply = options["apply"]
+        with transaction.atomic():
+            report = align(apply=apply)
+            if not apply:
+                transaction.set_rollback(True)
+        write_report(self.stdout, report)
+
+
+def align(*, apply):
+    report = {
+        "mode": "apply" if apply else "dry-run",
+        "organizations": [],
+        "branches": [],
+        "departments": [],
+        "memberships": [],
+        "summary": {"created": 0, "existing": 0, "updated": 0, "skipped": 0, "blocked": 0},
+    }
+    organizations = align_organizations(report, apply=apply)
+    branches = align_branches(report, organizations, apply=apply)
+    align_departments(report, organizations, apply=apply)
+    align_memberships(report, branches, apply=apply)
+    return report
+
+
+def align_organizations(report, *, apply):
+    organizations = {}
+    for name in ORGANIZATIONS:
+        organization = Organization.objects.filter(name=name).first()
+        if organization:
+            record(report, "organizations", "existing", name)
+        else:
+            record(report, "organizations", "created", name)
+            if apply:
+                organization = Organization.objects.create(name=name)
+        organizations[name] = organization
+    return organizations
+
+
+def align_branches(report, organizations, *, apply):
+    branches = {}
+    for org_name, targets in BRANCHES.items():
+        organization = organizations.get(org_name)
+        if not organization:
+            for code, name in targets:
+                record(report, "branches", "created", f"{org_name} / {name}")
+                branches.setdefault(org_name, []).append(name)
+            continue
+        for code, name in targets:
+            branch = Branch.objects.filter(organization=organization, code=code).first()
+            if branch:
+                record(report, "branches", "existing", f"{org_name} / {name}")
+            else:
+                record(report, "branches", "created", f"{org_name} / {name}")
+                if apply:
+                    branch = Branch.objects.create(organization=organization, code=code, name=name)
+            if branch:
+                branches.setdefault(org_name, []).append(branch)
+    return branches
+
+
+def align_departments(report, organizations, *, apply):
+    for org_name, organization in organizations.items():
+        for code, name in DEPARTMENTS:
+            if not organization:
+                record(report, "departments", "created", f"{org_name} / {name}")
+                continue
+            department = Department.objects.filter(organization=organization, code=code).first()
+            if department:
+                record(report, "departments", "existing", f"{org_name} / {name}")
+            else:
+                record(report, "departments", "created", f"{org_name} / {name}")
+                if apply:
+                    Department.objects.create(organization=organization, code=code, name=name)
+
+
+def align_memberships(report, branches, *, apply):
+    for membership in UserMembership.objects.select_related("organization", "branch").filter(is_active=True):
+        org_name = membership.organization.name
+        canonical_branches = branches.get(org_name, [])
+        if membership.branch_id:
+            record(report, "memberships", "existing", membership_label(membership))
+        elif len(canonical_branches) == 1:
+            branch = canonical_branches[0]
+            branch_name = getattr(branch, "name", branch)
+            record(report, "memberships", "updated", membership_label(membership), f"branch={branch_name}")
+            if apply:
+                membership.branch = branch
+                membership.save(update_fields=["branch", "updated_at"])
+        elif org_name in BRANCHES:
+            record(report, "memberships", "blocked", membership_label(membership), "multiple or missing canonical branches")
+        else:
+            record(report, "memberships", "skipped", membership_label(membership), "legacy or non-canonical organization")
+
+
+def record(report, section, status, name, reason=""):
+    report[section].append({"status": status.upper(), "name": str(name), "reason": reason})
+    report["summary"][status] += 1
+
+
+def membership_label(membership):
+    return f"user_id={membership.user_id} username={membership.user.username} organization={membership.organization.name}"
+
+
+def write_report(stdout, report):
+    stdout.write("RBAC master data seed alignment")
+    stdout.write("===============================")
+    stdout.write(f"Mode: {report['mode']}")
+    summary = report["summary"]
+    stdout.write(
+        "Summary: "
+        f"created={summary['created']}, existing={summary['existing']}, updated={summary['updated']}, "
+        f"skipped={summary['skipped']}, blocked={summary['blocked']}"
+    )
+    for section in ("organizations", "branches", "departments", "memberships"):
+        stdout.write("")
+        stdout.write(f"{section}:")
+        for row in report[section]:
+            suffix = f" ({row['reason']})" if row["reason"] else ""
+            stdout.write(f"  - {row['status']}: {row['name']}{suffix}")

--- a/backend/parties/tests.py
+++ b/backend/parties/tests.py
@@ -833,6 +833,73 @@ class MasterDataAlignmentPlanTests(TestCase):
         self.assertNotIn("pricing", output.lower())
 
 
+class MasterDataSeedAlignmentTests(TestCase):
+    def _call_command(self, *args):
+        stdout = StringIO()
+        call_command("rbac_master_data_seed_alignment", *args, stdout=stdout)
+        return stdout.getvalue()
+
+    def _role(self, code="seed-alignment-role"):
+        return Role.objects.create(code=code, name=code.title(), is_system=True)
+
+    def test_dry_run_does_not_create_master_data(self):
+        output = self._call_command()
+
+        self.assertIn("Mode: dry-run", output)
+        self.assertFalse(Organization.objects.filter(name="EFM PNG").exists())
+        self.assertFalse(Branch.objects.filter(name="Port Moresby").exists())
+        self.assertFalse(Department.objects.filter(name="Air Freight").exists())
+
+    def test_apply_creates_only_canonical_master_data(self):
+        legacy_eac_count = Organization.objects.filter(name="EFM Express Air Cargo").count()
+        output = self._call_command("--apply")
+
+        self.assertIn("Mode: apply", output)
+        self.assertTrue(Organization.objects.filter(name="EFM PNG").exists())
+        self.assertTrue(Branch.objects.filter(organization__name="EFM PNG", name="Port Moresby").exists())
+        self.assertTrue(Branch.objects.filter(organization__name="EFM Solomon Islands", name="Honiara").exists())
+        self.assertTrue(Department.objects.filter(organization__name="EFM Fiji", name="Customs").exists())
+        self.assertEqual(Organization.objects.filter(name="EFM Express Air Cargo").count(), legacy_eac_count)
+        self.assertFalse(Department.objects.filter(name="EAC").exists())
+        self.assertFalse(Department.objects.filter(name="Warehousing").exists())
+
+    def test_apply_is_idempotent(self):
+        self._call_command("--apply")
+        counts = (Organization.objects.count(), Branch.objects.count(), Department.objects.count())
+        output = self._call_command("--apply")
+
+        self.assertEqual(counts, (Organization.objects.count(), Branch.objects.count(), Department.objects.count()))
+        self.assertIn("created=0", output)
+        self.assertIn("EXISTING", output)
+
+    def test_membership_branch_population_only_when_single_branch_is_deterministic(self):
+        au = Organization.objects.create(name="EFM Australia", slug="efm-australia")
+        png = Organization.objects.create(name="EFM PNG", slug="efm-png")
+        role = self._role()
+        au_user = CustomUser.objects.create_user(username="au-user")
+        png_user = CustomUser.objects.create_user(username="png-user")
+        au_membership = UserMembership.objects.create(user=au_user, organization=au, role=role)
+        png_membership = UserMembership.objects.create(user=png_user, organization=png, role=role)
+
+        output = self._call_command("--apply")
+        au_membership.refresh_from_db()
+        png_membership.refresh_from_db()
+
+        self.assertEqual(au_membership.branch.name, "Brisbane")
+        self.assertIsNone(png_membership.branch)
+        self.assertIn("UPDATED: user_id=", output)
+        self.assertIn("BLOCKED: user_id=", output)
+
+    def test_legacy_test_org_is_not_deleted_or_modified(self):
+        test_org = Organization.objects.create(name="Test Org", slug="test-org")
+
+        self._call_command("--apply")
+        test_org.refresh_from_db()
+
+        self.assertEqual(test_org.name, "Test Org")
+        self.assertTrue(Organization.objects.filter(pk=test_org.pk).exists())
+
+
 class CustomerListAPITests(APITestCase):
     def setUp(self):
         self.client = APIClient()

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -2068,6 +2068,58 @@ How this feeds Phase 8L:
   master data and memberships are aligned, then verified again with
   `rbac_hierarchy_report` and `rbac_scope_completeness_report`.
 
+#### Phase 8L - Additive Master Data Seed and Membership Alignment
+
+Date: 2026-06-22
+
+Branch: `chore/rbac-master-data-seed-membership-alignment`
+
+Scope: additive master-data and deterministic membership writes only. No CRM or
+customer historical backfill, RBAC enforcement, query filtering changes,
+frontend changes, destructive updates, legacy organization deletion, or free-text
+inference.
+
+Command: `python backend/manage.py rbac_master_data_seed_alignment`
+
+Behavior:
+
+- Defaults to dry-run and rolls back all planned changes.
+- Requires `--apply` for writes.
+- Creates missing canonical organizations only: `EFM PNG`, `EFM Australia`,
+  `EFM Fiji`, and `EFM Solomon Islands`.
+- Creates missing canonical branches only: `Port Moresby` and `Lae` under
+  `EFM PNG`, `Brisbane` under `EFM Australia`, `Suva` under `EFM Fiji`, and
+  `Honiara` under `EFM Solomon Islands`.
+- Creates canonical organization-level departments only: `Air Freight`,
+  `Sea Freight`, `Customs`, and `Transport`.
+- Does not create, rename, delete, deactivate, or prefer `EFM Express Air Cargo`,
+  `EAC`, `Warehousing`, or `Test Org`.
+- Treats EAC only as legacy wording if encountered.
+- Populates active membership branch only when the membership already belongs to
+  a canonical organization with exactly one canonical branch. Multi-branch
+  organizations such as `EFM PNG` remain blocked for human review.
+
+Output:
+
+- Summary counts for created, existing, updated, skipped, and blocked records.
+- Per-section rows for organizations, branches, departments, and memberships.
+- Blocked memberships remain visible without changing access behavior.
+
+Safety:
+
+- No `delete()`, bulk `update()`, destructive rename, or CRM/customer record
+  updates.
+- No branch inference from customer names, routes, lanes, quote text, notes,
+  task descriptions, or other free text.
+- Re-running `--apply` is idempotent for canonical master data.
+
+How this feeds the next phase:
+
+- Rerun `rbac_master_data_alignment_plan`, `rbac_hierarchy_report`, and
+  `rbac_scope_completeness_report` after applying master data.
+- Review remaining blocked memberships, especially multi-branch users and legacy
+  organizations, before any historical customer/CRM backfill or enforcement.
+
 ## 12. What Not To Touch Yet
 
 Do not touch these in the first implementation slice:


### PR DESCRIPTION
## Summary

Adds Phase 8L additive RBAC master-data seed and membership alignment support.

This introduces a dry-run-first management command that creates only canonical organizations, branches, and departments, with writes gated behind `--apply`.

## Includes

- Adds `rbac_master_data_seed_alignment`
- Dry-run mode by default
- `--apply` required for writes
- Creates canonical organizations, branches, and departments only
- Excludes EAC, Warehousing, and Test Org from canonical seed data
- Skips memberships tied to legacy/non-canonical organizations
- Confirms idempotency on repeated apply
- Updates RBAC audit documentation
- Adds backend test coverage

## Results

Dry-run:
- `created=25`
- `existing=0`
- `updated=0`
- `skipped=15`
- `blocked=0`

First apply:
- `created=25`
- `existing=0`
- `updated=0`
- `skipped=15`
- `blocked=0`

Second apply:
- `created=0`
- `existing=25`
- `updated=0`
- `skipped=15`
- `blocked=0`

## Checks

- `python backend/manage.py makemigrations --check --dry-run` — no changes
- `python backend/manage.py check` — no issues
- `python backend/manage.py rbac_master_data_alignment_plan`
- `python backend/manage.py rbac_master_data_seed_alignment`
- `python backend/manage.py rbac_master_data_seed_alignment --apply`
- `pytest backend/parties/tests.py -q` — 52 passed
- `git diff --check`
- `graphify update .`
- `npx fallow --format json` — existing 99 baseline issues

## Notes

Historical CRM/customer backfill and RBAC enforcement remain blocked.

Active memberships remain unaligned because current users are still tied to legacy/non-canonical organizations.