### PR TITLE
chore(rbac): audit corrected organization hierarchy

### DIFF
--- a/backend/parties/management/commands/rbac_organization_model_redesign_audit.py
+++ b/backend/parties/management/commands/rbac_organization_model_redesign_audit.py
@@ -1,0 +1,371 @@
+import json
+from collections import Counter, defaultdict
+
+from django.apps import apps
+from django.core.management.base import BaseCommand
+from django.db import models
+
+from accounts.models import UserMembership
+from parties.models import Branch, Company, Contact, Department, Organization
+
+
+PARENT_ORGANIZATION = "Express Freight Management"
+LEGACY_OPERATING_ENTITIES = ("EFM PNG", "EFM Australia", "EFM Fiji", "EFM Solomon Islands")
+LEGACY_ARCHIVE_ORGANIZATIONS = ("EFM Express Air Cargo", "Test Org")
+LEGACY_EAC_ORGANIZATION = "EFM Express Air Cargo"
+TARGET_MODEL = "Option B: add OperatingEntity between Organization and Branch"
+SAMPLE_LIMIT = 5
+
+
+class Command(BaseCommand):
+    help = "Read-only Phase 10A audit for corrected organization hierarchy redesign."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--format", choices=["text", "json"], default="text")
+
+    def handle(self, *args, **options):
+        report = build_report()
+        if options["format"] == "json":
+            self.stdout.write(json.dumps(report, indent=2, sort_keys=True))
+            return
+        write_text(self.stdout, report)
+
+
+def build_report():
+    organizations = list(Organization.objects.order_by("name", "id"))
+    branches = list(Branch.objects.select_related("organization").order_by("organization__name", "name", "id"))
+    departments = list(
+        Department.objects.select_related("organization", "branch").order_by("organization__name", "name", "id")
+    )
+    memberships = list(
+        UserMembership.objects.select_related("user", "organization", "branch", "department", "role").order_by(
+            "organization__name", "user__username", "id"
+        )
+    )
+    dependency_counts = fk_dependency_counts()
+
+    return {
+        "phase": "10A",
+        "write_enabled": False,
+        "business_rule": (
+            "Express Freight Management is the only organization. EFM PNG, EFM Australia, EFM Fiji, "
+            "and EFM Solomon Islands are not organizations."
+        ),
+        "current_counts": {
+            "organizations": len(organizations),
+            "branches": len(branches),
+            "departments": len(departments),
+            "user_memberships": len(memberships),
+        },
+        "organizations": organization_rows(organizations),
+        "branches": branch_rows(branches),
+        "departments": department_rows(departments),
+        "memberships": membership_report(memberships),
+        "scoped_records": scoped_record_report(),
+        "quote_spot_productcode": quote_spot_productcode_report(),
+        "fk_dependencies": dependency_counts,
+        "migration_classification": migration_classification(organizations, branches, departments),
+        "duplicate_risks": duplicate_risks(branches, departments),
+        "recommended_target_model": recommended_target_model(),
+        "risks": risks(dependency_counts),
+        "migration_steps": migration_steps(),
+        "rollback_plan": rollback_plan(),
+        "test_strategy": test_strategy(),
+    }
+
+
+def organization_rows(organizations):
+    rows = []
+    for org in organizations:
+        rows.append(
+            {
+                "id": str(org.id),
+                "name": safe(org.name),
+                "slug": safe(org.slug),
+                "is_active": org.is_active,
+                "classification": classify_organization(org.name),
+                "branch_count": Branch.objects.filter(organization=org).count(),
+                "department_count": Department.objects.filter(organization=org).count(),
+                "membership_count": UserMembership.objects.filter(organization=org).count(),
+            }
+        )
+    return rows
+
+
+def branch_rows(branches):
+    return [
+        {
+            "id": str(branch.id),
+            "name": safe(branch.name),
+            "code": safe(branch.code),
+            "organization": safe(branch.organization.name),
+            "classification": "migrate/reparent" if branch.organization.name != PARENT_ORGANIZATION else "canonical keep",
+            "department_count": Department.objects.filter(branch=branch).count(),
+            "membership_count": UserMembership.objects.filter(branch=branch).count(),
+        }
+        for branch in branches
+    ]
+
+
+def department_rows(departments):
+    return [
+        {
+            "id": str(department.id),
+            "name": safe(department.name),
+            "code": safe(department.code),
+            "organization": safe(department.organization.name),
+            "branch": safe(department.branch.name) if department.branch else "",
+            "classification": (
+                "migrate/reparent"
+                if department.organization.name != PARENT_ORGANIZATION
+                else "canonical keep"
+            ),
+            "membership_count": UserMembership.objects.filter(department=department).count(),
+        }
+        for department in departments
+    ]
+
+
+def membership_report(memberships):
+    rows = []
+    by_status = Counter()
+    for membership in memberships:
+        status = "canonical keep" if membership.organization.name == PARENT_ORGANIZATION else "migrate/reparent"
+        if membership.organization.name == LEGACY_EAC_ORGANIZATION:
+            status = "migrate/reparent"
+        by_status[status] += 1
+        rows.append(
+            {
+                "id": membership.id,
+                "username": safe(membership.user.username),
+                "organization": safe(membership.organization.name),
+                "branch": safe(membership.branch.name) if membership.branch else "",
+                "department": safe(membership.department.name) if membership.department else "",
+                "role": safe(membership.role.code) if membership.role else "",
+                "is_active": membership.is_active,
+                "classification": status,
+            }
+        )
+    return {"count": len(memberships), "by_classification": dict(sorted(by_status.items())), "samples": rows[:SAMPLE_LIMIT]}
+
+
+def scoped_record_report():
+    specs = (
+        ("parties.Company", Company),
+        ("parties.Contact", Contact),
+        ("crm.Opportunity", apps.get_model("crm", "Opportunity")),
+        ("crm.Interaction", apps.get_model("crm", "Interaction")),
+        ("crm.Task", apps.get_model("crm", "Task")),
+        ("quotes.Quote", apps.get_model("quotes", "Quote")),
+        ("quotes.SpotPricingEnvelopeDB", apps.get_model("quotes", "SpotPricingEnvelopeDB")),
+        ("shipments.Shipment", apps.get_model("shipments", "Shipment")),
+    )
+    return {label: scoped_model_summary(model) for label, model in specs}
+
+
+def scoped_model_summary(model):
+    fields = {field.name: field for field in model._meta.fields}
+    summary = {"total": model.objects.count()}
+    for field in ("organization", "branch", "department"):
+        model_field = fields.get(field)
+        if isinstance(model_field, models.ForeignKey):
+            summary[f"with_{field}"] = model.objects.filter(**{f"{field}__isnull": False}).count()
+            if field == "organization":
+                legacy_filter = {f"{field}__name__in": legacy_org_names()}
+            else:
+                legacy_filter = {f"{field}__organization__name__in": legacy_org_names()}
+            summary[f"legacy_{field}"] = model.objects.filter(**legacy_filter).count()
+    summary["samples"] = sample_rows(model.objects.order_by("pk")[:SAMPLE_LIMIT])
+    return summary
+
+
+def quote_spot_productcode_report():
+    ProductCode = apps.get_model("pricing_v4", "ProductCode")
+    SPEChargeLineDB = apps.get_model("quotes", "SPEChargeLineDB")
+    return {
+        "quotes": scoped_model_summary(apps.get_model("quotes", "Quote")),
+        "spot_envelopes": scoped_model_summary(apps.get_model("quotes", "SpotPricingEnvelopeDB")),
+        "product_codes": {
+            "total": ProductCode.objects.count(),
+            "note": "ProductCode has no organization/branch/department FK; affected indirectly through rate ownership, SPOT charge resolution, and quote calculation context.",
+            "charge_lines_with_resolved_product_code": SPEChargeLineDB.objects.filter(resolved_product_code__isnull=False).count(),
+            "charge_lines_with_manual_resolved_product_code": SPEChargeLineDB.objects.filter(
+                manual_resolved_product_code__isnull=False
+            ).count(),
+        },
+    }
+
+
+def fk_dependency_counts():
+    targets = {
+        Organization: "organization",
+        Branch: "branch",
+        Department: "department",
+    }
+    rows = []
+    for model in sorted(apps.get_models(), key=lambda m: m._meta.label):
+        for field in model._meta.fields:
+            if isinstance(field, models.ForeignKey) and field.remote_field.model in targets:
+                legacy_filter = {f"{field.name}__name__in": legacy_org_names()}
+                if field.remote_field.model is Branch:
+                    legacy_filter = {f"{field.name}__organization__name__in": legacy_org_names()}
+                if field.remote_field.model is Department:
+                    legacy_filter = {f"{field.name}__organization__name__in": legacy_org_names()}
+                queryset = model.objects.filter(**{f"{field.name}__isnull": False})
+                rows.append(
+                    {
+                        "model": model._meta.label,
+                        "field": field.name,
+                        "target": targets[field.remote_field.model],
+                        "on_delete": getattr(field.remote_field.on_delete, "__name__", str(field.remote_field.on_delete)),
+                        "non_null_count": queryset.count(),
+                        "legacy_scope_count": model.objects.filter(**legacy_filter).count(),
+                        "samples": sample_rows(queryset.order_by("pk")[:SAMPLE_LIMIT]),
+                    }
+                )
+    return rows
+
+
+def migration_classification(organizations, branches, departments):
+    return {
+        "organizations": Counter(classify_organization(org.name) for org in organizations),
+        "branches": Counter("migrate/reparent" if b.organization.name != PARENT_ORGANIZATION else "canonical keep" for b in branches),
+        "departments": Counter(
+            "migrate/reparent" if d.organization.name != PARENT_ORGANIZATION else "canonical keep" for d in departments
+        ),
+        "labels": {
+            "canonical keep": "Express Freight Management and any already-correct child rows.",
+            "migrate/reparent": "Operating entities, branches, departments, memberships, and scoped records under legacy organizations.",
+            "archive/deactivate": "EFM Express Air Cargo and Test Org organization records after dependencies move.",
+            "delete only if safely unused": "Legacy organization rows with zero FK dependencies after audited migration.",
+        },
+    }
+
+
+def duplicate_risks(branches, departments):
+    branch_names = defaultdict(set)
+    department_names = defaultdict(set)
+    for branch in branches:
+        branch_names[branch.name.casefold()].add(branch.organization.name)
+    for department in departments:
+        department_names[department.name.casefold()].add(department.organization.name)
+    return {
+        "duplicated_branches_under_legacy_organizations": [
+            {"name": name, "organizations": sorted(orgs)}
+            for name, orgs in sorted(branch_names.items())
+            if len(orgs) > 1
+        ],
+        "duplicated_departments_under_legacy_organizations": [
+            {"name": name, "organizations": sorted(orgs)}
+            for name, orgs in sorted(department_names.items())
+            if len(orgs) > 1
+        ],
+    }
+
+
+def recommended_target_model():
+    return {
+        "selected": TARGET_MODEL,
+        "option_a": "Keep current tables and overload Branch as operating entity/branch hybrid. Fast, but ambiguous.",
+        "option_b": "Add OperatingEntity between Organization and Branch. Cleanest match to the corrected business hierarchy.",
+        "option_c": "Launch patch: keep one Organization, reparent current Branch/Department rows, defer OperatingEntity. Lowest short-term migration, but preserves naming debt.",
+        "reason": "Country division is a real business level, not the same thing as a physical branch.",
+    }
+
+
+def risks(dependencies):
+    legacy_refs = sum(row["legacy_scope_count"] for row in dependencies)
+    return [
+        f"{legacy_refs} FK references currently point at legacy organization/branch/department scope.",
+        "Current uniqueness constraints are per organization, so branch and department code collisions can block a one-organization collapse.",
+        "OrganizationBranding is one-to-one with Organization; branding must be separated from country/division identity before collapse.",
+        "Existing RBAC readiness tooling still treats EFM PNG/Australia/Fiji/Solomons as canonical organizations and must be revised in a later PR.",
+        "EAC wording must move to Air Freight department semantics without reviving EFM Express Air Cargo as a tenant.",
+    ]
+
+
+def migration_steps():
+    return [
+        "Freeze writes to organization/branch/department master data during migration window.",
+        "Create or confirm Express Freight Management as the single Organization.",
+        "Introduce OperatingEntity model or approved launch shim before moving country-level rows.",
+        "Map EFM PNG, EFM Australia, EFM Fiji, and EFM Solomon Islands to operating entities.",
+        "Reparent branches, departments, memberships, CRM/customer, quote, SPOT, shipment, role, and branding dependencies.",
+        "Archive/deactivate legacy organization rows only after dependency counts reach zero.",
+        "Run selectors, quote, SPOT, CRM, and RBAC regression checks before enforcement changes.",
+    ]
+
+
+def rollback_plan():
+    return [
+        "Keep pre-migration ID mapping for every organization, branch, department, and scoped record.",
+        "Run migration in one transaction where practical; otherwise checkpoint per dependency group.",
+        "Restore old FK values from the mapping table if validation fails before cutover.",
+        "Do not delete legacy rows in the launch migration; archive only after a separate zero-dependency audit.",
+    ]
+
+
+def test_strategy():
+    return [
+        "Assert this command is read-only and reports write_enabled=false.",
+        "Assert multiple Organization rows are detected.",
+        "Assert EFM Express Air Cargo is classified as legacy Air Freight wording, not an organization.",
+        "Assert duplicated branch and department names across legacy organizations are reported.",
+        "Assert memberships and scoped CRM/customer/quote/SPOT records are counted.",
+        "Assert JSON includes migration_classification and recommended_target_model.",
+    ]
+
+
+def classify_organization(name):
+    if name == PARENT_ORGANIZATION:
+        return "canonical keep"
+    if name in LEGACY_OPERATING_ENTITIES:
+        return "migrate/reparent"
+    if name in LEGACY_ARCHIVE_ORGANIZATIONS:
+        return "archive/deactivate"
+    return "delete only if safely unused"
+
+
+def legacy_org_names():
+    return LEGACY_OPERATING_ENTITIES + LEGACY_ARCHIVE_ORGANIZATIONS
+
+
+def sample_rows(queryset):
+    rows = []
+    for obj in queryset:
+        rows.append({"id": safe(obj.pk), "label": safe(obj)})
+    return rows
+
+
+def safe(value):
+    return str(value or "").encode("ascii", "replace").decode("ascii")
+
+
+def write_text(stdout, report):
+    stdout.write("RBAC organization model redesign audit - Phase 10A")
+    stdout.write("==================================================")
+    stdout.write("Mode: read-only diagnostics")
+    stdout.write(f"Business rule: {report['business_rule']}")
+    stdout.write(f"Recommended target model: {report['recommended_target_model']['selected']}")
+    stdout.write("")
+    counts = report["current_counts"]
+    stdout.write(
+        "Current counts: "
+        f"organizations={counts['organizations']}, branches={counts['branches']}, "
+        f"departments={counts['departments']}, memberships={counts['user_memberships']}"
+    )
+    stdout.write("")
+    stdout.write("Organizations:")
+    for org in report["organizations"]:
+        stdout.write(f"  - {org['name']} [{org['classification']}] branches={org['branch_count']} departments={org['department_count']} memberships={org['membership_count']}")
+    stdout.write("")
+    stdout.write("Dependency counts:")
+    for row in report["fk_dependencies"]:
+        stdout.write(
+            f"  - {row['model']}.{row['field']} -> {row['target']}: "
+            f"non_null={row['non_null_count']} legacy_scope={row['legacy_scope_count']} on_delete={row['on_delete']}"
+        )
+    stdout.write("")
+    stdout.write("Risks/blockers:")
+    for risk in report["risks"]:
+        stdout.write(f"  - {risk}")

