### PR TITLE
chore(rbac): apply membership reassignment table

### DIFF
--- a/backend/parties/management/commands/rbac_membership_reassignment_apply.py
+++ b/backend/parties/management/commands/rbac_membership_reassignment_apply.py
@@ -1,0 +1,144 @@
+import json
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from accounts.models import UserMembership
+
+from .rbac_membership_reassignment_table_validate import validate_csv
+
+
+class Command(BaseCommand):
+    help = "Apply approved RBAC membership reassignment CSV rows. Dry-run by default."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--input", required=True, help="CSV file to apply.")
+        parser.add_argument("--apply", action="store_true", help="Write READY rows. Defaults to dry-run.")
+        parser.add_argument(
+            "--format",
+            choices=["text", "json"],
+            default="text",
+            help="Output format. Defaults to text.",
+        )
+
+    def handle(self, *args, **options):
+        with transaction.atomic():
+            report = build_apply_report(options["input"], apply=options["apply"])
+            if not options["apply"]:
+                transaction.set_rollback(True)
+        if options["format"] == "json":
+            self.stdout.write(json.dumps(report, indent=2, sort_keys=True))
+            return
+        write_text(self.stdout, report)
+
+
+def build_apply_report(path, *, apply):
+    validation = validate_csv(path)
+    rows = [plan_row(row, apply=apply) for row in validation["rows"]]
+    return {
+        "mode": "apply" if apply else "dry-run",
+        "write_enabled": bool(apply),
+        "summary": {
+            "total": len(rows),
+            "planned": sum(1 for row in rows if row["status"] == "PLANNED"),
+            "applied": sum(1 for row in rows if row["status"] == "APPLIED"),
+            "unchanged": sum(1 for row in rows if row["status"] == "UNCHANGED"),
+            "blocked": sum(1 for row in rows if row["status"] == "BLOCKED"),
+        },
+        "rows": rows,
+    }
+
+
+def plan_row(row, *, apply):
+    if row["status"] != "READY":
+        return {
+            **public_row(row),
+            "status": "BLOCKED",
+            "previous": None,
+            "target": target_state(row),
+            "errors": row["errors"],
+        }
+
+    membership = (
+        UserMembership.objects.select_related("organization", "branch", "department", "role")
+        .filter(user__username=row["username"], is_active=True)
+        .order_by("-is_primary", "id")
+        .first()
+    )
+    if membership is None:
+        return {
+            **public_row(row),
+            "status": "BLOCKED",
+            "previous": None,
+            "target": target_state(row),
+            "errors": ["active membership not found"],
+        }
+
+    previous = membership_state(membership)
+    target = target_state(row)
+    unchanged = previous == target
+    status = "UNCHANGED" if unchanged else ("APPLIED" if apply else "PLANNED")
+    if apply and not unchanged:
+        membership.organization_id = row["target_organization_id"]
+        membership.branch_id = row["target_branch_id"]
+        membership.department_id = row["target_department_id"]
+        membership.role_id = row["target_role_id"]
+        membership.save(update_fields=["organization", "branch", "department", "role", "updated_at"])
+    return {
+        **public_row(row),
+        "status": status,
+        "previous": previous,
+        "target": target,
+        "errors": [],
+    }
+
+
+def public_row(row):
+    return {
+        "row_number": row["row_number"],
+        "username": row["username"],
+    }
+
+
+def membership_state(membership):
+    return {
+        "organization": label(membership.organization),
+        "branch": label(membership.branch),
+        "department": label(membership.department),
+        "role": getattr(membership.role, "code", None),
+    }
+
+
+def target_state(row):
+    return {
+        "organization": row["target_organization"],
+        "branch": row["target_branch"],
+        "department": row["target_department"],
+        "role": row["target_role"],
+    }
+
+
+def label(value):
+    if value is None:
+        return None
+    return getattr(value, "name", None) or getattr(value, "code", None) or str(value)
+
+
+def write_text(stdout, report):
+    summary = report["summary"]
+    stdout.write("RBAC membership reassignment apply")
+    stdout.write("==================================")
+    stdout.write(f"Mode: {report['mode']}")
+    stdout.write(
+        "Summary: "
+        f"total={summary['total']}, planned={summary['planned']}, applied={summary['applied']}, "
+        f"unchanged={summary['unchanged']}, blocked={summary['blocked']}"
+    )
+    stdout.write("")
+    stdout.write("rows:")
+    for row in report["rows"]:
+        errors = "; ".join(row["errors"]) if row["errors"] else "-"
+        stdout.write(
+            f"  - row={row['row_number']} username={row['username']} status={row['status']} "
+            f"previous={row['previous'] or '-'} target={row['target']} errors={errors}"
+        )

