### PR TITLE
chore(rbac): validate membership reassignment table

### DIFF
--- a/backend/parties/management/commands/rbac_membership_reassignment_table_validate.py
+++ b/backend/parties/management/commands/rbac_membership_reassignment_table_validate.py
@@ -1,0 +1,159 @@
+import csv
+import json
+
+from django.core.management.base import BaseCommand, CommandError
+
+from accounts.models import CustomUser, Role
+from parties.models import Branch, Department, Organization
+
+
+REQUIRED_COLUMNS = (
+    "username",
+    "target_organization",
+    "target_branch",
+    "target_department",
+    "target_role",
+    "approved",
+    "notes",
+)
+CANONICAL_ORGANIZATIONS = {"EFM PNG", "EFM Australia", "EFM Fiji", "EFM Solomon Islands"}
+CANONICAL_DEPARTMENTS = {"Air Freight", "Sea Freight", "Customs", "Transport"}
+EAC_VALUES = {"eac", "efm express air cargo", "express air cargo"}
+TRUE_VALUES = {"true", "yes"}
+
+
+class Command(BaseCommand):
+    help = "Read-only validation for an explicit RBAC membership reassignment CSV table."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--input", required=True, help="CSV file to validate.")
+        parser.add_argument(
+            "--format",
+            choices=["text", "json"],
+            default="text",
+            help="Output format. Defaults to text.",
+        )
+
+    def handle(self, *args, **options):
+        report = validate_csv(options["input"])
+        if options["format"] == "json":
+            self.stdout.write(json.dumps(report, indent=2, sort_keys=True))
+            return
+        write_text(self.stdout, report)
+
+
+def validate_csv(path):
+    try:
+        with open(path, encoding="utf-8-sig", newline="") as handle:
+            reader = csv.DictReader(handle)
+            missing_columns = [column for column in REQUIRED_COLUMNS if column not in (reader.fieldnames or [])]
+            if missing_columns:
+                raise CommandError(f"Missing required columns: {', '.join(missing_columns)}")
+            rows = [validate_row(row_number, row) for row_number, row in enumerate(reader, start=2)]
+    except OSError as exc:
+        raise CommandError(f"Unable to read input CSV: {exc}") from exc
+
+    seen = {}
+    for row in rows:
+        username = row["username"]
+        if not username:
+            continue
+        if username in seen:
+            row["errors"].append("duplicate username")
+            seen[username]["errors"].append("duplicate username")
+        else:
+            seen[username] = row
+
+    for row in rows:
+        row["status"] = "READY" if not row["errors"] else "BLOCKED"
+
+    return {
+        "write_enabled": False,
+        "summary": {
+            "total": len(rows),
+            "ready": sum(1 for row in rows if row["status"] == "READY"),
+            "blocked": sum(1 for row in rows if row["status"] == "BLOCKED"),
+        },
+        "rows": rows,
+    }
+
+
+def validate_row(row_number, row):
+    values = {column: clean(row.get(column)) for column in REQUIRED_COLUMNS}
+    errors = []
+    for column in REQUIRED_COLUMNS[:-1]:
+        if not values[column]:
+            errors.append(f"missing {column}")
+
+    user = CustomUser.objects.filter(username=values["username"]).first()
+    if values["username"] and user is None:
+        errors.append("user not found")
+    elif user and not user.is_active:
+        errors.append("user inactive")
+
+    organization = Organization.objects.filter(name=values["target_organization"]).first()
+    if contains_eac(values["target_organization"]):
+        errors.append("EAC target value is not allowed")
+    elif values["target_organization"] and values["target_organization"] not in CANONICAL_ORGANIZATIONS:
+        errors.append("target organization is not canonical")
+    elif values["target_organization"] and organization is None:
+        errors.append("target organization not found")
+
+    branch = None
+    if contains_eac(values["target_branch"]):
+        errors.append("EAC target value is not allowed")
+    elif organization and values["target_branch"]:
+        branch = Branch.objects.filter(organization=organization, name=values["target_branch"]).first()
+        if branch is None:
+            errors.append("target branch not found under target organization")
+
+    if contains_eac(values["target_department"]):
+        errors.append("EAC target value is not allowed")
+    elif values["target_department"] and values["target_department"] not in CANONICAL_DEPARTMENTS:
+        errors.append("target department is not canonical")
+    elif organization and values["target_department"]:
+        department_exists = Department.objects.filter(
+            organization=organization,
+            name=values["target_department"],
+        ).exists()
+        if not department_exists:
+            errors.append("target department not found under target organization")
+
+    if values["target_role"] and not Role.objects.filter(code=values["target_role"], is_active=True).exists():
+        errors.append("target role not found")
+
+    if values["approved"].lower() not in TRUE_VALUES:
+        errors.append("approved must be true or yes")
+
+    return {
+        "row_number": row_number,
+        **values,
+        "target_branch_id": str(branch.pk) if branch else None,
+        "status": "BLOCKED",
+        "errors": errors,
+    }
+
+
+def clean(value):
+    return (value or "").strip()
+
+
+def contains_eac(value):
+    return clean(value).lower() in EAC_VALUES
+
+
+def write_text(stdout, report):
+    summary = report["summary"]
+    stdout.write("RBAC membership reassignment table validation")
+    stdout.write("============================================")
+    stdout.write("Mode: read-only validation")
+    stdout.write(f"Summary: total={summary['total']}, ready={summary['ready']}, blocked={summary['blocked']}")
+    stdout.write("")
+    stdout.write("rows:")
+    for row in report["rows"]:
+        errors = "; ".join(row["errors"]) if row["errors"] else "-"
+        stdout.write(
+            f"  - row={row['row_number']} username={row['username'] or '-'} "
+            f"target={row['target_organization'] or '-'}/{row['target_branch'] or '-'}/{row['target_department'] or '-'} "
+            f"role={row['target_role'] or '-'} status={row['status']} errors={errors}"
+        )

