### PR TITLE
chore(rbac): add historical scope backfill planning diagnostics

### DIFF
--- a/backend/parties/management/commands/rbac_historical_scope_backfill_plan.py
+++ b/backend/parties/management/commands/rbac_historical_scope_backfill_plan.py
@@ -9,8 +9,9 @@ from parties.models import Company, Contact
 
 
 SCOPE_FIELDS = ("organization", "branch", "department")
-READY = "READY_FOR_BACKFILL_APPLY_DESIGN"
-NOT_READY = "NOT_READY_FOR_BACKFILL_APPLY_DESIGN"
+READY = "READY_FOR_BACKFILL_APPLY"
+READY_WITH_EXCLUSIONS = "READY_WITH_MANUAL_REVIEW_EXCLUSIONS"
+NOT_READY = "NOT_READY_FOR_BACKFILL_APPLY"
 BLOCKER_REASONS = {
     "multiple_owner_memberships",
     "owner_no_active_membership",
@@ -91,7 +92,8 @@ def build_report():
     summary = combined_summary(models)
     return {
         "write_enabled": False,
-        "readiness_status": READY if summary["unclassified_records"] == 0 else NOT_READY,
+        "readiness_status": readiness_status(summary),
+        "proposed_apply_strategy": proposed_apply_strategy(summary),
         "summary": summary,
         "models": models,
         "safe_evidence_sources": [
@@ -100,6 +102,32 @@ def build_report():
             "existing complete related customer/company scope",
         ],
         "unsafe_inference_rules": UNSAFE_INFERENCE_RULES,
+    }
+
+
+def readiness_status(summary):
+    if summary["unclassified_records"]:
+        return NOT_READY
+    if summary["manual_review_required"]:
+        return READY_WITH_EXCLUSIONS
+    return READY
+
+
+def proposed_apply_strategy(summary):
+    apply_eligible = (
+        summary["records_backfillable_from_owner_membership"]
+        + summary["records_backfillable_from_parent_scope"]
+    )
+    return {
+        "apply_eligible_records": apply_eligible,
+        "manual_review_excluded_records": summary["manual_review_required"],
+        "allowed_evidence_sources": [
+            "owner_membership",
+            "parent_scope",
+            "related_company_scope",
+        ],
+        "excluded_blocker_reasons": sorted(BLOCKER_REASONS),
+        "next_phase": "controlled dry-run-first backfill apply for apply-eligible records only",
     }
 
 
@@ -267,6 +295,13 @@ def write_text(stdout, report):
         f"parent_backfillable={summary['records_backfillable_from_parent_scope']}, "
         f"manual_review={summary['manual_review_required']}"
     )
+    strategy = report["proposed_apply_strategy"]
+    stdout.write(
+        "Apply strategy: "
+        f"safe apply candidates={strategy['apply_eligible_records']}, "
+        f"manual-review exclusions={strategy['manual_review_excluded_records']}"
+    )
+    stdout.write("Next apply command must exclude manual-review records unless separately approved.")
     for model_name, payload in report["models"].items():
         summary = payload["summary"]
         stdout.write("")

