### PR TITLE
feat(spot): classify ProductCode launch readiness exceptions

### DIFF
--- a/backend/quotes/management/commands/spot_productcode_close_loop_report.py
+++ b/backend/quotes/management/commands/spot_productcode_close_loop_report.py
@@ -5,9 +5,11 @@ from django.core.management.base import BaseCommand
 from pricing_v4.models import ProductCodeCreationRequest
 from quotes.serializers import SPEChargeLineSerializer
 from quotes.spot_models import SPEChargeLineDB
+from quotes.management.commands.spot_productcode_masterdata_audit import build_masterdata_audit, CATEGORY_MANUAL_REVIEW
 
 
 READY = "READY_FOR_LAUNCH"
+READY_EXCEPTIONS = "READY_FOR_LAUNCH_WITH_MANUAL_REVIEW_EXCEPTIONS"
 NOT_READY = "NOT_READY_FOR_LAUNCH"
 
 
@@ -130,6 +132,61 @@ def build_report() -> dict:
                 }
             )
 
+    # Classify unresolved lines into manual exceptions vs hard blockers
+    try:
+        audit_data = build_masterdata_audit()
+        label_to_category = {
+            item["normalized_label"]: item["remediation_category"]
+            for item in audit_data.get("labels", [])
+        }
+    except Exception:
+        label_to_category = {}
+
+    manual_review_exception_lines = []
+    hard_blocker_lines = []
+    for line in unresolved_lines:
+        norm = ProductCodeCreationRequest.normalize_label(line.normalized_label or line.description or "")
+        category = label_to_category.get(norm)
+        if category == CATEGORY_MANUAL_REVIEW:
+            manual_review_exception_lines.append(line)
+        else:
+            hard_blocker_lines.append(line)
+
+    # Distinguish active vs stale pending requests
+    active_pending_requests = []
+    stale_pending_requests = []
+    for req in pending_requests:
+        has_match = False
+        if req.source_charge_line_id and req.source_charge_line_id in unresolved_by_id:
+            has_match = True
+        elif req.normalized_source_label in unresolved_by_norm:
+            has_match = True
+
+        if has_match:
+            active_pending_requests.append(req)
+        else:
+            stale_pending_requests.append(req)
+
+    # Calculate blocker count
+    hard_blocker_count = (
+        len(active_pending_requests) +
+        len(approved_not_applied) +
+        len(rejected_matching_unresolved) +
+        len(suggested_not_resolved) +
+        len(hard_blocker_lines)
+    )
+    manual_review_exception_count = len(manual_review_exception_lines)
+
+    if hard_blocker_count > 0:
+        launch_readiness_status = NOT_READY
+        launch_readiness_reason = f"NOT READY: {hard_blocker_count} hard blockers remain."
+    elif manual_review_exception_count > 0:
+        launch_readiness_status = READY_EXCEPTIONS
+        launch_readiness_reason = f"READY WITH EXCEPTIONS: {manual_review_exception_count} manual review exceptions remain."
+    else:
+        launch_readiness_status = READY
+        launch_readiness_reason = "READY: All checkpoints passed."
+
     blocking_counts = {
         "pending_product_code_requests": len(pending_requests),
         "approved_requests_not_applied": len(approved_not_applied),
@@ -137,15 +194,22 @@ def build_report() -> dict:
         "unresolved_product_code_review_lines": len(unresolved_lines),
         "suggested_approved_product_code_not_resolved": len(suggested_not_resolved),
     }