--- a/backend/parties/tests.py
+++ b/backend/parties/tests.py
@@ -1014,6 +1014,179 @@ class MembershipReassignmentPlanTests(TestCase):
         self.assertIsNone(membership.branch)
 
 
+class MembershipReassignmentTableValidateTests(TestCase):
+    def _call_validate(self, rows, *args):
+        fd, path = tempfile.mkstemp(suffix=".csv")
+        os.close(fd)
+        with open(path, "w", encoding="utf-8", newline="") as handle:
+            writer = csv.DictWriter(
+                handle,
+                fieldnames=[
+                    "username",
+                    "target_organization",
+                    "target_branch",
+                    "target_department",
+                    "target_role",
+                    "approved",
+                    "notes",
+                ],
+            )
+            writer.writeheader()
+            writer.writerows(rows)
+        stdout = StringIO()
+        call_command("rbac_membership_reassignment_table_validate", "--input", path, *args, stdout=stdout)
+        return stdout.getvalue()
+
+    def _scope(self):
+        organization = Organization.objects.create(name="EFM Australia", slug="efm-australia")
+        Branch.objects.create(organization=organization, code="BNE", name="Brisbane")
+        Department.objects.create(organization=organization, code="AIR", name="Air Freight")
+        return organization
+
+    def _role(self):
+        role, _created = Role.objects.get_or_create(code="sales", defaults={"name": "Sales", "is_system": True})
+        return role
+
+    def _row(self, username="approved-user", **overrides):
+        row = {
+            "username": username,
+            "target_organization": "EFM Australia",
+            "target_branch": "Brisbane",
+            "target_department": "Air Freight",
+            "target_role": "sales",
+            "approved": "yes",
+            "notes": "approved",
+        }
+        row.update(overrides)
+        return row
+
+    def test_valid_approved_row_is_ready(self):
+        self._scope()
+        self._role()
+        CustomUser.objects.create_user(username="approved-user")
+
+        payload = json.loads(self._call_validate([self._row()], "--format", "json"))
+
+        self.assertEqual(payload["summary"], {"blocked": 0, "ready": 1, "total": 1})
+        self.assertEqual(payload["rows"][0]["status"], "READY")
+
+    def test_missing_user_is_blocked(self):
+        self._scope()
+        self._role()
+
+        payload = json.loads(self._call_validate([self._row(username="missing-user")], "--format", "json"))
+
+        self.assertIn("user not found", payload["rows"][0]["errors"])
+
+    def test_inactive_user_is_blocked(self):
+        self._scope()
+        self._role()
+        CustomUser.objects.create_user(username="inactive-user", is_active=False)
+
+        payload = json.loads(self._call_validate([self._row(username="inactive-user")], "--format", "json"))
+
+        self.assertIn("user inactive", payload["rows"][0]["errors"])
+
+    def test_non_canonical_organization_is_blocked(self):
+        Organization.objects.create(name="Express Freight Management", slug="express-freight-management")
+        self._role()
+        CustomUser.objects.create_user(username="legacy-org-user")
+
+        payload = json.loads(
+            self._call_validate(
+                [self._row(username="legacy-org-user", target_organization="Express Freight Management")],
+                "--format",
+                "json",
+            )
+        )
+
+        self.assertIn("target organization is not canonical", payload["rows"][0]["errors"])
+
+    def test_branch_must_belong_to_target_organization(self):
+        self._scope()
+        png = Organization.objects.create(name="EFM PNG", slug="efm-png")
+        Branch.objects.create(organization=png, code="POM", name="Port Moresby")
+        self._role()
+        CustomUser.objects.create_user(username="wrong-branch-user")
+
+        payload = json.loads(
+            self._call_validate(
+                [self._row(username="wrong-branch-user", target_branch="Port Moresby")],
+                "--format",
+                "json",
+            )
+        )
+
+        self.assertIn("target branch not found under target organization", payload["rows"][0]["errors"])
+
+    def test_non_canonical_department_is_blocked(self):
+        self._scope()
+        self._role()
+        CustomUser.objects.create_user(username="warehouse-user")
+
+        payload = json.loads(
+            self._call_validate(
+                [self._row(username="warehouse-user", target_department="Warehousing")],
+                "--format",
+                "json",
+            )
+        )
+
+        self.assertIn("target department is not canonical", payload["rows"][0]["errors"])
+
+    def test_eac_target_is_rejected(self):
+        self._scope()
+        self._role()
+        CustomUser.objects.create_user(username="eac-target-user")
+
+        payload = json.loads(
+            self._call_validate(
+                [self._row(username="eac-target-user", target_department="EAC")],
+                "--format",
+                "json",
+            )
+        )
+
+        self.assertIn("EAC target value is not allowed", payload["rows"][0]["errors"])
+
+    def test_duplicate_username_is_blocked(self):
+        self._scope()
+        self._role()
+        CustomUser.objects.create_user(username="duplicate-user")
+
+        payload = json.loads(
+            self._call_validate(
+                [self._row(username="duplicate-user"), self._row(username="duplicate-user")],
+                "--format",
+                "json",
+            )
+        )
+
+        self.assertEqual(payload["summary"]["blocked"], 2)
+        self.assertIn("duplicate username", payload["rows"][0]["errors"])
+        self.assertIn("duplicate username", payload["rows"][1]["errors"])
+
+    def test_unapproved_row_is_blocked(self):
+        self._scope()
+        self._role()
+        CustomUser.objects.create_user(username="unapproved-user")
+
+        payload = json.loads(
+            self._call_validate([self._row(username="unapproved-user", approved="no")], "--format", "json")
+        )
+
+        self.assertIn("approved must be true or yes", payload["rows"][0]["errors"])
+
+    def test_validation_does_not_write_memberships(self):
+        self._scope()
+        self._role()
+        user = CustomUser.objects.create_user(username="no-write-user")
+
+        self._call_validate([self._row(username="no-write-user")])
+
+        self.assertFalse(UserMembership.objects.filter(user=user).exists())
+
+
 class CustomerListAPITests(APITestCase):
     def setUp(self):
         self.client = APIClient()

