### PR TITLE
chore(rbac): add enforcement readiness diagnostics

### DIFF
--- a/backend/parties/management/commands/rbac_enforcement_readiness_report.py
+++ b/backend/parties/management/commands/rbac_enforcement_readiness_report.py
@@ -1,0 +1,178 @@
+import json
+
+from django.core.management.base import BaseCommand
+
+from .rbac_historical_scope_backfill_plan import build_report as build_backfill_report
+
+
+READY = "READY_FOR_ENFORCEMENT_DESIGN"
+NOT_READY = "NOT_READY_FOR_ENFORCEMENT_DESIGN"
+
+
+SURFACES = [
+    {
+        "name": "CRM opportunity list/detail",
+        "code_path": "backend/crm/views.py:OpportunityViewSet.get_queryset",
+        "current_state": "global_unfiltered",
+        "required_rule": "filter Opportunity by organization, branch, and department for scoped roles",
+    },
+    {
+        "name": "CRM interaction list/detail",
+        "code_path": "backend/crm/views.py:InteractionViewSet.get_queryset",
+        "current_state": "global_unfiltered",
+        "required_rule": "filter Interaction by direct scope or scoped company/opportunity parent",
+    },
+    {
+        "name": "CRM task list/detail",
+        "code_path": "backend/crm/views.py:TaskViewSet.get_queryset",
+        "current_state": "global_unfiltered",
+        "required_rule": "filter Task by direct scope or scoped company/opportunity parent",
+    },
+    {
+        "name": "Company/customer list",
+        "code_path": "backend/parties/views.py:CustomerV3ViewSet.get_queryset",
+        "current_state": "global_unfiltered",
+        "required_rule": "filter Company by organization, branch, and department for scoped roles",
+    },
+    {
+        "name": "Company selector search",
+        "code_path": "backend/parties/views.py:CompanyV3SearchView.get_queryset",
+        "current_state": "global_unfiltered",
+        "required_rule": "filter selector results to scoped Company records",
+    },
+    {
+        "name": "Contact selector by company",
+        "code_path": "backend/parties/views.py:CompanyContactListV3View.get_queryset",
+        "current_state": "parent_direct_lookup_unfiltered",
+        "required_rule": "authorize parent Company scope before returning Contact rows",
+    },
+    {
+        "name": "Opportunity selectors",
+        "code_path": "backend/crm/views.py:OpportunityViewSet.get_queryset",
+        "current_state": "global_unfiltered",
+        "required_rule": "filter opportunity selector options to scoped Opportunity records",
+    },
+    {
+        "name": "Interaction/Task selectors",
+        "code_path": "backend/crm/views.py:InteractionViewSet.get_queryset; backend/crm/views.py:TaskViewSet.get_queryset",
+        "current_state": "global_unfiltered",
+        "required_rule": "filter interaction and task selector options by scoped parent records",
+    },
+    {
+        "name": "Quote customer detail lookup",
+        "code_path": "backend/quotes/views/services.py:CustomerDetailAPIView._get_company",
+        "current_state": "partially_scope_filtered",
+        "required_rule": "replace legacy owner/quote organization filter with canonical scope checks",
+    },
+    {
+        "name": "Quote compute customer/contact lookup",
+        "code_path": "backend/quotes/views/calculation.py:QuoteCalculationAPIView",
+        "current_state": "direct_id_lookup_unfiltered",
+        "required_rule": "validate customer and contact scope before quote calculation",
+    },
+    {
+        "name": "SPOT customer lookup",
+        "code_path": "backend/quotes/spot_views.py",
+        "current_state": "direct_id_lookup_unfiltered",
+        "required_rule": "validate customer/contact scope before SPE quote creation",
+    },
+]
+
+
+class Command(BaseCommand):
+    help = "Read-only post-backfill validation and RBAC enforcement readiness diagnostics."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--format", choices=["text", "json"], default="text")
+
+    def handle(self, *args, **options):
+        report = build_report()
+        if options["format"] == "json":
+            self.stdout.write(json.dumps(report, indent=2, sort_keys=True))
+            return
+        write_text(self.stdout, report)
+
+
+def build_report():
+    backfill = build_backfill_report()
+    summary = backfill["summary"]
+    strategy = backfill["proposed_apply_strategy"]
+    blockers = []
+    if strategy["apply_eligible_records"]:
+        blockers.append("apply_eligible_records_remaining")
+    if summary["unclassified_records"]:
+        blockers.append("unclassified_records_remaining")
+    return {
+        "write_enabled": False,
+        "readiness_status": NOT_READY if blockers else READY,
+        "readiness_blockers": blockers,
+        "post_backfill": {
+            "summary": summary,
+            "models": {
+                name: {
+                    "summary": payload["summary"],
+                    "manual_review_exclusions": payload["blocker_reasons"],
+                }
+                for name, payload in backfill["models"].items()
+            },
+            "apply_eligible_records": strategy["apply_eligible_records"],
+            "manual_review_excluded_records": strategy["manual_review_excluded_records"],
+        },
+        "enforcement_surfaces": SURFACES,
+        "global_or_unfiltered_surfaces": [
+            surface for surface in SURFACES if "unfiltered" in surface["current_state"]
+        ],
+        "proposed_enforcement_rules": proposed_rules(),
+        "admin_override_considerations": [
+            "admin and superuser may require cross-scope visibility for operations",
+            "cross-scope access should be explicit and auditable",
+            "non-admin roles should use canonical membership organization/branch/department scope",
+        ],
+    }
+
+
+def proposed_rules():
+    return [
+        {
+            "role_scope": "admin",
+            "rule": "allow cross-scope access where business-approved; preserve audit trail",
+        },
+        {
+            "role_scope": "manager",
+            "rule": "allow records in the user's canonical organization/branch/department scope",
+        },
+        {
+            "role_scope": "sales",
+            "rule": "allow own records plus explicitly approved scoped records",
+        },
+        {
+            "role_scope": "finance/system",
+            "rule": "define explicit read/write override before enabling enforcement",
+        },
+    ]
+
+
+def write_text(stdout, report):
+    stdout.write("RBAC enforcement readiness report")
+    stdout.write("=================================")
+    stdout.write("Mode: read-only diagnostics")
+    stdout.write(f"Readiness: {report['readiness_status']}")
+    post = report["post_backfill"]
+    summary = post["summary"]
+    stdout.write(
+        "Post-backfill: "
+        f"total={summary['total_records']}, complete={summary['records_complete']}, "
+        f"missing_org={summary['records_missing_organization']}, "
+        f"missing_branch={summary['records_missing_branch']}, "
+        f"missing_department={summary['records_missing_department']}, "
+        f"apply_eligible={post['apply_eligible_records']}, "
+        f"manual_review={post['manual_review_excluded_records']}"
+    )
+    stdout.write("")
+    stdout.write("Surfaces currently global/unfiltered:")
+    for surface in report["global_or_unfiltered_surfaces"]:
+        stdout.write(f"- {surface['name']}: {surface['current_state']} ({surface['code_path']})")
+    stdout.write("")
+    stdout.write("Required enforcement rules:")
+    for rule in report["proposed_enforcement_rules"]:
+        stdout.write(f"- {rule['role_scope']}: {rule['rule']}")