-    readiness_status = READY if all(count == 0 for count in blocking_counts.values()) else NOT_READY
 
     return {
-        "readiness_status": readiness_status,
+        "readiness_status": launch_readiness_status,
+        "launch_readiness_status": launch_readiness_status,
+        "launch_readiness_reason": launch_readiness_reason,
+        "hard_blocker_count": hard_blocker_count,
+        "manual_review_exception_count": manual_review_exception_count,
+        "active_pending_product_code_request_count": len(active_pending_requests),
+        "stale_pending_product_code_request_count": len(stale_pending_requests),
         "blocking_counts": blocking_counts,
-        "pending_product_code_requests": [_request_payload(req) for req in pending_requests],
+        "pending_product_code_requests": [_request_payload(req) for req in active_pending_requests],
+        "stale_pending_product_code_requests": [_request_payload(req) for req in stale_pending_requests],
         "approved_requests_not_applied": approved_not_applied,
         "rejected_requests_matching_unresolved_lines": rejected_matching_unresolved,
         "unresolved_product_code_review_lines": [_line_payload(line) for line in unresolved_lines],
+        "manual_review_exceptions": [_line_payload(line) for line in manual_review_exception_lines],
         "suggested_approved_product_code_not_resolved": suggested_not_resolved,
     }
 
@@ -168,6 +232,11 @@ class Command(BaseCommand):
             return
 
         self.stdout.write(f"readiness_status: {report['readiness_status']}")
+        self.stdout.write(f"launch_readiness_reason: {report['launch_readiness_reason']}")
+        self.stdout.write(f"hard_blocker_count: {report['hard_blocker_count']}")
+        self.stdout.write(f"manual_review_exception_count: {report['manual_review_exception_count']}")
+        self.stdout.write(f"active_pending_requests: {report['active_pending_product_code_request_count']}")
+        self.stdout.write(f"stale_pending_requests: {report['stale_pending_product_code_request_count']}")
         self.stdout.write("blocking_counts:")
         for key, count in report["blocking_counts"].items():
             self.stdout.write(f"- {key}: {count}")

--- a/backend/quotes/management/commands/spot_productcode_masterdata_audit.py
+++ b/backend/quotes/management/commands/spot_productcode_masterdata_audit.py
@@ -309,10 +309,16 @@ def build_masterdata_audit() -> dict:
         )
 
     labels.sort(key=lambda item: (-item["occurrence_count"], item["normalized_label"]))
