### PR TITLE
chore(rbac): design OperatingEntity hierarchy model

### DIFF
--- a/backend/parties/management/commands/rbac_operating_entity_model_design.py
+++ b/backend/parties/management/commands/rbac_operating_entity_model_design.py
@@ -1,0 +1,146 @@
+import json
+
+from django.apps import apps
+from django.core.management.base import BaseCommand
+from django.db import models
+
+
+COUNTRY_ENTITIES = ("EFM PNG", "EFM Australia", "EFM Fiji", "EFM Solomon Islands")
+ONLY_ORGANIZATION = "Express Freight Management"
+SCOPE_MODELS_NEEDING_ENTITY = {
+    "accounts.UserMembership",
+    "parties.Branch",
+    "parties.Department",
+    "parties.Company",
+    "parties.Contact",
+    "crm.Opportunity",
+    "crm.Interaction",
+    "crm.Task",
+    "quotes.Quote",
+    "quotes.SpotPricingEnvelopeDB",
+    "shipments.Shipment",
+    "shipments.ShipmentAddress",
+}
+
+
+class Command(BaseCommand):
+    help = "Read-only Phase 10C OperatingEntity hierarchy model design report."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--format", choices=["text", "json"], default="text")
+
+    def handle(self, *args, **options):
+        report = build_report()
+        if options["format"] == "json":
+            self.stdout.write(json.dumps(report, indent=2, sort_keys=True))
+            return
+        write_text(self.stdout, report)
+
+
+def build_report():
+    return {
+        "phase": "10C",
+        "write_enabled": False,
+        "target_hierarchy": {
+            "organization": ONLY_ORGANIZATION,
+            "operating_entities": list(COUNTRY_ENTITIES),
+            "branches": ["Port Moresby", "Lae", "Brisbane", "Suva", "Honiara"],
+            "departments": ["Air Freight", "Sea Freight", "Customs", "Transport"],
+        },
+        "proposed_model": proposed_model(),
+        "current_scope_references": current_scope_references(),
+        "migration_order": [
+            "add OperatingEntity model only; no data migration or enforcement",
+            "seed EFM PNG, EFM Australia, EFM Fiji, and EFM Solomon Islands under Express Freight Management",
+            "add nullable Branch.operating_entity and link branches after duplicate-code review",
+            "add nullable UserMembership.operating_entity and update membership planning/readiness tooling",
+            "add nullable operating_entity to records that need country-division scope",
+            "only then consider selector/API/queryset/RBAC enforcement changes",
+        ],
+        "risks": [
+            "Branch and Department codes are currently unique per Organization, not per OperatingEntity.",
+            "OrganizationBranding is one-to-one with Organization; country-specific branding needs a separate approved design.",
+            "UserMembership target semantics change from organization/branch/department to organization/operating_entity/branch/department.",
+            "Older readiness and reassignment commands still encode country-as-organization assumptions.",
+            "Rollback requires old Organization id to new OperatingEntity id mappings before any apply phase.",
+        ],
+    }
+
+
+def proposed_model():
+    return {
+        "name": "OperatingEntity",
+        "table": "parties_operatingentity",
+        "fields": [
+            {"name": "id", "type": "UUIDField", "primary_key": True},
+            {"name": "organization", "type": "ForeignKey(Organization)", "on_delete": "CASCADE", "related_name": "operating_entities"},
+            {"name": "code", "type": "CharField(max_length=24)", "examples": ["PNG", "AU", "FJ", "SB"]},
+            {"name": "name", "type": "CharField(max_length=120)", "examples": list(COUNTRY_ENTITIES)},
+            {"name": "slug", "type": "SlugField(max_length=64)"},
+            {"name": "country_code", "type": "CharField(max_length=2)", "examples": ["PG", "AU", "FJ", "SB"]},
+            {"name": "is_active", "type": "BooleanField", "default": True, "db_index": True},
+            {"name": "created_at", "type": "DateTimeField(auto_now_add=True)"},
+            {"name": "updated_at", "type": "DateTimeField(auto_now=True)"},
+        ],
+        "constraints": [
+            "UniqueConstraint(fields=['organization', 'code'])",
+            "UniqueConstraint(fields=['organization', 'slug'])",
+            "UniqueConstraint(fields=['organization', 'name'])",
+        ],
+        "indexes": [
+            "Index(fields=['organization', 'is_active'])",
+            "Index(fields=['organization', 'country_code'])",
+        ],
+        "relationships": [
+            "Organization has many OperatingEntity records.",
+            "Branch should later point to OperatingEntity and remain under Organization during transition.",
+            "Department should remain under Branch, with Organization retained until cleanup.",
+            "UserMembership should later include OperatingEntity between Organization and Branch.",
+        ],
+    }
+
+
+def current_scope_references():
+    rows = []
+    target_names = {"Organization", "Branch", "Department"}
+    for model in apps.get_models():
+        fields = []
+        for field in model._meta.get_fields():
+            if not isinstance(field, (models.ForeignKey, models.OneToOneField)):
+                continue
+            remote_model = getattr(field, "remote_field", None) and field.remote_field.model
+            if remote_model and remote_model.__name__ in target_names:
+                fields.append({"field": field.name, "target": remote_model.__name__, "nullable": getattr(field, "null", False)})
+        if fields:
+            label = model._meta.label
+            rows.append(
+                {
+                    "model": label,
+                    "fields": fields,
+                    "operating_entity_need": classify_model(label),
+                }
+            )
+    return sorted(rows, key=lambda row: row["model"])
+
+
+def classify_model(label):
+    if label == "parties.OrganizationBranding":
+        return "review_branding_model_separately"
+    if label in SCOPE_MODELS_NEEDING_ENTITY:
+        return "needs_operating_entity_later"
+    if label in {"accounts.Role", "parties.Organization"}:
+        return "organization_parent_only"
+    return "review_before_migration"
+
+
+def write_text(stdout, report):
+    stdout.write("OperatingEntity model design - Phase 10C")
+    stdout.write("=========================================")
+    stdout.write("Mode: read-only design")
+    stdout.write(f"Organization: {report['target_hierarchy']['organization']}")
+    stdout.write(f"Operating entities: {', '.join(report['target_hierarchy']['operating_entities'])}")
+    stdout.write("")
+    stdout.write("Current scope references:")
+    for row in report["current_scope_references"]:
+        fields = ", ".join(f"{field['field']}->{field['target']}" for field in row["fields"])
+        stdout.write(f"  - {row['model']}: {row['operating_entity_need']} ({fields})")