--- a/backend/parties/tests.py
+++ b/backend/parties/tests.py
@@ -2382,6 +2382,142 @@ class PostMembershipApplyReadinessTests(TestCase):
         self.assertEqual(membership.organization.name, "EFM Australia")
 
 
+class OrganizationModelRedesignAuditTests(TestCase):
+    def setUp(self):
+        UserMembership.objects.all().delete()
+        CustomUser.objects.all().delete()
+        Branch.objects.all().delete()
+        Department.objects.all().delete()
+        Organization.objects.all().delete()
+
+    def _call_audit(self, *args):
+        stdout = StringIO()
+        call_command("rbac_organization_model_redesign_audit", *args, stdout=stdout)
+        return stdout.getvalue()
+
+    def _role(self):
+        return Role.objects.create(code="admin", name="Admin", is_system=True)
+
+    def _fixtures(self):
+        parent = Organization.objects.create(name="Express Freight Management", slug="express-freight-management")
+        png = Organization.objects.create(name="EFM PNG", slug="efm-png")
+        au = Organization.objects.create(name="EFM Australia", slug="efm-australia")
+        eac = Organization.objects.create(name="EFM Express Air Cargo", slug="efm-express-air-cargo")
+        test_org = Organization.objects.create(name="Test Org", slug="test-org")
+
+        png_pom = Branch.objects.create(organization=png, code="POM", name="Port Moresby")
+        au_pom = Branch.objects.create(organization=au, code="POM", name="Port Moresby")
+        png_air = Department.objects.create(organization=png, branch=png_pom, code="AIR", name="Air Freight")
+        au_air = Department.objects.create(organization=au, branch=au_pom, code="AIR", name="Air Freight")
+
+        user = CustomUser.objects.create_user(username="phase10a-user")
+        membership = UserMembership.objects.create(
+            user=user,
+            organization=eac,
+            branch=png_pom,
+            department=png_air,
+            role=self._role(),
+        )
+        company = Company.objects.create(name="Phase 10A Customer", organization=png, branch=png_pom, department=png_air)
+        Contact.objects.create(
+            company=company,
+            first_name="Phase",
+            last_name="Contact",
+            email="phase10a@example.com",
+            organization=png,
+            branch=png_pom,
+            department=png_air,
+        )
+        Opportunity.objects.create(
+            company=company,
+            title="Phase 10A Opportunity",
+            service_type="AIR",
+            organization=png,
+            branch=png_pom,
+            department=png_air,
+        )
+        Quote.objects.create(customer=company, organization=png, branch=png_pom, department=png_air)
+        SpotPricingEnvelopeDB.objects.create(
+            organization=png,
+            branch=png_pom,
+            department=png_air,
+            shipment_context_json={"origin": "POM", "destination": "BNE"},
+            conditions_json={},
+            spot_trigger_reason_code="TEST",
+            spot_trigger_reason_text="Test trigger",
+            expires_at=timezone.now(),
+        )
+        return {
+            "parent": parent,
+            "png": png,
+            "au": au,
+            "eac": eac,
+            "test_org": test_org,
+            "membership": membership,
+            "company": company,
+            "png_air": png_air,
+            "au_air": au_air,
+        }
+
+    def test_json_reports_corrected_business_rule_and_target_model(self):
+        self._fixtures()
+
+        payload = json.loads(self._call_audit("--format", "json"))
+
+        self.assertFalse(payload["write_enabled"])
+        self.assertIn("Express Freight Management is the only organization", payload["business_rule"])
+        self.assertEqual(
+            payload["recommended_target_model"]["selected"],
+            "Option B: add OperatingEntity between Organization and Branch",
+        )
+        self.assertEqual(payload["current_counts"]["organizations"], 5)
+
+    def test_detects_multiple_organizations_and_legacy_eac(self):
+        self._fixtures()
+
+        payload = json.loads(self._call_audit("--format", "json"))
+
+        classifications = {row["name"]: row["classification"] for row in payload["organizations"]}
+        self.assertEqual(classifications["Express Freight Management"], "canonical keep")
+        self.assertEqual(classifications["EFM PNG"], "migrate/reparent")
+        self.assertEqual(classifications["EFM Australia"], "migrate/reparent")
+        self.assertEqual(classifications["EFM Express Air Cargo"], "archive/deactivate")
+        self.assertEqual(classifications["Test Org"], "archive/deactivate")
+
+    def test_detects_duplicated_branches_and_departments_under_legacy_orgs(self):
+        self._fixtures()
+
+        payload = json.loads(self._call_audit("--format", "json"))
+
+        branch_names = {row["name"] for row in payload["duplicate_risks"]["duplicated_branches_under_legacy_organizations"]}
+        department_names = {row["name"] for row in payload["duplicate_risks"]["duplicated_departments_under_legacy_organizations"]}
+        self.assertIn("port moresby", branch_names)
+        self.assertIn("air freight", department_names)
+
+    def test_reports_memberships_and_scoped_record_dependencies(self):
+        self._fixtures()
+
+        payload = json.loads(self._call_audit("--format", "json"))
+
+        self.assertEqual(payload["memberships"]["count"], 1)
+        self.assertGreater(payload["scoped_records"]["parties.Company"]["with_organization"], 0)
+        self.assertGreater(payload["scoped_records"]["crm.Opportunity"]["with_organization"], 0)
+        self.assertGreater(payload["quote_spot_productcode"]["quotes"]["with_organization"], 0)
+        self.assertGreater(payload["quote_spot_productcode"]["spot_envelopes"]["with_organization"], 0)
+        self.assertTrue(
+            any(row["model"] == "accounts.UserMembership" and row["field"] == "organization" for row in payload["fk_dependencies"])
+        )
+
+    def test_command_is_read_only(self):
+        fixtures = self._fixtures()
+        before = fixtures["membership"].organization_id
+
+        self._call_audit()
+
+        fixtures["membership"].refresh_from_db()
+        self.assertEqual(fixtures["membership"].organization_id, before)
+
+
 class FinalUserBlockerResolutionPlanTests(TestCase):
     def setUp(self):
         UserMembership.objects.all().delete()

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -2801,6 +2801,127 @@ Final enforcement sign-off:
   `rbac_enforcement_readiness_report` remain intentionally unprotected after
   Phase 9D and this UI sign-off.
 
