### PR TITLE
feat(rbac): complete UI visibility and permission sign-off

### DIFF
--- a/backend/parties/management/commands/rbac_enforcement_readiness_report.py
+++ b/backend/parties/management/commands/rbac_enforcement_readiness_report.py
@@ -13,67 +13,67 @@ SURFACES = [
     {
         "name": "CRM opportunity list/detail",
         "code_path": "backend/crm/views.py:OpportunityViewSet.get_queryset",
-        "current_state": "global_unfiltered",
+        "current_state": "scoped_queryset_enforced",
         "required_rule": "filter Opportunity by organization, branch, and department for scoped roles",
     },
     {
         "name": "CRM interaction list/detail",
         "code_path": "backend/crm/views.py:InteractionViewSet.get_queryset",
-        "current_state": "global_unfiltered",
+        "current_state": "scoped_queryset_enforced",
         "required_rule": "filter Interaction by direct scope or scoped company/opportunity parent",
     },
     {
         "name": "CRM task list/detail",
         "code_path": "backend/crm/views.py:TaskViewSet.get_queryset",
-        "current_state": "global_unfiltered",
+        "current_state": "scoped_queryset_enforced",
         "required_rule": "filter Task by direct scope or scoped company/opportunity parent",
     },
     {
         "name": "Company/customer list",
         "code_path": "backend/parties/views.py:CustomerV3ViewSet.get_queryset",
-        "current_state": "global_unfiltered",
+        "current_state": "scoped_queryset_enforced",
         "required_rule": "filter Company by organization, branch, and department for scoped roles",
     },
     {
         "name": "Company selector search",
         "code_path": "backend/parties/views.py:CompanyV3SearchView.get_queryset",
-        "current_state": "global_unfiltered",
+        "current_state": "scoped_queryset_enforced",
         "required_rule": "filter selector results to scoped Company records",
     },
     {
         "name": "Contact selector by company",
         "code_path": "backend/parties/views.py:CompanyContactListV3View.get_queryset",
-        "current_state": "parent_direct_lookup_unfiltered",
+        "current_state": "parent_scope_authorized",
         "required_rule": "authorize parent Company scope before returning Contact rows",
     },
     {
         "name": "Opportunity selectors",
         "code_path": "backend/crm/views.py:OpportunityViewSet.get_queryset",
-        "current_state": "global_unfiltered",
+        "current_state": "scoped_queryset_enforced",
         "required_rule": "filter opportunity selector options to scoped Opportunity records",
     },
     {
         "name": "Interaction/Task selectors",
         "code_path": "backend/crm/views.py:InteractionViewSet.get_queryset; backend/crm/views.py:TaskViewSet.get_queryset",
-        "current_state": "global_unfiltered",
+        "current_state": "scoped_queryset_enforced",
         "required_rule": "filter interaction and task selector options by scoped parent records",
     },
     {
         "name": "Quote customer detail lookup",
         "code_path": "backend/quotes/views/services.py:CustomerDetailAPIView._get_company",
-        "current_state": "partially_scope_filtered",
+        "current_state": "scoped_lookup_enforced",
         "required_rule": "replace legacy owner/quote organization filter with canonical scope checks",
     },
     {
         "name": "Quote compute customer/contact lookup",
         "code_path": "backend/quotes/views/calculation.py:QuoteCalculationAPIView",
-        "current_state": "direct_id_lookup_unfiltered",
+        "current_state": "direct_id_scope_enforced",
         "required_rule": "validate customer and contact scope before quote calculation",
     },
     {
         "name": "SPOT customer lookup",
         "code_path": "backend/quotes/spot_views.py",
-        "current_state": "direct_id_lookup_unfiltered",
+        "current_state": "direct_id_scope_enforced",
         "required_rule": "validate customer/contact scope before SPE quote creation",
     },
 ]
@@ -170,8 +170,11 @@ def write_text(stdout, report):
     )
     stdout.write("")
     stdout.write("Surfaces currently global/unfiltered:")
