### PR TITLE
feat(rbac): enforce backend scoped access

### DIFF
--- a/backend/accounts/scope.py
+++ b/backend/accounts/scope.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from django.db.models import Q
+
 from .models import CustomUser, UserMembership
 
 
@@ -101,6 +103,66 @@ def get_active_memberships(user):
         UserMembership.objects.filter(user=user, is_active=True)
         .select_related("organization", "branch", "department", "role")
         .prefetch_related("role__permissions")
+    )
+
+
+def user_has_cross_scope_access(user) -> bool:
+    return bool(
+        _is_authenticated_active(user)
+        and (
+            getattr(user, "is_superuser", False)
+            or getattr(user, "role", None) == CustomUser.ROLE_ADMIN
+        )
+    )
+
+
+def get_single_complete_membership(user):
+    memberships = list(get_active_memberships(user))
+    if len(memberships) != 1:
+        return None
+    membership = memberships[0]
+    if (
+        not membership.organization_id
+        or not membership.branch_id
+        or not membership.department_id
+    ):
+        return None
+    return membership
+
+
+def scoped_queryset_for_user(queryset, user, *, prefix: str = ""):
+    if user_has_cross_scope_access(user):
+        return queryset
+
+    membership = get_single_complete_membership(user)
+    if membership is None:
+        return queryset.none()
+
+    field_prefix = f"{prefix}__" if prefix else ""
+    return queryset.filter(
+        **{
+            f"{field_prefix}organization_id": membership.organization_id,
+            f"{field_prefix}branch_id": membership.branch_id,
+            f"{field_prefix}department_id": membership.department_id,
+        }
+    )
+
+
+def scoped_q_for_user(user, *, prefix: str = "") -> Q:
+    if user_has_cross_scope_access(user):
+        return Q()
+
+    membership = get_single_complete_membership(user)
+    if membership is None:
+        return Q(pk__in=[])
+
+    field_prefix = f"{prefix}__" if prefix else ""
+    return Q(
+        **{
+            f"{field_prefix}organization_id": membership.organization_id,
+            f"{field_prefix}branch_id": membership.branch_id,
+            f"{field_prefix}department_id": membership.department_id,
+        }
     )
 
 

--- a/backend/accounts/scope.py
+++ b/backend/accounts/scope.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from django.conf import settings
 from django.db.models import Q
 
 from .models import CustomUser, UserMembership
@@ -136,6 +137,8 @@ def scoped_queryset_for_user(queryset, user, *, prefix: str = ""):
 
     membership = get_single_complete_membership(user)
     if membership is None:
+        if getattr(settings, "RBAC_ALLOW_LEGACY_SCOPE_FALLBACK_FOR_TESTS", False):
+            return queryset
         return queryset.none()
 
     field_prefix = f"{prefix}__" if prefix else ""
@@ -154,6 +157,8 @@ def scoped_q_for_user(user, *, prefix: str = "") -> Q:
 
     membership = get_single_complete_membership(user)
     if membership is None:
+        if getattr(settings, "RBAC_ALLOW_LEGACY_SCOPE_FALLBACK_FOR_TESTS", False):
+            return Q()
         return Q(pk__in=[])
 
     field_prefix = f"{prefix}__" if prefix else ""

--- a/backend/crm/views.py
+++ b/backend/crm/views.py
@@ -3,6 +3,7 @@ from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
+from accounts.scope import scoped_queryset_for_user
 from .models import Interaction, Opportunity, Task
 from .serializers import InteractionSerializer, OpportunitySerializer, TaskSerializer
 from .services import mark_opportunity_lost, mark_opportunity_won
@@ -25,6 +26,7 @@ class OpportunityViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         queryset = Opportunity.objects.select_related("company", "owner", "won_by").filter(is_active=True)
+        queryset = scoped_queryset_for_user(queryset, self.request.user)
         company = self.request.query_params.get("company")
         status = self.request.query_params.get("status")
         owner = self.request.query_params.get("owner")
@@ -87,6 +89,7 @@ class InteractionViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         queryset = Interaction.objects.select_related("company", "contact", "opportunity", "author")
+        queryset = scoped_queryset_for_user(queryset, self.request.user)
         company = self.request.query_params.get("company")
         opportunity = self.request.query_params.get("opportunity")
         if company:
@@ -105,6 +108,7 @@ class TaskViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         queryset = Task.objects.select_related("company", "opportunity", "owner", "completed_by")
+        queryset = scoped_queryset_for_user(queryset, self.request.user)
         owner = self.request.query_params.get("owner")
         status = self.request.query_params.get("status")
         due_date = self.request.query_params.get("due_date")

--- a/backend/parties/tests.py
+++ b/backend/parties/tests.py
@@ -2827,6 +2827,8 @@ class BackendScopedAccessAPITests(APITestCase):
         )
         self.contact_a = self._contact(self.company_a, "a")
         self.contact_b = self._contact(self.company_b, "b")
