### PR TITLE
chore(rbac): add historical scope backfill apply

### DIFF
--- a/backend/parties/management/commands/rbac_historical_scope_backfill_apply.py
+++ b/backend/parties/management/commands/rbac_historical_scope_backfill_apply.py
@@ -1,0 +1,211 @@
+import json
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from accounts.scope import get_active_memberships
+from crm.models import Interaction, Opportunity, Task
+from parties.models import Company, Contact
+
+from .rbac_historical_scope_backfill_plan import SCOPE_FIELDS, classify_record
+
+
+MODEL_SPECS = {
+    "Company": {
+        "queryset": lambda: Company.objects.select_related(
+            "organization", "branch", "department", "account_owner"
+        ).order_by("name", "id"),
+        "owner_field": "account_owner",
+        "parent_fields": (),
+    },
+    "Contact": {
+        "queryset": lambda: Contact.objects.select_related("company", "organization", "branch", "department").order_by(
+            "company__name", "last_name", "first_name", "id"
+        ),
+        "owner_field": None,
+        "parent_fields": ("company",),
+    },
+    "Opportunity": {
+        "queryset": lambda: Opportunity.objects.select_related(
+            "company", "owner", "organization", "branch", "department"
+        ).order_by("created_at", "id"),
+        "owner_field": "owner",
+        "parent_fields": ("company",),
+    },
+    "Interaction": {
+        "queryset": lambda: Interaction.objects.select_related(
+            "company", "opportunity", "author", "organization", "branch", "department"
+        ).order_by("created_at", "id"),
+        "owner_field": "author",
+        "parent_fields": ("opportunity", "company"),
+    },
+    "Task": {
+        "queryset": lambda: Task.objects.select_related(
+            "company", "opportunity", "owner", "organization", "branch", "department"
+        ).order_by("due_date", "created_at", "id"),
+        "owner_field": "owner",
+        "parent_fields": ("opportunity", "company"),
+    },
+}
+
+
+class Command(BaseCommand):
+    help = "Dry-run by default; optionally backfill safe historical CRM/customer scope."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--apply", action="store_true", help="Write safe scope backfills. Defaults to dry-run.")
+        parser.add_argument(
+            "--format",
+            choices=["text", "json"],
+            default="text",
+            help="Output format. Defaults to text.",
+        )
+
+    def handle(self, *args, **options):
+        apply = options["apply"]
+        if apply:
+            with transaction.atomic():
+                report = build_report(apply=True)
+        else:
+            report = build_report(apply=False)
+
+        if options["format"] == "json":
+            self.stdout.write(json.dumps(report, indent=2, sort_keys=True))
+            return
+        write_text(self.stdout, report)
+
+
+def build_report(*, apply):
+    models = {model_name: inspect_model(model_name, spec) for model_name, spec in MODEL_SPECS.items()}
+    if apply:
+        apply_planned_actions(models)
+    for payload in models.values():
+        payload.pop("_actions", None)
+    return {
+        "mode": "apply" if apply else "dry-run",
+        "write_enabled": apply,
+        "models": models,
+        "summary": combined_summary(models),
+    }
+
+
+def inspect_model(model_name, spec):
+    summary = empty_summary()
+    samples = []
+    actions = []
+    for record in spec["queryset"]():
+        classification = classify_record(
+            record,
+            owner_field=spec["owner_field"],
+            parent_fields=spec["parent_fields"],
+        )
+        action = action_for(record, classification)
+        actions.append({"record": record, "action": action})
+        summary[action["status"]] += 1
+        sample = None
+        if action["status"] in {"planned", "skipped", "blocked"} and len(samples) < 10:
+            sample = {
+                "id": str(record.pk),
+                "status": action["status"],
+                "source": action["source"],
+                "reason": action["reason"],
+                "fields": action["fields"],
+            }
+            action["sample"] = sample
+            samples.append(sample)
+
+    return {"summary": summary, "samples": samples, "_actions": actions}
+
+
+def apply_planned_actions(models):
+    for payload in models.values():
+        summary = payload["summary"]
+        for item in payload["_actions"]:
+            action = item["action"]
+            if action["status"] != "planned":
+                continue
+            result = apply_action(item["record"], action)
+            summary["planned"] -= 1
+            summary[result] += 1
+            if action.get("sample"):
+                action["sample"]["status"] = result
+                if result != "applied":
+                    action["sample"]["reason"] = action["reason"]
+
+
+def apply_action(record, action):
+    source_object = action["source_object"]
+    fields = [
+        field
+        for field in action["fields"]
+        if not getattr(record, f"{field}_id", None) and getattr(source_object, f"{field}_id", None)
+    ]
+    if not fields:
+        action["reason"] = "safe_evidence_no_missing_fields"
+        return "blocked"
+
+    for field in fields:
+        setattr(record, field, getattr(source_object, field))
+    update_fields = [*fields, "updated_at"] if hasattr(record, "updated_at") else fields
+    record.save(update_fields=update_fields)
+    return "applied"
+
+
+def action_for(record, classification):
+    if classification["status"] == "complete":
+        return empty_action("unchanged", "already_complete")
+    if classification["status"] != "backfillable":
+        return empty_action("skipped", classification["blocker_reason"])
+
+    source_object = classification["parent"] if classification["source"] == "parent_scope" else None
+    if classification["source"] == "owner_membership":
+        source_object = next(iter(get_active_memberships(classification["owner"])))
+    fields = [
+        field
+        for field in SCOPE_FIELDS
+        if not getattr(record, f"{field}_id", None) and getattr(source_object, f"{field}_id", None)
+    ]
+    if not fields:
+        return empty_action("blocked", "safe_evidence_no_missing_fields")
+    return {
+        "status": "planned",
+        "source": classification["source"],
+        "source_object": source_object,
+        "reason": None,
+        "fields": fields,
+    }
+
+
+def empty_action(status, reason):
+    return {"status": status, "source": None, "source_object": None, "reason": reason, "fields": []}
+
+
+def empty_summary():
+    return {"planned": 0, "applied": 0, "unchanged": 0, "skipped": 0, "blocked": 0}
+
+
+def combined_summary(models):
+    summary = empty_summary()
+    for payload in models.values():
+        for key, value in payload["summary"].items():
+            summary[key] += value
+    return summary
+
+
+def write_text(stdout, report):
+    summary = report["summary"]
+    stdout.write("RBAC historical scope backfill apply")
+    stdout.write("====================================")
+    stdout.write(f"Mode: {report['mode']}")
+    stdout.write(
+        "Summary: "
+        f"planned={summary['planned']}, applied={summary['applied']}, unchanged={summary['unchanged']}, "
+        f"skipped={summary['skipped']}, blocked={summary['blocked']}"
+    )
+    for model_name, payload in report["models"].items():
+        model_summary = payload["summary"]
+        stdout.write(
+            f"{model_name}: planned={model_summary['planned']}, applied={model_summary['applied']}, "
+            f"unchanged={model_summary['unchanged']}, skipped={model_summary['skipped']}, "
+            f"blocked={model_summary['blocked']}"
+        )