--- a/backend/parties/management/commands/rbac_historical_scope_backfill_plan.py
+++ b/backend/parties/management/commands/rbac_historical_scope_backfill_plan.py
@@ -1,0 +1,297 @@
+import json
+from collections import Counter
+
+from django.core.management.base import BaseCommand
+
+from accounts.scope import get_active_memberships
+from crm.models import Interaction, Opportunity, Task
+from parties.models import Company, Contact
+
+
+SCOPE_FIELDS = ("organization", "branch", "department")
+READY = "READY_FOR_BACKFILL_APPLY_DESIGN"
+NOT_READY = "NOT_READY_FOR_BACKFILL_APPLY_DESIGN"
+BLOCKER_REASONS = {
+    "multiple_owner_memberships",
+    "owner_no_active_membership",
+    "parent_scope_incomplete",
+    "no_safe_evidence",
+}
+UNSAFE_INFERENCE_RULES = [
+    "customer name",
+    "route",
+    "lane",
+    "notes",
+    "free text",
+    "quote description",
+    "email text",
+    "inferred branch from geography",
+    "inferred department from wording",
+]
+
+
+class Command(BaseCommand):
+    help = "Read-only historical CRM/customer scope backfill planning diagnostics."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--format",
+            choices=["text", "json"],
+            default="text",
+            help="Output format. Defaults to text.",
+        )
+
+    def handle(self, *args, **options):
+        report = build_report()
+        if options["format"] == "json":
+            self.stdout.write(json.dumps(report, indent=2, sort_keys=True))
+            return
+        write_text(self.stdout, report)
+
+
+def build_report():
+    models = {
+        "Company": inspect_model(
+            Company.objects.select_related("organization", "branch", "department", "account_owner").order_by("name", "id"),
+            owner_field="account_owner",
+            label_field="name",
+        ),
+        "Contact": inspect_model(
+            Contact.objects.select_related("company", "organization", "branch", "department").order_by(
+                "company__name", "last_name", "first_name", "id"
+            ),
+            parent_fields=("company",),
+            label_func=lambda row: f"{row.first_name} {row.last_name}".strip(),
+        ),
+        "Opportunity": inspect_model(
+            Opportunity.objects.select_related("company", "owner", "organization", "branch", "department").order_by(
+                "created_at", "id"
+            ),
+            owner_field="owner",
+            parent_fields=("company",),
+            label_field="title",
+        ),
+        "Interaction": inspect_model(
+            Interaction.objects.select_related(
+                "company", "opportunity", "author", "organization", "branch", "department"
+            ).order_by("created_at", "id"),
+            owner_field="author",
+            parent_fields=("opportunity", "company"),
+            label_field="interaction_type",
+        ),
+        "Task": inspect_model(
+            Task.objects.select_related("company", "opportunity", "owner", "organization", "branch", "department").order_by(
+                "due_date", "created_at", "id"
+            ),
+            owner_field="owner",
+            parent_fields=("opportunity", "company"),
+            label_field="status",
+        ),
+    }
+    summary = combined_summary(models)
+    return {
+        "write_enabled": False,
+        "readiness_status": READY if summary["unclassified_records"] == 0 else NOT_READY,
+        "summary": summary,
+        "models": models,
+        "safe_evidence_sources": [
+            "existing complete parent scope",
+            "existing complete owner/account_owner active membership",
+            "existing complete related customer/company scope",
+        ],
+        "unsafe_inference_rules": UNSAFE_INFERENCE_RULES,
+    }
+
+
+def inspect_model(queryset, *, owner_field=None, parent_fields=(), label_field=None, label_func=None):
+    summary = empty_summary()
+    blocker_counts = Counter()
+    sample_blocked_records = []
+
+    for record in queryset:
+        classification = classify_record(record, owner_field=owner_field, parent_fields=parent_fields)
+        update_summary(summary, record, classification)
+        if classification["blocker_reason"]:
+            blocker_counts[classification["blocker_reason"]] += 1
+            if len(sample_blocked_records) < 10:
+                sample_blocked_records.append(sample_record(record, classification, label_field, label_func))
+
+    for reason in sorted(BLOCKER_REASONS):
+        blocker_counts.setdefault(reason, 0)
+    return {
+        "summary": summary,
+        "blocker_reasons": dict(sorted(blocker_counts.items())),
+        "sample_blocked_records": sample_blocked_records,
+    }
+
+
+def classify_record(record, *, owner_field, parent_fields):
+    if complete_scope(record):
+        return {"status": "complete", "source": None, "blocker_reason": None, "parent": None, "owner": None}
+
+    parent = first_parent(record, parent_fields)
+    if parent and complete_scope(parent):
+        return {"status": "backfillable", "source": "parent_scope", "blocker_reason": None, "parent": parent, "owner": None}
+
+    owner = getattr(record, owner_field, None) if owner_field else None
+    memberships = list(get_active_memberships(owner)) if owner else []
+    if len(memberships) == 1 and complete_scope(memberships[0]):
+        return {
+            "status": "backfillable",
+            "source": "owner_membership",
+            "blocker_reason": None,
+            "parent": parent,
+            "owner": owner,
+        }
+    if len(memberships) > 1:
+        reason = "multiple_owner_memberships"
+    elif owner and not memberships:
+        reason = "owner_no_active_membership"
+    elif parent and not complete_scope(parent):
+        reason = "parent_scope_incomplete"
+    else:
+        reason = "no_safe_evidence"
+    return {"status": "blocked", "source": None, "blocker_reason": reason, "parent": parent, "owner": owner}
+
+
+def first_parent(record, parent_fields):
+    for field in parent_fields:
+        parent = getattr(record, field, None)
+        if parent is not None:
+            return parent
+    return None
+
+
+def complete_scope(record):
+    return all(getattr(record, f"{field}_id", None) for field in SCOPE_FIELDS)
+
+
+def update_summary(summary, record, classification):
+    summary["total_records"] += 1
+    for field in SCOPE_FIELDS:
+        if not getattr(record, f"{field}_id", None):
+            summary[f"records_missing_{field}"] += 1
+    if classification["status"] == "complete":
+        summary["records_complete"] += 1
+    elif classification["source"] == "owner_membership":
+        summary["records_backfillable_from_owner_membership"] += 1
+    elif classification["source"] == "parent_scope":
+        summary["records_backfillable_from_parent_scope"] += 1
+    elif classification["blocker_reason"] == "multiple_owner_memberships":
+        summary["records_blocked_owner_multiple_active_memberships"] += 1
+    elif classification["blocker_reason"] == "owner_no_active_membership":
+        summary["records_blocked_owner_no_active_membership"] += 1
+    elif classification["blocker_reason"] == "parent_scope_incomplete":
+        summary["records_blocked_parent_scope_incomplete"] += 1
+    elif classification["blocker_reason"] == "no_safe_evidence":
+        summary["records_blocked_no_safe_evidence"] += 1
+    else:
+        summary["unclassified_records"] += 1
+
+
+def empty_summary():
+    return {
+        "total_records": 0,
+        "records_missing_organization": 0,
+        "records_missing_branch": 0,
+        "records_missing_department": 0,
+        "records_complete": 0,
+        "records_backfillable_from_owner_membership": 0,
+        "records_backfillable_from_parent_scope": 0,
+        "records_blocked_owner_multiple_active_memberships": 0,
+        "records_blocked_owner_no_active_membership": 0,
+        "records_blocked_parent_scope_incomplete": 0,
+        "records_blocked_no_safe_evidence": 0,
+        "unclassified_records": 0,
+    }
+
+
+def combined_summary(models):
+    summary = empty_summary()
+    for payload in models.values():
+        for key, value in payload["summary"].items():
+            summary[key] += value
+    summary["manual_review_required"] = (
+        summary["records_blocked_owner_multiple_active_memberships"]
+        + summary["records_blocked_owner_no_active_membership"]
+        + summary["records_blocked_parent_scope_incomplete"]
+        + summary["records_blocked_no_safe_evidence"]
+    )
+    return summary
+
+
+def sample_record(record, classification, label_field, label_func):
+    parent = classification["parent"]
+    owner = classification["owner"]
+    return {
+        "id": str(record.pk),
+        "name": ascii_safe(label_func(record) if label_func else getattr(record, label_field, "")),
+        "blocker_reason": classification["blocker_reason"],
+        "owner_evidence": owner_evidence(owner),
+        "parent_evidence": parent_evidence(parent),
+    }
+
+
+def owner_evidence(owner):
+    if owner is None:
+        return None
+    memberships = list(get_active_memberships(owner))
+    return {
+        "username": ascii_safe(owner.username),
+        "active_memberships": len(memberships),
+        "complete_active_memberships": sum(1 for membership in memberships if complete_scope(membership)),
+    }
+
+
+def parent_evidence(parent):
+    if parent is None:
+        return None
+    return {
+        "model": parent.__class__.__name__,
+        "id": str(parent.pk),
+        "scope_complete": complete_scope(parent),
+        "missing_scope": [field for field in SCOPE_FIELDS if not getattr(parent, f"{field}_id", None)],
+    }
+
+
+def write_text(stdout, report):
+    stdout.write("RBAC historical scope backfill plan")
+    stdout.write("===================================")
+    stdout.write("Mode: read-only diagnostics")
+    stdout.write(f"Readiness: {report['readiness_status']}")
+    summary = report["summary"]
+    stdout.write(
+        "Combined totals: "
+        f"total={summary['total_records']}, complete={summary['records_complete']}, "
+        f"owner_backfillable={summary['records_backfillable_from_owner_membership']}, "
+        f"parent_backfillable={summary['records_backfillable_from_parent_scope']}, "
+        f"manual_review={summary['manual_review_required']}"
+    )
+    for model_name, payload in report["models"].items():
+        summary = payload["summary"]
+        stdout.write("")
+        stdout.write(f"{model_name}:")
+        stdout.write(
+            f"  total={summary['total_records']}, missing_org={summary['records_missing_organization']}, "
+            f"missing_branch={summary['records_missing_branch']}, "
+            f"missing_department={summary['records_missing_department']}, complete={summary['records_complete']}"
+        )
+        stdout.write(
+            f"  owner_backfillable={summary['records_backfillable_from_owner_membership']}, "
+            f"parent_backfillable={summary['records_backfillable_from_parent_scope']}, "
+            f"owner_multiple={summary['records_blocked_owner_multiple_active_memberships']}, "
+            f"owner_none={summary['records_blocked_owner_no_active_membership']}, "
+            f"parent_incomplete={summary['records_blocked_parent_scope_incomplete']}, "
+            f"no_safe_evidence={summary['records_blocked_no_safe_evidence']}"
+        )
+        for sample in payload["sample_blocked_records"]:
+            stdout.write(
+                f"  - blocked id={sample['id']} name={sample['name'] or '-'} "
+                f"reason={sample['blocker_reason']}"
+            )
+
+
+def ascii_safe(value):
+    if value is None:
+        return None
+    return str(value).encode("ascii", "replace").decode("ascii")