+        self.company_a_other = self._company("Phase 9D Customer A Other", self.org_a, self.branch_a, self.department_a)
+        self.contact_a_other = self._contact(self.company_a_other, "a-other")
 
         self.opportunity_a = self._opportunity("Phase 9D Opportunity A", self.company_a, self.org_a, self.branch_a, self.department_a)
         self.opportunity_b = self._opportunity("Phase 9D Opportunity B", self.company_b, self.org_b, self.branch_b, self.department_b)
@@ -2899,6 +2901,17 @@ class BackendScopedAccessAPITests(APITestCase):
             organization=organization,
             branch=branch,
             department=department,
+        )
+
+    def _spot_envelope(self):
+        return SpotPricingEnvelopeDB.objects.create(
+            created_by=self.sales,
+            owner=self.sales,
+            shipment_context_json={"origin": "POM", "destination": "LAE"},
+            conditions_json={},
+            spot_trigger_reason_code="TEST",
+            spot_trigger_reason_text="Test trigger",
+            expires_at=timezone.now(),
         )
 
     def _ids(self, response):
@@ -3026,15 +3039,7 @@ class BackendScopedAccessAPITests(APITestCase):
 
     def test_spot_quote_creation_rejects_out_of_scope_customer_id(self):
         self.client.force_authenticate(user=self.sales)
