### PR TITLE
feat(spot): apply human-approved ProductCode decisions

### DIFF
--- a/backend/quotes/management/commands/spot_productcode_decision_apply.py
+++ b/backend/quotes/management/commands/spot_productcode_decision_apply.py
@@ -1,0 +1,409 @@
+import csv
+import json
+import os
+from decimal import Decimal
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.utils import timezone
+from django.contrib.auth import get_user_model
+
+from pricing_v4.models import ChargeAlias, ProductCode
+from quotes.spot_models import SPEChargeLineDB
+from quotes.management.commands.spot_productcode_masterdata_audit import normalize_label
+from quotes.management.commands.spot_productcode_close_loop_report import build_report as build_close_loop_report
+
+CREATE_ALIAS_MAPPING = "CREATE_ALIAS_MAPPING"
+CREATE_NEW_PRODUCT_CODE = "CREATE_NEW_PRODUCT_CODE"
+APPLY_EXISTING_PRODUCT_CODE = "APPLY_EXISTING_PRODUCT_CODE"
+LEAVE_FOR_MANUAL_REVIEW = "LEAVE_FOR_MANUAL_REVIEW"
+
+VALID_ACTIONS = {
+    CREATE_ALIAS_MAPPING,
+    CREATE_NEW_PRODUCT_CODE,
+    APPLY_EXISTING_PRODUCT_CODE,
+    LEAVE_FOR_MANUAL_REVIEW,
+}
+
+
+def robust_normalize(value: str | None) -> str:
+    if not value:
+        return ""
+    # Standardize en-dash and em-dash to standard hyphen
+    val = str(value).replace("–", "-").replace("—", "-")
+    # Collapse whitespace and lowercase
+    return " ".join(val.split()).lower()
+
+
+class Command(BaseCommand):
+    help = "Applies human-approved SPOT ProductCode decision table mappings."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--csv",
+            required=True,
+            help="Path to the reviewed CSV decision table.",
+        )
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Actually apply changes to the database. Default is dry-run.",
+        )
+        parser.add_argument(
+            "--format",
+            choices=["json", "text"],
+            default="text",
+            help="Output format (json or text). Default is text.",
+        )
+
+    def handle(self, *args, **options):
+        csv_path = options["csv"]
+        dry_run = not options["apply"]
+        output_format = options["format"]
+
+        if not os.path.exists(csv_path):
+            raise CommandError(f"CSV file does not exist: {csv_path}")
+
+        # Get system user/reconciliation user
+        User = get_user_model()
+        system_user = (
+            User.objects.filter(username="system").first()
+            or User.objects.filter(is_superuser=True).first()
+            or User.objects.first()
+        )
+
+        try:
+            close_loop_report = build_close_loop_report()
+            readiness_before = close_loop_report["readiness_status"]
+            unresolved_count_before = close_loop_report["blocking_counts"]["unresolved_product_code_review_lines"]
+        except Exception:
+            readiness_before = "UNKNOWN"
+            unresolved_count_before = 999999
+
+        summary = {
+            "dry_run": dry_run,
+            "writes_performed": not dry_run,
+            "approved_rows_seen": 0,
+            "aliases_created": 0,
+            "aliases_existing": 0,
+            "product_codes_created": 0,
+            "charge_lines_resolved": 0,
+            "manual_review_deferred": 0,
+            "skipped_count": 0,
+            "error_count": 0,
+            "readiness_before": readiness_before,
+            "readiness_after": readiness_before,
+            "unique_charge_lines_selected": 0,
+            "duplicate_charge_line_matches": 0,
+            "charge_line_ids_selected": [],
+            "per_row_results": [],
+        }
+
+        # Load all unresolved charge lines matching masterdata audit criteria
+        unresolved_lines = list(
+            SPEChargeLineDB.objects.filter(
+                normalization_status__in=[
+                    SPEChargeLineDB.NormalizationStatus.UNMAPPED,
+                    SPEChargeLineDB.NormalizationStatus.AMBIGUOUS,
+                ]
+            ).exclude(
+                manual_resolution_status=SPEChargeLineDB.ManualResolutionStatus.RESOLVED,
+                manual_resolved_product_code__isnull=False,
+            )
+        )
+
+        charge_line_ids_selected = set()
+        duplicate_charge_line_matches = 0
+
+        try:
+            with transaction.atomic():
+                with open(csv_path, "r", encoding="utf-8-sig") as f:
+                    reader = csv.DictReader(f)
+                    for row_idx, row in enumerate(reader, start=2):
+                        normalized_label = row.get("normalized_label")
+                        approved_action = row.get("approved_action")
+                        approved_by_human = (row.get("approved_by_human") or "").strip().lower()
+                        confidence = (row.get("confidence") or "").strip().upper()
+
+                        if not normalized_label:
+                            summary["skipped_count"] += 1
+                            summary["per_row_results"].append({
+                                "row_index": row_idx,
+                                "status": "SKIPPED",
+                                "reason": "MISSING_NORMALIZED_LABEL",
+                            })
+                            continue
+
+                        # Filter for only approved high-confidence rows
+                        if approved_by_human != "true" or confidence != "HIGH":
+                            summary["skipped_count"] += 1
+                            summary["per_row_results"].append({
+                                "row_index": row_idx,
+                                "normalized_label": normalized_label,
+                                "status": "SKIPPED",
+                                "reason": "UNAPPROVED_OR_LOW_CONFIDENCE",
+                            })
+                            continue
+
+                        if approved_action not in VALID_ACTIONS:
+                            summary["skipped_count"] += 1
+                            summary["per_row_results"].append({
+                                "row_index": row_idx,
+                                "normalized_label": normalized_label,
+                                "status": "SKIPPED",
+                                "reason": f"INVALID_ACTION_{approved_action}",
+                            })
+                            continue
+
+                        summary["approved_rows_seen"] += 1
+
+                        # Find matching unresolved charge lines robustly by normalized_label ONLY
+                        csv_norm = robust_normalize(normalized_label)
+                        matching_lines = []
+                        for line in unresolved_lines:
+                            if robust_normalize(line.normalized_label) == csv_norm:
+                                matching_lines.append(line)
+
+                        if approved_action == LEAVE_FOR_MANUAL_REVIEW:
+                            summary["manual_review_deferred"] += len(matching_lines)
+                            summary["per_row_results"].append({
+                                "row_index": row_idx,
+                                "normalized_label": normalized_label,
+                                "action": approved_action,
+                                "status": "DEFERRED",
+                                "matching_lines_count": len(matching_lines),
+                                "notes": row.get("decision_notes"),
+                            })
+                            continue
+
+                        elif approved_action in (CREATE_ALIAS_MAPPING, APPLY_EXISTING_PRODUCT_CODE):
+                            pc_id = row.get("approved_product_code_id")
+                            if not pc_id:
+                                summary["error_count"] += 1
+                                summary["per_row_results"].append({
+                                    "row_index": row_idx,
+                                    "normalized_label": normalized_label,
+                                    "action": approved_action,
+                                    "status": "ERROR",
+                                    "reason": "MISSING_PRODUCT_CODE_ID",
+                                })
+                                continue
+
+                            product_code = ProductCode.objects.filter(id=pc_id).first()
+                            if not product_code:
+                                summary["error_count"] += 1
+                                summary["per_row_results"].append({
+                                    "row_index": row_idx,
+                                    "normalized_label": normalized_label,
+                                    "action": approved_action,
+                                    "status": "ERROR",
+                                    "reason": "PRODUCT_CODE_NOT_FOUND",
+                                })
+                                continue
+
+                            # Create ChargeAlias if CREATE_ALIAS_MAPPING
+                            if approved_action == CREATE_ALIAS_MAPPING:
+                                alias_norm = normalize_label(normalized_label)
+                                existing_alias = ChargeAlias.objects.filter(
+                                    normalized_alias_text=alias_norm,
+                                    product_code=product_code,
+                                ).first()
+
+                                if existing_alias:
+                                    summary["aliases_existing"] += 1
+                                else:
+                                    if not dry_run:
+                                        ChargeAlias.objects.create(
+                                            alias_text=normalized_label,
+                                            product_code=product_code,
+                                            is_active=True,
+                                            review_status=ChargeAlias.ReviewStatus.APPROVED,
+                                            alias_source=ChargeAlias.AliasSource.ADMIN,
+                                        )
+                                    summary["aliases_created"] += 1
+
+                            # Resolve charge lines
+                            resolved_ids = []
+                            for line in matching_lines:
+                                line_id_str = str(line.id)
+                                if line_id_str in charge_line_ids_selected:
+                                    duplicate_charge_line_matches += 1
+                                    continue
+
+                                charge_line_ids_selected.add(line_id_str)
+
+                                if not dry_run:
+                                    line.manual_resolution_status = SPEChargeLineDB.ManualResolutionStatus.RESOLVED
+                                    line.manual_resolved_product_code = product_code
+                                    line.manual_resolution_by = system_user
+                                    line.manual_resolution_at = timezone.now()
+                                    line.save()
+                                resolved_ids.append(line_id_str)
+
+                            summary["per_row_results"].append({
+                                "row_index": row_idx,
+                                "normalized_label": normalized_label,
+                                "action": approved_action,
+                                "status": "APPLIED" if not dry_run else "WOULD_APPLY",
+                                "product_code": product_code.code,
+                                "resolved_line_ids": resolved_ids,
+                            })
+
+                        elif approved_action == CREATE_NEW_PRODUCT_CODE:
+                            new_id = row.get("approved_create_product_code_id")
+                            new_code = row.get("approved_create_product_code_code")
+                            new_desc = row.get("approved_create_product_code_description")
+                            new_domain = row.get("approved_create_product_code_domain")
+                            new_category = row.get("approved_create_product_code_category")
+                            new_basis = row.get("approved_create_product_code_basis")
+
+                            if not (new_id and new_code and new_desc and new_domain and new_category and new_basis):
+                                summary["error_count"] += 1
+                                summary["per_row_results"].append({
+                                    "row_index": row_idx,
+                                    "normalized_label": normalized_label,
+                                    "action": approved_action,
+                                    "status": "ERROR",
+                                    "reason": "MISSING_NEW_PRODUCT_CODE_FIELDS",
+                                })
+                                continue
+
+                            # Check for duplicates
+                            if ProductCode.objects.filter(id=new_id).exists() or ProductCode.objects.filter(code=new_code).exists():
+                                summary["error_count"] += 1
+                                summary["per_row_results"].append({
+                                    "row_index": row_idx,
+                                    "normalized_label": normalized_label,
+                                    "action": approved_action,
+                                    "status": "ERROR",
+                                    "reason": "DUPLICATE_PRODUCT_CODE_ID_OR_CODE",
+                                })
+                                continue
+
+                            # Create ProductCode
+                            if not dry_run:
+                                product_code = ProductCode.objects.create(
+                                    id=new_id,
+                                    code=new_code,
+                                    description=new_desc,
+                                    domain=new_domain,
+                                    category=new_category,
+                                    default_unit=new_basis,
+                                    is_gst_applicable=False,
+                                    gst_treatment=ProductCode.GST_TREATMENT_ZERO_RATED,
+                                    gst_rate=Decimal("0.1000"),
+                                    gl_revenue_code="4000",
+                                    gl_cost_code="5000",
+                                )
+                            else:
+                                # Mock for dry-run resolution reporting
+                                product_code = ProductCode(id=new_id, code=new_code)
+
+                            summary["product_codes_created"] += 1
+
+                            # Create ChargeAlias
+                            alias_norm = normalize_label(normalized_label)
+                            existing_alias = ChargeAlias.objects.filter(
+                                normalized_alias_text=alias_norm,
+                                product_code=product_code,
+                            ).first()
+
+                            if existing_alias:
+                                summary["aliases_existing"] += 1
+                            else:
+                                if not dry_run:
+                                    ChargeAlias.objects.create(
+                                        alias_text=normalized_label,
+                                        product_code=product_code,
+                                        is_active=True,
+                                        review_status=ChargeAlias.ReviewStatus.APPROVED,
+                                        alias_source=ChargeAlias.AliasSource.ADMIN,
+                                    )
+                                summary["aliases_created"] += 1
+
+                            # Resolve charge lines
+                            resolved_ids = []
+                            for line in matching_lines:
+                                line_id_str = str(line.id)
+                                if line_id_str in charge_line_ids_selected:
+                                    duplicate_charge_line_matches += 1
+                                    continue
+
+                                charge_line_ids_selected.add(line_id_str)
+
+                                if not dry_run:
+                                    line.manual_resolution_status = SPEChargeLineDB.ManualResolutionStatus.RESOLVED
+                                    line.manual_resolved_product_code = product_code
+                                    line.manual_resolution_by = system_user
+                                    line.manual_resolution_at = timezone.now()
+                                    line.save()
+                                resolved_ids.append(line_id_str)
+
+                            summary["per_row_results"].append({
+                                "row_index": row_idx,
+                                "normalized_label": normalized_label,
+                                "action": approved_action,
+                                "status": "APPLIED" if not dry_run else "WOULD_APPLY",
+                                "product_code": product_code.code,
+                                "resolved_line_ids": resolved_ids,
+                            })
+
+                # Populate unique metrics
+                summary["unique_charge_lines_selected"] = len(charge_line_ids_selected)
+                summary["duplicate_charge_line_matches"] = duplicate_charge_line_matches
+                summary["charge_line_ids_selected"] = sorted(list(charge_line_ids_selected))
+                summary["charge_lines_resolved"] = len(charge_line_ids_selected)
+
+                # Safety check: must not exceed unresolved count before
+                if len(charge_line_ids_selected) > unresolved_count_before:
+                    summary["error_count"] += 1
+                    raise CommandError(
+                        f"Safety Check Failed: Total unique charge lines selected ({len(charge_line_ids_selected)}) "
+                        f"exceeds unresolved baseline ({unresolved_count_before}). Aborting."
+                    )
+
+                if dry_run:
+                    raise DryRunRollback()
+
+        except DryRunRollback:
+            # Expected dry-run rollback
+            pass
+        except Exception as e:
+            if not isinstance(e, DryRunRollback):
+                summary["error_count"] += 1
+                summary["per_row_results"].append({
+                    "status": "ERROR",
+                    "reason": str(e),
+                })
+            if output_format == "json":
+                self.stdout.write(json.dumps(summary, indent=2, sort_keys=True))
+            else:
+                self.stderr.write(f"Error processing CSV: {e}")
+            raise e
+
+        # Calculate readiness after
+        try:
+            readiness_after = build_close_loop_report()["readiness_status"]
+            summary["readiness_after"] = readiness_after
+        except Exception:
+            pass
+
+        if output_format == "json":
+            self.stdout.write(json.dumps(summary, indent=2, sort_keys=True))
+        else:
+            self.stdout.write("=== SPOT ProductCode Decision Apply Output ===")
+            self.stdout.write(f"Dry Run: {summary['dry_run']}")
+            self.stdout.write(f"Approved Rows Seen: {summary['approved_rows_seen']}")
+            self.stdout.write(f"Aliases Created: {summary['aliases_created']}")
+            self.stdout.write(f"Aliases Existing: {summary['aliases_existing']}")
+            self.stdout.write(f"Product Codes Created: {summary['product_codes_created']}")
+            self.stdout.write(f"Unique Charge Lines Selected: {summary['unique_charge_lines_selected']}")
+            self.stdout.write(f"Duplicate Charge Line Matches: {summary['duplicate_charge_line_matches']}")
+            self.stdout.write(f"Charge Lines Resolved: {summary['charge_lines_resolved']}")
+            self.stdout.write(f"Deferred for Manual Review: {summary['manual_review_deferred']}")
+            self.stdout.write(f"Skipped Rows: {summary['skipped_count']}")
+            self.stdout.write(f"Errors: {summary['error_count']}")
+            self.stdout.write(f"Readiness Before: {summary['readiness_before']} -> After: {summary['readiness_after']}")
+
+
+class DryRunRollback(Exception):
+    pass

