### PR TITLE
chore(rbac): add obsolete user cleanup plan

### DIFF
--- a/backend/parties/management/commands/rbac_obsolete_user_cleanup_plan.py
+++ b/backend/parties/management/commands/rbac_obsolete_user_cleanup_plan.py
@@ -1,0 +1,176 @@
+import json
+
+from django.core.management.base import BaseCommand
+
+from accounts.models import CustomUser, UserMembership
+from crm.models import Interaction, Opportunity, Task
+from parties.models import Company
+from quotes.models import Quote
+from quotes.spot_models import SpotPricingEnvelopeDB
+
+
+OBSOLETE_USERNAMES = ("finance", "nas", "system_user", "testuser", "unassigned_user")
+
+
+class Command(BaseCommand):
+    help = "Read-only plan for obsolete/test/duplicate RBAC user cleanup."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--format",
+            choices=["text", "json"],
+            default="text",
+            help="Output format. Defaults to text.",
+        )
+
+    def handle(self, *args, **options):
+        report = build_report()
+        if options["format"] == "json":
+            self.stdout.write(json.dumps(report, indent=2, sort_keys=True))
+            return
+        write_text(self.stdout, report)
+
+
+def build_report():
+    rows = [inspect_user(username) for username in OBSOLETE_USERNAMES]
+    summary = {
+        "total": len(rows),
+        "deactivate_user": sum(1 for row in rows if row["recommended_action"] == "DEACTIVATE_USER"),
+        "deactivate_membership": sum(
+            1 for row in rows if row["recommended_action"] == "DEACTIVATE_MEMBERSHIP"
+        ),
+        "review_dependencies": sum(1 for row in rows if row["recommended_action"] == "REVIEW_DEPENDENCIES"),
+        "not_found": sum(1 for row in rows if row["recommended_action"] == "NOT_FOUND"),
+    }
+    return {
+        "write_enabled": False,
+        "safety": [
+            "read-only only",
+            "no user deletion or deactivation",
+            "no membership modification",
+            "no CRM/customer backfill",
+            "no RBAC enforcement",
+        ],
+        "summary": summary,
+        "users": rows,
+    }
+
+
+def inspect_user(username):
+    user = CustomUser.objects.filter(username=username).first()
+    if user is None:
+        return {
+            "username": username,
+            "is_active": None,
+            "current_organization": "",
+            "branch": "",
+            "department": "",
+            "role": "",
+            "has_active_membership": False,
+            "dependency_counts": empty_counts(),
+            "recommended_action": "NOT_FOUND",
+            "blocker_reason": "user not found",
+        }
+
+    membership = (
+        UserMembership.objects.select_related("organization", "branch", "department", "role")
+        .filter(user=user, is_active=True)
+        .order_by("-is_primary", "id")
+        .first()
+    )
+    counts = dependency_counts(user)
+    total_dependencies = sum(counts.values())
+    if total_dependencies:
+        action = "REVIEW_DEPENDENCIES"
+        reason = f"{total_dependencies} related ownership/dependency record(s) require review"
+    elif membership:
+        action = "DEACTIVATE_MEMBERSHIP"
+        reason = "active membership exists; deactivate membership before retiring user"
+    else:
+        action = "DEACTIVATE_USER"
+        reason = "no active membership or counted ownership dependencies"
+
+    return {
+        "username": username,
+        "is_active": user.is_active,
+        "current_organization": label(membership.organization if membership else user.organization),
+        "branch": label(membership.branch if membership else None),
+        "department": label(membership.department) if membership else safe(user.department),
+        "role": safe(getattr(membership.role, "code", "")) if membership else safe(user.role),
+        "has_active_membership": bool(membership),
+        "dependency_counts": counts,
+        "recommended_action": action,
+        "blocker_reason": reason,
+    }
+
+
+def dependency_counts(user):
+    return {
+        "customer_account_owner": Company.objects.filter(account_owner=user).count(),
+        "crm_opportunity_owner": Opportunity.objects.filter(owner=user).count(),
+        "crm_opportunity_won_by": Opportunity.objects.filter(won_by=user).count(),
+        "crm_interaction_author": Interaction.objects.filter(author=user).count(),
+        "crm_task_owner": Task.objects.filter(owner=user).count(),
+        "crm_task_completed_by": Task.objects.filter(completed_by=user).count(),
+        "quote_created_by": Quote.objects.filter(created_by=user).count(),
+        "quote_owner": Quote.objects.filter(owner=user).count(),
+        "quote_finalized_by": Quote.objects.filter(finalized_by=user).count(),
+        "quote_sent_by": Quote.objects.filter(sent_by=user).count(),
+        "spot_envelope_created_by": SpotPricingEnvelopeDB.objects.filter(created_by=user).count(),
+        "spot_envelope_owner": SpotPricingEnvelopeDB.objects.filter(owner=user).count(),
+    }
+
+
+def empty_counts():
+    return {
+        "customer_account_owner": 0,
+        "crm_opportunity_owner": 0,
+        "crm_opportunity_won_by": 0,
+        "crm_interaction_author": 0,
+        "crm_task_owner": 0,
+        "crm_task_completed_by": 0,
+        "quote_created_by": 0,
+        "quote_owner": 0,
+        "quote_finalized_by": 0,
+        "quote_sent_by": 0,
+        "spot_envelope_created_by": 0,
+        "spot_envelope_owner": 0,
+    }
+
+
+def write_text(stdout, report):
+    summary = report["summary"]
+    stdout.write("RBAC obsolete user cleanup plan")
+    stdout.write("===============================")
+    stdout.write("Mode: read-only diagnostics")
+    stdout.write(
+        "Summary: "
+        f"total={summary['total']}, "
+        f"deactivate_user={summary['deactivate_user']}, "
+        f"deactivate_membership={summary['deactivate_membership']}, "
+        f"review_dependencies={summary['review_dependencies']}, "
+        f"not_found={summary['not_found']}"
+    )
+    stdout.write("")
+    stdout.write("users:")
+    for row in report["users"]:
+        deps = sum(row["dependency_counts"].values())
+        stdout.write(
+            f"  - username={row['username']} is_active={row['is_active']} "
+            f"org={row['current_organization'] or '-'} branch={row['branch'] or '-'} "
+            f"department={row['department'] or '-'} role={row['role'] or '-'} "
+            f"active_membership={row['has_active_membership']} dependencies={deps} "
+            f"action={row['recommended_action']} blocker={row['blocker_reason']}"
+        )
+
+
+def label(value):
+    if value is None:
+        return ""
+    return safe(getattr(value, "name", None) or getattr(value, "code", None) or str(value))
+
+
+def safe(value):
+    if value is None:
+        return ""
+    return str(value).encode("ascii", "replace").decode("ascii")