--- a/backend/parties/management/commands/rbac_membership_reassignment_table_validate.py
+++ b/backend/parties/management/commands/rbac_membership_reassignment_table_validate.py
@@ -100,6 +100,8 @@ def validate_row(row_number, row):
         errors.append("target organization not found")
 
     branch = None
+    department = None
+    role = None
     if contains_eac(values["target_branch"]):
         errors.append("EAC target value is not allowed")
     elif organization and values["target_branch"]:
@@ -112,15 +114,17 @@ def validate_row(row_number, row):
     elif values["target_department"] and values["target_department"] not in CANONICAL_DEPARTMENTS:
         errors.append("target department is not canonical")
     elif organization and values["target_department"]:
-        department_exists = Department.objects.filter(
+        department = Department.objects.filter(
             organization=organization,
             name=values["target_department"],
-        ).exists()
-        if not department_exists:
+        ).first()
+        if department is None:
             errors.append("target department not found under target organization")
 
-    if values["target_role"] and not Role.objects.filter(code=values["target_role"], is_active=True).exists():
-        errors.append("target role not found")
+    if values["target_role"]:
+        role = Role.objects.filter(code=values["target_role"], is_active=True).first()
+        if role is None:
+            errors.append("target role not found")
 
     if values["approved"].lower() not in TRUE_VALUES:
         errors.append("approved must be true or yes")
@@ -128,7 +132,10 @@ def validate_row(row_number, row):
     return {
         "row_number": row_number,
         **values,
+        "target_organization_id": str(organization.pk) if organization else None,
         "target_branch_id": str(branch.pk) if branch else None,
+        "target_department_id": str(department.pk) if department else None,
+        "target_role_id": str(role.pk) if role else None,
         "status": "BLOCKED",
         "errors": errors,
     }

--- a/backend/parties/tests.py
+++ b/backend/parties/tests.py
@@ -1187,6 +1187,158 @@ class MembershipReassignmentTableValidateTests(TestCase):
         self.assertFalse(UserMembership.objects.filter(user=user).exists())
 
 