--- a/backend/parties/management/commands/rbac_historical_scope_backfill_plan.py
+++ b/backend/parties/management/commands/rbac_historical_scope_backfill_plan.py
@@ -158,7 +158,7 @@ def classify_record(record, *, owner_field, parent_fields):
         return {"status": "complete", "source": None, "blocker_reason": None, "parent": None, "owner": None}
 
     parent = first_parent(record, parent_fields)
-    if parent and complete_scope(parent):
+    if parent and safe_parent_scope(parent):
         return {"status": "backfillable", "source": "parent_scope", "blocker_reason": None, "parent": parent, "owner": None}
 
     owner = getattr(record, owner_field, None) if owner_field else None
@@ -188,6 +188,14 @@ def first_parent(record, parent_fields):
         if parent is not None:
             return parent
     return None
+
+
+def safe_parent_scope(parent):
+    if not complete_scope(parent):
+        return False
+    parent_owner = getattr(parent, "account_owner", None) or getattr(parent, "owner", None)
+    parent_memberships = list(get_active_memberships(parent_owner)) if parent_owner else []
+    return not (len(parent_memberships) == 1 and complete_scope(parent_memberships[0]))
 
 
 def complete_scope(record):

--- a/backend/parties/tests.py
+++ b/backend/parties/tests.py
@@ -617,6 +617,29 @@ class HistoricalScopeBackfillPlanTests(TestCase):
         summary = payload["models"]["Contact"]["summary"]
         self.assertEqual(summary["records_backfillable_from_parent_scope"], 1)
 