--- a/backend/parties/tests.py
+++ b/backend/parties/tests.py
@@ -1126,6 +1126,84 @@ class MembershipReassignmentCsvDraftTests(TestCase):
         self.assertEqual(membership.department, department)
 
 
+class ObsoleteUserCleanupPlanTests(TestCase):
+    def _call_plan(self, *args):
+        stdout = StringIO()
+        call_command("rbac_obsolete_user_cleanup_plan", *args, stdout=stdout)
+        return stdout.getvalue()
+
+    def _role(self, code="sales"):
+        role, _created = Role.objects.get_or_create(
+            code=code,
+            organization=None,
+            defaults={"name": code.title(), "is_system": True},
+        )
+        return role
+
+    def _scope(self):
+        org = Organization.objects.create(name="EFM PNG", slug="efm-png")
+        branch = Branch.objects.create(organization=org, code="POM", name="Port Moresby")
+        department = Department.objects.create(organization=org, code="AIR", name="Air Freight")
+        return org, branch, department
+
+    def test_missing_users_are_reported_not_found(self):
+        payload = json.loads(self._call_plan("--format", "json"))
+
+        finance = next(row for row in payload["users"] if row["username"] == "finance")
+        self.assertFalse(payload["write_enabled"])
+        self.assertEqual(finance["recommended_action"], "NOT_FOUND")
+        self.assertEqual(finance["blocker_reason"], "user not found")
+
+    def test_user_without_membership_or_dependencies_can_be_deactivated(self):
+        CustomUser.objects.create_user(username="testuser")
+
+        payload = json.loads(self._call_plan("--format", "json"))
+
+        row = next(row for row in payload["users"] if row["username"] == "testuser")
+        self.assertEqual(row["recommended_action"], "DEACTIVATE_USER")
+        self.assertFalse(row["has_active_membership"])
+
+    def test_active_membership_is_planned_before_user_deactivation(self):
+        org, branch, department = self._scope()
+        user = CustomUser.objects.create_user(username="unassigned_user")
+        UserMembership.objects.create(
+            user=user,
+            organization=org,
+            branch=branch,
+            department=department,
+            role=self._role(),
+        )
+
+        payload = json.loads(self._call_plan("--format", "json"))
+
+        row = next(row for row in payload["users"] if row["username"] == "unassigned_user")
+        self.assertEqual(row["recommended_action"], "DEACTIVATE_MEMBERSHIP")
+        self.assertTrue(row["has_active_membership"])
+        self.assertEqual(row["current_organization"], "EFM PNG")
+        self.assertEqual(row["branch"], "Port Moresby")
+        self.assertEqual(row["department"], "Air Freight")
+
+    def test_related_customer_dependency_blocks_cleanup(self):
+        user = CustomUser.objects.create_user(username="finance")
+        Company.objects.create(name="Owned Cleanup Customer", account_owner=user)
+
+        payload = json.loads(self._call_plan("--format", "json"))
+
+        row = next(row for row in payload["users"] if row["username"] == "finance")
+        self.assertEqual(row["recommended_action"], "REVIEW_DEPENDENCIES")
+        self.assertEqual(row["dependency_counts"]["customer_account_owner"], 1)
+
+    def test_text_output_summarizes_actions(self):
+        CustomUser.objects.create_user(username="nas")
+
+        output = self._call_plan()
+
+        self.assertIn("RBAC obsolete user cleanup plan", output)
+        self.assertIn("Mode: read-only diagnostics", output)
+        self.assertIn("username=nas", output)
+        self.assertIn("action=DEACTIVATE_USER", output)
+
+
 class MembershipReassignmentTableValidateTests(TestCase):
     def _call_validate(self, rows, *args):
         fd, path = tempfile.mkstemp(suffix=".csv")

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -2374,6 +2374,48 @@ How this feeds the next phase:
 - CRM/customer backfill and RBAC enforcement remain blocked until readiness
   diagnostics pass after approved membership reassignment.
 
