### PR TITLE
chore(rbac): add post membership apply readiness diagnostics

### DIFF
--- a/backend/parties/management/commands/rbac_post_membership_apply_readiness.py
+++ b/backend/parties/management/commands/rbac_post_membership_apply_readiness.py
@@ -1,0 +1,204 @@
+import json
+from collections import Counter
+
+from django.core.management.base import BaseCommand
+
+from accounts.models import CustomUser, UserMembership
+from parties.models import Branch, Department, Organization
+
+
+CANONICAL_ORGANIZATIONS = ("EFM PNG", "EFM Australia", "EFM Fiji", "EFM Solomon Islands")
+CANONICAL_BRANCHES = {
+    "EFM PNG": ("Port Moresby", "Lae"),
+    "EFM Australia": ("Brisbane",),
+    "EFM Fiji": ("Suva",),
+    "EFM Solomon Islands": ("Honiara",),
+}
+CANONICAL_DEPARTMENTS = ("Air Freight", "Sea Freight", "Customs", "Transport")
+
+
+class Command(BaseCommand):
+    help = "Read-only RBAC readiness diagnostics after membership reassignment apply."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--format",
+            choices=["text", "json"],
+            default="text",
+            help="Output format. Defaults to text.",
+        )
+
+    def handle(self, *args, **options):
+        report = build_report()
+        if options["format"] == "json":
+            self.stdout.write(json.dumps(report, indent=2, sort_keys=True))
+            return
+        write_text(self.stdout, report)
+
+
+def build_report():
+    organizations = {org.name: org for org in Organization.objects.filter(name__in=CANONICAL_ORGANIZATIONS)}
+    branches = list(Branch.objects.select_related("organization").filter(organization__name__in=CANONICAL_ORGANIZATIONS))
+    departments = list(
+        Department.objects.select_related("organization").filter(organization__name__in=CANONICAL_ORGANIZATIONS)
+    )
+    memberships = list(
+        UserMembership.objects.select_related("user", "organization", "branch", "department", "role")
+        .filter(is_active=True)
+        .order_by("user__username", "id")
+    )
+    active_users = list(CustomUser.objects.filter(is_active=True).order_by("username", "id"))
+
+    canonical = canonical_report(organizations, branches, departments)
+    membership = membership_report(memberships, active_users)
+    blockers = blockers_for(canonical, membership)
+    return {
+        "write_enabled": False,
+        "canonical": canonical,
+        "memberships": membership,
+        "readiness": {
+            "status": "READY_FOR_BACKFILL_PLANNING" if not blockers else "NOT_READY_FOR_BACKFILL_PLANNING",
+            "blockers": blockers,
+        },
+    }
+
+
+def canonical_report(organizations, branches, departments):
+    branch_names_by_org = {}
+    for branch in branches:
+        branch_names_by_org.setdefault(branch.organization.name, set()).add(branch.name)
+    department_names_by_org = {}
+    for department in departments:
+        department_names_by_org.setdefault(department.organization.name, set()).add(department.name)
+    missing_branches = {
+        org_name: [name for name in branch_names if name not in branch_names_by_org.get(org_name, set())]
+        for org_name, branch_names in CANONICAL_BRANCHES.items()
+    }
+    missing_departments = {
+        org_name: [name for name in CANONICAL_DEPARTMENTS if name not in department_names_by_org.get(org_name, set())]
+        for org_name in CANONICAL_ORGANIZATIONS
+    }
+    return {
+        "organizations_present": sorted(organizations),
+        "organizations_missing": [name for name in CANONICAL_ORGANIZATIONS if name not in organizations],
+        "branches_missing": {org: names for org, names in missing_branches.items() if names},
+        "departments_missing": {org: names for org, names in missing_departments.items() if names},
+    }
+
+
+def membership_report(memberships, active_users):
+    canonical_orgs = set(CANONICAL_ORGANIZATIONS)
+    memberships_by_user = {}
+    for membership in memberships:
+        memberships_by_user.setdefault(membership.user_id, []).append(membership)
+    active_user_ids = {user.id for user in active_users}
+    no_membership_users = [user_row(user) for user in active_users if user.id not in memberships_by_user]
+    multiple_membership_users = [
+        user_row(memberships_for_user[0].user)
+        for user_id, memberships_for_user in memberships_by_user.items()
+        if user_id in active_user_ids and len(memberships_for_user) > 1
+    ]
+    return {
+        "active_users": len(active_users),
+        "active_memberships": len(memberships),
+        "complete_canonical_memberships": sum(1 for membership in memberships if membership_is_complete_canonical(membership)),
+        "missing_organization": sum(1 for membership in memberships if membership.organization_id is None),
+        "missing_branch": sum(1 for membership in memberships if membership.branch_id is None),
+        "missing_department": sum(1 for membership in memberships if membership.department_id is None),
+        "missing_role": sum(1 for membership in memberships if membership.role_id is None),
+        "legacy_non_canonical_organization_memberships": sum(
+            1 for membership in memberships if membership.organization and membership.organization.name not in canonical_orgs
+        ),
+        "users_with_no_active_membership": len(no_membership_users),
+        "users_with_multiple_active_memberships": len(multiple_membership_users),
+        "no_active_membership_examples": no_membership_users[:10],
+        "multiple_active_membership_examples": multiple_membership_users[:10],
+        "active_memberships_by_status": dict(sorted(Counter(membership_status(membership) for membership in memberships).items())),
+    }
+
+
+def membership_is_complete_canonical(membership):
+    return (
+        membership.organization
+        and membership.organization.name in CANONICAL_ORGANIZATIONS
+        and membership.branch_id
+        and membership.department_id
+        and membership.role_id
+    )
+
+
+def membership_status(membership):
+    if not membership.organization_id:
+        return "missing_organization"
+    if membership.organization.name not in CANONICAL_ORGANIZATIONS:
+        return "legacy_organization"
+    if not membership.branch_id:
+        return "missing_branch"
+    if not membership.department_id:
+        return "missing_department"
+    if not membership.role_id:
+        return "missing_role"
+    return "complete_canonical"
+
+
+def blockers_for(canonical, membership):
+    blockers = []
+    if canonical["organizations_missing"]:
+        blockers.append(f"missing canonical organizations: {canonical['organizations_missing']}")
+    if canonical["branches_missing"]:
+        blockers.append(f"missing canonical branches: {canonical['branches_missing']}")
+    if canonical["departments_missing"]:
+        blockers.append(f"missing canonical departments: {canonical['departments_missing']}")
+    for key in ("legacy_non_canonical_organization_memberships", "missing_organization", "missing_branch", "missing_department", "missing_role", "users_with_no_active_membership", "users_with_multiple_active_memberships"):
+        if membership[key]:
+            blockers.append(f"{key}: {membership[key]}")
+    return blockers
+
+
+def user_row(user):
+    return {
+        "user_id": str(user.id),
+        "username": safe(user.username),
+        "email": safe(user.email),
+    }
+
+
+def write_text(stdout, report):
+    readiness = report["readiness"]
+    canonical = report["canonical"]
+    membership = report["memberships"]
+    stdout.write("RBAC post-membership-apply readiness")
+    stdout.write("====================================")
+    stdout.write("Mode: read-only diagnostics")
+    stdout.write(f"Readiness: {readiness['status']}")
+    stdout.write("")
+    stdout.write("Canonical master data:")
+    stdout.write(f"  organizations_missing={canonical['organizations_missing']}")
+    stdout.write(f"  branches_missing={canonical['branches_missing']}")
+    stdout.write(f"  departments_missing={canonical['departments_missing']}")
+    stdout.write("")
+    stdout.write(
+        "Memberships: "
+        f"active_users={membership['active_users']}, "
+        f"active_memberships={membership['active_memberships']}, "
+        f"complete_canonical={membership['complete_canonical_memberships']}, "
+        f"missing_org={membership['missing_organization']}, "
+        f"missing_branch={membership['missing_branch']}, "
+        f"missing_department={membership['missing_department']}, "
+        f"missing_role={membership['missing_role']}, "
+        f"legacy_org_memberships={membership['legacy_non_canonical_organization_memberships']}, "
+        f"users_no_membership={membership['users_with_no_active_membership']}, "
+        f"users_multiple_memberships={membership['users_with_multiple_active_memberships']}"
+    )
+    stdout.write(f"  by_status={membership['active_memberships_by_status']}")
+    if readiness["blockers"]:
+        stdout.write("")
+        stdout.write("Blockers:")
+        for blocker in readiness["blockers"]:
+            stdout.write(f"  - {blocker}")
+
+
+def safe(value):
+    if value is None:
+        return None
+    return str(value).encode("ascii", "replace").decode("ascii")