+class MembershipReassignmentApplyTests(TestCase):
+    def _write_csv(self, rows):
+        fd, path = tempfile.mkstemp(suffix=".csv")
+        os.close(fd)
+        with open(path, "w", encoding="utf-8", newline="") as handle:
+            writer = csv.DictWriter(
+                handle,
+                fieldnames=[
+                    "username",
+                    "target_organization",
+                    "target_branch",
+                    "target_department",
+                    "target_role",
+                    "approved",
+                    "notes",
+                ],
+            )
+            writer.writeheader()
+            writer.writerows(rows)
+        return path
+
+    def _call_apply(self, rows, *args):
+        stdout = StringIO()
+        call_command("rbac_membership_reassignment_apply", "--input", self._write_csv(rows), *args, stdout=stdout)
+        return stdout.getvalue()
+
+    def _scope(self):
+        organization = Organization.objects.create(name="EFM Australia", slug="efm-australia")
+        branch = Branch.objects.create(organization=organization, code="BNE", name="Brisbane")
+        department = Department.objects.create(organization=organization, code="AIR", name="Air Freight")
+        legacy_org = Organization.objects.create(name="Legacy Org", slug="legacy-org")
+        legacy_department = Department.objects.create(organization=legacy_org, code="SEA", name="Sea Freight")
+        role, _created = Role.objects.get_or_create(code="sales", defaults={"name": "Sales", "is_system": True})
+        return organization, branch, department, legacy_org, legacy_department, role
+
+    def _row(self, username="apply-user", **overrides):
+        row = {
+            "username": username,
+            "target_organization": "EFM Australia",
+            "target_branch": "Brisbane",
+            "target_department": "Air Freight",
+            "target_role": "sales",
+            "approved": "yes",
+            "notes": "approved",
+        }
+        row.update(overrides)
+        return row
+
+    def _membership(self, username="apply-user"):
+        _org, _branch, _dept, legacy_org, legacy_department, role = self._scope()
+        user = CustomUser.objects.create_user(username=username)
+        return UserMembership.objects.create(
+            user=user,
+            organization=legacy_org,
+            department=legacy_department,
+            role=role,
+        )
+
+    def test_dry_run_does_not_write(self):
+        membership = self._membership()
+
+        output = self._call_apply([self._row()])
+        membership.refresh_from_db()
+
+        self.assertIn("Mode: dry-run", output)
+        self.assertIn("status=PLANNED", output)
+        self.assertEqual(membership.organization.name, "Legacy Org")
+        self.assertIsNone(membership.branch)
+
+    def test_apply_updates_ready_membership(self):
+        membership = self._membership()
+
+        output = self._call_apply([self._row()], "--apply")
+        membership.refresh_from_db()
+
+        self.assertIn("status=APPLIED", output)
+        self.assertEqual(membership.organization.name, "EFM Australia")
+        self.assertEqual(membership.branch.name, "Brisbane")
+        self.assertEqual(membership.department.name, "Air Freight")
+        self.assertEqual(membership.role.code, "sales")
+
+    def test_blocked_row_not_applied(self):
+        membership = self._membership(username="blocked-user")
+
+        output = self._call_apply([self._row(username="blocked-user", target_organization="EAC")], "--apply")
+        membership.refresh_from_db()
+
+        self.assertIn("status=BLOCKED", output)
+        self.assertEqual(membership.organization.name, "Legacy Org")
+
+    def test_duplicate_username_blocked(self):
+        membership = self._membership(username="dupe-apply-user")
+
+        output = self._call_apply(
+            [self._row(username="dupe-apply-user"), self._row(username="dupe-apply-user")],
+            "--apply",
+        )
+        membership.refresh_from_db()
+
+        self.assertIn("blocked=2", output)
+        self.assertEqual(membership.organization.name, "Legacy Org")
+
+    def test_unapproved_row_blocked(self):
+        membership = self._membership(username="unapproved-apply-user")
+
+        output = self._call_apply([self._row(username="unapproved-apply-user", approved="no")], "--apply")
+        membership.refresh_from_db()
+
+        self.assertIn("approved must be true or yes", output)
+        self.assertEqual(membership.organization.name, "Legacy Org")
+
+    def test_missing_role_blocked(self):
+        membership = self._membership(username="missing-role-apply-user")
+
+        output = self._call_apply(
+            [self._row(username="missing-role-apply-user", target_role="missing-role")],
+            "--apply",
+        )
+        membership.refresh_from_db()
+
+        self.assertIn("target role not found", output)
+        self.assertEqual(membership.organization.name, "Legacy Org")
+
+    def test_idempotent_second_apply(self):
+        membership = self._membership(username="idempotent-user")
+
+        self._call_apply([self._row(username="idempotent-user")], "--apply")
+        output = self._call_apply([self._row(username="idempotent-user")], "--apply")
+        membership.refresh_from_db()
+
+        self.assertIn("unchanged=1", output)
+        self.assertEqual(membership.organization.name, "EFM Australia")
+
+    def test_previous_state_reported(self):
+        self._membership(username="previous-state-user")
+
+        payload = json.loads(self._call_apply([self._row(username="previous-state-user")], "--format", "json"))
+
+        row = payload["rows"][0]
+        self.assertEqual(row["previous"]["organization"], "Legacy Org")
+        self.assertEqual(row["target"]["organization"], "EFM Australia")
+
+    def test_no_customer_or_crm_writes_occur(self):
+        membership = self._membership(username="no-customer-write-user")
+        company = Company.objects.create(name="No Write Customer", organization=membership.organization)
+
+        self._call_apply([self._row(username="no-customer-write-user")], "--apply")
+        company.refresh_from_db()
+
+        self.assertEqual(company.organization.name, "Legacy Org")
+
+
 class CustomerListAPITests(APITestCase):
     def setUp(self):
         self.client = APIClient()

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -2232,6 +2232,46 @@ How this feeds the next phase:
 - CRM/customer backfill and RBAC enforcement remain blocked until reassignment
   is applied and diagnostics are rerun.
 