--- a/backend/parties/tests.py
+++ b/backend/parties/tests.py
@@ -531,6 +531,151 @@ class CustomerCrmBackfillReportTests(TestCase):
         self.assertNotIn("Do not leak this task description", output)
 
 
+class HistoricalScopeBackfillPlanTests(TestCase):
+    def _call_plan(self, *args):
+        stdout = StringIO()
+        call_command("rbac_historical_scope_backfill_plan", *args, stdout=stdout)
+        return stdout.getvalue()
+
+    def _scope(self, suffix=""):
+        organization = Organization.objects.create(
+            name=f"Historical Org {suffix}".strip(),
+            slug=f"historical-org-{suffix or 'default'}",
+            is_active=True,
+        )
+        branch = Branch.objects.create(organization=organization, code=f"H{suffix}"[:16], name="Historical Branch")
+        department = Department.objects.create(
+            organization=organization,
+            branch=branch,
+            code=f"HD{suffix}"[:24],
+            name="Historical Department",
+        )
+        return organization, branch, department
+
+    def _role(self, code="historical-role"):
+        return Role.objects.create(code=code, name=code.title(), is_system=True)
+
+    def _member(self, username, suffix=""):
+        organization, branch, department = self._scope(suffix or username)
+        user = CustomUser.objects.create_user(username=username, password="x")
+        UserMembership.objects.create(
+            user=user,
+            organization=organization,
+            branch=branch,
+            department=department,
+            role=self._role(f"{username}-role"[:32]),
+        )
+        return user
+
+    def test_read_only_command_does_not_write(self):
+        user = self._member("readonly-owner")
+        company = Company.objects.create(name="Read Only Customer", account_owner=user)
+
+        before = (company.organization_id, company.branch_id, company.department_id)
+        payload = json.loads(self._call_plan("--format", "json"))
+
+        company.refresh_from_db()
+        self.assertFalse(payload["write_enabled"])
+        self.assertEqual((company.organization_id, company.branch_id, company.department_id), before)
+
+    def test_complete_records_are_counted(self):
+        organization, branch, department = self._scope("complete")
+        Company.objects.create(
+            name="Complete Historical Customer",
+            organization=organization,
+            branch=branch,
+            department=department,
+        )
+
+        payload = json.loads(self._call_plan("--format", "json"))
+
+        self.assertEqual(payload["models"]["Company"]["summary"]["records_complete"], 1)
+        self.assertEqual(payload["models"]["Company"]["summary"]["records_missing_organization"], 0)
+
+    def test_missing_scope_with_complete_owner_membership_is_backfillable(self):
+        user = self._member("owner-backfill")
+        Company.objects.create(name="Owner Backfill Customer", account_owner=user)
+
+        payload = json.loads(self._call_plan("--format", "json"))
+
+        summary = payload["models"]["Company"]["summary"]
+        self.assertEqual(summary["records_backfillable_from_owner_membership"], 1)
+        self.assertEqual(summary["records_blocked_no_safe_evidence"], 0)
+
+    def test_missing_scope_with_complete_parent_scope_is_backfillable(self):
+        organization, branch, department = self._scope("parent")
+        company = Company.objects.create(
+            name="Parent Scope Customer",
+            organization=organization,
+            branch=branch,
+            department=department,
+        )
+        Contact.objects.create(company=company, first_name="Parent", last_name="Contact", email="phase9a-parent@example.com")
+
+        payload = json.loads(self._call_plan("--format", "json"))
+
+        summary = payload["models"]["Contact"]["summary"]
+        self.assertEqual(summary["records_backfillable_from_parent_scope"], 1)
+
+    def test_multiple_owner_memberships_are_blocked(self):
+        organization, branch, department = self._scope("multi")
+        other_branch = Branch.objects.create(organization=organization, code="H2", name="Second Branch")
+        other_department = Department.objects.create(
+            organization=organization,
+            branch=other_branch,
+            code="HD2",
+            name="Second Department",
+        )
+        user = CustomUser.objects.create_user(username="multi-historical", password="x")
+        role = self._role("multi-historical-role")
+        UserMembership.objects.create(user=user, organization=organization, branch=branch, department=department, role=role)
+        UserMembership.objects.create(
+            user=user,
+            organization=organization,
+            branch=other_branch,
+            department=other_department,
+            role=role,
+            is_primary=False,
+        )
+        Company.objects.create(name="Multi Owner Customer", account_owner=user)
+
+        payload = json.loads(self._call_plan("--format", "json"))
+
+        company = payload["models"]["Company"]
+        self.assertEqual(company["summary"]["records_blocked_owner_multiple_active_memberships"], 1)
+        self.assertEqual(company["sample_blocked_records"][0]["blocker_reason"], "multiple_owner_memberships")
+
+    def test_no_owner_membership_is_blocked(self):
+        user = CustomUser.objects.create_user(username="no-membership-historical", password="x")
+        Company.objects.create(name="No Membership Customer", account_owner=user)
+
+        payload = json.loads(self._call_plan("--format", "json"))
+
+        summary = payload["models"]["Company"]["summary"]
+        self.assertEqual(summary["records_blocked_owner_no_active_membership"], 1)
+
+    def test_incomplete_parent_scope_is_blocked(self):
+        organization, _branch, _department = self._scope("partial-parent")
+        company = Company.objects.create(name="Partial Parent Customer", organization=organization)
+        Contact.objects.create(company=company, first_name="Partial", last_name="Parent", email="phase9a-partial@example.com")
+
+        payload = json.loads(self._call_plan("--format", "json"))
+
+        contact = payload["models"]["Contact"]
+        self.assertEqual(contact["summary"]["records_blocked_parent_scope_incomplete"], 1)
+        self.assertEqual(contact["sample_blocked_records"][0]["parent_evidence"]["missing_scope"], ["branch", "department"])
+
+    def test_json_output_and_readiness_classify_manual_review(self):
+        Company.objects.create(name="Manual Review Customer")
+
+        payload = json.loads(self._call_plan("--format", "json"))
+
+        self.assertIn("Company", payload["models"])
+        self.assertEqual(payload["models"]["Company"]["sample_blocked_records"][0]["blocker_reason"], "no_safe_evidence")
+        self.assertEqual(payload["readiness_status"], "READY_FOR_BACKFILL_APPLY_DESIGN")
+        self.assertEqual(payload["summary"]["manual_review_required"], 1)
+
+
 class ScopeCompletenessReportTests(TestCase):
     def _call_report(self, *args):
         stdout = StringIO()