+#### Phase 10A - Corrected Organization Hierarchy Redesign Audit
+
+Date: 2026-06-28
+
+Branch: `codex/phase-10a-org-hierarchy-audit`
+
+Scope: read-only audit and redesign plan for correcting the business hierarchy
+before any migration, enforcement, selector, API, or data cleanup work.
+
+Corrected business rule:
+
+> Express Freight Management is the only organization. EFM PNG, EFM Australia,
+> EFM Fiji, and EFM Solomon Islands are not organizations.
+
+Target hierarchy:
+
+```text
+Organization: Express Freight Management
+  -> Operating Entity / Country Division: EFM PNG, EFM Australia, EFM Fiji, EFM Solomon Islands
+      -> Branch: Port Moresby, Lae, Brisbane, Suva, Honiara
+          -> Department: Air Freight, Sea Freight, Customs, Transport, etc.
+```
+
+Legacy wording:
+
+- `EFM Express Air Cargo` / `EAC` is not an organization.
+- EAC should be treated as Air Freight department wording only.
+- `Test Org` is not a production organization and should be archived or
+  deleted only after dependency counts prove it is unused.
+
+Command:
+
+```bash
+python backend/manage.py rbac_organization_model_redesign_audit
+python backend/manage.py rbac_organization_model_redesign_audit --format json
+```
+
+Purpose:
+
+- Audit current `Organization`, `Branch`, `Department`, and `UserMembership`
+  records.
+- Audit CRM/customer, quote, SPOT, shipment, role, branding, and any other FK
+  dependencies on `Organization`, `Branch`, or `Department`.
+- Classify rows as `canonical keep`, `migrate/reparent`,
+  `archive/deactivate`, or `delete only if safely unused`.
+- Report duplicate branch and department names that are currently hidden by
+  per-organization uniqueness.
+- Compare target schema options and recommend the clean model.
+
+Recommended target model:
+
+- Option B: add an `OperatingEntity` model between `Organization` and `Branch`.
+- Reason: country division is a real business level and should not be overloaded
+  into either tenant/company identity or physical branch identity.
+
+Options considered:
+
+- Option A: keep current tables and repurpose `Branch` as an operating
+  entity/branch hybrid. This is fast but ambiguous.
+- Option B: add `OperatingEntity` between `Organization` and `Branch`. This is
+  the cleanest match to the corrected hierarchy.
+- Option C: launch patch with one `Organization`, current `Branch` /
+  `Department` rows reparented, and full operating-entity model later. This is
+  the smallest short-term migration but leaves naming debt.
+
+Risks and blockers:
+
+- Existing readiness tooling still treats EFM PNG, EFM Australia, EFM Fiji, and
+  EFM Solomon Islands as canonical organizations. That assumption must be
+  changed in a later PR before any apply/backfill/enforcement work.
+- `Branch` and `Department` uniqueness is currently scoped by organization, so
+  collapsing organizations can expose duplicate codes or names.
+- `OrganizationBranding` is one-to-one with `Organization`; country or division
+  branding needs a separate design before organization collapse.
+- CRM/customer, quote, SPOT, shipment, role, membership, and branding FKs must
+  be reparented from legacy organizations before old rows can be archived.
+- Do not delete or deactivate legacy organizations until dependency counts are
+  zero and rollback mappings exist.
+
+Migration outline:
+
+1. Freeze organization/branch/department master-data writes during the migration
+   window.
+2. Create or confirm `Express Freight Management` as the single organization.
+3. Add `OperatingEntity` or approve an explicit launch shim.
+4. Map EFM PNG, EFM Australia, EFM Fiji, and EFM Solomon Islands to operating
+   entities.
+5. Reparent branches, departments, memberships, CRM/customer, quote, SPOT,
+   shipment, role, and branding dependencies.
+6. Archive/deactivate old organization rows only after dependency counts reach
+   zero.
+7. Run selectors, quote, SPOT, CRM, and RBAC regression checks before any
+   enforcement changes.
+
+Rollback plan:
+
+- Preserve old organization, branch, department, and scoped-record IDs in a
+  mapping artifact.
+- Use a transaction where practical; otherwise checkpoint by dependency group.
+- Restore FK values from the mapping if validation fails before cutover.
+- Keep legacy rows until a separate zero-dependency audit proves they are safe
+  to remove.
+
+Safety:
+
+- The command is read-only and reports `write_enabled=false`.
+- It does not write, migrate, enforce RBAC, delete, deactivate, or reparent
+  records.
+- It does not change quote, SPOT, ProductCode, CRM, customer, shipment, or
+  selector behavior.
+
+Test coverage:
+
+- Command is read-only.
+- Multiple organization records are detected.
+- Legacy `EFM Express Air Cargo` is detected and classified away from
+  organization status.
+- Duplicated branches and departments under legacy organizations are reported.
+- Memberships and scoped CRM/customer/quote/SPOT records are counted.
+- JSON includes migration classification and the recommended target model.
+
 ## 12. What Not To Touch Yet
 
 Do not touch these in the first implementation slice:


### PR DESCRIPTION
## Summary
- Add read-only `rbac_organization_model_redesign_audit` command with text/json output.
- Report current Organization/Branch/Department/UserMembership state, scoped CRM/customer/quote/SPOT/shipment dependencies, duplicate branch/department risks, migration classification, target model options, risks, migration steps, rollback plan, and test strategy.
- Document Phase 10A corrected business rule in `docs/rbac-organisation-audit-plan.md`.

## Files changed
- `backend/parties/management/commands/rbac_organization_model_redesign_audit.py` - new read-only Phase 10A audit command.
- `backend/parties/tests.py` - focused tests for read-only behavior, legacy EAC detection, duplicates, scoped dependency counts, and JSON shape.
- `docs/rbac-organisation-audit-plan.md` - Phase 10A plan and corrected business rule.

## Intentionally not changed
- No migrations.
- No RBAC enforcement changes.
- No selector/API/queryset changes.
- No record writes, deletes, deactivations, or reparenting.
- No ProductCode, SPOT, quote pricing, CRM UI, or shipment behavior changes.

## Verification
- `npx fallow --format json` passed; baseline reported 99 issues.
- `npx fallow dead-code --format json` returned non-zero with 99 existing dead-code findings.
- `npx fallow dupes --format json` passed; baseline reported 21 clone groups.
- `npx fallow health --format json` returned non-zero with existing complexity findings.
- `python backend\manage.py rbac_organization_model_redesign_audit --format json` passed.
- `python backend\manage.py test parties.tests.PostMembershipApplyReadinessTests parties.tests.OrganizationModelRedesignAuditTests` passed: 16 tests.
- `python backend\manage.py makemigrations --check --dry-run` passed: no changes detected.
- `git diff --check` passed with line-ending warnings only.
- `graphify update .` passed; HTML viz skipped because graph is above the 5000 node limit.

## Live audit snapshot
- Organizations: 7
- Branches: 15
- Departments: 31
- User memberships: 16
- Legacy-scope FK references: 1099
- Quote legacy scope: organization=62, branch=2, department=36
- SPOT legacy scope: organization=63, branch=1, department=14
- ProductCode total: 64; ProductCode has no org/branch/department FK and is affected indirectly through quote/SPOT context.

## Recommendation
Recommended target model: Option B, add `OperatingEntity` between `Organization` and `Branch`.

Main blockers: existing readiness tooling still treats country entities as canonical organizations; current uniqueness is per organization; branding is one-to-one with Organization; legacy FKs must be reparented before archive/delete work.