--- a/backend/parties/tests.py
+++ b/backend/parties/tests.py
@@ -1339,6 +1339,178 @@ class MembershipReassignmentApplyTests(TestCase):
         self.assertEqual(company.organization.name, "Legacy Org")
 
 
+class PostMembershipApplyReadinessTests(TestCase):
+    def setUp(self):
+        UserMembership.objects.all().delete()
+        CustomUser.objects.all().delete()
+        Branch.objects.all().delete()
+        Department.objects.all().delete()
+        Organization.objects.all().delete()
+
+    def _call_report(self, *args):
+        stdout = StringIO()
+        call_command("rbac_post_membership_apply_readiness", *args, stdout=stdout)
+        return stdout.getvalue()
+
+    def _role(self):
+        role, _created = Role.objects.get_or_create(
+            code="sales",
+            organization=None,
+            defaults={"name": "Sales", "is_system": True},
+        )
+        return role
+
+    def _canonical_master_data(self, *, skip_org=None, skip_branch=None, skip_department=None):
+        branches = {
+            "EFM PNG": ("Port Moresby", "Lae"),
+            "EFM Australia": ("Brisbane",),
+            "EFM Fiji": ("Suva",),
+            "EFM Solomon Islands": ("Honiara",),
+        }
+        departments = ("Air Freight", "Sea Freight", "Customs", "Transport")
+        organizations = {}
+        for org_name, branch_names in branches.items():
+            if org_name == skip_org:
+                continue
+            org = Organization.objects.create(name=org_name, slug=org_name.lower().replace(" ", "-"))
+            organizations[org_name] = org
+            for branch_name in branch_names:
+                if (org_name, branch_name) != skip_branch:
+                    Branch.objects.create(organization=org, code=branch_name[:3].upper(), name=branch_name)
+            for department_name in departments:
+                if (org_name, department_name) != skip_department:
+                    Department.objects.create(organization=org, code=department_name[:3].upper(), name=department_name)
+        return organizations
+
+    def _complete_membership(self, username="ready-user", org_name="EFM Australia"):
+        org = Organization.objects.get(name=org_name)
+        branch = Branch.objects.filter(organization=org).first()
+        department = Department.objects.filter(organization=org, name="Air Freight").first()
+        user = CustomUser.objects.create_user(username=username)
+        return UserMembership.objects.create(
+            user=user,
+            organization=org,
+            branch=branch,
+            department=department,
+            role=self._role(),
+        )
+
+    def test_ready_state(self):
+        self._canonical_master_data()
+        self._complete_membership()
+
+        payload = json.loads(self._call_report("--format", "json"))
+
+        self.assertEqual(payload["readiness"]["status"], "READY_FOR_BACKFILL_PLANNING")
+        self.assertEqual(payload["memberships"]["complete_canonical_memberships"], 1)
+
+    def test_missing_canonical_org_blocks(self):
+        self._canonical_master_data(skip_org="EFM Fiji")
+        self._complete_membership()
+
+        payload = json.loads(self._call_report("--format", "json"))
+
+        self.assertEqual(payload["readiness"]["status"], "NOT_READY_FOR_BACKFILL_PLANNING")
+        self.assertIn("EFM Fiji", payload["canonical"]["organizations_missing"])
+
+    def test_missing_branch_blocks(self):
+        self._canonical_master_data(skip_branch=("EFM Australia", "Brisbane"))
+        self._complete_membership()
+
+        payload = json.loads(self._call_report("--format", "json"))
+
+        self.assertIn("EFM Australia", payload["canonical"]["branches_missing"])
+
+    def test_missing_department_blocks(self):
+        self._canonical_master_data(skip_department=("EFM Australia", "Air Freight"))
+        self._complete_membership()
+
+        payload = json.loads(self._call_report("--format", "json"))
+
+        self.assertIn("EFM Australia", payload["canonical"]["departments_missing"])
+
+    def test_legacy_membership_blocks(self):
+        self._canonical_master_data()
+        legacy = Organization.objects.create(name="Legacy Org", slug="legacy-org")
+        user = CustomUser.objects.create_user(username="legacy-user")
+        UserMembership.objects.create(user=user, organization=legacy, role=self._role())
+
+        payload = json.loads(self._call_report("--format", "json"))
+
+        self.assertEqual(payload["memberships"]["legacy_non_canonical_organization_memberships"], 1)
+
+    def test_missing_branch_membership_blocks(self):
+        self._canonical_master_data()
+        org = Organization.objects.get(name="EFM Australia")
+        user = CustomUser.objects.create_user(username="missing-branch-ready-user")
+        UserMembership.objects.create(
+            user=user,
+            organization=org,
+            department=Department.objects.get(organization=org, name="Air Freight"),
+            role=self._role(),
+        )
+
+        payload = json.loads(self._call_report("--format", "json"))
+
+        self.assertEqual(payload["memberships"]["missing_branch"], 1)
+
+    def test_missing_department_membership_blocks(self):
+        self._canonical_master_data()
+        org = Organization.objects.get(name="EFM Australia")
+        user = CustomUser.objects.create_user(username="missing-dept-ready-user")
+        UserMembership.objects.create(
+            user=user,
+            organization=org,
+            branch=Branch.objects.get(organization=org, name="Brisbane"),
+            role=self._role(),
+        )
+
+        payload = json.loads(self._call_report("--format", "json"))
+
+        self.assertEqual(payload["memberships"]["missing_department"], 1)
+
+    def test_active_user_with_no_membership_blocks(self):
+        self._canonical_master_data()
+        CustomUser.objects.create_user(username="no-membership-user")
+
+        payload = json.loads(self._call_report("--format", "json"))
+
+        self.assertEqual(payload["memberships"]["users_with_no_active_membership"], 1)
+
+    def test_multiple_active_memberships_block(self):
+        self._canonical_master_data()
+        membership = self._complete_membership()
+        UserMembership.objects.create(
+            user=membership.user,
+            organization=membership.organization,
+            branch=membership.branch,
+            department=membership.department,
+            role=membership.role,
+            is_primary=False,
+        )
+
+        payload = json.loads(self._call_report("--format", "json"))
+
+        self.assertEqual(payload["memberships"]["users_with_multiple_active_memberships"], 1)
+
+    def test_json_output_contains_write_disabled(self):
+        self._canonical_master_data()
+        self._complete_membership()
+
+        payload = json.loads(self._call_report("--format", "json"))
+
+        self.assertFalse(payload["write_enabled"])
+
+    def test_report_does_not_write(self):
+        self._canonical_master_data()
+        membership = self._complete_membership()
+
+        self._call_report()
+        membership.refresh_from_db()
+
+        self.assertEqual(membership.organization.name, "EFM Australia")
+
+
 class CustomerListAPITests(APITestCase):
     def setUp(self):
         self.client = APIClient()

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -2272,6 +2272,53 @@ How this feeds the next phase:
 - Historical customer/CRM backfill and enforcement remain blocked until
   canonical memberships are complete and validated.
 