--- a/backend/parties/tests.py
+++ b/backend/parties/tests.py
@@ -2615,6 +2615,39 @@ class HierarchyToolingAlignmentAuditTests(TestCase):
         self.assertTrue(future_scope["spot_save_uses_resolve_create_scope_for_user"])
 
 
+class OperatingEntityModelDesignTests(TestCase):
+    def _call_design(self, *args):
+        stdout = StringIO()
+        call_command("rbac_operating_entity_model_design", *args, stdout=stdout)
+        return stdout.getvalue()
+
+    def test_json_defines_operating_entity_design(self):
+        payload = json.loads(self._call_design("--format", "json"))
+
+        self.assertFalse(payload["write_enabled"])
+        self.assertEqual(payload["target_hierarchy"]["organization"], "Express Freight Management")
+        self.assertEqual(payload["proposed_model"]["name"], "OperatingEntity")
+        self.assertIn("UniqueConstraint(fields=['organization', 'code'])", payload["proposed_model"]["constraints"])
+        self.assertIn("add OperatingEntity model only; no data migration or enforcement", payload["migration_order"])
+
+    def test_classifies_current_scope_references(self):
+        payload = json.loads(self._call_design("--format", "json"))
+        references = {row["model"]: row for row in payload["current_scope_references"]}
+
+        self.assertEqual(references["parties.Branch"]["operating_entity_need"], "needs_operating_entity_later")
+        self.assertEqual(references["accounts.UserMembership"]["operating_entity_need"], "needs_operating_entity_later")
+        self.assertEqual(references["parties.OrganizationBranding"]["operating_entity_need"], "review_branding_model_separately")
+
+    def test_command_is_read_only(self):
+        org = Organization.objects.create(name="Express Freight Management", slug="express-freight-management")
+
+        self._call_design()
+
+        org.refresh_from_db()
+        self.assertEqual(org.name, "Express Freight Management")
+        self.assertTrue(org.is_active)
+
+
 class FinalUserBlockerResolutionPlanTests(TestCase):
     def setUp(self):
         UserMembership.objects.all().delete()

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -3006,6 +3006,76 @@ Safe next PR order:
 4. Add controlled migration/apply tooling with rollback mappings.
 5. Only after clean diagnostics, revisit enforcement/readiness selectors.
 