+    def test_owner_derived_parent_scope_does_not_create_new_apply_candidate(self):
+        owner = self._member("owner-derived-parent")
+        organization, branch, department = self._scope("owner-derived-parent-scope")
+        company = Company.objects.create(
+            name="Owner Derived Parent Scope Customer",
+            account_owner=owner,
+            organization=organization,
+            branch=branch,
+            department=department,
+        )
+        Contact.objects.create(
+            company=company,
+            first_name="Owner",
+            last_name="Derived",
+            email="phase9a-owner-derived@example.com",
+        )
+
+        payload = json.loads(self._call_plan("--format", "json"))
+
+        contact = payload["models"]["Contact"]
+        self.assertEqual(contact["summary"]["records_backfillable_from_parent_scope"], 0)
+        self.assertEqual(contact["summary"]["records_blocked_no_safe_evidence"], 1)
+
     def test_multiple_owner_memberships_are_blocked(self):
         organization, branch, department = self._scope("multi")
         other_branch = Branch.objects.create(organization=organization, code="H2", name="Second Branch")
@@ -707,6 +730,242 @@ class HistoricalScopeBackfillPlanTests(TestCase):
         self.assertIn("safe apply candidates=1", output)
         self.assertIn("manual-review exclusions=1", output)
         self.assertIn("Next apply command must exclude manual-review records", output)