+#### Phase 8O - Apply Approved Membership Reassignment Table
+
+Date: 2026-06-22
+
+Branch: `chore/rbac-membership-reassignment-apply`
+
+Scope: controlled membership writes only from a validated CSV table. No
+organization, branch, department, user, or role creation. No CRM/customer
+historical backfill, RBAC enforcement, query filtering changes, destructive
+cleanup, or free-text inference.
+
+Command:
+`python backend/manage.py rbac_membership_reassignment_apply --input <csv>`
+
+Behavior:
+
+- Defaults to dry-run.
+- Requires `--apply` for writes.
+- Reuses `rbac_membership_reassignment_table_validate` validation logic.
+- Applies only rows whose validation status is `READY`.
+- Leaves `BLOCKED` rows untouched and reports their validation errors.
+- Updates the active user's membership to the validated target organization,
+  branch, department, and role.
+- Reports previous membership state and target state for every ready row.
+- Is idempotent: a second apply reports already matching rows as `UNCHANGED`.
+
+Safety:
+
+- Does not create master data, users, or roles.
+- Rejects EAC target values through the shared validator.
+- Does not infer from customer names, CRM records, quote routes, lanes, notes,
+  task text, or other free text.
+- Does not update customer/CRM records or selectors.
+
+How this feeds the next phase:
+
+- After applying an approved table, rerun membership and scope diagnostics.
+- Historical customer/CRM backfill and enforcement remain blocked until
+  canonical memberships are complete and validated.
+
 ## 12. What Not To Touch Yet
 
 Do not touch these in the first implementation slice:


### PR DESCRIPTION
## Summary

Adds Phase 8O controlled membership reassignment apply support.

## Includes

- Adds `rbac_membership_reassignment_apply`
- Dry-run by default
- Writes only with `--apply`
- Reuses Phase 8N validation
- Applies only READY rows
- Skips BLOCKED rows
- Reports previous and target membership state
- Confirms idempotency with UNCHANGED on second apply
- Keeps scope limited to memberships only

## Checks

- `python backend/manage.py makemigrations --check --dry-run` — no changes
- `python backend/manage.py check` — no issues
- `python backend/manage.py rbac_membership_reassignment_table_validate --input docs/rbac-membership-reassignment-template.csv`
- `python backend/manage.py rbac_membership_reassignment_apply --input docs/rbac-membership-reassignment-template.csv`
- `python backend/manage.py rbac_membership_reassignment_apply --input docs/rbac-membership-reassignment-template.csv --format json`
- `pytest backend/parties/tests.py -q` — 78 passed
- `git diff --check`
- `graphify update .`
- `npx fallow --format json` — existing 99 baseline issues

## Notes

No CRM/customer backfill, RBAC enforcement, selector filtering, or inference logic is included.