--- a/backend/quotes/tests/test_spot_productcode_decision_apply_command.py
+++ b/backend/quotes/tests/test_spot_productcode_decision_apply_command.py
@@ -1,0 +1,544 @@
+import csv
+import json
+from datetime import timedelta
+from io import StringIO
+from pathlib import Path
+
+from django.contrib.auth import get_user_model
+from django.core.management import call_command, CommandError
+from django.test import TestCase
+from django.utils import timezone
+
+from pricing_v4.models import ChargeAlias, ProductCode
+from quotes.spot_models import SPEChargeLineDB, SpotPricingEnvelopeDB
+from quotes.management.commands.spot_productcode_close_loop_report import build_report as build_close_loop_report
+
+
+
+class SpotProductCodeDecisionApplyTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = get_user_model().objects.create_user(
+            username="spot-decision-user",
+            password="pass123",
+            role="sales",
+        )
+
+    def setUp(self):
+        self.envelope = SpotPricingEnvelopeDB.objects.create(
+            status=SpotPricingEnvelopeDB.Status.DRAFT,
+            shipment_context_json={"origin_code": "POM", "destination_code": "SYD"},
+            conditions_json={},
+            spot_trigger_reason_code="MISSING_SCOPE_RATES",
+            spot_trigger_reason_text="Missing required rate components",
+            created_by=self.user,
+            expires_at=timezone.now() + timedelta(hours=4),
+        )
+        self.csv_dir = Path("tmp")
+        self.csv_dir.mkdir(exist_ok=True)
+        self.csv_path = self.csv_dir / "test_decision_reviewed.csv"
+
+    def tearDown(self):
+        if self.csv_path.exists():
+            self.csv_path.unlink()
+
+    def _line(self, label):
+        return SPEChargeLineDB.objects.create(
+            envelope=self.envelope,
+            code="UNMAPPED",
+            description=label,
+            amount="10.00",
+            currency="PGK",
+            unit=SPEChargeLineDB.Unit.PER_SHIPMENT,
+            bucket=SPEChargeLineDB.Bucket.ORIGIN_CHARGES,
+            source_label=label,
+            normalized_label=label.lower(),
+            normalization_status=SPEChargeLineDB.NormalizationStatus.UNMAPPED,
+            source_reference="test",
+            entered_by=self.user,
+            entered_at=timezone.now(),
+        )
+
+    def _product_code(self, pc_id, code, description):
+        return ProductCode.objects.create(
+            id=pc_id,
+            code=code,
+            description=description,
+            domain=ProductCode.DOMAIN_EXPORT,
+            category=ProductCode.CATEGORY_DOCUMENTATION,
+            is_gst_applicable=False,
+            gst_rate="0.00",
+            gst_treatment=ProductCode.GST_TREATMENT_ZERO_RATED,
+            gl_revenue_code="4100",
+            gl_cost_code="5100",
+            default_unit=ProductCode.UNIT_SHIPMENT,
+        )
+
+    def _write_csv(self, rows):
+        fieldnames = [
+            "normalized_label",
+            "approved_action",
+            "approved_product_code_id",
+            "approved_product_code_code",
+            "approved_product_code_description",
+            "approved_create_product_code_id",
+            "approved_create_product_code_code",
+            "approved_create_product_code_description",
+            "approved_create_product_code_domain",
+            "approved_create_product_code_category",
+            "approved_create_product_code_basis",
+            "confidence",
+            "approved_by_human",
+            "decision_notes",
+        ]
+        with open(self.csv_path, "w", newline="", encoding="utf-8-sig") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            for r in rows:
+                row_dict = {k: r.get(k, "") for k in fieldnames}
+                writer.writerow(row_dict)
+
+    def test_dry_run_performs_no_writes(self):
+        line = self._line("AWB Fee")
+        pc = self._product_code(9011, "EXP-AWB", "AWB Fee")
+        self._write_csv([{
+            "normalized_label": "awb fee",
+            "approved_action": "CREATE_ALIAS_MAPPING",
+            "approved_product_code_id": pc.id,
+            "confidence": "HIGH",
+            "approved_by_human": "true",
+        }])
+
+        stdout = StringIO()
+        call_command(
+            "spot_productcode_decision_apply",
+            "--csv",
+            str(self.csv_path),
+            "--format",
+            "json",
+            stdout=stdout,
+        )
+        payload = json.loads(stdout.getvalue())
+
+        self.assertTrue(payload["dry_run"])
+        self.assertEqual(payload["charge_lines_resolved"], 1)
+
+        # Verify DB not changed
+        line.refresh_from_db()
+        self.assertNotEqual(line.manual_resolution_status, SPEChargeLineDB.ManualResolutionStatus.RESOLVED)
+        self.assertIsNone(line.manual_resolved_product_code)
+
+    def test_apply_performs_writes(self):
+        line = self._line("AWB Fee")
+        pc = self._product_code(9011, "EXP-AWB", "AWB Fee")
+        self._write_csv([{
+            "normalized_label": "awb fee",
+            "approved_action": "CREATE_ALIAS_MAPPING",
+            "approved_product_code_id": pc.id,
+            "confidence": "HIGH",
+            "approved_by_human": "true",
+        }])
+
+        stdout = StringIO()
+        call_command(
+            "spot_productcode_decision_apply",
+            "--csv",
+            str(self.csv_path),
+            "--apply",
+            "--format",
+            "json",
+            stdout=stdout,
+        )
+        payload = json.loads(stdout.getvalue())
+
+        self.assertFalse(payload["dry_run"])
+        self.assertEqual(payload["charge_lines_resolved"], 1)
+
+        # Verify DB is updated
+        line.refresh_from_db()
+        self.assertEqual(line.manual_resolution_status, SPEChargeLineDB.ManualResolutionStatus.RESOLVED)
+        self.assertEqual(line.manual_resolved_product_code, pc)
+
+    def test_unapproved_rows_skipped(self):
+        line = self._line("AWB Fee")
+        pc = self._product_code(9011, "EXP-AWB", "AWB Fee")
+        self._write_csv([{
+            "normalized_label": "awb fee",
+            "approved_action": "CREATE_ALIAS_MAPPING",
+            "approved_product_code_id": pc.id,
+            "confidence": "HIGH",
+            "approved_by_human": "false",
+        }])
+
+        stdout = StringIO()
+        call_command(
+            "spot_productcode_decision_apply",
+            "--csv",
+            str(self.csv_path),
+            "--apply",
+            "--format",
+            "json",
+            stdout=stdout,
+        )
+        payload = json.loads(stdout.getvalue())
+
+        self.assertEqual(payload["charge_lines_resolved"], 0)
+        self.assertEqual(payload["skipped_count"], 1)
+
+    def test_low_confidence_rows_skipped(self):
+        line = self._line("AWB Fee")
+        pc = self._product_code(9011, "EXP-AWB", "AWB Fee")
+        self._write_csv([{
+            "normalized_label": "awb fee",
+            "approved_action": "CREATE_ALIAS_MAPPING",
+            "approved_product_code_id": pc.id,
+            "confidence": "LOW",
+            "approved_by_human": "true",
+        }])
+
+        stdout = StringIO()
+        call_command(
+            "spot_productcode_decision_apply",
+            "--csv",
+            str(self.csv_path),
+            "--apply",
+            "--format",
+            "json",
+            stdout=stdout,
+        )
+        payload = json.loads(stdout.getvalue())
+
+        self.assertEqual(payload["charge_lines_resolved"], 0)
+        self.assertEqual(payload["skipped_count"], 1)
+
+    def test_create_alias_mapping_creates_alias_and_resolves_lines(self):
+        line = self._line("AWB Fee")
+        pc = self._product_code(9011, "EXP-AWB", "AWB Fee")
+        self._write_csv([{
+            "normalized_label": "awb fee",
+            "approved_action": "CREATE_ALIAS_MAPPING",
+            "approved_product_code_id": pc.id,
+            "confidence": "HIGH",
+            "approved_by_human": "true",
+        }])
+
+        stdout = StringIO()
+        call_command(
+            "spot_productcode_decision_apply",
+            "--csv",
+            str(self.csv_path),
+            "--apply",
+            "--format",
+            "json",
+            stdout=stdout,
+        )
+        payload = json.loads(stdout.getvalue())
+
+        self.assertEqual(payload["aliases_created"], 1)
+        self.assertEqual(payload["charge_lines_resolved"], 1)
+
+        # Check alias in DB
+        alias = ChargeAlias.objects.filter(normalized_alias_text="awb fee").first()
+        self.assertIsNotNone(alias)
+        self.assertEqual(alias.product_code, pc)
+
+    def test_duplicate_alias_handled_safely(self):
+        pc = self._product_code(9011, "EXP-AWB", "AWB Fee")
+        ChargeAlias.objects.create(
+            alias_text="awb fee",
+            product_code=pc,
+            is_active=True,
+        )
+
+        self._write_csv([{
+            "normalized_label": "awb fee",
+            "approved_action": "CREATE_ALIAS_MAPPING",
+            "approved_product_code_id": pc.id,
+            "confidence": "HIGH",
+            "approved_by_human": "true",
+        }])
+
+        stdout = StringIO()
+        call_command(
+            "spot_productcode_decision_apply",
+            "--csv",
+            str(self.csv_path),
+            "--apply",
+            "--format",
+            "json",
+            stdout=stdout,
+        )
+        payload = json.loads(stdout.getvalue())
+
+        self.assertEqual(payload["aliases_existing"], 1)
+        self.assertEqual(payload["aliases_created"], 0)
+
+    def test_missing_product_code_skips_safely(self):
+        self._write_csv([{
+            "normalized_label": "awb fee",
+            "approved_action": "CREATE_ALIAS_MAPPING",
+            "approved_product_code_id": 9999,
+            "confidence": "HIGH",
+            "approved_by_human": "true",
+        }])
+
+        stdout = StringIO()
+        call_command(
+            "spot_productcode_decision_apply",
+            "--csv",
+            str(self.csv_path),
+            "--apply",
+            "--format",
+            "json",
+            stdout=stdout,
+        )
+        payload = json.loads(stdout.getvalue())
+
+        self.assertEqual(payload["error_count"], 1)
+        self.assertEqual(payload["per_row_results"][0]["reason"], "PRODUCT_CODE_NOT_FOUND")
+
+    def test_create_new_product_code_creates_product_code_and_resolves_lines(self):
+        line = self._line("Air Transfer Fee")
+        self._write_csv([{
+            "normalized_label": "air transfer fee",
+            "approved_action": "CREATE_NEW_PRODUCT_CODE",
+            "approved_create_product_code_id": "2073",
+            "approved_create_product_code_code": "IMP-AIR-TRANSFER",
+            "approved_create_product_code_description": "Import Air Transfer Fee",
+            "approved_create_product_code_domain": "IMPORT",
+            "approved_create_product_code_category": "HANDLING",
+            "approved_create_product_code_basis": "SHIPMENT",
+            "confidence": "HIGH",
+            "approved_by_human": "true",
+        }])
+
+        stdout = StringIO()
+        call_command(
+            "spot_productcode_decision_apply",
+            "--csv",
+            str(self.csv_path),
+            "--apply",
+            "--format",
+            "json",
+            stdout=stdout,
+        )
+        payload = json.loads(stdout.getvalue())
+
+        self.assertEqual(payload["product_codes_created"], 1)
+        self.assertEqual(payload["aliases_created"], 1)
+        self.assertEqual(payload["charge_lines_resolved"], 1)
+
+        # Verify created product code
+        pc = ProductCode.objects.filter(id=2073).first()
+        self.assertIsNotNone(pc)
+        self.assertEqual(pc.code, "IMP-AIR-TRANSFER")
+        self.assertEqual(pc.domain, "IMPORT")
+        self.assertEqual(pc.category, "HANDLING")
+        self.assertEqual(pc.default_unit, "SHIPMENT")
+
+    def test_duplicate_product_code_skips_safely(self):
+        self._product_code(2073, "IMP-AIR-TRANSFER", "Existing")
+        self._write_csv([{
+            "normalized_label": "air transfer fee",
+            "approved_action": "CREATE_NEW_PRODUCT_CODE",
+            "approved_create_product_code_id": "2073",
+            "approved_create_product_code_code": "IMP-AIR-TRANSFER",
+            "approved_create_product_code_description": "Import Air Transfer Fee",
+            "approved_create_product_code_domain": "IMPORT",
+            "approved_create_product_code_category": "HANDLING",
+            "approved_create_product_code_basis": "SHIPMENT",
+            "confidence": "HIGH",
+            "approved_by_human": "true",
+        }])
+
+        stdout = StringIO()
+        call_command(
+            "spot_productcode_decision_apply",
+            "--csv",
+            str(self.csv_path),
+            "--apply",
+            "--format",
+            "json",
+            stdout=stdout,
+        )
+        payload = json.loads(stdout.getvalue())
+
+        self.assertEqual(payload["error_count"], 1)
+        self.assertEqual(payload["per_row_results"][0]["reason"], "DUPLICATE_PRODUCT_CODE_ID_OR_CODE")
+
+    def test_leave_for_manual_review_does_not_resolve(self):
+        line = self._line("Service Fee")
+        self._write_csv([{
+            "normalized_label": "service fee",
+            "approved_action": "LEAVE_FOR_MANUAL_REVIEW",
+            "confidence": "HIGH",
+            "approved_by_human": "true",
+        }])
+
+        stdout = StringIO()
+        call_command(
+            "spot_productcode_decision_apply",
+            "--csv",
+            str(self.csv_path),
+            "--apply",
+            "--format",
+            "json",
+            stdout=stdout,
+        )
+        payload = json.loads(stdout.getvalue())
+
+        self.assertEqual(payload["manual_review_deferred"], 1)
+        self.assertEqual(payload["charge_lines_resolved"], 0)
+
+        # Check not resolved
+        line.refresh_from_db()
+        self.assertNotEqual(line.manual_resolution_status, SPEChargeLineDB.ManualResolutionStatus.RESOLVED)
+
+    def test_robust_matching_with_en_dash(self):
+        line1 = self._line("airfreight akl – pom via px(bne)")
+        line2 = self._line("airfreight akl - pom via px(bne)")
+        pc = self._product_code(2001, "IMP-FRT-AIR", "Import Air Freight")
+
+        self._write_csv([{
+            "normalized_label": "airfreight akl – pom via px(bne)",
+            "approved_action": "CREATE_ALIAS_MAPPING",
+            "approved_product_code_id": pc.id,
+            "confidence": "HIGH",
+            "approved_by_human": "true",
+        }])
+
+        stdout = StringIO()
+        call_command(
+            "spot_productcode_decision_apply",
+            "--csv",
+            str(self.csv_path),
+            "--apply",
+            "--format",
+            "json",
+            stdout=stdout,
+        )
+        payload = json.loads(stdout.getvalue())
+
+        self.assertEqual(payload["charge_lines_resolved"], 2)
+
+        line1.refresh_from_db()
+        line2.refresh_from_db()
+        self.assertEqual(line1.manual_resolution_status, SPEChargeLineDB.ManualResolutionStatus.RESOLVED)
+        self.assertEqual(line2.manual_resolution_status, SPEChargeLineDB.ManualResolutionStatus.RESOLVED)
+
+    def test_json_output_shape(self):
+        self._write_csv([])
+        stdout = StringIO()
+        call_command(
+            "spot_productcode_decision_apply",
+            "--csv",
+            str(self.csv_path),
+            "--format",
+            "json",
+            stdout=stdout,
+        )
+        payload = json.loads(stdout.getvalue())
+
+        expected_keys = {
+            "dry_run",
+            "writes_performed",
+            "approved_rows_seen",
+            "aliases_created",
+            "aliases_existing",
+            "product_codes_created",
+            "charge_lines_resolved",
+            "manual_review_deferred",
+            "skipped_count",
+            "error_count",
+            "readiness_before",
+            "readiness_after",
+            "unique_charge_lines_selected",
+            "duplicate_charge_line_matches",
+            "charge_line_ids_selected",
+            "per_row_results",
+        }
+        self.assertTrue(expected_keys.issubset(payload.keys()))
+
+    def test_duplicate_charge_line_de_duplication(self):
+        line = self._line("AWB Fee")
+        pc = self._product_code(9011, "EXP-AWB", "AWB Fee")
+        # Define two rows that both match the same normalized_label
+        self._write_csv([
+            {
+                "normalized_label": "awb fee",
+                "approved_action": "CREATE_ALIAS_MAPPING",
+                "approved_product_code_id": pc.id,
+                "confidence": "HIGH",
+                "approved_by_human": "true",
+            },
+            {
+                "normalized_label": "awb fee",
+                "approved_action": "CREATE_ALIAS_MAPPING",
+                "approved_product_code_id": pc.id,
+                "confidence": "HIGH",
+                "approved_by_human": "true",
+            }
+        ])
+
+        stdout = StringIO()
+        call_command(
+            "spot_productcode_decision_apply",
+            "--csv",
+            str(self.csv_path),
+            "--apply",
+            "--format",
+            "json",
+            stdout=stdout,
+        )
+        payload = json.loads(stdout.getvalue())
+
+        self.assertEqual(payload["charge_lines_resolved"], 1)
+        self.assertEqual(payload["unique_charge_lines_selected"], 1)
+        self.assertEqual(payload["duplicate_charge_line_matches"], 1)
+
+    def test_safety_check_fails_when_exceeding_baseline(self):
+        self._line("AWB Fee")
+        self._line("Doc Fee")
+        pc = self._product_code(9011, "EXP-AWB", "AWB Fee")
+        self._write_csv([
+            {
+                "normalized_label": "awb fee",
+                "approved_action": "CREATE_ALIAS_MAPPING",
+                "approved_product_code_id": pc.id,
+                "confidence": "HIGH",
+                "approved_by_human": "true",
+            },
+            {
+                "normalized_label": "doc fee",
+                "approved_action": "CREATE_ALIAS_MAPPING",
+                "approved_product_code_id": pc.id,
+                "confidence": "HIGH",
+                "approved_by_human": "true",
+            }
+        ])
+
+        # We mock build_close_loop_report to return baseline unresolved lines = 1
+        # but our CSV will resolve 2 lines. This should fail the safety check.
+        original_build = build_close_loop_report
+        try:
+            # Overwrite global function mock
+            import quotes.management.commands.spot_productcode_decision_apply as target_module
+            target_module.build_close_loop_report = lambda: {
+                "readiness_status": "NOT_READY_FOR_LAUNCH",
+                "blocking_counts": {
+                    "unresolved_product_code_review_lines": 1
+                }
+            }
+
+            with self.assertRaises(CommandError):
+                call_command(
+                    "spot_productcode_decision_apply",
+                    "--csv",
+                    str(self.csv_path),
+                    "--apply",
+                    "--format",
+                    "json",
+                )
+        finally:
+            import quotes.management.commands.spot_productcode_decision_apply as target_module
+            target_module.build_close_loop_report = original_build