--- a/backend/parties/tests.py
+++ b/backend/parties/tests.py
@@ -672,8 +672,41 @@ class HistoricalScopeBackfillPlanTests(TestCase):
 
         self.assertIn("Company", payload["models"])
         self.assertEqual(payload["models"]["Company"]["sample_blocked_records"][0]["blocker_reason"], "no_safe_evidence")
-        self.assertEqual(payload["readiness_status"], "READY_FOR_BACKFILL_APPLY_DESIGN")
+        self.assertEqual(payload["readiness_status"], "READY_WITH_MANUAL_REVIEW_EXCLUSIONS")
         self.assertEqual(payload["summary"]["manual_review_required"], 1)
+        self.assertEqual(payload["proposed_apply_strategy"]["apply_eligible_records"], 0)
+        self.assertEqual(payload["proposed_apply_strategy"]["manual_review_excluded_records"], 1)
+        self.assertIn("no_safe_evidence", payload["proposed_apply_strategy"]["excluded_blocker_reasons"])
+
+    def test_fully_backfillable_data_is_ready_for_apply(self):
+        user = self._member("fully-ready-owner")
+        Company.objects.create(name="Fully Ready Customer", account_owner=user)
+
+        payload = json.loads(self._call_plan("--format", "json"))
+
+        self.assertEqual(payload["readiness_status"], "READY_FOR_BACKFILL_APPLY")
+        self.assertEqual(payload["proposed_apply_strategy"]["apply_eligible_records"], 1)
+        self.assertEqual(payload["proposed_apply_strategy"]["manual_review_excluded_records"], 0)
+
+    def test_unclassified_summary_is_not_ready_for_apply(self):
+        from parties.management.commands.rbac_historical_scope_backfill_plan import empty_summary, readiness_status
+
+        summary = empty_summary()
+        summary["manual_review_required"] = 0
+        summary["unclassified_records"] = 1
+
+        self.assertEqual(readiness_status(summary), "NOT_READY_FOR_BACKFILL_APPLY")
+
+    def test_text_output_reports_apply_strategy(self):
+        user = self._member("text-ready-owner")
+        Company.objects.create(name="Text Ready Customer", account_owner=user)
+        Company.objects.create(name="Text Manual Review Customer")
+
+        output = self._call_plan()
+
+        self.assertIn("safe apply candidates=1", output)
+        self.assertIn("manual-review exclusions=1", output)
+        self.assertIn("Next apply command must exclude manual-review records", output)
 
 
 class ScopeCompletenessReportTests(TestCase):

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -2515,6 +2515,60 @@ python backend/manage.py rbac_post_membership_apply_readiness --format json
 
 Target readiness: `READY_FOR_BACKFILL_PLANNING`.
 