+#### Phase 10C - OperatingEntity Model Design Plan
+
+Date: 2026-06-28
+
+Branch: `codex/phase-10c-operating-entity-design`
+
+Scope: read-only schema design only. No migrations, data writes, reparenting,
+selector/API/queryset changes, or RBAC enforcement changes.
+
+Command:
+
+```bash
+python backend/manage.py rbac_operating_entity_model_design
+python backend/manage.py rbac_operating_entity_model_design --format json
+```
+
+Target hierarchy:
+
+- Organization: `Express Freight Management` only.
+- OperatingEntity: `EFM PNG`, `EFM Australia`, `EFM Fiji`,
+  `EFM Solomon Islands`.
+- Branch: `Port Moresby`, `Lae`, `Brisbane`, `Suva`, `Honiara`.
+- Department: `Air Freight`, `Sea Freight`, `Customs`, `Transport`.
+
+Proposed `OperatingEntity` model:
+
+- Fields: `id`, `organization`, `code`, `name`, `slug`, `country_code`,
+  `is_active`, `created_at`, `updated_at`.
+- Constraints: unique `organization + code`, `organization + slug`, and
+  `organization + name`.
+- Indexes: `organization + is_active` and `organization + country_code`.
+- Relationships: `Organization` has many operating entities; `Branch` should
+  later link to one operating entity; `Department` remains below branch;
+  `UserMembership` later becomes organization + operating entity + branch +
+  department.
+
+Current reference classification:
+
+- Needs `OperatingEntity` later: `Branch`, `Department`, `UserMembership`,
+  scoped CRM/customer records, shipments, Quote, and SPOT scope records.
+- Review separately: `OrganizationBranding`, because it is one-to-one with
+  `Organization` and cannot represent country-specific branding without a
+  separate approved design.
+- Organization parent only: roles and organization-level configuration that
+  should remain attached to `Express Freight Management`.
+
+Migration order:
+
+1. Add `OperatingEntity` model only; no data migration or enforcement.
+2. Seed `EFM PNG`, `EFM Australia`, `EFM Fiji`, and `EFM Solomon Islands`
+   under `Express Freight Management`.
+3. Add nullable `Branch.operating_entity` and link branches after duplicate-code
+   review.
+4. Add nullable `UserMembership.operating_entity` and update membership
+   planning/readiness tooling.
+5. Add nullable `operating_entity` to records that need country-division scope.
+6. Only then consider selector/API/queryset/RBAC enforcement changes.
+
+Risks:
+
+- Branch and department codes are currently unique per organization, not per
+  operating entity.
+- `OrganizationBranding` is one-to-one with `Organization`; country-specific
+  branding requires a separate design.
+- Membership semantics change and must not be inferred without a migration map.
+- Older readiness/reassignment commands still contain country-as-organization
+  assumptions.
+- Rollback requires old Organization id to new OperatingEntity id mappings
+  before any apply phase.
+
 ## 12. What Not To Touch Yet
 
 Do not touch these in the first implementation slice:


### PR DESCRIPTION
## Summary
- Add read-only `rbac_operating_entity_model_design` command for Phase 10C.
- Document the proposed `OperatingEntity` model fields, constraints, indexes, and relationships.
- Report current models referencing Organization / Branch / Department and classify later OperatingEntity impact.
- Document proposed migration order, risks, rollback mapping requirements, and next safe steps.

## Intentionally not changed
- No migrations.
- No schema changes.
- No data writes or reparenting.
- No selector/API/queryset/enforcement changes.
- No Quote/SPOT logic changes.

## Verification reported by Codex
- `python backend\manage.py rbac_operating_entity_model_design --format json` passed.
- `python backend\manage.py test parties.tests.OperatingEntityModelDesignTests` passed: 3 tests.
- `python backend\manage.py test parties.tests` passed: 173 tests.
- `python backend\manage.py makemigrations --check --dry-run` passed.
- `npx fallow --format json` passed with existing 99 findings.
- `graphify update .` passed.