-    for surface in report["global_or_unfiltered_surfaces"]:
-        stdout.write(f"- {surface['name']}: {surface['current_state']} ({surface['code_path']})")
+    if report["global_or_unfiltered_surfaces"]:
+        for surface in report["global_or_unfiltered_surfaces"]:
+            stdout.write(f"- {surface['name']}: {surface['current_state']} ({surface['code_path']})")
+    else:
+        stdout.write("- none")
     stdout.write("")
     stdout.write("Required enforcement rules:")
     for rule in report["proposed_enforcement_rules"]:

--- a/backend/parties/tests.py
+++ b/backend/parties/tests.py
@@ -1049,7 +1049,7 @@ class EnforcementReadinessReportTests(TestCase):
 
         self.assertEqual(payload["readiness_status"], "READY_FOR_ENFORCEMENT_DESIGN")
         self.assertTrue(payload["enforcement_surfaces"])
-        self.assertTrue(payload["global_or_unfiltered_surfaces"])
+        self.assertEqual(payload["global_or_unfiltered_surfaces"], [])
         self.assertIn("proposed_enforcement_rules", payload)
         self.assertIn("admin_override_considerations", payload)
 

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -2744,6 +2744,63 @@ Safety:
   permissions, or change ProductCode/SPOT validation rules beyond customer and
   contact access checks.
 
+#### Phase 9E - Frontend/UI RBAC Visibility and Final Sign-Off
+
+Date: 2026-06-23
+
+Branch: `codex/phase-9e-ui-rbac-signoff`
+
+Scope: align frontend visibility and user-facing error handling with the
+backend scoped-access rules completed in Phase 9D. Security remains enforced
+server-side; frontend changes only prevent misleading controls and surface
+clear scoped-access messages.
+
+UI surfaces checked:
+
+- Customer list and direct customer creation route.
+- Customer detail/edit route, including CRM activity, tasks, pricing overrides,
+  archive/delete, and save controls.
+- Company/customer selectors used by quotes and CRM flows.
+- Company contact selector used by quote and SPOT flows.
+- Quote customer/contact direct-ID validation error display.
+- SPOT create-quote customer/contact direct-ID validation error display.
+
+Frontend behavior:
+
+- Non-admin users do not see direct customer creation controls and direct
+  navigation to the new-customer route shows a restricted-access message.
+- Customer profile and commercial-term editing controls are admin-only.
+- Scoped non-admin users can still view in-scope customer summary, CRM activity,
+  tasks, and read-only pricing override information.
+- Selector empty states continue to render as empty scoped results instead of
+  exposing hidden records.
+- Backend `detail`, `error`, and `message` payloads are preserved for 403/404
+  and validation failures so quote/SPOT/customer screens show readable access
+  messages.
+
+Final permission matrix:
+
+| Role / user state | Customer/company/contact access | CRM opportunity/interaction/task access | Quote/SPOT customer/contact direct IDs | Admin customer master-data UI | Manual-review unscoped records |
+| --- | --- | --- | --- | --- | --- |
+| Admin / superuser | Cross-scope access allowed by explicit backend override | Cross-scope access allowed by explicit backend override | Accepted when the referenced records exist and are valid | Visible and enabled | Visible for review |
+| Manager | In-scope organization/branch/department only | In-scope organization/branch/department only | Out-of-scope or invalid IDs rejected by backend | Hidden/disabled | Hidden |
+| Sales | In-scope organization/branch/department only | In-scope organization/branch/department only | Out-of-scope or invalid IDs rejected by backend | Hidden/disabled | Hidden |
+| Finance/system | No CRM/customer access unless an explicit complete membership and backend permission allow it | No CRM write/admin behavior added in this phase | Out-of-scope or invalid IDs rejected by backend | Hidden/disabled | Hidden |
+| Incomplete-membership user | No scoped customer/CRM records | No scoped customer/CRM records | Rejected by backend scoped-access checks | Hidden/disabled | Hidden |
+
+Final enforcement sign-off:
+
+- Company, contact, opportunity, interaction, and task list/detail APIs remain
+  protected by backend scoped querysets.
+- Quote calculation and SPOT create-quote continue to reject unavailable
+  customer/contact IDs before pricing or quote creation.
+- Manual-review unscoped records remain excluded from normal scoped users.
+- No selector, API, queryset, pricing, ProductCode, SPOT validation, or
+  historical backfill behavior is changed by Phase 9E.
+- No known backend enforcement surfaces identified by
+  `rbac_enforcement_readiness_report` remain intentionally unprotected after
+  Phase 9D and this UI sign-off.
+
 ## 12. What Not To Touch Yet
 
 Do not touch these in the first implementation slice:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "test:quote-edit-hydration": "node scripts/quote-edit-hydration.test.mjs",
     "test:quote-detail-helpers": "node scripts/quote-detail-helpers.test.mjs",
     "test:crm-quote-prefill": "node scripts/crm-quote-prefill.test.mjs",
