### PR TITLE
chore(rbac): add membership reassignment plan report

### DIFF
--- a/backend/parties/management/commands/rbac_membership_reassignment_plan.py
+++ b/backend/parties/management/commands/rbac_membership_reassignment_plan.py
@@ -1,0 +1,181 @@
+import json
+from collections import Counter
+
+from django.core.management.base import BaseCommand, CommandError
+
+from accounts.models import UserMembership
+from parties.models import Branch, Department, Organization
+
+
+CANONICAL_ORGANIZATIONS = ("EFM PNG", "EFM Australia", "EFM Fiji", "EFM Solomon Islands")
+CANONICAL_BRANCHES = {
+    "EFM PNG": ("Port Moresby", "Lae"),
+    "EFM Australia": ("Brisbane",),
+    "EFM Fiji": ("Suva",),
+    "EFM Solomon Islands": ("Honiara",),
+}
+CANONICAL_DEPARTMENTS = ("Air Freight", "Sea Freight", "Customs", "Transport")
+LEGACY_EAC_NAMES = {"EAC", "EFM Express Air Cargo", "Express Air Cargo"}
+
+
+class Command(BaseCommand):
+    help = "Read-only plan for moving active memberships from legacy orgs to canonical RBAC master data."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--format",
+            choices=["text", "json"],
+            default="text",
+            help="Output format. Defaults to text.",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=100,
+            help="Maximum text rows to print. JSON always includes all rows.",
+        )
+
+    def handle(self, *args, **options):
+        if options["limit"] < 1:
+            raise CommandError("--limit must be a positive integer.")
+        report = build_report()
+        if options["format"] == "json":
+            self.stdout.write(json.dumps(report, indent=2, sort_keys=True))
+            return
+        write_text(self.stdout, report, limit=options["limit"])
+
+
+def build_report():
+    memberships = (
+        UserMembership.objects.select_related("user", "organization", "branch", "department", "role")
+        .filter(is_active=True)
+        .order_by("user__username", "organization__name", "id")
+    )
+    rows = [plan_membership(membership) for membership in memberships]
+    return {
+        "write_enabled": False,
+        "safety": [
+            "read-only only",
+            "no CRM/customer backfill",
+            "no RBAC enforcement",
+            "no free-text, route, lane, quote, note, task, or customer-name inference",
+            "EAC is legacy wording only; Air Freight is the canonical department when explicitly safe",
+        ],
+        "summary": dict(sorted(Counter(row["status"] for row in rows).items())),
+        "memberships": rows,
+    }
+
+
+def plan_membership(membership):
+    current_org = membership.organization
+    current_branch = membership.branch
+    current_department = membership.department
+
+    suggested_org = suggest_organization(current_org)
+    suggested_department = suggest_department(current_department)
+    suggested_branch, branch_reason = suggest_branch(suggested_org, current_branch)
+    status, reason = status_for(
+        current_org=current_org,
+        current_branch=current_branch,
+        current_department=current_department,
+        suggested_org=suggested_org,
+        suggested_branch=suggested_branch,
+        suggested_department=suggested_department,
+        branch_reason=branch_reason,
+    )
+    return {
+        "user_id": str(membership.user_id),
+        "username": safe(membership.user.username),
+        "email": safe(membership.user.email),
+        "current_organization": label(current_org),
+        "current_branch": label(current_branch),
+        "current_department": label(current_department),
+        "current_role": safe(getattr(membership.role, "code", "")),
+        "suggested_organization": suggested_org,
+        "suggested_branch": suggested_branch,
+        "suggested_department": suggested_department,
+        "status": status,
+        "reason": reason,
+    }
+
+
+def suggest_organization(organization):
+    if organization and organization.name in CANONICAL_ORGANIZATIONS:
+        return organization.name
+    return None
+
+
+def suggest_branch(suggested_org, current_branch):
+    if not suggested_org:
+        return None, "organization is not canonical"
+    canonical = CANONICAL_BRANCHES[suggested_org]
+    if current_branch and current_branch.name in canonical:
+        return current_branch.name, "current branch is canonical"
+    if len(canonical) == 1:
+        return canonical[0], "single canonical branch"
+    return None, "multiple canonical branches require manual choice"
+
+
+def suggest_department(department):
+    if department is None:
+        return None
+    if department.name in CANONICAL_DEPARTMENTS:
+        return department.name
+    if department.name in LEGACY_EAC_NAMES or department.code in LEGACY_EAC_NAMES:
+        return "Air Freight"
+    return None
+
+
+def status_for(*, current_org, current_branch, current_department, suggested_org, suggested_branch, suggested_department, branch_reason):
+    org_canonical = bool(current_org and current_org.name in CANONICAL_ORGANIZATIONS)
+    branch_canonical = bool(suggested_branch and current_branch and current_branch.name == suggested_branch)
+    department_canonical = bool(
+        suggested_department and current_department and current_department.name == suggested_department
+    )
+    if org_canonical and branch_canonical and department_canonical:
+        return "ALREADY_CANONICAL", "membership already has canonical organization, branch, and department"
+    if not suggested_org:
+        if suggested_department:
+            return "NEEDS_MANUAL_DECISION", "legacy organization requires human target organization and branch decision"
+        return "NEEDS_MANUAL_DECISION", "legacy organization is not safely mappable to a canonical organization"
+    if not suggested_branch:
+        return "BLOCKED", branch_reason
+    if not suggested_department:
+        return "NEEDS_MANUAL_DECISION", "department is missing or not safely canonical"
+    return "READY", "canonical organization plus deterministic branch/department suggestion"
+
+
+def write_text(stdout, report, *, limit):
+    stdout.write("RBAC membership reassignment plan")
+    stdout.write("=================================")
+    stdout.write("Mode: read-only diagnostics")
+    stdout.write(f"Summary: {report['summary']}")
+    stdout.write("")
+    stdout.write("memberships:")
+    for row in report["memberships"][:limit]:
+        stdout.write(
+            "  - "
+            f"user_id={row['user_id']} username={row['username']} "
+            f"current_org={row['current_organization'] or '-'} "
+            f"current_branch={row['current_branch'] or '-'} "
+            f"current_department={row['current_department'] or '-'} "
+            f"suggested_org={row['suggested_organization'] or '-'} "
+            f"suggested_branch={row['suggested_branch'] or '-'} "
+            f"suggested_department={row['suggested_department'] or '-'} "
+            f"status={row['status']} reason={row['reason']}"
+        )
+    remaining = len(report["memberships"]) - limit
+    if remaining > 0:
+        stdout.write(f"... {remaining} more memberships omitted; use --limit or --format json")
+
+
+def label(value):
+    if value is None:
+        return None
+    return safe(getattr(value, "name", None) or getattr(value, "code", None) or str(value))
+
+
+def safe(value):
+    if value is None:
+        return None
+    return str(value).encode("ascii", "replace").decode("ascii")