--- a/backend/parties/tests.py
+++ b/backend/parties/tests.py
@@ -968,6 +968,92 @@ class HistoricalScopeBackfillApplyTests(TestCase):
         self.assertEqual(after["proposed_apply_strategy"]["apply_eligible_records"], 0)
 
 
+class EnforcementReadinessReportTests(TestCase):
+    def _call_report(self, *args):
+        stdout = StringIO()
+        call_command("rbac_enforcement_readiness_report", *args, stdout=stdout)
+        return stdout.getvalue()
+
+    def _scope(self, suffix=""):
+        organization = Organization.objects.create(
+            name=f"Enforcement Org {suffix}".strip(),
+            slug=f"enforcement-org-{suffix or 'default'}",
+            is_active=True,
+        )
+        branch = Branch.objects.create(organization=organization, code=f"E{suffix}"[:16], name="Enforcement Branch")
+        department = Department.objects.create(
+            organization=organization,
+            branch=branch,
+            code=f"ED{suffix}"[:24],
+            name="Enforcement Department",
+        )
+        return organization, branch, department
+
+    def _member(self, username):
+        organization, branch, department = self._scope(username)
+        role = Role.objects.create(code=f"{username}-role"[:32], name=username, is_system=True)
+        user = CustomUser.objects.create_user(username=username, password="x")
+        UserMembership.objects.create(
+            user=user,
+            organization=organization,
+            branch=branch,
+            department=department,
+            role=role,
+        )
+        return user, organization, branch, department
+
+    def test_command_is_read_only(self):
+        user, _organization, _branch, _department = self._member("enforcement-readonly")
+        company = Company.objects.create(name="Enforcement Readonly Customer", account_owner=user)
+
+        payload = json.loads(self._call_report("--format", "json"))
+
+        company.refresh_from_db()
+        self.assertFalse(payload["write_enabled"])
+        self.assertIsNone(company.organization_id)
+        self.assertIsNone(company.branch_id)
+        self.assertIsNone(company.department_id)
+
+    def test_reports_complete_missing_and_manual_review_counts(self):
+        organization, branch, department = self._scope("complete")
+        Company.objects.create(
+            name="Complete Enforcement Customer",
+            organization=organization,
+            branch=branch,
+            department=department,
+        )
+        Company.objects.create(name="Manual Enforcement Customer")
+
+        payload = json.loads(self._call_report("--format", "json"))
+
+        post = payload["post_backfill"]
+        self.assertEqual(post["summary"]["records_complete"], 1)
+        self.assertEqual(post["summary"]["records_missing_organization"], 1)
+        self.assertEqual(post["manual_review_excluded_records"], 1)
+        self.assertEqual(post["models"]["Company"]["manual_review_exclusions"]["no_safe_evidence"], 1)
+
+    def test_apply_candidates_make_report_not_ready(self):
+        user, _organization, _branch, _department = self._member("enforcement-candidate")
+        Company.objects.create(name="Candidate Enforcement Customer", account_owner=user)
+
+        payload = json.loads(self._call_report("--format", "json"))
+
+        self.assertEqual(payload["post_backfill"]["apply_eligible_records"], 1)
+        self.assertEqual(payload["readiness_status"], "NOT_READY_FOR_ENFORCEMENT_DESIGN")
+        self.assertIn("apply_eligible_records_remaining", payload["readiness_blockers"])
+
+    def test_json_reports_surfaces_and_ready_status(self):
+        Company.objects.create(name="Manual Only Enforcement Customer")
+
+        payload = json.loads(self._call_report("--format", "json"))
+
+        self.assertEqual(payload["readiness_status"], "READY_FOR_ENFORCEMENT_DESIGN")
+        self.assertTrue(payload["enforcement_surfaces"])
+        self.assertTrue(payload["global_or_unfiltered_surfaces"])
+        self.assertIn("proposed_enforcement_rules", payload)
+        self.assertIn("admin_override_considerations", payload)
+
+
 class ScopeCompletenessReportTests(TestCase):
     def _call_report(self, *args):
         stdout = StringIO()

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -2637,6 +2637,48 @@ Expected result after a successful apply:
 - `manual_review_excluded_records` remain excluded and require separate review
   before any later apply phase touches them.
 