+#### Phase 9A - Historical Scope Backfill Planning Diagnostics
+
+Date: 2026-06-23
+
+Branch: `codex/phase-9a-historical-scope-backfill-plan`
+
+Scope: read-only diagnostics for historical customer and CRM scope backfill
+planning after membership readiness reached `READY_FOR_BACKFILL_PLANNING`.
+
+Command:
+
+```bash
+python backend/manage.py rbac_historical_scope_backfill_plan
+python backend/manage.py rbac_historical_scope_backfill_plan --format json
+```
+
+Purpose:
+
+- Inspect `Company`, `Contact`, `Opportunity`, `Interaction`, and `Task`
+  records that expose organization, branch, and department scope fields.
+- Report total, missing organization, missing branch, missing department, and
+  complete record counts per model.
+- Classify missing-scope records as backfillable only from safe evidence:
+  complete parent scope, complete owner/account-owner active membership, or
+  complete related company/customer scope.
+- Report manual-review blockers for multiple owner memberships, no owner
+  membership, incomplete parent scope, and no safe evidence.
+- Include safe sample blocker rows with id, name/title where available,
+  owner evidence, parent evidence, and blocker reason.
+
+Unsafe inference rules:
+
+- Do not infer branch, department, or organization from customer name, route,
+  lane, notes, free text, quote description, email text, geography, or wording.
+- Ambiguous evidence is reported for manual review instead of guessed.
+
+Output statuses:
+
+- `READY_FOR_BACKFILL_APPLY_DESIGN`: every record is either complete,
+  backfillable from safe evidence, or explicitly classified for manual review.
+- `NOT_READY_FOR_BACKFILL_APPLY_DESIGN`: reserved for unclassified records or
+  diagnostic gaps that prevent apply-design planning.
+
+Safety:
+
+- The command is read-only and reports `write_enabled=false`.
+- It does not backfill records, enforce RBAC, change selectors, change APIs,
+  change UI permissions, or write customer/CRM data.
+
+Next phase:
+
+- Use Phase 9A output to design a dry-run-first historical scope backfill apply
+  command, with manual-review rows excluded unless separately approved.
+
 ## 12. What Not To Touch Yet
 
 Do not touch these in the first implementation slice:

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -2553,10 +2553,18 @@ Unsafe inference rules:
 
 Output statuses:
 