+#### Phase 8P - Post-Apply RBAC Readiness Diagnostics
+
+Date: 2026-06-22
+
+Branch: `chore/rbac-post-membership-apply-readiness`
+
+Scope: read-only readiness diagnostics only. No membership writes, reassignment
+apply, CRM/customer historical backfill, RBAC enforcement, query filtering
+changes, or selector changes.
+
+Command: `python backend/manage.py rbac_post_membership_apply_readiness`
+
+Purpose:
+
+- Verify canonical organizations, branches, and departments are present.
+- Verify active memberships are complete and canonical.
+- Gate whether the project is ready for controlled CRM/customer historical
+  backfill planning.
+
+Readiness statuses:
+
+- `READY_FOR_BACKFILL_PLANNING`
+- `NOT_READY_FOR_BACKFILL_PLANNING`
+
+Readiness blockers:
+
+- Missing canonical organization, branch, or department.
+- Active membership tied to a legacy or non-canonical organization.
+- Active membership missing organization, branch, department, or role.
+- Active user with no active membership.
+- User with multiple active memberships unless a later policy explicitly
+  documents and permits that case.
+
+Output:
+
+- Text summary by default.
+- `--format json` for machine-readable review.
+- Counts for active users, active memberships, complete canonical memberships,
+  missing fields, legacy memberships, users without memberships, users with
+  multiple memberships, and blocker reasons.
+
+How this feeds the next phase:
+
+- If ready, the next phase can design controlled CRM/customer historical
+  backfill planning.
+- If not ready, resolve canonical master-data or membership blockers first.
+
 ## 12. What Not To Touch Yet
 
 Do not touch these in the first implementation slice:


### PR DESCRIPTION
## Summary

Adds Phase 8P read-only post-membership-apply readiness diagnostics.

## Includes

- Adds `rbac_post_membership_apply_readiness`
- Supports text and JSON output
- Reports canonical org/branch/department completeness
- Reports active membership completeness
- Reports legacy/non-canonical membership blockers
- Reports users without memberships and multiple active memberships
- Outputs final readiness for backfill planning

## Checks

- `python backend/manage.py makemigrations --check --dry-run` — no changes
- `python backend/manage.py check` — no issues
- `python backend/manage.py rbac_master_data_alignment_plan`
- `python backend/manage.py rbac_membership_reassignment_plan`
- `python backend/manage.py rbac_post_membership_apply_readiness`
- `python backend/manage.py rbac_post_membership_apply_readiness --format json`
- `pytest backend/parties/tests.py -q` — 89 passed
- `git diff --check`
- `graphify update .`
- `npx fallow --format json` — existing 99 baseline issues

## Notes

Read-only only. No membership apply, CRM/customer backfill, RBAC enforcement, selector filtering, schema, or frontend changes.