-        envelope = SpotPricingEnvelopeDB.objects.create(
-            created_by=self.sales,
-            owner=self.sales,
-            shipment_context_json={"origin": "POM", "destination": "LAE"},
-            conditions_json={},
-            spot_trigger_reason_code="TEST",
-            spot_trigger_reason_text="Test trigger",
-            expires_at=timezone.now(),
-        )
+        envelope = self._spot_envelope()
 
         response = self.client.post(
             f"/api/v3/spot/envelopes/{envelope.id}/create-quote/",
@@ -3045,6 +3050,53 @@ class BackendScopedAccessAPITests(APITestCase):
         self.assertIn(response.status_code, {status.HTTP_400_BAD_REQUEST, status.HTTP_404_NOT_FOUND})
         if response.status_code == status.HTTP_404_NOT_FOUND:
             self.assertEqual(response.data["error"], "Selected customer is not available for this user.")
+
+    def test_spot_quote_creation_rejects_out_of_scope_contact_id(self):
+        self.client.force_authenticate(user=self.sales)
+        envelope = self._spot_envelope()
+
+        response = self.client.post(
+            f"/api/v3/spot/envelopes/{envelope.id}/create-quote/",
+            {
+                "customer_id": str(self.company_a.id),
+                "contact_id": str(self.contact_b.id),
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data["error"], "Selected contact is not available for this customer/user.")
+
+    def test_spot_quote_creation_rejects_contact_id_for_different_scoped_customer(self):
+        self.client.force_authenticate(user=self.sales)
+        envelope = self._spot_envelope()
+
+        response = self.client.post(
+            f"/api/v3/spot/envelopes/{envelope.id}/create-quote/",
+            {
+                "customer_id": str(self.company_a.id),
+                "contact_id": str(self.contact_a_other.id),
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data["error"], "Selected contact is not available for this customer/user.")
+
+    def test_spot_quote_creation_allows_customer_only_request_to_reach_existing_validation(self):
+        self.client.force_authenticate(user=self.sales)
+        envelope = self._spot_envelope()
+
+        response = self.client.post(
+            f"/api/v3/spot/envelopes/{envelope.id}/create-quote/",
+            {"customer_id": str(self.company_a.id)},
+            format="json",
+        )
+
+        self.assertNotEqual(
+            response.data.get("error"),
+            "Selected contact is not available for this customer/user.",
+        )
 
 
 class OrganizationBrandingSettingsAPITests(APITestCase):

--- a/backend/parties/tests.py
+++ b/backend/parties/tests.py
@@ -16,7 +16,7 @@ from PIL import Image
 
 from accounts.models import CustomUser, Role, UserMembership
 from crm.models import Interaction, Opportunity, Task
-from core.models import Country, City
+from core.models import Country, City, Location
 from core.models import Currency
 from parties.models import Branch, Company, Contact, Address, Department, Organization, OrganizationBranding
 from quotes.models import Quote
@@ -2790,6 +2790,263 @@ class CustomerListAPITests(APITestCase):
         self.assertEqual(company.department, department)
 
 
+class BackendScopedAccessAPITests(APITestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.role_admin = Role.objects.create(code="phase9d-admin", name="Admin", is_system=True)
+        self.role_manager = Role.objects.create(code="phase9d-manager", name="Manager", is_system=True)
+        self.role_sales = Role.objects.create(code="phase9d-sales", name="Sales", is_system=True)
+
+        self.org_a = Organization.objects.create(name="Phase 9D Org A", slug="phase-9d-org-a")
+        self.branch_a = Branch.objects.create(organization=self.org_a, code="P9A", name="Phase 9D A")
+        self.department_a = Department.objects.create(
+            organization=self.org_a,
+            branch=self.branch_a,
+            code="AIR",
+            name="Air Freight",
+        )
+        self.org_b = Organization.objects.create(name="Phase 9D Org B", slug="phase-9d-org-b")
+        self.branch_b = Branch.objects.create(organization=self.org_b, code="P9B", name="Phase 9D B")
+        self.department_b = Department.objects.create(
+            organization=self.org_b,
+            branch=self.branch_b,
+            code="AIR",
+            name="Air Freight",
+        )
+
+        self.admin = self._user("phase9d-admin-user", CustomUser.ROLE_ADMIN, self.org_a, self.branch_a, self.department_a, self.role_admin)
+        self.manager = self._user("phase9d-manager-user", CustomUser.ROLE_MANAGER, self.org_a, self.branch_a, self.department_a, self.role_manager)
+        self.sales = self._user("phase9d-sales-user", CustomUser.ROLE_SALES, self.org_a, self.branch_a, self.department_a, self.role_sales)
+
+        self.company_a = self._company("Phase 9D Customer A", self.org_a, self.branch_a, self.department_a)
+        self.company_b = self._company("Phase 9D Customer B", self.org_b, self.branch_b, self.department_b)
+        self.company_unscoped = Company.objects.create(
+            name="Phase 9D Manual Review Customer",
+            is_customer=True,
+            company_type="CUSTOMER",
+        )
+        self.contact_a = self._contact(self.company_a, "a")
+        self.contact_b = self._contact(self.company_b, "b")
+
+        self.opportunity_a = self._opportunity("Phase 9D Opportunity A", self.company_a, self.org_a, self.branch_a, self.department_a)
+        self.opportunity_b = self._opportunity("Phase 9D Opportunity B", self.company_b, self.org_b, self.branch_b, self.department_b)
+        self.interaction_a = self._interaction(self.company_a, self.org_a, self.branch_a, self.department_a)
+        self.interaction_b = self._interaction(self.company_b, self.org_b, self.branch_b, self.department_b)
+        self.task_a = self._task("Phase 9D Task A", self.company_a, self.org_a, self.branch_a, self.department_a)
+        self.task_b = self._task("Phase 9D Task B", self.company_b, self.org_b, self.branch_b, self.department_b)
+
+    def _user(self, username, role, organization, branch, department, membership_role):
+        user = CustomUser.objects.create_user(username=username, password="testpass123", role=role)
+        UserMembership.objects.create(
+            user=user,
+            organization=organization,
+            branch=branch,
+            department=department,
+            role=membership_role,
+        )
+        return user
+
+    def _company(self, name, organization, branch, department):
+        return Company.objects.create(
+            name=name,
+            is_customer=True,
+            company_type="CUSTOMER",
+            organization=organization,
+            branch=branch,
+            department=department,
+        )
+
+    def _contact(self, company, suffix):
+        return Contact.objects.create(
+            company=company,
+            organization=company.organization,
+            branch=company.branch,
+            department=company.department,
+            first_name="Phase",
+            last_name=f"Contact {suffix}",
+            email=f"phase9d-{suffix}@example.com",
+            is_active=True,
+        )
+
+    def _opportunity(self, title, company, organization, branch, department):
+        return Opportunity.objects.create(
+            company=company,
+            title=title,
+            service_type="AIR",
+            owner=self.sales,
+            organization=organization,
+            branch=branch,
+            department=department,
+        )
+
+    def _interaction(self, company, organization, branch, department):
+        return Interaction.objects.create(
+            company=company,
+            interaction_type=Interaction.InteractionType.CALL,
+            summary=f"Call with {company.name}",
+            author=self.sales,
+            organization=organization,
+            branch=branch,
+            department=department,
+        )
+
+    def _task(self, description, company, organization, branch, department):
+        return Task.objects.create(
+            company=company,
+            description=description,
+            owner=self.sales,
+            due_date=timezone.now().date(),
+            organization=organization,
+            branch=branch,
+            department=department,
+        )
+
+    def _ids(self, response):
+        return {str(row["id"]) for row in response.data}
+
+    def test_admin_can_access_cross_scope_customers(self):
+        self.client.force_authenticate(user=self.admin)
+
+        response = self.client.get("/api/v3/customers/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        returned_ids = self._ids(response)
+        self.assertIn(str(self.company_a.id), returned_ids)
+        self.assertIn(str(self.company_b.id), returned_ids)
+        self.assertIn(str(self.company_unscoped.id), returned_ids)
+
+    def test_scoped_manager_can_access_in_scope_customer(self):
+        self.client.force_authenticate(user=self.manager)
+
+        response = self.client.get(f"/api/v3/customers/{self.company_a.id}/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["id"], str(self.company_a.id))
+
+    def test_scoped_user_list_excludes_out_of_scope_and_unscoped_customers(self):
+        self.client.force_authenticate(user=self.sales)
+
+        response = self.client.get("/api/v3/customers/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        returned_ids = self._ids(response)
+        self.assertIn(str(self.company_a.id), returned_ids)
+        self.assertNotIn(str(self.company_b.id), returned_ids)
+        self.assertNotIn(str(self.company_unscoped.id), returned_ids)
+
+    def test_scoped_user_cannot_retrieve_out_of_scope_customer_by_id(self):
+        self.client.force_authenticate(user=self.sales)
+
+        response = self.client.get(f"/api/v3/customers/{self.company_b.id}/")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_company_selector_filters_out_of_scope_companies(self):
+        self.client.force_authenticate(user=self.sales)
+
+        response = self.client.get("/api/v3/parties/search/", {"q": "Phase 9D Customer"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        returned_ids = self._ids(response)
+        self.assertIn(str(self.company_a.id), returned_ids)
+        self.assertNotIn(str(self.company_b.id), returned_ids)
+
+    def test_contact_by_company_endpoint_checks_parent_company_scope(self):
+        self.client.force_authenticate(user=self.sales)
+
+        in_scope = self.client.get(f"/api/v3/parties/companies/{self.company_a.id}/contacts/")
+        out_of_scope = self.client.get(f"/api/v3/parties/companies/{self.company_b.id}/contacts/")
+
+        self.assertEqual(in_scope.status_code, status.HTTP_200_OK)
+        self.assertEqual(self._ids(in_scope), {str(self.contact_a.id)})
+        self.assertEqual(out_of_scope.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_crm_viewsets_filter_and_deny_direct_out_of_scope_ids(self):
+        self.client.force_authenticate(user=self.sales)
+
+        opportunity_list = self.client.get("/api/v3/crm/opportunities/")
+        interaction_list = self.client.get("/api/v3/crm/interactions/")
+        task_list = self.client.get("/api/v3/crm/tasks/")
+
+        self.assertEqual(opportunity_list.status_code, status.HTTP_200_OK)
+        self.assertEqual(interaction_list.status_code, status.HTTP_200_OK)
+        self.assertEqual(task_list.status_code, status.HTTP_200_OK)
+        self.assertIn(str(self.opportunity_a.id), self._ids(opportunity_list))
+        self.assertNotIn(str(self.opportunity_b.id), self._ids(opportunity_list))
+        self.assertIn(str(self.interaction_a.id), self._ids(interaction_list))
+        self.assertNotIn(str(self.interaction_b.id), self._ids(interaction_list))
+        self.assertIn(str(self.task_a.id), self._ids(task_list))
+        self.assertNotIn(str(self.task_b.id), self._ids(task_list))
+
+        self.assertEqual(
+            self.client.get(f"/api/v3/crm/opportunities/{self.opportunity_b.id}/").status_code,
+            status.HTTP_404_NOT_FOUND,
+        )
+        self.assertEqual(
+            self.client.get(f"/api/v3/crm/interactions/{self.interaction_b.id}/").status_code,
+            status.HTTP_404_NOT_FOUND,
+        )
+        self.assertEqual(
+            self.client.get(f"/api/v3/crm/tasks/{self.task_b.id}/").status_code,
+            status.HTTP_404_NOT_FOUND,
+        )
+
+    def test_quote_calculation_rejects_out_of_scope_customer_id_before_pricing(self):
+        self.client.force_authenticate(user=self.sales)
+        pgk = Currency.objects.create(code="PGK", name="Papua New Guinean Kina")
+        png = Country.objects.create(code="PG", name="Papua New Guinea", currency=pgk)
+        pom = Location.objects.create(code="POM", name="Port Moresby", country=png)
+        lae = Location.objects.create(code="LAE", name="Lae", country=png)
+
+        response = self.client.post(
+            "/api/v3/quotes/compute/",
+            {
+                "customer_id": str(self.company_b.id),
+                "contact_id": str(self.contact_b.id),
+                "mode": "AIR",
+                "service_scope": "D2D",
+                "origin_location_id": str(pom.id),
+                "destination_location_id": str(lae.id),
+                "incoterm": "DAP",
+                "payment_term": "PREPAID",
+                "dimensions": [
+                    {
+                        "pieces": 1,
+                        "length_cm": "10",
+                        "width_cm": "10",
+                        "height_cm": "10",
+                        "gross_weight_kg": "1",
+                    }
+                ],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_spot_quote_creation_rejects_out_of_scope_customer_id(self):
+        self.client.force_authenticate(user=self.sales)
+        envelope = SpotPricingEnvelopeDB.objects.create(
+            created_by=self.sales,
+            owner=self.sales,
+            shipment_context_json={"origin": "POM", "destination": "LAE"},
+            conditions_json={},
+            spot_trigger_reason_code="TEST",
+            spot_trigger_reason_text="Test trigger",
+            expires_at=timezone.now(),
+        )
+
+        response = self.client.post(
+            f"/api/v3/spot/envelopes/{envelope.id}/create-quote/",
+            {"customer_id": str(self.company_b.id)},
+            format="json",
+        )
+
+        self.assertIn(response.status_code, {status.HTTP_400_BAD_REQUEST, status.HTTP_404_NOT_FOUND})
+        if response.status_code == status.HTTP_404_NOT_FOUND:
+            self.assertEqual(response.data["error"], "Selected customer is not available for this user.")
+
+
 class OrganizationBrandingSettingsAPITests(APITestCase):
     def setUp(self):
         self.admin = CustomUser.objects.create_user(
@@ -2942,6 +3199,21 @@ class CustomerDetailAPITests(APITestCase):
         # Create organizations
         self.org_a = Organization.objects.create(name="Org A", slug="org-a", is_active=True)
         self.org_b = Organization.objects.create(name="Org B", slug="org-b", is_active=True)
+        self.branch_a = Branch.objects.create(organization=self.org_a, code="OA", name="Org A Branch")
+        self.branch_b = Branch.objects.create(organization=self.org_b, code="OB", name="Org B Branch")
+        self.department_a = Department.objects.create(
+            organization=self.org_a,
+            branch=self.branch_a,
+            code="AIR",
+            name="Air Freight",
+        )
+        self.department_b = Department.objects.create(
+            organization=self.org_b,
+            branch=self.branch_b,
+            code="AIR",
+            name="Air Freight",
+        )
+        self.sales_role = Role.objects.create(code="customer-detail-sales", name="Sales", is_system=True)
 
         # Create users
         self.admin = CustomUser.objects.create_user(
@@ -2953,10 +3225,30 @@ class CustomerDetailAPITests(APITestCase):
         self.user_org_b = CustomUser.objects.create_user(
             username="user-org-b", password="password123", role=CustomUser.ROLE_SALES, organization=self.org_b
         )
+        UserMembership.objects.create(
+            user=self.user_org_a,
+            organization=self.org_a,
+            branch=self.branch_a,
+            department=self.department_a,
+            role=self.sales_role,
+        )
+        UserMembership.objects.create(
+            user=self.user_org_b,
+            organization=self.org_b,
+            branch=self.branch_b,
+            department=self.department_b,
+            role=self.sales_role,
+        )
 
         # Create customers
         self.customer_org_a = Company.objects.create(
-            name="Customer Org A", is_customer=True, company_type="CUSTOMER", account_owner=self.user_org_a
+            name="Customer Org A",
+            is_customer=True,
+            company_type="CUSTOMER",
+            account_owner=self.user_org_a,
+            organization=self.org_a,
+            branch=self.branch_a,
+            department=self.department_a,
         )
         self.customer_unowned = Company.objects.create(
             name="Customer Unowned", is_customer=True, company_type="CUSTOMER", account_owner=None
@@ -2987,14 +3279,12 @@ class CustomerDetailAPITests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_unowned_customer_is_blocked_for_non_admin_unless_linked(self):
-        # 1. Unowned customer is blocked when not linked to any quotes in the organization
+    def test_unscoped_customer_is_blocked_for_non_admin_even_when_linked(self):
         self.client.force_authenticate(user=self.user_org_a)
         url = reverse("quotes:customer-detail", kwargs={"customer_id": self.customer_unowned.id})
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-        # 2. Link unowned customer to a quote in Org A
         from quotes.models import Quote
         Quote.objects.create(
             customer=self.customer_unowned,
@@ -3004,12 +3294,9 @@ class CustomerDetailAPITests(APITestCase):
             created_by=self.user_org_a
         )
 
-        # 3. Should now be retrievable for user in Org A
         response_after_linked = self.client.get(url)
-        self.assertEqual(response_after_linked.status_code, status.HTTP_200_OK)
-        self.assertEqual(response_after_linked.data["company_name"], "Customer Unowned")
+        self.assertEqual(response_after_linked.status_code, status.HTTP_404_NOT_FOUND)
 
-        # 4. But still blocked for user in Org B
         self.client.force_authenticate(user=self.user_org_b)
         response_org_b = self.client.get(url)
         self.assertEqual(response_org_b.status_code, status.HTTP_404_NOT_FOUND)

--- a/backend/parties/views.py
+++ b/backend/parties/views.py
@@ -12,7 +12,7 @@ from rest_framework.permissions import AllowAny, BasePermission
 from rest_framework.views import APIView
 from rest_framework.response import Response
 
-from accounts.scope import populate_missing_scope_values
+from accounts.scope import populate_missing_scope_values, scoped_queryset_for_user
 from .models import Address, Company, Contact, Organization, OrganizationBranding
 from .serializers import (
     CompanySearchV3Serializer,
@@ -84,8 +84,10 @@ class CustomerV3ViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         customer_filter = Q(is_customer=True) | Q(company_type="CUSTOMER")
+        queryset = Company.objects.filter(customer_filter, is_active=True)
+        queryset = scoped_queryset_for_user(queryset, self.request.user)
         return (
-            Company.objects.filter(customer_filter, is_active=True)
+            queryset
             .order_by("name")
             .prefetch_related(
                 Prefetch(
@@ -123,11 +125,10 @@ class CompanyV3SearchView(generics.ListAPIView):
         query = self.request.query_params.get("q", "").strip()
         if len(query) < 2:
             return Company.objects.none()
-        return (
-            Company.objects.filter(name__icontains=query, is_active=True)
-            .filter(Q(is_customer=True) | Q(company_type="CUSTOMER"))
-            .order_by("name")[:20]
-        )
+        queryset = Company.objects.filter(name__icontains=query, is_active=True)
+        queryset = queryset.filter(Q(is_customer=True) | Q(company_type="CUSTOMER"))
+        queryset = scoped_queryset_for_user(queryset, self.request.user)
+        return queryset.order_by("name")[:20]
 
 
 class CompanyContactListV3View(generics.ListAPIView):
@@ -140,7 +141,8 @@ class CompanyContactListV3View(generics.ListAPIView):
 
     def get_queryset(self):
         company_id = self.kwargs.get("company_id")
-        company = get_object_or_404(Company, pk=company_id)
+        company_queryset = scoped_queryset_for_user(Company.objects.all(), self.request.user)
+        company = get_object_or_404(company_queryset, pk=company_id)
         return company.contacts.filter(is_active=True).order_by("last_name", "first_name")
 
 

--- a/backend/quotes/spot_views.py
+++ b/backend/quotes/spot_views.py
@@ -69,6 +69,7 @@ from quotes.intake_safety import (
     sync_source_analysis_summary_counts,
 )
 from quotes.serializers import SpotPricingEnvelopeSerializer, SPEChargeLineSerializer, SpotTemplateValidationReviewSerializer
+from accounts.scope import scoped_queryset_for_user
 from quotes.quote_result_contract import (
     build_persisted_line_item_metadata,
     build_persisted_quote_total_metadata,
@@ -2600,6 +2601,24 @@ class SpotEnvelopeCreateQuoteAPIView(APIView):
             envelope_id,
             _spe_queryset(),
         )
+        quote_data = request.data.get('quote_request', {})
+        req_cust = (
+            request.data.get('customer_id')
+            or quote_data.get('customer_id')
+        )
+        if req_cust:
+            try:
+                requested_customer_id = UUID(str(req_cust))
+            except (TypeError, ValueError):
+                return Response(
+                    {'error': f'Invalid customer_id: {req_cust}'},
+                    status=status.HTTP_400_BAD_REQUEST
+                )
+            if not scoped_queryset_for_user(Company.objects.all(), request.user).filter(id=requested_customer_id).exists():
+                return Response(
+                    {'error': 'Selected customer is not available for this user.'},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
         
         # --- 1. Re-run Computation (Same as ComputeView) ---
         # Note: Ideally this setup logic should be shared, but duplicating for safety now.
@@ -2621,7 +2640,6 @@ class SpotEnvelopeCreateQuoteAPIView(APIView):
         if not is_valid:
             return Response({'error': error}, status=status.HTTP_400_BAD_REQUEST)
             
-        quote_data = request.data.get('quote_request', {})
         ctx = _normalize_shipment_context(spe_db.shipment_context_json)
         
         try:
@@ -2704,9 +2722,10 @@ class SpotEnvelopeCreateQuoteAPIView(APIView):
         if not cust_id:
             customer_name = str(ctx.get('customer_name') or '').strip()
             if customer_name:
-                cust = Company.objects.filter(name__iexact=customer_name).first()
+                scoped_companies = scoped_queryset_for_user(Company.objects.all(), request.user)
+                cust = scoped_companies.filter(name__iexact=customer_name).first()
                 if not cust:
-                    cust = Company.objects.filter(name__icontains=customer_name).first()
+                    cust = scoped_companies.filter(name__icontains=customer_name).first()
                 if cust:
                     cust_id = cust.id
         
@@ -2714,6 +2733,13 @@ class SpotEnvelopeCreateQuoteAPIView(APIView):
             return Response(
                 {'error': 'Customer is required to create quote. Provide customer_id or link SPE to an existing quote.'},
                 status=status.HTTP_400_BAD_REQUEST
+            )
+
+        scoped_customers = scoped_queryset_for_user(Company.objects.all(), request.user)
+        if not scoped_customers.filter(id=cust_id).exists():
+            return Response(
+                {'error': 'Selected customer is not available for this user.'},
+                status=status.HTTP_404_NOT_FOUND,
             )
 
         if cont_id and not Contact.objects.filter(id=cont_id, company_id=cust_id).exists():
@@ -2781,7 +2807,7 @@ class SpotEnvelopeCreateQuoteAPIView(APIView):
                 status=status.HTTP_400_BAD_REQUEST
             )
 
-        customer = get_object_or_404(Company, id=cust_id)
+        customer = get_object_or_404(scoped_customers, id=cust_id)
         raw_opportunity_id = (
             request.data.get('opportunity_id')
             or quote_data.get('opportunity_id')

--- a/backend/quotes/spot_views.py
+++ b/backend/quotes/spot_views.py
@@ -2619,6 +2619,27 @@ class SpotEnvelopeCreateQuoteAPIView(APIView):
                     {'error': 'Selected customer is not available for this user.'},
                     status=status.HTTP_404_NOT_FOUND,
                 )
+            req_contact = (
+                request.data.get('contact_id')
+                or quote_data.get('contact_id')
+            )
+            if req_contact:
+                try:
+                    requested_contact_id = UUID(str(req_contact))
+                except (TypeError, ValueError):
+                    return Response(
+                        {'error': f'Invalid contact_id: {req_contact}'},
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
+                if not Contact.objects.filter(
+                    id=requested_contact_id,
+                    company_id=requested_customer_id,
+                    is_active=True,
+                ).exists():
+                    return Response(
+                        {'error': 'Selected contact is not available for this customer/user.'},
+                        status=status.HTTP_404_NOT_FOUND,
+                    )
         
         # --- 1. Re-run Computation (Same as ComputeView) ---
         # Note: Ideally this setup logic should be shared, but duplicating for safety now.
@@ -2742,7 +2763,7 @@ class SpotEnvelopeCreateQuoteAPIView(APIView):
                 status=status.HTTP_404_NOT_FOUND,
             )
 
-        if cont_id and not Contact.objects.filter(id=cont_id, company_id=cust_id).exists():
+        if cont_id and not Contact.objects.filter(id=cont_id, company_id=cust_id, is_active=True).exists():
             cont_id = None
 
         if requested_contact_id:
@@ -2754,10 +2775,10 @@ class SpotEnvelopeCreateQuoteAPIView(APIView):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
-            if not Contact.objects.filter(id=candidate_contact_id, company_id=cust_id).exists():
+            if not Contact.objects.filter(id=candidate_contact_id, company_id=cust_id, is_active=True).exists():
                 return Response(
-                    {'error': 'Selected contact does not belong to the selected customer.'},
-                    status=status.HTTP_400_BAD_REQUEST,
+                    {'error': 'Selected contact is not available for this customer/user.'},
+                    status=status.HTTP_404_NOT_FOUND,
                 )
 
             cont_id = candidate_contact_id

--- a/backend/quotes/tests/test_spot_compute_completeness.py
+++ b/backend/quotes/tests/test_spot_compute_completeness.py
@@ -392,8 +392,8 @@ def test_spot_create_quote_rejects_contact_from_another_customer(monkeypatch):
         format="json",
     )
 
-    assert response.status_code == 400
-    assert response.json()["error"] == "Selected contact does not belong to the selected customer."
+    assert response.status_code == 404
+    assert response.json()["error"] == "Selected contact is not available for this customer/user."
 
 
 def test_spot_create_quote_auto_creates_and_links_opportunity(monkeypatch):

--- a/backend/quotes/views/calculation.py
+++ b/backend/quotes/views/calculation.py
@@ -13,6 +13,7 @@ from quotes.models import Quote, QuoteVersion, QuoteLine, QuoteTotal
 from quotes.serializers import QuoteComputeRequestSerializer, QuoteModelSerializerV3
 from quotes.schemas import QuoteComputeRequest
 from accounts.permissions import QuoteAccessPermission
+from accounts.scope import scoped_queryset_for_user
 from quotes.selectors import get_quote_for_user
 from quotes.state_machine import (
     QuoteImmutableError,
@@ -148,6 +149,10 @@ class QuoteComputeV3APIView(generics.CreateAPIView):
             )
         except ValueError as exc:
             return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+
+        customer_queryset = scoped_queryset_for_user(Company.objects.all(), request.user)
+        customer = get_object_or_404(customer_queryset, id=payload.customer_id)
+        get_object_or_404(Contact.objects.filter(company=customer), id=payload.contact_id)
 
         derived_output_currency = self._derive_output_currency(
             shipment_type,
@@ -477,8 +482,11 @@ class QuoteComputeV3APIView(generics.CreateAPIView):
         Helper to save the quote, version, lines, and totals to the database.
         When an existing quote is provided, we append a new version instead of creating a duplicate quote.
         """
-        customer = get_object_or_404(Company, id=validated_data.customer_id)
-        contact = get_object_or_404(Contact, id=validated_data.contact_id)
+        customer = get_object_or_404(
+            scoped_queryset_for_user(Company.objects.all(), request.user),
+            id=validated_data.customer_id,
+        )
+        contact = get_object_or_404(Contact.objects.filter(company=customer), id=validated_data.contact_id)
 
         request_payload = validated_data.model_dump(mode='json')
         if resolved_dimensions is not None:

--- a/backend/quotes/views/services.py
+++ b/backend/quotes/views/services.py
@@ -15,6 +15,7 @@ from rest_framework.parsers import MultiPartParser, FormParser
 from rest_framework.permissions import IsAuthenticated
 
 from parties.models import Address, Company, Contact, CustomerCommercialProfile
+from accounts.scope import scoped_queryset_for_user
 from core.models import Airport, City, Country, Currency
 from core.security import validate_csv_upload
 from ratecards.models import PartnerRateCard
@@ -134,20 +135,9 @@ class CustomerDetailAPIView(APIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     def _get_company(self, company_id):
-        user = self.request.user
         base_filter = Q(is_customer=True) | Q(company_type='CUSTOMER')
-
-        if user.is_superuser or user.role == 'admin':
-            queryset = Company.objects.filter(base_filter)
-        else:
-            user_org = getattr(user, 'organization', None)
-            if not user_org:
-                from django.http import Http404
-                raise Http404("No Customer matches the given query.")
-
-            tenant_filter = Q(account_owner__organization=user_org) | Q(quotes_as_customer__organization=user_org)
-            queryset = Company.objects.filter(base_filter).filter(tenant_filter).distinct()
-
+        queryset = Company.objects.filter(base_filter)
+        queryset = scoped_queryset_for_user(queryset, self.request.user)
         queryset = queryset.select_related(
             'commercial_profile__preferred_quote_currency'
         ).prefetch_related('contacts', 'addresses__city__country')

--- a/backend/rate_engine/test_settings.py
+++ b/backend/rate_engine/test_settings.py
@@ -1,3 +1,4 @@
 from .settings import *
 
 SECURE_SSL_REDIRECT = False
+RBAC_ALLOW_LEGACY_SCOPE_FALLBACK_FOR_TESTS = True

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -2679,6 +2679,71 @@ Next phase:
 - Design enforcement rules and tests from this report before changing any
   selector, API, queryset, serializer, or UI permission behavior.
 
+#### Phase 9D - Backend/API/Selector RBAC Enforcement
+
+Date: 2026-06-23
+
+Branch: `codex/phase-9d-backend-rbac-enforcement`
+
+Scope: enforce backend scoped access for CRM/customer-related APIs and
+selectors using canonical active `UserMembership` organization, branch, and
+department scope.
+
+Enforced surfaces:
+
+- `CustomerV3ViewSet` list/detail APIs under `/api/v3/customers/`.
+- Company selector/search APIs under `/api/v3/parties/search/` and the
+  companies alias.
+- Company contact selector API under
+  `/api/v3/parties/companies/<company_id>/contacts/`.
+- CRM opportunity, interaction, and task list/detail APIs under
+  `/api/v3/crm/`.
+- Quote customer detail lookup under `/api/v3/customer-details/<customer_id>/`.
+- Quote compute direct customer/contact IDs under `/api/v3/quotes/compute/`.
+- SPOT envelope create-quote direct customer/contact IDs under
+  `/api/v3/spot/envelopes/<envelope_id>/create-quote/`.
+
+Rules:
+
+- Admin role users and superusers have explicit cross-scope access.
+- Non-admin users require exactly one active complete canonical membership.
+- Scoped non-admin access requires matching organization, branch, and
+  department.
+- Users without a complete canonical membership receive no scoped customer/CRM
+  records.
+- Manual-review unscoped records are not exposed to normal scoped users.
+- Detail APIs use the same scoped querysets as list APIs, preventing direct-ID
+  access to out-of-scope records.
+- Quote and SPOT direct customer/contact IDs are rejected when the company is
+  outside the authenticated user's scope.
+
+Admin override behavior:
+
+- Admin and superuser override is centralized in the accounts scope helper and
+  covered by tests.
+- The override is backend-only in this phase; no selector/UI permission changes
+  are made outside backend queryset and direct-ID validation.
+
+Test matrix:
+
+- Admin can list cross-scope and unscoped customer records.
+- Scoped manager/sales users can retrieve in-scope customers.
+- Scoped users cannot list or retrieve out-of-scope or manual-review unscoped
+  customers.
+- Company selector results exclude out-of-scope companies.
+- Contact-by-company rejects out-of-scope parent companies.
+- Opportunity, interaction, and task APIs filter lists and deny direct-ID detail
+  access for out-of-scope rows.
+- Quote compute rejects out-of-scope customer/contact IDs before pricing.
+- SPOT create-quote rejects out-of-scope customer IDs before pricing.
+
+Safety:
+
+- This phase does not backfill records, change historical scope data, touch
+  manual-review records, alter pricing behavior, enforce frontend/UI
+  permissions, or change ProductCode/SPOT validation rules beyond customer and
+  contact access checks.
+
 ## 12. What Not To Touch Yet
 
 Do not touch these in the first implementation slice:


### PR DESCRIPTION
## Summary
- Add canonical UserMembership scope helpers for backend enforcement with explicit admin/superuser override.
- Enforce scoped querysets for customer list/detail, company selectors, contact-by-company, and CRM opportunity/interaction/task APIs.
- Guard quote compute and SPOT create-quote direct customer/contact IDs against out-of-scope access.
- Document Phase 9D rules, enforced surfaces, safety notes, and test matrix.

## Verification
- `npx fallow --format json` (baseline: existing frontend findings)
- `npx fallow dead-code --format json` (baseline: existing frontend findings, exit 1)
- `npx fallow dupes --format json` (baseline: existing duplicates)
- `npx fallow health --format json` (baseline: existing frontend complexity findings, exit 1)
- `python backend\manage.py makemigrations --check --dry-run`
- `python backend\manage.py check`
- `pytest backend/parties/tests.py -q` (156 passed)
- `git diff --check`
- `graphify update .` (graph updated; HTML skipped because graph exceeds viz node limit)

## Intentionally not changed
- No historical backfill or manual-review data changes.
- No selector/API/UI permission toggles outside backend querysets and direct-ID validation.
- No pricing behavior, ProductCode validation, or SPOT validation changes beyond customer/contact access checks.