### PR DESCRIPTION
## Summary

Adds the Phase 7H SPOT/ProductCode decision apply command.

This command consumes a reviewed human-approved CSV and applies only HIGH-confidence approved decisions for unresolved SPOT ProductCode labels.

## Key changes

- Add `spot_productcode_decision_apply` management command
- Add dry-run-by-default behavior
- Require explicit `--apply` for persistent database writes
- Read reviewed CSV using UTF-8-SIG handling
- Process only rows where `approved_by_human=true` and `confidence=HIGH`
- Support:
  - `CREATE_ALIAS_MAPPING`
  - `CREATE_NEW_PRODUCT_CODE`
  - `LEAVE_FOR_MANUAL_REVIEW`
- Create aliases idempotently
- Create approved new ProductCodes safely
- Resolve matching unresolved SPOT charge lines without changing pricing amounts
- Add duplicate/de-duplication protection so each charge line is selected once
- Add safety check that selected charge lines do not exceed the close-loop unresolved baseline
- Add JSON summary output with per-row results
- Add command test coverage

## Verification

Local verification reported:

- `python backend/manage.py test quotes.tests.test_spot_productcode_decision_apply_command`
  - `Ran 14 tests ... OK`
- `python backend/manage.py makemigrations --check --dry-run`
  - No changes detected
- `git diff --check`
  - Clean
- `graphify update .`
  - Successful
- Dry-run command:
  - `python backend/manage.py spot_productcode_decision_apply --csv tmp/spot_productcode_decision_table_reviewed.csv --format json`

## Dry-run result

Corrected dry-run result after hardening matching/de-duplication:

- unresolved baseline: 78
- unique charge lines selected: 73
- manual review deferred: 5
- total handled: 78
- writes performed: false
- error count: 0

## Safety notes

This PR does not include the reviewed CSV and does not apply local data changes.

The command remains dry-run by default. Database writes require `--apply`.

No pricing amounts, quote totals, currencies, tax values, RBAC rules, finalisation logic, selectors, or frontend behavior are changed.