-- `READY_FOR_BACKFILL_APPLY_DESIGN`: every record is either complete,
-  backfillable from safe evidence, or explicitly classified for manual review.
-- `NOT_READY_FOR_BACKFILL_APPLY_DESIGN`: reserved for unclassified records or
-  diagnostic gaps that prevent apply-design planning.
+- `READY_FOR_BACKFILL_APPLY`: all missing-scope records are safe apply
+  candidates from approved evidence.
+- `READY_WITH_MANUAL_REVIEW_EXCLUSIONS`: safe apply candidates exist, and all
+  remaining unresolved records are explicitly classified for manual review.
+  Manual-review records do not block apply design, but they must be excluded
+  from apply unless separately approved.
+- `NOT_READY_FOR_BACKFILL_APPLY`: at least one record is unclassified or the
+  diagnostic cannot explain how it should be handled.
+
+The JSON output includes `proposed_apply_strategy` with safe apply candidate
+counts, manual-review exclusion counts, allowed evidence sources, excluded
+blocker reasons, and the next-phase recommendation.
 
 Safety:
 
@@ -2567,7 +2575,9 @@ Safety:
 Next phase:
 
 - Use Phase 9A output to design a dry-run-first historical scope backfill apply
-  command, with manual-review rows excluded unless separately approved.
+  command for safe eligible records only.
+- Exclude all manual-review rows from the apply command unless they are
+  separately reviewed and approved.
 
 ## 12. What Not To Touch Yet
 


### PR DESCRIPTION
## Summary
- add read-only Phase 9A historical scope backfill planning diagnostics
- classify Company, Contact, Opportunity, Interaction, and Task scope gaps by safe evidence or manual-review blocker
- document Phase 9A command usage, evidence rules, unsafe inference rules, readiness status, and next phase

## Validation
- npx fallow --format json
- npx fallow dead-code --format json
- npx fallow dupes --format json
- npx fallow health --format json
- python backend\\manage.py makemigrations --check --dry-run
- python backend\\manage.py check
- python backend\\manage.py rbac_historical_scope_backfill_plan
- python backend\\manage.py rbac_historical_scope_backfill_plan --format json
- pytest backend/parties/tests.py -q
- git diff --check
- graphify update .

## Safety
- read-only command only
- no backfill writes
- no RBAC enforcement
- no selector, API, or UI permission changes