+
+
+class HistoricalScopeBackfillApplyTests(TestCase):
+    def _call_apply(self, *args):
+        stdout = StringIO()
+        call_command("rbac_historical_scope_backfill_apply", *args, stdout=stdout)
+        return stdout.getvalue()
+
+    def _call_plan(self, *args):
+        stdout = StringIO()
+        call_command("rbac_historical_scope_backfill_plan", *args, stdout=stdout)
+        return stdout.getvalue()
+
+    def _scope(self, suffix=""):
+        organization = Organization.objects.create(
+            name=f"Apply Org {suffix}".strip(),
+            slug=f"apply-org-{suffix or 'default'}",
+            is_active=True,
+        )
+        branch = Branch.objects.create(organization=organization, code=f"A{suffix}"[:16], name="Apply Branch")
+        department = Department.objects.create(
+            organization=organization,
+            branch=branch,
+            code=f"AD{suffix}"[:24],
+            name="Apply Department",
+        )
+        return organization, branch, department
+
+    def _role(self, code="apply-role"):
+        return Role.objects.create(code=code, name=code.title(), is_system=True)
+
+    def _member(self, username, suffix=""):
+        organization, branch, department = self._scope(suffix or username)
+        user = CustomUser.objects.create_user(username=username, password="x")
+        UserMembership.objects.create(
+            user=user,
+            organization=organization,
+            branch=branch,
+            department=department,
+            role=self._role(f"{username}-role"[:32]),
+        )
+        return user, organization, branch, department
+
+    def test_dry_run_does_not_write(self):
+        user, _organization, _branch, _department = self._member("dry-run-owner")
+        company = Company.objects.create(name="Dry Run Apply Customer", account_owner=user)
+
+        payload = json.loads(self._call_apply("--format", "json"))
+
+        company.refresh_from_db()
+        self.assertEqual(payload["models"]["Company"]["summary"]["planned"], 1)
+        self.assertIsNone(company.organization_id)
+        self.assertIsNone(company.branch_id)
+        self.assertIsNone(company.department_id)
+
+    def test_apply_backfills_company_from_account_owner_membership(self):
+        user, organization, branch, department = self._member("company-owner")
+        company = Company.objects.create(name="Company Owner Apply Customer", account_owner=user)
+
+        payload = json.loads(self._call_apply("--apply", "--format", "json"))
+
+        company.refresh_from_db()
+        self.assertEqual(payload["models"]["Company"]["summary"]["applied"], 1)
+        self.assertEqual(company.organization, organization)
+        self.assertEqual(company.branch, branch)
+        self.assertEqual(company.department, department)
+
+    def test_apply_backfills_contact_from_parent_company_scope(self):
+        organization, branch, department = self._scope("contact-parent")
+        company = Company.objects.create(
+            name="Contact Parent Apply Customer",
+            organization=organization,
+            branch=branch,
+            department=department,
+        )
+        contact = Contact.objects.create(
+            company=company,
+            first_name="Apply",
+            last_name="Contact",
+            email="phase9b-contact@example.com",
+        )
+
+        self._call_apply("--apply")
+
+        contact.refresh_from_db()
+        self.assertEqual(contact.organization, organization)
+        self.assertEqual(contact.branch, branch)
+        self.assertEqual(contact.department, department)
+
+    def test_apply_uses_preflight_plan_and_does_not_cascade_parent_backfill(self):
+        user, organization, branch, department = self._member("preflight-owner")
+        company = Company.objects.create(name="Preflight Parent Apply Customer", account_owner=user)
+        contact = Contact.objects.create(
+            company=company,
+            first_name="Preflight",
+            last_name="Contact",
+            email="phase9b-preflight@example.com",
+        )
+
+        payload = json.loads(self._call_apply("--apply", "--format", "json"))
+
+        company.refresh_from_db()
+        contact.refresh_from_db()
+        self.assertEqual(payload["models"]["Company"]["summary"]["applied"], 1)
+        self.assertEqual(payload["models"]["Contact"]["summary"]["applied"], 0)
+        self.assertEqual(company.organization, organization)
+        self.assertEqual(company.branch, branch)
+        self.assertEqual(company.department, department)
+        self.assertIsNone(contact.organization_id)
+        self.assertIsNone(contact.branch_id)
+        self.assertIsNone(contact.department_id)
+
+    def test_apply_backfills_crm_models_from_safe_owner_or_parent_evidence(self):
+        owner, organization, branch, department = self._member("crm-owner")
+        company = Company.objects.create(
+            name="CRM Parent Apply Customer",
+            organization=organization,
+            branch=branch,
+            department=department,
+        )
+        opportunity = Opportunity.objects.create(
+            company=company,
+            title="Owner scoped opportunity",
+            service_type="AIR",
+            owner=owner,
+        )
+        interaction = Interaction.objects.create(
+            company=company,
+            opportunity=opportunity,
+            author=owner,
+            interaction_type=Interaction.InteractionType.CALL,
+            summary="Hidden body",
+        )
+        task = Task.objects.create(
+            company=company,
+            opportunity=opportunity,
+            owner=owner,
+            due_date=timezone.now().date(),
+            description="Hidden task body",
+        )
+
+        payload = json.loads(self._call_apply("--apply", "--format", "json"))
+
+        for record in (opportunity, interaction, task):
+            record.refresh_from_db()
+            self.assertEqual(record.organization, organization)
+            self.assertEqual(record.branch, branch)
+            self.assertEqual(record.department, department)
+        self.assertEqual(payload["models"]["Opportunity"]["summary"]["applied"], 1)
+        self.assertEqual(payload["models"]["Interaction"]["summary"]["applied"], 1)
+        self.assertEqual(payload["models"]["Task"]["summary"]["applied"], 1)
+
+    def test_apply_excludes_manual_review_records(self):
+        organization, _branch, _department = self._scope("manual")
+        no_member = CustomUser.objects.create_user(username="apply-no-member", password="x")
+        multi_user = CustomUser.objects.create_user(username="apply-multi", password="x")
+        role = self._role("apply-multi-role")
+        branch_one = Branch.objects.create(organization=organization, code="M1", name="Manual One")
+        branch_two = Branch.objects.create(organization=organization, code="M2", name="Manual Two")
+        department_one = Department.objects.create(organization=organization, branch=branch_one, code="MD1", name="Manual One")
+        department_two = Department.objects.create(organization=organization, branch=branch_two, code="MD2", name="Manual Two")
+        UserMembership.objects.create(user=multi_user, organization=organization, branch=branch_one, department=department_one, role=role)
+        UserMembership.objects.create(
+            user=multi_user,
+            organization=organization,
+            branch=branch_two,
+            department=department_two,
+            role=role,
+            is_primary=False,
+        )
+        no_safe = Company.objects.create(name="No Evidence Apply Customer")
+        owner_none = Company.objects.create(name="No Membership Apply Customer", account_owner=no_member)
+        owner_multi = Company.objects.create(name="Multi Membership Apply Customer", account_owner=multi_user)
+        partial_parent = Company.objects.create(name="Partial Parent Apply Customer", organization=organization)
+        contact = Contact.objects.create(
+            company=partial_parent,
+            first_name="Partial",
+            last_name="Apply",
+            email="phase9b-partial@example.com",
+        )
+
+        payload = json.loads(self._call_apply("--apply", "--format", "json"))
+
+        for record in (no_safe, owner_none, owner_multi, partial_parent, contact):
+            record.refresh_from_db()
+            self.assertIsNone(record.branch_id)
+            self.assertIsNone(record.department_id)
+        self.assertEqual(payload["summary"]["skipped"], 5)
+        self.assertEqual(payload["summary"]["applied"], 0)
+
+    def test_apply_is_idempotent_and_does_not_overwrite_complete_scope(self):
+        user, owner_org, owner_branch, owner_department = self._member("idempotent-owner")
+        existing_org, existing_branch, existing_department = self._scope("existing")
+        company = Company.objects.create(name="Idempotent Apply Customer", account_owner=user)
+        contact = Contact.objects.create(
+            company=company,
+            first_name="Idempotent",
+            last_name="Contact",
+            email="phase9b-idempotent@example.com",
+        )
+        complete = Company.objects.create(
+            name="Already Complete Apply Customer",
+            account_owner=user,
+            organization=existing_org,
+            branch=existing_branch,
+            department=existing_department,
+        )
+
+        first = json.loads(self._call_apply("--apply", "--format", "json"))
+        second = json.loads(self._call_apply("--apply", "--format", "json"))
+
+        complete.refresh_from_db()
+        contact.refresh_from_db()
+        self.assertEqual(first["models"]["Company"]["summary"]["applied"], 1)
+        self.assertEqual(second["models"]["Company"]["summary"]["applied"], 0)
+        self.assertEqual(second["models"]["Contact"]["summary"]["applied"], 0)
+        self.assertIsNone(contact.organization_id)
+        self.assertIsNone(contact.branch_id)
+        self.assertIsNone(contact.department_id)
+        self.assertEqual(complete.organization, existing_org)
+        self.assertNotEqual(complete.organization, owner_org)
+        self.assertNotEqual(complete.branch, owner_branch)
+        self.assertNotEqual(complete.department, owner_department)
+
+    def test_json_output_includes_counts_and_post_apply_plan_improves(self):
+        user, _organization, _branch, _department = self._member("plan-improves-owner")
+        Company.objects.create(name="Plan Improves Apply Customer", account_owner=user)
+
+        before = json.loads(self._call_plan("--format", "json"))
+        payload = json.loads(self._call_apply("--apply", "--format", "json"))
+        after = json.loads(self._call_plan("--format", "json"))
+
+        self.assertIn("applied", payload["models"]["Company"]["summary"])
+        self.assertEqual(before["proposed_apply_strategy"]["apply_eligible_records"], 1)
+        self.assertEqual(after["summary"]["records_complete"], 1)
+        self.assertEqual(after["proposed_apply_strategy"]["apply_eligible_records"], 0)
 
 
 class ScopeCompletenessReportTests(TestCase):

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -2579,6 +2579,64 @@ Next phase:
 - Exclude all manual-review rows from the apply command unless they are
   separately reviewed and approved.
 