+    "test:rbac-error-response": "node scripts/rbac-error-response.test.mjs",
     "test:domestic-service-scope": "node scripts/domestic-service-scope.test.mjs",
     "test:spot-finalization": "node scripts/spot-finalization.test.mjs",
     "test:spot-workspace-helpers": "node scripts/spot-workspace-helpers.test.mjs",

--- a/frontend/scripts/rbac-error-response.test.mjs
+++ b/frontend/scripts/rbac-error-response.test.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import ts from "typescript";
+
+const frontendRoot = path.resolve(process.cwd());
+const sharedSourcePath = path.join(frontendRoot, "src", "lib", "api", "shared.ts");
+
+function transpile(source, fileName) {
+  return ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName,
+  }).outputText;
+}
+
+async function loadSharedApi() {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "rbac-error-response-test-"));
+  const apiDir = path.join(tempDir, "lib", "api");
+  const libDir = path.join(tempDir, "lib");
+
+  try {
+    await mkdir(apiDir, { recursive: true });
+    await mkdir(libDir, { recursive: true });
+
+    const sharedSource = await readFile(sharedSourcePath, "utf8");
+    const sharedModule = transpile(sharedSource, sharedSourcePath).replace(
+      /from ['"]\.\.\/config['"]/g,
+      "from '../config.mjs'",
+    );
+
+    await writeFile(path.join(apiDir, "shared.mjs"), sharedModule, "utf8");
+    await writeFile(path.join(libDir, "config.mjs"), `export const API_BASE_URL = "http://testserver";`, "utf8");
+
+    return await import(`file://${path.join(apiDir, "shared.mjs")}`);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+const { parseErrorResponse } = await loadSharedApi();
+
+{
+  const response = new Response(JSON.stringify({ error: "Selected contact is not available for this customer/user." }), {
+    status: 400,
+    headers: { "content-type": "application/json" },
+  });
+  assert.equal(await parseErrorResponse(response), "Selected contact is not available for this customer/user.");
+}
+
+{
+  const response = new Response(JSON.stringify({ message: "Customer is outside your active scope." }), {
+    status: 403,
+    headers: { "content-type": "application/json" },
+  });
+  assert.equal(await parseErrorResponse(response), "Customer is outside your active scope.");
+}
+
+{
+  const response = new Response("not json", { status: 404, statusText: "Not Found" });
+  assert.equal(await parseErrorResponse(response), "This record is not available to your current scope.");
+}
+
+console.log("RBAC error response tests passed");

--- a/frontend/src/app/customers/[id]/edit/page.tsx
+++ b/frontend/src/app/customers/[id]/edit/page.tsx
@@ -174,7 +174,7 @@ export default function EditCustomerPage() {
           });
         } catch (fetchError) {
           console.error(fetchError);
-          setError("Failed to fetch customer data.");
+          setError(fetchError instanceof Error ? fetchError.message : "Failed to fetch customer data.");
         }
       };
       fetchCustomer();