+#### Phase 8S - Obsolete User Cleanup Plan
+
+Date: 2026-06-22
+
+Branch: `codex/phase-8s-obsolete-user-cleanup-plan`
+
+Scope: read-only obsolete/test/duplicate user cleanup planning only. No user
+deletion, user deactivation, membership deactivation, membership updates,
+CRM/customer historical backfill, RBAC enforcement, query filtering changes, or
+selector changes.
+
+Command: `python backend/manage.py rbac_obsolete_user_cleanup_plan`
+
+Purpose:
+
+- Inspect the business-approved obsolete users: `finance`, `nas`,
+  `system_user`, `testuser`, and `unassigned_user`.
+- Report current active state, organization, branch, department, role, and
+  whether an active membership exists.
+- Report direct ownership/dependency counts for customer, CRM, quote, and SPOT
+  records when available.
+- Recommend only a cleanup planning action: `DEACTIVATE_USER`,
+  `DEACTIVATE_MEMBERSHIP`, `REVIEW_DEPENDENCIES`, or `NOT_FOUND`.
+
+Safety:
+
+- The command does not call `save()`, `update()`, `delete()`, or apply
+  membership changes.
+- The command does not backfill CRM/customer records.
+- The command does not infer from CRM text, customers, quotes, routes, lanes,
+  notes, task text, or free text.
+- The command supports `--format json` for review evidence.
+
+How this feeds the next phase:
+
+- Rows with dependencies require manual review before any deactivation command
+  exists.
+- Rows without dependencies can feed a later explicit, write-capable
+  deactivation phase only after approval.
+- CRM/customer backfill and RBAC enforcement remain blocked until obsolete-user
+  cleanup decisions are complete and readiness diagnostics pass.
+
 ## 12. What Not To Touch Yet
 
 Do not touch these in the first implementation slice:


### PR DESCRIPTION
## Summary

Adds Phase 8S read-only RBAC obsolete user cleanup planning diagnostics.

## Includes

* Adds `rbac_obsolete_user_cleanup_plan`
* Reports obsolete/test user cleanup recommendations
* Reports active membership scope and dependency counts
* Supports text and JSON output
* Adds focused backend tests
* Updates RBAC audit documentation

## Sample Findings

```text
finance          DEACTIVATE_MEMBERSHIP
nas              DEACTIVATE_MEMBERSHIP
system_user      DEACTIVATE_USER
testuser         REVIEW_DEPENDENCIES
unassigned_user  DEACTIVATE_MEMBERSHIP
```

## Validation

* `python backend/manage.py makemigrations --check --dry-run` ✓
* `python backend/manage.py check` ✓
* `python backend/manage.py rbac_obsolete_user_cleanup_plan` ✓
* `python backend/manage.py rbac_obsolete_user_cleanup_plan --format json` ✓
* `pytest backend/parties/tests.py -q` ✓ (102 passed)
* `git diff --check` ✓
* `graphify update .` ✓
* `npx fallow --format json` ✓ (existing 99 baseline frontend findings)

## Safety Boundary

This phase is read-only.

No:

* User deactivation
* Membership changes
* CRM/customer backfill
* Quote updates
* RBAC enforcement
* Selector changes

## Purpose

Provides evidence-based cleanup recommendations before introducing any write-capable obsolete-user cleanup workflow.