+#### Phase 9B - Controlled Historical Scope Backfill Apply
+
+Date: 2026-06-23
+
+Branch: `codex/phase-9b-historical-scope-backfill-apply`
+
+Scope: dry-run-first historical organization, branch, and department backfill
+for records classified by Phase 9A as safe apply candidates.
+
+Command:
+
+```bash
+python backend/manage.py rbac_historical_scope_backfill_apply
+python backend/manage.py rbac_historical_scope_backfill_apply --format json
+python backend/manage.py rbac_historical_scope_backfill_apply --apply
+```
+
+Apply rules:
+
+- Dry-run is the default. Writes require `--apply`.
+- Apply mode runs in a database transaction.
+- The command fills missing scope fields only; it does not overwrite complete
+  existing scope.
+- Safe evidence sources are complete owner/account-owner active membership and
+  complete parent object scope. Related company/customer scope is represented
+  through parent company scope for contacts and CRM objects.
+- The command is idempotent: records completed by one apply run become
+  unchanged on later runs.
+
+Exclusion rules:
+
+- Manual-review records are skipped, not modified.
+- Excluded blocker reasons include multiple owner memberships, owner with no
+  active membership, incomplete parent scope, no safe evidence, and any
+  ambiguous or changed evidence that is no longer safe at apply time.
+- The command does not infer scope from customer names, routes, lanes, notes,
+  email text, geography, wording, quote descriptions, or free text.
+
+Safety:
+
+- The command does not enforce RBAC, change selectors, change APIs, change UI
+  permissions, or modify manual-review records.
+- It does not change customer/CRM business content beyond the three nullable
+  scope fields on safe eligible records.
+
+Post-apply validation:
+
+```bash
+python backend/manage.py rbac_historical_scope_backfill_plan --format json
+```
+
+Expected result after a successful apply:
+
+- `records_complete` increases by the number of safely applied records.
+- `proposed_apply_strategy.apply_eligible_records` reduces.
+- `manual_review_excluded_records` remain excluded and require separate review
+  before any later apply phase touches them.
+
 ## 12. What Not To Touch Yet
 
 Do not touch these in the first implementation slice:


### PR DESCRIPTION
## Summary
- Adds a dry-run-first historical scope backfill apply command for Phase 9B.
- Applies only Phase 9A preflight-safe candidates.
- Keeps manual-review records excluded unless separately approved.
- Tightens parent-scope planning so owner-derived parent scope does not create a later automatic apply candidate.
- Adds tests and Phase 9B documentation.

## Safety
- Dry-run is the default; writes require `--apply`.
- Applies only records with safe evidence from Phase 9A.
- Excludes manual-review records, including no-safe-evidence, incomplete parent scope, no owner membership, multiple owner memberships, and ambiguous evidence.
- Does not enforce RBAC, change selectors, change APIs, change UI permissions, or infer scope from names/routes/notes/free text.

## Validation reported by Codex
- `python backend\manage.py makemigrations --check --dry-run` PASS
- `python backend\manage.py check` PASS
- `pytest backend/parties/tests.py -q` PASS: 143 passed, 16 warnings
- `git diff --check` PASS
- `graphify update .` PASS; HTML skipped due graph size
- `npx fallow --format json` PASS with existing frontend baseline findings

## Local command outputs reported by Codex
Dry-run before apply:
```text
Summary: planned=268, applied=0, unchanged=0, skipped=533, blocked=0
Company: planned=1
Contact: planned=0, skipped=298
Opportunity: planned=69
Interaction: planned=198
Task: planned=0
```

Apply:
```text
Summary: planned=0, applied=268, unchanged=0, skipped=533, blocked=0
Company: applied=1, skipped=235
Contact: applied=0, skipped=298
Opportunity: applied=69
Interaction: applied=198
Task: applied=0
```

Post-apply planning:
```text
readiness_status=READY_WITH_MANUAL_REVIEW_EXCLUSIONS
records_complete=268
apply_eligible_records=0
manual_review_excluded_records=533
unclassified_records=0
```