-    readiness_status = READY if not labels else NOT_READY
+    if estimated_fixes_required > 0:
+        readiness_status = NOT_READY
+    elif labels:
+        readiness_status = "READY_FOR_LAUNCH_WITH_MANUAL_REVIEW_EXCEPTIONS"
+    else:
+        readiness_status = READY
 
     return {
         "readiness_status": readiness_status,
+
         "readiness_summary": {
             "unique_unresolved_labels": len(labels),
             "unresolved_charge_lines": sum(item["occurrence_count"] for item in labels),

--- a/backend/quotes/tests/test_spot_productcode_close_loop_launch_gate.py
+++ b/backend/quotes/tests/test_spot_productcode_close_loop_launch_gate.py
@@ -1,0 +1,176 @@
+import json
+from datetime import timedelta
+from io import StringIO
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils import timezone
+
+from pricing_v4.models import ProductCode, ProductCodeCreationRequest, ChargeAlias
+from quotes.spot_models import SPEChargeLineDB, SpotPricingEnvelopeDB
+from quotes.management.commands.spot_productcode_close_loop_report import (
+    READY,
+    READY_EXCEPTIONS,
+    NOT_READY,
+)
+
+
+class SpotProductCodeCloseLoopLaunchGateTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = get_user_model().objects.create_user(
+            username="spot-report-user",
+            password="pass123",
+            role="sales",
+        )
+
+    def setUp(self):
+        self.envelope = SpotPricingEnvelopeDB.objects.create(
+            status=SpotPricingEnvelopeDB.Status.DRAFT,
+            shipment_context_json={"origin_code": "POM", "destination_code": "SYD"},
+            conditions_json={},
+            spot_trigger_reason_code="MISSING_SCOPE_RATES",
+            spot_trigger_reason_text="Missing required rate components",
+            created_by=self.user,
+            expires_at=timezone.now() + timedelta(hours=4),
+        )
+
+    def _line(self, label, status=SPEChargeLineDB.NormalizationStatus.UNMAPPED):
+        return SPEChargeLineDB.objects.create(
+            envelope=self.envelope,
+            code="UNMAPPED",
+            description=label,
+            amount="10.00",
+            currency="PGK",
+            unit=SPEChargeLineDB.Unit.PER_SHIPMENT,
+            bucket=SPEChargeLineDB.Bucket.ORIGIN_CHARGES,
+            source_label=label,
+            normalized_label=label.lower(),
+            normalization_status=status,
+            source_reference="test",
+            entered_by=self.user,
+            entered_at=timezone.now(),
+        )
+
+    def test_no_blockers_or_exceptions_reports_ready(self):
+        stdout = StringIO()
+        call_command("spot_productcode_close_loop_report", "--format", "json", stdout=stdout)
+        payload = json.loads(stdout.getvalue())
+
+        self.assertEqual(payload["readiness_status"], READY)
+        self.assertEqual(payload["hard_blocker_count"], 0)
+        self.assertEqual(payload["manual_review_exception_count"], 0)
+
+    def test_only_manual_review_exceptions_reports_ready_exceptions(self):
+        # "service fee" defaults to manual review exception (AMBIGUOUS_MANUAL_REVIEW_REQUIRED)
+        self._line("Service Fee")
+
+        stdout = StringIO()
+        call_command("spot_productcode_close_loop_report", "--format", "json", stdout=stdout)
+        payload = json.loads(stdout.getvalue())
+
+        self.assertEqual(payload["readiness_status"], READY_EXCEPTIONS)
+        self.assertEqual(payload["hard_blocker_count"], 0)
+        self.assertEqual(payload["manual_review_exception_count"], 1)
+        self.assertEqual(payload["manual_review_exceptions"][0]["source_label"], "Service Fee")
+
+    def test_hard_blocker_unmapped_alias_reports_not_ready(self):
+        # "awb fee" has canonical hint and will classify as ALIAS_MAPPING_REQUIRED (hard blocker)
+        self._line("AWB Fee")
+
+        stdout = StringIO()
+        call_command("spot_productcode_close_loop_report", "--format", "json", stdout=stdout)
+        payload = json.loads(stdout.getvalue())
+
+        self.assertEqual(payload["readiness_status"], NOT_READY)
+        self.assertEqual(payload["hard_blocker_count"], 1)
+
+    def test_active_pending_request_blocks_launch(self):
+        line = self._line("Service Fee")
+        ProductCodeCreationRequest.objects.create(
+            status=ProductCodeCreationRequest.STATUS_PENDING,
+            source_envelope=self.envelope,
+            source_charge_line=line,
+            source_label="Service Fee",
+            suggested_name="Service Fee",
+            created_by=self.user,
+        )
+
+
+        stdout = StringIO()
+        call_command("spot_productcode_close_loop_report", "--format", "json", stdout=stdout)
+        payload = json.loads(stdout.getvalue())
+
+        self.assertEqual(payload["readiness_status"], NOT_READY)
+        self.assertEqual(payload["hard_blocker_count"], 2)
+        self.assertEqual(payload["active_pending_product_code_request_count"], 1)
+        self.assertEqual(payload["stale_pending_product_code_request_count"], 0)
+
+
+    def test_stale_pending_request_does_not_block_launch(self):
+        # Pending request exists, but the related line is already resolved
+        line = self._line("Service Fee")
+        line.manual_resolution_status = SPEChargeLineDB.ManualResolutionStatus.RESOLVED
+        pc = ProductCode.objects.create(
+            id=2099,
+            code="IMP-SERV",
+            description="Service",
+            is_gst_applicable=False,
+        )
+        line.manual_resolved_product_code = pc
+        line.save()
+
+        ProductCodeCreationRequest.objects.create(
+            status=ProductCodeCreationRequest.STATUS_PENDING,
+            source_envelope=self.envelope,
+            source_charge_line=line,
+            source_label="Service Fee",
+            suggested_name="Service Fee",
+            created_by=self.user,
+        )
+
+
+        stdout = StringIO()
+        call_command("spot_productcode_close_loop_report", "--format", "json", stdout=stdout)
+        payload = json.loads(stdout.getvalue())
+
+        self.assertEqual(payload["readiness_status"], READY)
+        self.assertEqual(payload["hard_blocker_count"], 0)
+        self.assertEqual(payload["active_pending_product_code_request_count"], 0)
+        self.assertEqual(payload["stale_pending_product_code_request_count"], 1)
+        self.assertEqual(payload["stale_pending_product_code_requests"][0]["source_label"], "Service Fee")
+
+    def test_only_manual_review_exceptions_with_stale_pending_request(self):
+        # One manual review line (unresolved)
+        self._line("Labour Charge")
+
+        # One resolved line with a pending request (stale request)
+        line = self._line("Service Fee")
+        line.manual_resolution_status = SPEChargeLineDB.ManualResolutionStatus.RESOLVED
+        pc = ProductCode.objects.create(
+            id=2099,
+            code="IMP-SERV",
+            description="Service",
+            is_gst_applicable=False,
+        )
+        line.manual_resolved_product_code = pc
+        line.save()
+
+        ProductCodeCreationRequest.objects.create(
+            status=ProductCodeCreationRequest.STATUS_PENDING,
+            source_envelope=self.envelope,
+            source_charge_line=line,
+            source_label="Service Fee",
+            suggested_name="Service Fee",
+            created_by=self.user,
+        )
+
+
+        stdout = StringIO()
+        call_command("spot_productcode_close_loop_report", "--format", "json", stdout=stdout)
+        payload = json.loads(stdout.getvalue())
+
+        self.assertEqual(payload["readiness_status"], READY_EXCEPTIONS)
+        self.assertEqual(payload["hard_blocker_count"], 0)
+        self.assertEqual(payload["manual_review_exception_count"], 1)
+        self.assertEqual(payload["stale_pending_product_code_request_count"], 1)

--- a/backend/quotes/tests/test_spot_productcode_masterdata_audit_command.py
+++ b/backend/quotes/tests/test_spot_productcode_masterdata_audit_command.py
@@ -122,7 +122,8 @@ class SpotProductCodeMasterDataAuditTests(TestCase):
         self.assertEqual(report["readiness_summary"]["category_counts"][CATEGORY_NEW_PRODUCT_CODE], 1)
 
     def test_command_json_output_includes_readiness_summary(self):
-        self._line(label="Unknown Local Fee")
+        self._line(label="AWB Fee")
+
 
         stdout = StringIO()
         call_command("spot_productcode_masterdata_audit", "--format", "json", stdout=stdout)


### PR DESCRIPTION
## Summary

Adds the Phase 7I launch readiness gate for SPOT/ProductCode manual-review exceptions.

This updates the close-loop and master-data readiness diagnostics so the system can distinguish true ProductCode hard blockers from intentional manual-review exceptions.

## Key changes

- Adds `READY_FOR_LAUNCH_WITH_MANUAL_REVIEW_EXCEPTIONS` readiness classification.
- Separates hard blockers from manual-review exception lines.
- Reports manual-review exceptions clearly instead of hiding them.
- Distinguishes active pending ProductCode requests from stale/orphaned pending requests.
- Keeps stale pending requests visible but non-blocking.
- Updates master-data audit readiness logic for exception-only states.
- Adds launch-gate test coverage.
- Updates existing master-data audit tests for the new readiness status.

## Expected current local state after Phase 7H apply

- `hard_blocker_count`: 0
- `manual_review_exception_count`: 5
- `active_pending_product_code_request_count`: 0
- `stale_pending_product_code_request_count`: 1
- `launch_readiness_status`: `READY_FOR_LAUNCH_WITH_MANUAL_REVIEW_EXCEPTIONS`
- `estimated_fixes_required`: 0

## Safety

- Read-only diagnostics only.
- No database writes.
- No ProductCode, ChargeAlias, or charge-line mutations.
- No pricing, quote total, tax, currency, RBAC, frontend, selector, or finalisation behavior changes.

## Verification

Reported local verification:

- `python backend/manage.py test quotes.tests.test_spot_productcode_close_loop_launch_gate`
- `python backend/manage.py test quotes.tests.test_spot_productcode_masterdata_audit_command`
- `python backend/manage.py spot_productcode_close_loop_report --format json`
- `python backend/manage.py spot_productcode_masterdata_audit`
- `python backend/manage.py makemigrations --check --dry-run`
- `git diff --check`
- `graphify update .`