--- a/backend/parties/tests.py
+++ b/backend/parties/tests.py
@@ -900,6 +900,120 @@ class MasterDataSeedAlignmentTests(TestCase):
         self.assertTrue(Organization.objects.filter(pk=test_org.pk).exists())
 
 
+class MembershipReassignmentPlanTests(TestCase):
+    def _call_report(self, *args):
+        stdout = StringIO()
+        call_command("rbac_membership_reassignment_plan", *args, stdout=stdout)
+        return stdout.getvalue()
+
+    def _role(self, code="membership-plan-role"):
+        return Role.objects.create(code=code, name=code.title(), is_system=True)
+
+    def test_already_canonical_membership(self):
+        org = Organization.objects.create(name="EFM Australia", slug="efm-australia")
+        branch = Branch.objects.create(organization=org, code="BNE", name="Brisbane")
+        department = Department.objects.create(organization=org, code="AIR", name="Air Freight")
+        user = CustomUser.objects.create_user(username="canonical-user")
+        UserMembership.objects.create(user=user, organization=org, branch=branch, department=department, role=self._role())
+
+        payload = json.loads(self._call_report("--format", "json"))
+
+        row = payload["memberships"][0]
+        self.assertEqual(row["status"], "ALREADY_CANONICAL")
+        self.assertEqual(row["suggested_organization"], "EFM Australia")
+        self.assertEqual(row["suggested_branch"], "Brisbane")
+        self.assertEqual(row["suggested_department"], "Air Freight")
+
+    def test_legacy_organization_needs_manual_decision(self):
+        legacy, _created = Organization.objects.get_or_create(
+            name="EFM Express Air Cargo",
+            defaults={"slug": "efm-express-air-cargo"},
+        )
+        department, _created = Department.objects.get_or_create(
+            organization=legacy,
+            code="AIR",
+            defaults={"name": "Air Freight"},
+        )
+        user = CustomUser.objects.create_user(username="legacy-user")
+        UserMembership.objects.create(user=user, organization=legacy, department=department, role=self._role())
+
+        payload = json.loads(self._call_report("--format", "json"))
+
+        row = payload["memberships"][0]
+        self.assertEqual(row["status"], "NEEDS_MANUAL_DECISION")
+        self.assertIsNone(row["suggested_organization"])
+        self.assertIsNone(row["suggested_branch"])
+        self.assertEqual(row["suggested_department"], "Air Freight")
+
+    def test_missing_branch_on_single_branch_org_is_ready(self):
+        org = Organization.objects.create(name="EFM Fiji", slug="efm-fiji")
+        Branch.objects.create(organization=org, code="SUV", name="Suva")
+        department = Department.objects.create(organization=org, code="CUS", name="Customs")
+        user = CustomUser.objects.create_user(username="missing-branch-user")
+        UserMembership.objects.create(user=user, organization=org, department=department, role=self._role())
+
+        payload = json.loads(self._call_report("--format", "json"))
+
+        row = payload["memberships"][0]
+        self.assertEqual(row["status"], "READY")
+        self.assertEqual(row["suggested_branch"], "Suva")
+
+    def test_missing_department_needs_manual_decision(self):
+        org = Organization.objects.create(name="EFM Fiji", slug="efm-fiji")
+        branch = Branch.objects.create(organization=org, code="SUV", name="Suva")
+        user = CustomUser.objects.create_user(username="missing-department-user")
+        UserMembership.objects.create(user=user, organization=org, branch=branch, role=self._role())
+
+        payload = json.loads(self._call_report("--format", "json"))
+
+        row = payload["memberships"][0]
+        self.assertEqual(row["status"], "NEEDS_MANUAL_DECISION")
+        self.assertIsNone(row["suggested_department"])
+
+    def test_multi_branch_organization_blocks_missing_branch(self):
+        org = Organization.objects.create(name="EFM PNG", slug="efm-png")
+        Department.objects.create(organization=org, code="SEA", name="Sea Freight")
+        user = CustomUser.objects.create_user(username="png-user")
+        UserMembership.objects.create(
+            user=user,
+            organization=org,
+            department=Department.objects.get(organization=org, code="SEA"),
+            role=self._role(),
+        )
+
+        payload = json.loads(self._call_report("--format", "json"))
+
+        row = payload["memberships"][0]
+        self.assertEqual(row["status"], "BLOCKED")
+        self.assertIsNone(row["suggested_branch"])
+
+    def test_eac_department_maps_to_air_freight_only(self):
+        org = Organization.objects.create(name="EFM Australia", slug="efm-australia")
+        Branch.objects.create(organization=org, code="BNE", name="Brisbane")
+        eac_department = Department.objects.create(organization=org, code="EAC", name="EAC")
+        user = CustomUser.objects.create_user(username="eac-dept-user")
+        UserMembership.objects.create(user=user, organization=org, department=eac_department, role=self._role())
+
+        payload = json.loads(self._call_report("--format", "json"))
+
+        row = payload["memberships"][0]
+        self.assertEqual(row["status"], "READY")
+        self.assertEqual(row["suggested_department"], "Air Freight")
+        self.assertNotEqual(row["suggested_department"], "EAC")
+
+    def test_report_does_not_write(self):
+        org = Organization.objects.create(name="EFM Fiji", slug="efm-fiji")
+        Branch.objects.create(organization=org, code="SUV", name="Suva")
+        department = Department.objects.create(organization=org, code="TRN", name="Transport")
+        user = CustomUser.objects.create_user(username="readonly-user")
+        membership = UserMembership.objects.create(user=user, organization=org, department=department, role=self._role())
+
+        self._call_report()
+        membership.refresh_from_db()
+
+        self.assertIsNone(membership.branch)
+
+
 class CustomerListAPITests(APITestCase):
     def setUp(self):
         self.client = APIClient()

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -2120,6 +2120,61 @@ How this feeds the next phase:
 - Review remaining blocked memberships, especially multi-branch users and legacy
   organizations, before any historical customer/CRM backfill or enforcement.
 