@@ -564,7 +564,19 @@ export default function EditCustomerPage() {
     });
   };
 
-  if (!customer) return <div>Loading...</div>;
+  if (!customer) {
+    return (
+      <StandardPageContainer>
+        {error ? (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        ) : (
+          <div>Loading...</div>
+        )}
+      </StandardPageContainer>
+    );
+  }
 
   const isOverseas = customer.audience_type !== 'LOCAL_PNG_CUSTOMER';
   const cityOptions = cities.map((city) => ({
@@ -702,6 +714,7 @@ export default function EditCustomerPage() {
         </CardContent>
       </Card>
 
+      {canEditCustomerMaster ? (
       <form onSubmit={handleSubmit} className="space-y-6">
         <div className={isSaving || isDeleting || isArchiving ? "space-y-6 pointer-events-none opacity-70" : "space-y-6"}>
         <Card className="border-slate-200 shadow-sm">
@@ -986,6 +999,13 @@ export default function EditCustomerPage() {
           </Button>
         </PageActionBar>
       </form>
+      ) : (
+        <Alert>
+          <AlertDescription>
+            Customer profile and commercial terms are admin-only. You can still view in-scope customer details, CRM activity, tasks, and pricing overrides.
+          </AlertDescription>
+        </Alert>
+      )}
 
       <Card className="border-slate-200 bg-slate-50/60 shadow-sm">
         <CardHeader className="flex flex-col gap-4 border-b border-slate-200 bg-slate-50/80 md:flex-row md:items-start md:justify-between">

--- a/frontend/src/app/customers/new/page.tsx
+++ b/frontend/src/app/customers/new/page.tsx
@@ -112,6 +112,7 @@ export default function NewCustomerPage() {
   useUnsavedChangesGuard(isDirty);
   const returnTo = useReturnTo();
   const pageCopy = getNewCustomerCopy(user?.role as "admin" | "manager" | "sales" | "finance" | undefined);
+  const canCreateCustomer = user?.role === "admin";
   const confirmLeave = async () => {
     if (!isDirty) {
       return true;
@@ -274,6 +275,24 @@ export default function NewCustomerPage() {
     && formData.contact_person_email.trim()
     && formData.contact_person_phone.trim(),
   );
+
+  if (user && !canCreateCustomer) {
+    return (
+      <div className="space-y-6">
+        <PageBackButton fallbackHref="/customers" returnTo={returnTo} />
+        <Alert>
+          <AlertDescription>
+            Customer creation is restricted to administrators. Use in-scope customer search and CRM activity instead.
+          </AlertDescription>
+        </Alert>
+        <PageActionBar>
+          <Button type="button" variant="outline" onClick={() => router.push(returnTo || "/customers")}>
+            Back to Customers
+          </Button>
+        </PageActionBar>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">

--- a/frontend/src/lib/api/parties.ts
+++ b/frontend/src/lib/api/parties.ts
@@ -11,16 +11,16 @@ export async function searchCompanies(query: string): Promise<CompanySearchResul
     return await getJson<CompanySearchResult[]>(
       API_BASE_URL + `/api/v3/parties/companies/search/?q=${encodeURIComponent(query)}`,
     );
-  } catch {
-    throw new Error("Failed to search companies");
+  } catch (error) {
+    throw new Error(error instanceof Error ? `Failed to search companies: ${error.message}` : "Failed to search companies");
   }
 }
 
 export async function getCompany(companyId: string): Promise<CompanySearchResult> {
   try {
     return await getJson<CompanySearchResult>(API_BASE_URL + `/api/v3/customers/${companyId}/`);
-  } catch {
-    throw new Error("Failed to fetch company");
+  } catch (error) {
+    throw new Error(error instanceof Error ? `Failed to fetch company: ${error.message}` : "Failed to fetch company");
   }
 }
 
@@ -30,24 +30,24 @@ export async function listCustomers(): Promise<CompanySearchResult[]> {
       API_BASE_URL + "/api/v3/customers/",
     );
     return Array.isArray(payload) ? payload : payload.results || [];
-  } catch {
-    throw new Error("Failed to fetch customers");
+  } catch (error) {
+    throw new Error(error instanceof Error ? `Failed to fetch customers: ${error.message}` : "Failed to fetch customers");
   }
 }
 
 export async function getContactsForCompany(companyId: string): Promise<Contact[]> {
   try {
     return await getJson<Contact[]>(API_BASE_URL + `/api/v3/parties/companies/${companyId}/contacts/`);
-  } catch {
-    throw new Error("Failed to fetch contacts");
+  } catch (error) {
+    throw new Error(error instanceof Error ? `Failed to fetch contacts: ${error.message}` : "Failed to fetch contacts");
   }
 }
 
 export async function getCustomerDetail(customerId: string): Promise<Customer> {
   try {
     return await getJson<Customer>(API_BASE_URL + `/api/v3/customer-details/${customerId}/`);
-  } catch {
-    throw new Error("Failed to fetch customer details");
+  } catch (error) {
+    throw new Error(error instanceof Error ? `Failed to fetch customer details: ${error.message}` : "Failed to fetch customer details");
   }
 }
 

--- a/frontend/src/lib/api/shared.ts
+++ b/frontend/src/lib/api/shared.ts
@@ -25,13 +25,25 @@ export const parseErrorResponse = async (response: Response): Promise<string> =>
       return data;
     }
     if (data && typeof data === "object") {
-      if ("detail" in data && typeof data.detail === "string") {
-        return data.detail;
+      for (const key of ["detail", "error", "message"] as const) {
+        const value = (data as Record<string, unknown>)[key];
+        if (typeof value === "string") {
+          return value;
+        }
+        if (Array.isArray(value) && typeof value[0] === "string") {
+          return value[0];
+        }
       }
       return JSON.stringify(data);
     }
   } catch {
     // ignore parse errors
+  }
+  if (response.status === 403) {
+    return "You do not have permission to access this record.";
+  }
+  if (response.status === 404) {
+    return "This record is not available to your current scope.";
   }
   return response.statusText || "Unknown error";
 };


### PR DESCRIPTION
## Summary
- Align frontend customer UI visibility with Phase 9D backend RBAC enforcement: non-admin users cannot use the direct customer-create route, and customer master-data edit controls are admin-only.
- Preserve backend scoped-access error messages in shared API helpers so customer, quote, selector, and SPOT flows display readable 403/404/validation errors.
- Update the read-only enforcement readiness report to reflect Phase 9D protected surfaces and add the final Phase 9E permission/sign-off matrix to the RBAC audit plan.

## Verification
- `npx fallow --format json` baseline: completed with existing frontend findings.
- `npx fallow dead-code --format json` baseline: completed with existing frontend findings.
- `npx fallow dupes --format json` baseline: completed.
- `npx fallow health --format json` baseline: completed with existing health findings.
- `python backend\manage.py makemigrations --check --dry-run` -> no changes detected.
- `python backend\manage.py check` -> no issues.
- `python backend\manage.py rbac_enforcement_readiness_report` -> `READY_FOR_ENFORCEMENT_DESIGN`, `apply_eligible=0`, `manual_review=533`, global/unfiltered surfaces: none.
- `python backend\manage.py rbac_enforcement_readiness_report --format json` -> `global_or_unfiltered_surfaces: []`.
- `pytest backend/parties/tests.py -q` -> 159 passed.
- `npm --prefix frontend run test:rbac-error-response` -> passed.
- `npm --prefix frontend run typecheck` -> passed.
- `npm --prefix frontend run build` -> passed with existing unrelated lint warnings.
- `git diff --check` -> passed.
- `graphify update .` -> graph updated; HTML viz skipped because graph exceeds configured node limit.

## Intentional non-changes
- No backend scope rules changed.
- No backfill or historical scope data changes.
- No pricing, ProductCode, quote calculation, or SPOT validation logic changes.
- No broad UI redesign.