+#### Phase 9C - Post-Backfill Validation and Enforcement Readiness
+
+Date: 2026-06-23
+
+Branch: `codex/phase-9c-enforcement-readiness`
+
+Scope: read-only diagnostics after historical scope backfill apply, before any
+selector, API, queryset, serializer, or UI permission enforcement work.
+
+Command:
+
+```bash
+python backend/manage.py rbac_enforcement_readiness_report
+python backend/manage.py rbac_enforcement_readiness_report --format json
+```
+
+Purpose:
+
+- Reuse the historical scope backfill planner to confirm complete records,
+  remaining missing scope, manual-review exclusions by reason, and
+  `apply_eligible_records`.
+- Report readiness as `READY_FOR_ENFORCEMENT_DESIGN` only when no safe apply
+  candidates or unclassified records remain.
+- Audit the current CRM, customer/company/contact selector, opportunity,
+  interaction/task, and quote/customer lookup surfaces.
+- Identify surfaces that are still global, unfiltered, partially filtered, or
+  direct-id lookups.
+- Propose the minimum enforcement rules needed for role/scope design, including
+  admin and cross-scope override considerations.
+
+Safety:
+
+- The command is read-only and reports `write_enabled=false`.
+- It does not enforce RBAC, change selectors, APIs, querysets, serializers, or
+  UI permissions.
+- It does not backfill or modify customer, CRM, quote, or SPOT records.
+
+Next phase:
+
+- Design enforcement rules and tests from this report before changing any
+  selector, API, queryset, serializer, or UI permission behavior.
+
 ## 12. What Not To Touch Yet
 
 Do not touch these in the first implementation slice:


### PR DESCRIPTION
## Summary
- Add read-only `rbac_enforcement_readiness_report` command with text and JSON output.
- Reuse the historical scope backfill planner to validate post-backfill completeness, missing scope, manual-review exclusions, and remaining apply candidates.
- Report current CRM/customer/contact/opportunity/task/quote customer lookup enforcement surfaces and proposed role/scope enforcement rules.
- Document Phase 9C in the RBAC audit plan.

## Validation
- `python backend\manage.py makemigrations --check --dry-run`
- `python backend\manage.py check`
- `python backend\manage.py rbac_enforcement_readiness_report`
- `python backend\manage.py rbac_enforcement_readiness_report --format json`
- `pytest backend/parties/tests.py -q`
- `git diff --check`
- `graphify update .`
- Fallow baseline before work: combined passed with existing 99 frontend issues; dead-code/health exited nonzero on existing frontend findings; dupes passed.

## Current local diagnostic result
- `readiness_status=NOT_READY_FOR_ENFORCEMENT_DESIGN`
- `records_complete=268`
- `apply_eligible_records=2`
- `manual_review_excluded_records=531`

## Notes
- This PR is diagnostic only. It does not enforce RBAC, change selectors, APIs, querysets, serializers, UI permissions, or backfill data.