### PR TITLE
chore(rbac): add final user blocker resolution apply

### DIFF
--- a/backend/parties/management/commands/rbac_final_user_blocker_resolution_apply.py
+++ b/backend/parties/management/commands/rbac_final_user_blocker_resolution_apply.py
@@ -37,10 +37,13 @@ class Command(BaseCommand):
 
 def build_apply_report(*, apply):
     context = resolve_context()
-    actions = [testuser_action(context, apply=apply), sysadmin_action(context, apply=apply)]
+    actions = [testuser_action(context, apply=False), sysadmin_action(context, apply=False)]
+    blocked_count = sum(1 for row in actions if row["status"] == "BLOCKED")
+    if apply and blocked_count == 0:
+        actions = [testuser_action(context, apply=True), sysadmin_action(context, apply=True)]
     return {
         "mode": "apply" if apply else "dry-run",
-        "write_enabled": bool(apply) and not context["errors"],
+        "write_enabled": bool(apply) and blocked_count == 0,
         "resolver_errors": context["errors"],
         "summary": {
             "total": len(actions),
@@ -126,7 +129,7 @@ def testuser_action(context, *, apply):
         status = "APPLIED" if apply and (spot_count or was_active) else ("PLANNED" if not apply else "UNCHANGED")
     else:
         details.append("testuser_deactivated=False")
-        status = "BLOCKED" if apply else "PLANNED"
+        status = "BLOCKED"
     row.update({"status": status, "after_dependency_counts": after, "details": details})
     return row
 

--- a/backend/parties/management/commands/rbac_final_user_blocker_resolution_apply.py
+++ b/backend/parties/management/commands/rbac_final_user_blocker_resolution_apply.py
@@ -1,0 +1,225 @@
+import json
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from accounts.models import CustomUser, Role, UserMembership
+from parties.models import Branch, Department, Organization
+from quotes.spot_models import SpotPricingEnvelopeDB
+
+from .rbac_final_user_blocker_resolution_plan import SYSADMIN_TARGET, candidate_admin_users, membership_state
+from .rbac_obsolete_user_cleanup_plan import dependency_counts, empty_counts
+
+
+class Command(BaseCommand):
+    help = "Dry-run by default; optionally apply final RBAC user blocker resolution."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--apply", action="store_true", help="Write final blocker fixes. Defaults to dry-run.")
+        parser.add_argument(
+            "--format",
+            choices=["text", "json"],
+            default="text",
+            help="Output format. Defaults to text.",
+        )
+
+    def handle(self, *args, **options):
+        apply = options["apply"]
+        with transaction.atomic():
+            report = build_apply_report(apply=apply)
+            if not apply or report["summary"]["blocked"]:
+                transaction.set_rollback(True)
+        if options["format"] == "json":
+            self.stdout.write(json.dumps(report, indent=2, sort_keys=True))
+            return
+        write_text(self.stdout, report)
+
+
+def build_apply_report(*, apply):
+    context = resolve_context()
+    actions = [testuser_action(context, apply=apply), sysadmin_action(context, apply=apply)]
+    return {
+        "mode": "apply" if apply else "dry-run",
+        "write_enabled": bool(apply) and not context["errors"],
+        "resolver_errors": context["errors"],
+        "summary": {
+            "total": len(actions),
+            "planned": sum(1 for row in actions if row["status"] == "PLANNED"),
+            "applied": sum(1 for row in actions if row["status"] == "APPLIED"),
+            "unchanged": sum(1 for row in actions if row["status"] == "UNCHANGED"),
+            "blocked": sum(1 for row in actions if row["status"] == "BLOCKED"),
+        },
+        "actions": actions,
+    }
+
+
+def resolve_context():
+    errors = []
+    target_admin = resolve_target_admin(errors)
+    target_scope = resolve_sysadmin_scope(errors)
+    sysadmin_count = CustomUser.objects.filter(username="sysadmin").count()
+    if sysadmin_count != 1:
+        errors.append(f"sysadmin user resolved {sysadmin_count} rows")
+    elif UserMembership.objects.filter(user__username="sysadmin", is_active=True).count() > 1:
+        errors.append("multiple active sysadmin memberships")
+    return {"target_admin": target_admin, "target_scope": target_scope, "errors": errors}
+
+
+def resolve_target_admin(errors):
+    candidates = candidate_admin_users()
+    preferred = [
+        row for row in candidates if row["username"] == "nason.martin" or row["email"].lower().startswith("nason.martin")
+    ]
+    selected = preferred[0] if len(preferred) == 1 else (candidates[0] if len(candidates) == 1 else None)
+    if selected is None:
+        errors.append("target admin user could not be resolved uniquely")
+        return None
+    return CustomUser.objects.get(id=selected["user_id"])
+
+
+def resolve_sysadmin_scope(errors):
+    target = SYSADMIN_TARGET
+    org = one(Organization.objects.filter(name=target["organization"]), "target organization", errors)
+    branch = one(Branch.objects.filter(organization=org, name=target["branch"]), "target branch", errors) if org else None
+    department = (
+        one(Department.objects.filter(organization=org, name=target["department"]), "target department", errors)
+        if org
+        else None
+    )
+    role = one(Role.objects.filter(organization__isnull=True, code=target["role"]), "target role", errors)
+    if not all([org, branch, department, role]):
+        return None
+    return {"organization": org, "branch": branch, "department": department, "role": role}
+
+
+def one(queryset, name, errors):
+    count = queryset.count()
+    if count != 1:
+        errors.append(f"{name} resolved {count} rows")
+        return None
+    return queryset.get()
+
+
+def testuser_action(context, *, apply):
+    user = CustomUser.objects.filter(username="testuser").first()
+    before = dependency_counts(user) if user else empty_counts()
+    row = base_action("testuser", "RESOLVE_TESTUSER_SPOT_CREATED_BY", before)
+    if context["errors"]:
+        return blocked(row, context["errors"])
+    if user is None:
+        return blocked(row, ["testuser not found"])
+    if not user.is_active and sum(before.values()) == 0:
+        row.update({"status": "UNCHANGED", "after_dependency_counts": before, "details": ["testuser already inactive"]})
+        return row
+
+    spot_count = SpotPricingEnvelopeDB.objects.filter(created_by=user).count()
+    was_active = user.is_active
+    if apply and spot_count:
+        SpotPricingEnvelopeDB.objects.filter(created_by=user).update(created_by=context["target_admin"])
+    after = dependency_counts(user) if apply else simulated_testuser_counts(before)
+    details = [f"spot_created_by_reassigned={spot_count}", f"target_user={context['target_admin'].username}"]
+    if sum(after.values()) == 0 and not UserMembership.objects.filter(user=user, is_active=True).exists():
+        if apply and user.is_active:
+            user.is_active = False
+            user.save(update_fields=["is_active"])
+        details.append("testuser_deactivated=True")
+        status = "APPLIED" if apply and (spot_count or was_active) else ("PLANNED" if not apply else "UNCHANGED")
+    else:
+        details.append("testuser_deactivated=False")
+        status = "BLOCKED" if apply else "PLANNED"
+    row.update({"status": status, "after_dependency_counts": after, "details": details})
+    return row
+
+
+def simulated_testuser_counts(counts):
+    after = dict(counts)
+    after["spot_envelope_created_by"] = 0
+    return after
+
+
+def sysadmin_action(context, *, apply):
+    user = CustomUser.objects.filter(username="sysadmin").first()
+    before = dependency_counts(user) if user else empty_counts()
+    row = base_action("sysadmin", "RESOLVE_SYSADMIN_MEMBERSHIP", before)
+    if context["errors"]:
+        return blocked(row, context["errors"])
+    if user is None:
+        return blocked(row, ["sysadmin not found"])
+
+    active = list(
+        UserMembership.objects.select_related("organization", "branch", "department", "role")
+        .filter(user=user, is_active=True)
+        .order_by("id")
+    )
+    if len(active) > 1:
+        return blocked(row, ["multiple active sysadmin memberships"])
+
+    target = context["target_scope"]
+    if len(active) == 1 and membership_matches(active[0], target):
+        row.update(
+            {
+                "status": "UNCHANGED",
+                "after_dependency_counts": before,
+                "details": ["sysadmin canonical membership already active"],
+            }
+        )
+        return row
+
+    if apply:
+        if active:
+            active[0].is_active = False
+            active[0].save(update_fields=["is_active", "updated_at"])
+        UserMembership.objects.create(user=user, is_primary=True, is_active=True, **target)
+    row.update(
+        {
+            "status": "APPLIED" if apply else "PLANNED",
+            "after_dependency_counts": before,
+            "details": [
+                f"previous={membership_state(active[0]) if active else None}",
+                "target=EFM PNG / Port Moresby / Air Freight / admin",
+            ],
+        }
+    )
+    return row
+
+
+def membership_matches(membership, target):
+    return (
+        membership.organization_id == target["organization"].id
+        and membership.branch_id == target["branch"].id
+        and membership.department_id == target["department"].id
+        and membership.role_id == target["role"].id
+    )
+
+
+def base_action(username, action, before):
+    return {
+        "username": username,
+        "action": action,
+        "status": "PLANNED",
+        "before_dependency_counts": before,
+        "after_dependency_counts": before,
+        "details": [],
+    }
+
+
+def blocked(row, errors):
+    row.update({"status": "BLOCKED", "details": list(errors)})
+    return row
+
+
+def write_text(stdout, report):
+    summary = report["summary"]
+    stdout.write("RBAC final user blocker resolution apply")
+    stdout.write("========================================")
+    stdout.write(f"Mode: {report['mode']}")
+    stdout.write(
+        "Summary: "
+        f"total={summary['total']}, planned={summary['planned']}, applied={summary['applied']}, "
+        f"unchanged={summary['unchanged']}, blocked={summary['blocked']}"
+    )
+    for row in report["actions"]:
+        stdout.write(
+            f"  - username={row['username']} status={row['status']} action={row['action']} "
+            f"details={'; '.join(row['details']) or '-'}"
+        )

--- a/backend/parties/tests.py
+++ b/backend/parties/tests.py
@@ -2079,14 +2079,22 @@ class FinalUserBlockerResolutionApplyTests(TestCase):
         self.assertFalse(testuser.is_active)
 
     def test_apply_refuses_testuser_deactivation_if_dependencies_remain(self):
-        _admin, testuser, _sysadmin, _legacy_membership = self._fixtures(with_customer_dependency=True)
+        _admin, testuser, sysadmin, legacy_membership = self._fixtures(with_customer_dependency=True)
 
         payload = json.loads(self._call_apply("--apply", "--format", "json"))
 
         testuser.refresh_from_db()
+        legacy_membership.refresh_from_db()
         self.assertEqual(payload["summary"]["blocked"], 1)
+        self.assertEqual(payload["summary"]["applied"], 0)
+        self.assertNotIn("APPLIED", {row["status"] for row in payload["actions"]})
         self.assertTrue(testuser.is_active)
         self.assertEqual(SpotPricingEnvelopeDB.objects.filter(created_by=testuser).count(), 2)
+        self.assertTrue(legacy_membership.is_active)
+        self.assertEqual(
+            list(UserMembership.objects.filter(user=sysadmin, is_active=True).values_list("organization__name", flat=True)),
+            ["EFM Express Air Cargo"],
+        )
 
     def test_apply_moves_sysadmin_to_canonical_membership(self):
         _admin, _testuser, sysadmin, legacy_membership = self._fixtures()

--- a/backend/parties/tests.py
+++ b/backend/parties/tests.py
@@ -1982,6 +1982,174 @@ class FinalUserBlockerResolutionPlanTests(TestCase):
         self.assertTrue(membership.is_active)
 
 
+class FinalUserBlockerResolutionApplyTests(TestCase):
+    def setUp(self):
+        UserMembership.objects.all().delete()
+        CustomUser.objects.all().delete()
+        Branch.objects.all().delete()
+        Department.objects.all().delete()
+        Organization.objects.all().delete()
+
+    def _call_apply(self, *args):
+        stdout = StringIO()
+        call_command("rbac_final_user_blocker_resolution_apply", *args, stdout=stdout)
+        return stdout.getvalue()
+
+    def _role(self, code="admin"):
+        role, _created = Role.objects.get_or_create(
+            code=code,
+            organization=None,
+            defaults={"name": code.title(), "is_system": True},
+        )
+        return role
+
+    def _canonical_master_data(self):
+        specs = {
+            "EFM PNG": ("Port Moresby", "Lae"),
+            "EFM Australia": ("Brisbane",),
+            "EFM Fiji": ("Suva",),
+            "EFM Solomon Islands": ("Honiara",),
+        }
+        for org_name, branches in specs.items():
+            org = Organization.objects.create(name=org_name, slug=org_name.lower().replace(" ", "-"))
+            for branch_name in branches:
+                Branch.objects.create(organization=org, code=branch_name[:3].upper(), name=branch_name)
+            for department_name in ("Air Freight", "Sea Freight", "Customs", "Transport"):
+                Department.objects.create(organization=org, code=department_name[:3].upper(), name=department_name)
+
+    def _canonical_scope(self):
+        org = Organization.objects.get(name="EFM PNG")
+        return (
+            org,
+            Branch.objects.get(organization=org, name="Port Moresby"),
+            Department.objects.get(organization=org, name="Air Freight"),
+        )
+
+    def _fixtures(self, *, with_customer_dependency=False):
+        self._canonical_master_data()
+        org, branch, department = self._canonical_scope()
+        admin = CustomUser.objects.create_user(
+            username="nason.martin",
+            email="nason.martin@efmpng.com",
+            role=CustomUser.ROLE_ADMIN,
+        )
+        UserMembership.objects.create(user=admin, organization=org, branch=branch, department=department, role=self._role())
+        testuser = CustomUser.objects.create_user(username="testuser", email="test@example.com")
+        for _index in range(2):
+            envelope = SpotPricingEnvelopeDB.objects.create(
+                created_by=testuser,
+                owner=admin,
+                shipment_context_json={"origin": "POM", "destination": "LAE"},
+                conditions_json={},
+                spot_trigger_reason_code="TEST",
+                spot_trigger_reason_text="Test trigger",
+                expires_at=timezone.now(),
+            )
+            envelope.owner = admin
+            envelope.save(update_fields=["owner"])
+        if with_customer_dependency:
+            Company.objects.create(name="Testuser Customer", account_owner=testuser)
+        legacy = Organization.objects.create(name="EFM Express Air Cargo", slug="efm-express-air-cargo")
+        sysadmin = CustomUser.objects.create_user(username="sysadmin", role=CustomUser.ROLE_ADMIN)
+        legacy_membership = UserMembership.objects.create(user=sysadmin, organization=legacy, role=self._role())
+        return admin, testuser, sysadmin, legacy_membership
+
+    def test_dry_run_does_not_write(self):
+        _admin, testuser, _sysadmin, legacy_membership = self._fixtures()
+
+        payload = json.loads(self._call_apply("--format", "json"))
+
+        testuser.refresh_from_db()
+        legacy_membership.refresh_from_db()
+        self.assertEqual(payload["mode"], "dry-run")
+        self.assertEqual(payload["summary"]["planned"], 2)
+        self.assertTrue(testuser.is_active)
+        self.assertTrue(SpotPricingEnvelopeDB.objects.filter(created_by=testuser).exists())
+        self.assertTrue(legacy_membership.is_active)
+
+    def test_apply_reassigns_spot_created_by_and_deactivates_testuser(self):
+        admin, testuser, _sysadmin, _legacy_membership = self._fixtures()
+
+        payload = json.loads(self._call_apply("--apply", "--format", "json"))
+
+        testuser.refresh_from_db()
+        self.assertEqual(payload["summary"]["applied"], 2)
+        self.assertFalse(SpotPricingEnvelopeDB.objects.filter(created_by=testuser).exists())
+        self.assertEqual(SpotPricingEnvelopeDB.objects.filter(created_by=admin).count(), 2)
+        self.assertFalse(testuser.is_active)
+
+    def test_apply_refuses_testuser_deactivation_if_dependencies_remain(self):
+        _admin, testuser, _sysadmin, _legacy_membership = self._fixtures(with_customer_dependency=True)
+
+        payload = json.loads(self._call_apply("--apply", "--format", "json"))
+
+        testuser.refresh_from_db()
+        self.assertEqual(payload["summary"]["blocked"], 1)
+        self.assertTrue(testuser.is_active)
+        self.assertEqual(SpotPricingEnvelopeDB.objects.filter(created_by=testuser).count(), 2)
+
+    def test_apply_moves_sysadmin_to_canonical_membership(self):
+        _admin, _testuser, sysadmin, legacy_membership = self._fixtures()
+
+        self._call_apply("--apply")
+
+        legacy_membership.refresh_from_db()
+        active = UserMembership.objects.select_related("organization", "branch", "department", "role").get(
+            user=sysadmin,
+            is_active=True,
+        )
+        self.assertFalse(legacy_membership.is_active)
+        self.assertEqual(active.organization.name, "EFM PNG")
+        self.assertEqual(active.branch.name, "Port Moresby")
+        self.assertEqual(active.department.name, "Air Freight")
+        self.assertEqual(active.role.code, "admin")
+
+    def test_apply_is_idempotent(self):
+        self._fixtures()
+
+        self._call_apply("--apply")
+        payload = json.loads(self._call_apply("--apply", "--format", "json"))
+
+        self.assertEqual(payload["summary"]["unchanged"], 2)
+
+    def test_json_output_includes_before_after_counts(self):
+        self._fixtures()
+
+        payload = json.loads(self._call_apply("--format", "json"))
+        row = next(action for action in payload["actions"] if action["username"] == "testuser")
+
+        self.assertEqual(row["before_dependency_counts"]["spot_envelope_created_by"], 2)
+        self.assertEqual(row["after_dependency_counts"]["spot_envelope_created_by"], 0)
+
+    def test_missing_targets_fail_safely(self):
+        testuser = CustomUser.objects.create_user(username="testuser")
+        SpotPricingEnvelopeDB.objects.create(
+            created_by=testuser,
+            shipment_context_json={"origin": "POM", "destination": "LAE"},
+            conditions_json={},
+            spot_trigger_reason_code="TEST",
+            spot_trigger_reason_text="Test trigger",
+            expires_at=timezone.now(),
+        )
+
+        payload = json.loads(self._call_apply("--apply", "--format", "json"))
+
+        testuser.refresh_from_db()
+        self.assertGreater(payload["summary"]["blocked"], 0)
+        self.assertTrue(testuser.is_active)
+        self.assertTrue(SpotPricingEnvelopeDB.objects.filter(created_by=testuser).exists())
+
+    def test_readiness_improves_after_apply(self):
+        self._fixtures()
+
+        self._call_apply("--apply")
+        stdout = StringIO()
+        call_command("rbac_post_membership_apply_readiness", "--format", "json", stdout=stdout)
+        payload = json.loads(stdout.getvalue())
+
+        self.assertEqual(payload["readiness"]["status"], "READY_FOR_BACKFILL_PLANNING")
+
+
 class CustomerListAPITests(APITestCase):
     def setUp(self):
         self.client = APIClient()

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -2469,6 +2469,52 @@ Safety:
   records, backfill CRM/customer records, enforce RBAC, or change selectors.
 - JSON evidence is available with `--format json`.
 
+#### Phase 8W - Final RBAC User Blocker Resolution Apply
+
+Date: 2026-06-23
+
+Branch: `codex/phase-8w-final-blocker-resolution-apply`
+
+Scope: controlled dry-run-first apply for the final RBAC readiness blockers
+reported by `rbac_final_user_blocker_resolution_plan`.
+
+Command:
+
+```bash
+python backend/manage.py rbac_final_user_blocker_resolution_apply
+python backend/manage.py rbac_final_user_blocker_resolution_apply --format json
+python backend/manage.py rbac_final_user_blocker_resolution_apply --apply
+```
+
+Apply behavior:
+
+- Reassign `testuser` SPOT envelope `created_by` records to a deterministic
+  active canonical admin user, preferring `nason.martin` when present and valid.
+- Deactivate `testuser` only after counted dependency blockers are cleared and
+  no active membership exists.
+- Replace the active `sysadmin` legacy membership by deactivating it and
+  creating exactly one active canonical membership:
+  `EFM PNG / Port Moresby / Air Freight / admin`.
+
+Safety:
+
+- Dry-run is the default. Writes require `--apply`.
+- Apply runs in a transaction and rolls back if a blocker is reported.
+- The command fails safely if target users, organization, branch, department,
+  or role cannot be uniquely resolved.
+- The command does not delete users or memberships, reassign CRM/customer
+  records, backfill records, enable selector/API RBAC, change UI permissions,
+  or touch unrelated users.
+
+Post-apply validation:
+
+```bash
+python backend/manage.py rbac_final_user_blocker_resolution_plan --format json
+python backend/manage.py rbac_post_membership_apply_readiness --format json
+```
+
+Target readiness: `READY_FOR_BACKFILL_PLANNING`.
+
 ## 12. What Not To Touch Yet
 
 Do not touch these in the first implementation slice:


### PR DESCRIPTION
## Summary
- Add dry-run-first `rbac_final_user_blocker_resolution_apply` for the final Phase 8W RBAC blockers.
- Reassign `testuser` SPOT envelope `created_by` records to deterministic canonical admin `nason.martin` when available, then deactivate `testuser` only after dependencies clear.
- Resolve `sysadmin` by deactivating the legacy active membership and creating the canonical `EFM PNG / Port Moresby / Air Freight / admin` membership.
- Document Phase 8W usage, safety rules, and post-apply validation.

## Safety
- Defaults to dry-run; writes require `--apply`.
- Applies inside a transaction and rolls back if any blocker is reported.
- Does not delete users or memberships, touch CRM/customer backfill, enable selector/API RBAC, change UI permissions, or modify unrelated users.

## Validation
- `python backend/manage.py makemigrations --check --dry-run`
- `python backend/manage.py check`
- `python backend/manage.py rbac_final_user_blocker_resolution_apply`
- `python backend/manage.py rbac_final_user_blocker_resolution_apply --format json`
- `python backend/manage.py rbac_final_user_blocker_resolution_apply --apply`
- `python backend/manage.py rbac_final_user_blocker_resolution_plan --format json`
- `python backend/manage.py rbac_post_membership_apply_readiness --format json`
- `pytest backend/parties/tests.py -q`
- `git diff --check`
- `graphify update .`
- `npx fallow --format json`

## Notes
- Local apply reached `READY_FOR_BACKFILL_PLANNING` after resolving the blockers.
- Fallow still reports the existing frontend baseline findings; no frontend cleanup is included.