+#### Phase 8M - Legacy Membership Reassignment Plan
+
+Date: 2026-06-22
+
+Branch: `chore/rbac-membership-reassignment-plan`
+
+Scope: read-only diagnostics only. No membership writes, CRM/customer
+historical backfill, RBAC enforcement, query filtering changes, destructive
+updates, or free-text inference.
+
+Command: `python backend/manage.py rbac_membership_reassignment_plan`
+
+Purpose:
+
+- Inspect active `UserMembership` records.
+- Report current organization, branch, department, and role using safe identity
+  fields only.
+- Suggest canonical organization, branch, and department only when current
+  membership fields make the answer deterministic.
+- Classify each row as `ALREADY_CANONICAL`, `READY`,
+  `NEEDS_MANUAL_DECISION`, or `BLOCKED`.
+
+Explicit safe rules:
+
+- Canonical organizations are `EFM PNG`, `EFM Australia`, `EFM Fiji`, and
+  `EFM Solomon Islands`.
+- Canonical departments are `Air Freight`, `Sea Freight`, `Customs`, and
+  `Transport`.
+- `EAC` and `EFM Express Air Cargo` are legacy wording only and are never target
+  organization or department names.
+- A current department explicitly named or coded `EAC` may only suggest the
+  canonical department `Air Freight`; it does not determine organization or
+  branch.
+- Missing branch is deterministic only for canonical organizations with one
+  canonical branch, such as `EFM Australia`, `EFM Fiji`, or
+  `EFM Solomon Islands`.
+- Missing branch under multi-branch organizations such as `EFM PNG` is blocked
+  for human review.
+
+Non-goals:
+
+- No writes to `UserMembership`.
+- No historical customer/CRM backfill.
+- No selector or enforcement changes.
+- No branch or department inference from customer names, CRM records, quote
+  routes, lanes, notes, task text, or other free text.
+
+How this feeds the next phase:
+
+- Use this report to build an approved, explicit membership reassignment table.
+- Only after human approval should a later phase add a write-capable membership
+  reassignment command.
+- Customer/CRM backfill and RBAC enforcement remain blocked until canonical
+  memberships are populated and diagnostics are rerun.
+
 ## 12. What Not To Touch Yet
 
 Do not touch these in the first implementation slice:


### PR DESCRIPTION
## Summary

Adds Phase 8M read-only RBAC membership reassignment planning diagnostics.

## Includes

- Adds `rbac_membership_reassignment_plan`
- Supports text and JSON output
- Supports `--limit`
- Reports safe user identity, current membership scope, deterministic suggestions, status, and reason
- Keeps the command read-only
- Does not infer from CRM/customer/quote/route/lane/free text
- Treats EAC only as legacy wording; canonical department remains `Air Freight`
- Adds focused backend tests
- Updates RBAC audit documentation

## Checks

- `python backend/manage.py makemigrations --check --dry-run` — no changes
- `python backend/manage.py check` — no issues
- `python backend/manage.py rbac_master_data_alignment_plan`
- `python backend/manage.py rbac_master_data_seed_alignment`
- `python backend/manage.py rbac_membership_reassignment_plan`
- `python backend/manage.py rbac_membership_reassignment_plan --format json`
- `pytest backend/parties/tests.py -q` — 59 passed
- `git diff --check`
- `graphify update .`
- `npx fallow --format json` — existing 99 baseline issues

## Notes

No membership writes, historical backfill, selector changes, or RBAC enforcement are included.

Current dev DB memberships remain manual decisions because they sit under legacy/non-canonical organizations. The next phase requires an approved explicit reassignment table before any write-capable membership move.