--- a/docs/rbac-membership-reassignment-template.csv
+++ b/docs/rbac-membership-reassignment-template.csv
@@ -1,0 +1,2 @@
+username,target_organization,target_branch,target_department,target_role,approved,notes
+example.user,EFM Australia,Brisbane,Air Freight,sales,yes,Replace this sample row with approved production decisions.

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -2175,6 +2175,63 @@ How this feeds the next phase:
 - Customer/CRM backfill and RBAC enforcement remain blocked until canonical
   memberships are populated and diagnostics are rerun.
 
+#### Phase 8N - Explicit Membership Reassignment Table Validation
+
+Date: 2026-06-22
+
+Branch: `chore/rbac-membership-reassignment-table-validation`
+
+Scope: read-only validation only. No membership writes, CRM/customer historical
+backfill, RBAC enforcement, query filtering changes, destructive updates, or
+free-text inference.
+
+Command:
+`python backend/manage.py rbac_membership_reassignment_table_validate --input <csv>`
+
+CSV columns:
+
+- `username`
+- `target_organization`
+- `target_branch`
+- `target_department`
+- `target_role`
+- `approved`
+- `notes`
+
+Validation rules:
+
+- User must exist and be active.
+- Target organization must exist and be one of `EFM PNG`, `EFM Australia`,
+  `EFM Fiji`, or `EFM Solomon Islands`.
+- Target branch must exist under the target organization.
+- Target department must exist under the target organization and be canonical:
+  `Air Freight`, `Sea Freight`, `Customs`, or `Transport`.
+- Target role must exist and be active.
+- `approved` must be explicitly `true` or `yes`.
+- Duplicate usernames are blocked.
+- Required fields must be present and populated.
+- `EAC`, `EFM Express Air Cargo`, and `Express Air Cargo` are rejected as target
+  values.
+
+Output:
+
+- Text summary by default.
+- `--format json` for machine-readable review.
+- Rows are classified as `READY` or `BLOCKED` with errors.
+- `write_enabled=false` in JSON output.
+
+Template:
+
+- `docs/rbac-membership-reassignment-template.csv`
+
+How this feeds the next phase:
+
+- Business owners should fill the CSV with explicit approved target values.
+- Only `READY` rows should be eligible for a later write-capable reassignment
+  command.
+- CRM/customer backfill and RBAC enforcement remain blocked until reassignment
+  is applied and diagnostics are rerun.
+
 ## 12. What Not To Touch Yet
 
 Do not touch these in the first implementation slice:


### PR DESCRIPTION
## Summary

Adds Phase 8N read-only CSV validation for explicit RBAC membership reassignment decisions.

## Includes

- Adds `rbac_membership_reassignment_table_validate`
- Supports text and JSON output
- Adds sample CSV template
- Validates users, canonical organization/branch/department targets, roles, duplicate usernames, approval flags, and EAC target rejection
- Keeps the command read-only
- Adds focused backend tests
- Updates RBAC documentation

## Checks

- `python backend/manage.py makemigrations --check --dry-run` — no changes
- `python backend/manage.py check` — no issues
- `python backend/manage.py rbac_membership_reassignment_plan`
- `python backend/manage.py rbac_membership_reassignment_table_validate --input docs/rbac-membership-reassignment-template.csv`
- `python backend/manage.py rbac_membership_reassignment_table_validate --input docs/rbac-membership-reassignment-template.csv --format json`
- `pytest backend/parties/tests.py -q` — 69 passed
- `git diff --check`
- `graphify update .`
- `npx fallow --format json` — existing 99 baseline issues

## Notes

No writes, CRM backfill, selector changes, or RBAC enforcement are included.