### PR TITLE
feat(rbac): align scope resolution with OperatingEntity

### DIFF
--- a/backend/accounts/scope.py
+++ b/backend/accounts/scope.py
@@ -57,6 +57,7 @@ LEGACY_AUTHENTICATED_PERMISSION_CODES = {
 @dataclass(frozen=True)
 class EffectiveUserScope:
     organization_ids: frozenset[Any]
+    operating_entity_ids: frozenset[Any]
     branch_ids: frozenset[Any]
     department_ids: frozenset[Any]
     department_codes: frozenset[str]
@@ -70,6 +71,7 @@ class EffectiveUserScope:
 @dataclass(frozen=True)
 class CreateScope:
     organization: Any = None
+    operating_entity: Any = None
     branch: Any = None
     department: Any = None
     owner: Any = None
@@ -102,9 +104,42 @@ def get_active_memberships(user):
 
     return (
         UserMembership.objects.filter(user=user, is_active=True)
-        .select_related("organization", "branch", "department", "role")
+        .select_related("organization", "operating_entity", "branch", "branch__operating_entity", "department", "role")
         .prefetch_related("role__permissions")
     )
+
+
+def membership_operating_entity(membership):
+    if getattr(membership, "operating_entity_id", None):
+        return membership.operating_entity
+    branch = getattr(membership, "branch", None)
+    if branch is not None and getattr(branch, "operating_entity_id", None):
+        return branch.operating_entity
+    return None
+
+
+def membership_operating_entity_id(membership):
+    entity = membership_operating_entity(membership)
+    return getattr(entity, "id", None)
+
+
+def _agreed_membership_operating_entity(memberships):
+    values = {membership_operating_entity_id(membership) for membership in memberships}
+    if len(values) == 1 and next(iter(values)) is not None:
+        return membership_operating_entity(memberships[0])
+    return None
+
+
+def _model_has_field(model, field_name: str) -> bool:
+    current_model = model
+    parts = field_name.split("__")
+    try:
+        for part in parts:
+            field = current_model._meta.get_field(part)
+            current_model = getattr(field, "related_model", None) or current_model
+    except Exception:
+        return False
+    return True
 
 
 def user_has_cross_scope_access(user) -> bool:
@@ -142,13 +177,15 @@ def scoped_queryset_for_user(queryset, user, *, prefix: str = ""):
         return queryset.none()
 
     field_prefix = f"{prefix}__" if prefix else ""
-    return queryset.filter(
-        **{
-            f"{field_prefix}organization_id": membership.organization_id,
-            f"{field_prefix}branch_id": membership.branch_id,
-            f"{field_prefix}department_id": membership.department_id,
-        }
-    )
+    filters = {
+        f"{field_prefix}organization_id": membership.organization_id,
+        f"{field_prefix}branch_id": membership.branch_id,
+        f"{field_prefix}department_id": membership.department_id,
+    }
+    operating_entity_id = membership_operating_entity_id(membership)
+    if operating_entity_id and _model_has_field(queryset.model, f"{field_prefix}operating_entity"):
+        filters[f"{field_prefix}operating_entity_id"] = operating_entity_id
+    return queryset.filter(**filters)
 
 
 def scoped_q_for_user(user, *, prefix: str = "") -> Q:
@@ -162,13 +199,12 @@ def scoped_q_for_user(user, *, prefix: str = "") -> Q:
         return Q(pk__in=[])
 
     field_prefix = f"{prefix}__" if prefix else ""
-    return Q(
-        **{
-            f"{field_prefix}organization_id": membership.organization_id,
-            f"{field_prefix}branch_id": membership.branch_id,
-            f"{field_prefix}department_id": membership.department_id,
-        }
-    )
+    filters = {
+        f"{field_prefix}organization_id": membership.organization_id,
+        f"{field_prefix}branch_id": membership.branch_id,
+        f"{field_prefix}department_id": membership.department_id,
+    }
+    return Q(**filters)
 
 
 def _agreed_membership_value(memberships, field_name, id_field_name):
@@ -187,6 +223,7 @@ def resolve_create_scope_for_user(user) -> CreateScope:
         membership = memberships[0]
         return CreateScope(
             organization=membership.organization,
+            operating_entity=membership_operating_entity(membership),
             branch=membership.branch,
             department=membership.department,
             owner=user,
@@ -197,6 +234,7 @@ def resolve_create_scope_for_user(user) -> CreateScope:
     if len(memberships) > 1:
         return CreateScope(
             organization=_agreed_membership_value(memberships, "organization", "organization_id"),
+            operating_entity=_agreed_membership_operating_entity(memberships),
             branch=_agreed_membership_value(memberships, "branch", "branch_id"),
             department=_agreed_membership_value(memberships, "department", "department_id"),
             owner=user,
@@ -218,6 +256,7 @@ def _membership_create_scope_for_user(user) -> CreateScope:
         membership = memberships[0]
         return CreateScope(
             organization=membership.organization,
+            operating_entity=membership_operating_entity(membership),
             branch=membership.branch,
             department=membership.department,
             owner=user,
@@ -228,6 +267,7 @@ def _membership_create_scope_for_user(user) -> CreateScope:
     if len(memberships) > 1:
         return CreateScope(
             organization=_agreed_membership_value(memberships, "organization", "organization_id"),
+            operating_entity=_agreed_membership_operating_entity(memberships),
             branch=_agreed_membership_value(memberships, "branch", "branch_id"),
             department=_agreed_membership_value(memberships, "department", "department_id"),
             owner=user,
@@ -322,6 +362,7 @@ def get_effective_user_scope(user) -> EffectiveUserScope:
     if not _is_authenticated_active(user):
         return EffectiveUserScope(
             organization_ids=frozenset(),
+            operating_entity_ids=frozenset(),
             branch_ids=frozenset(),
             department_ids=frozenset(),
             department_codes=frozenset(),
@@ -343,6 +384,11 @@ def get_effective_user_scope(user) -> EffectiveUserScope:
             membership.branch_id
             for membership in memberships
             if membership.branch_id
+        }
+        operating_entity_ids = {
+            operating_entity_id
+            for operating_entity_id in (membership_operating_entity_id(membership) for membership in memberships)
+            if operating_entity_id
         }
         department_ids = {
             membership.department_id
@@ -370,6 +416,7 @@ def get_effective_user_scope(user) -> EffectiveUserScope:
 
         return EffectiveUserScope(
             organization_ids=frozenset(organization_ids),
+            operating_entity_ids=frozenset(operating_entity_ids),
             branch_ids=frozenset(branch_ids),
             department_ids=frozenset(department_ids),
             department_codes=frozenset(department_codes),
@@ -386,6 +433,7 @@ def get_effective_user_scope(user) -> EffectiveUserScope:
 
     return EffectiveUserScope(
         organization_ids=frozenset({organization_id} if organization_id else set()),
+        operating_entity_ids=frozenset(),
         branch_ids=frozenset(),
         department_ids=frozenset(),
         department_codes=frozenset({department_code} if department_code else set()),
@@ -457,6 +505,10 @@ def user_can_access_branch(user, branch) -> bool:
     if branch_organization_id not in scope.organization_ids:
         return False
 
+    branch_operating_entity_id = getattr(branch, "operating_entity_id", None)
+    if branch_operating_entity_id and scope.operating_entity_ids and branch_operating_entity_id not in scope.operating_entity_ids:
+        return False
+
     if not scope.has_null_branch_scope:
         return False
 
@@ -485,6 +537,15 @@ def user_can_access_department(user, department) -> bool:
 
     department_organization_id = getattr(department, "organization_id", None)
     if department_organization_id not in scope.organization_ids:
+        return False
+
+    branch = getattr(department, "branch", None)
+    department_operating_entity_id = getattr(branch, "operating_entity_id", None)
+    if (
+        department_operating_entity_id
+        and scope.operating_entity_ids
+        and department_operating_entity_id not in scope.operating_entity_ids
+    ):
         return False
 
     department_code = _normalize_department_code(getattr(department, "code", ""))

--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -24,6 +24,8 @@ from .models import CustomUser, Permission, Role, RolePermission, UserMembership
 from .scope import (
     get_active_memberships,
     get_effective_user_scope,
+    resolve_create_scope_for_user,
+    scoped_queryset_for_user,
     user_can_access_branch,
     user_can_access_department,
     user_can_access_organization,
@@ -324,6 +326,38 @@ class RBACScopeHelperTests(TestCase):
             slug='efm-png',
             country_code='PG',
         )
+        self.branch_a.operating_entity = self.operating_entity_a
+        self.branch_a.save(update_fields=['operating_entity'])
+        self.operating_entity_a_alt = OperatingEntity.objects.create(
+            organization=self.org_a,
+            code='AUS',
+            name='EFM Australia',
+            slug='efm-australia',
+            country_code='AU',
+        )
+        self.branch_a_alt = Branch.objects.create(
+            organization=self.org_a,
+            operating_entity=self.operating_entity_a_alt,
+            code='BNE',
+            name='Brisbane',
+        )
+        self.department_a_alt = Department.objects.create(
+            organization=self.org_a,
+            branch=self.branch_a_alt,
+            code='BNEAIR',
+            name='Brisbane Air Freight',
+        )
+        self.branch_a_legacy = Branch.objects.create(
+            organization=self.org_a,
+            code='LEG',
+            name='Legacy Branch',
+        )
+        self.department_a_legacy = Department.objects.create(
+            organization=self.org_a,
+            branch=self.branch_a_legacy,
+            code='LEGAIR',
+            name='Legacy Air Freight',
+        )
         self.branch_b = Branch.objects.create(
             organization=self.org_b,
             code='LAE',
@@ -425,19 +459,80 @@ class RBACScopeHelperTests(TestCase):
 
         membership.refresh_from_db()
         scope = get_effective_user_scope(user)
+        create_scope = resolve_create_scope_for_user(user)
 
         self.assertEqual(membership.operating_entity, self.operating_entity_a)
+        self.assertEqual(create_scope.operating_entity, self.operating_entity_a)
         self.assertIn(self.org_a.id, scope.organization_ids)
+        self.assertIn(self.operating_entity_a.id, scope.operating_entity_ids)
         self.assertIn(self.branch_a.id, scope.branch_ids)
 
-    def test_membership_operating_entity_can_remain_null_during_transition(self):
-        user = self._create_user(username='null-operating-entity-user')
+    def test_membership_operating_entity_infers_from_branch_during_transition(self):
+        user = self._create_user(username='branch-inferred-operating-entity-user')
         membership = self._create_membership(user)
 
         membership.refresh_from_db()
+        create_scope = resolve_create_scope_for_user(user)
+        scope = get_effective_user_scope(user)
 
         self.assertIsNone(membership.operating_entity)
+        self.assertEqual(create_scope.operating_entity, self.operating_entity_a)
+        self.assertIn(self.operating_entity_a.id, scope.operating_entity_ids)
         self.assertEqual(list(get_active_memberships(user)), [membership])
+
+    def test_membership_without_operating_entity_or_branch_link_preserves_old_scope(self):
+        user = self._create_user(username='legacy-null-operating-entity-user')
+        membership = self._create_membership(user, branch=self.branch_a_legacy, department=self.department_a_legacy)
+
+        create_scope = resolve_create_scope_for_user(user)
+        scope = get_effective_user_scope(user)
+
+        self.assertIsNone(membership.operating_entity)
+        self.assertIsNone(create_scope.operating_entity)
+        self.assertEqual(create_scope.organization, self.org_a)
+        self.assertEqual(create_scope.branch, self.branch_a_legacy)
+        self.assertEqual(create_scope.department, self.department_a_legacy)
+        self.assertEqual(scope.operating_entity_ids, frozenset())
+
+    def test_operating_entity_limits_org_wide_branch_and_department_access_when_known(self):
+        user = self._create_user(username='entity-wide-admin')
+        self._create_membership(
+            user,
+            role=self.admin_role,
+            operating_entity=self.operating_entity_a,
+            branch=None,
+            department=None,
+        )
+
+        self.assertTrue(user_can_access_branch(user, self.branch_a))
+        self.assertTrue(user_can_access_department(user, self.department_a))
+        self.assertFalse(user_can_access_branch(user, self.branch_a_alt))
+        self.assertFalse(user_can_access_department(user, self.department_a_alt))
+
+    def test_scoped_queryset_adds_operating_entity_only_for_models_that_have_field(self):
+        user = self._create_user(username='entity-filter-user')
+        self._create_membership(user, operating_entity=self.operating_entity_a)
+        matching = UserMembership.objects.create(
+            user=self._create_user(username='entity-filter-target'),
+            organization=self.org_a,
+            operating_entity=self.operating_entity_a,
+            branch=self.branch_a,
+            department=self.department_a,
+            role=self.manager_role,
+        )
+        UserMembership.objects.create(
+            user=self._create_user(username='entity-filter-other'),
+            organization=self.org_a,
+            operating_entity=self.operating_entity_a_alt,
+            branch=self.branch_a,
+            department=self.department_a,
+            role=self.manager_role,
+        )
+
+        scoped_ids = set(scoped_queryset_for_user(UserMembership.objects.all(), user).values_list("id", flat=True))
+
+        self.assertIn(matching.id, scoped_ids)
+        self.assertNotIn(UserMembership.objects.get(user__username='entity-filter-other').id, scoped_ids)
 
     def test_inactive_membership_ignored(self):
         user = self._create_user()

--- a/backend/parties/management/commands/rbac_post_membership_apply_readiness.py
+++ b/backend/parties/management/commands/rbac_post_membership_apply_readiness.py
@@ -98,6 +98,7 @@ def canonical_report(organizations, operating_entities, branches, departments):
     }
     entity_names = {entity.name for entity in operating_entities}
     duplicate_codes = duplicate_codes_for(organizations.values(), operating_entities, branches, departments)
+    branches_with_operating_entity = sum(1 for branch in branches if branch.operating_entity_id)
     return {
         "organizations_present": sorted(organizations),
         "organizations_missing": [name for name in CANONICAL_TOP_ORGANIZATIONS if name not in organizations],
@@ -105,6 +106,12 @@ def canonical_report(organizations, operating_entities, branches, departments):
         "operating_entities_missing": [name for name in CANONICAL_OPERATING_ENTITIES if name not in entity_names],
         "branches_missing": {org: names for org, names in missing_branches.items() if names},
         "branches_missing_operating_entity": [branch_row(branch) for branch in branches if branch.operating_entity_id is None],
+        "branch_operating_entity_completeness": {
+            "total": len(branches),
+            "with_operating_entity": branches_with_operating_entity,
+            "missing_operating_entity": len(branches) - branches_with_operating_entity,
+            "ready": bool(branches) and branches_with_operating_entity == len(branches),
+        },
         "operating_entities_without_branches": sorted(
             entity.name for entity in operating_entities if entity.name not in branch_names_by_entity
         ),
@@ -140,15 +147,22 @@ def membership_report(memberships, active_users):
         for user_id, memberships_for_user in memberships_by_user.items()
         if user_id in active_user_ids and len(memberships_for_user) > 1
     ]
-    missing_operating_entity = sum(1 for membership in memberships if membership.operating_entity_id is None)
+    missing_operating_entity = [membership for membership in memberships if membership.operating_entity_id is None]
+    inferable_from_branch = [
+        membership for membership in missing_operating_entity if membership.branch_id and membership.branch.operating_entity_id
+    ]
+    not_inferable = [membership for membership in missing_operating_entity if membership not in inferable_from_branch]
     return {
         "active_users": len(active_users),
         "active_memberships": len(memberships),
         "complete_canonical_memberships": sum(1 for membership in memberships if membership_is_complete_canonical(membership)),
         "missing_organization": sum(1 for membership in memberships if membership.organization_id is None),
         "missing_branch": sum(1 for membership in memberships if membership.branch_id is None),
-        "memberships_missing_operating_entity": missing_operating_entity,
-        "missing_operating_entity": missing_operating_entity,
+        "memberships_missing_operating_entity": len(missing_operating_entity),
+        "memberships_inferable_from_branch": len(inferable_from_branch),
+        "memberships_not_inferable": len(not_inferable),
+        "scope_resolution_operating_entity_ready": len(not_inferable) == 0,
+        "missing_operating_entity": len(missing_operating_entity),
         "missing_department": sum(1 for membership in memberships if membership.department_id is None),
         "missing_role": sum(1 for membership in memberships if membership.role_id is None),
         "legacy_non_canonical_organization_memberships": sum(
@@ -178,6 +192,8 @@ def membership_status(membership):
     if membership.organization.name not in CANONICAL_TOP_ORGANIZATIONS + CANONICAL_ORGANIZATIONS:
         return "legacy_organization"
     if not membership.operating_entity_id:
+        if membership.branch_id and membership.branch.operating_entity_id:
+            return "operating_entity_inferable_from_branch"
         return "missing_operating_entity"
     if not membership.branch_id:
         return "missing_branch"
@@ -234,6 +250,7 @@ def write_text(stdout, report):
     stdout.write(f"  operating_entities_missing={canonical['operating_entities_missing']}")
     stdout.write(f"  branches_missing={canonical['branches_missing']}")
     stdout.write(f"  branches_missing_operating_entity={len(canonical['branches_missing_operating_entity'])}")
+    stdout.write(f"  branch_operating_entity_completeness={canonical['branch_operating_entity_completeness']}")
     stdout.write(f"  operating_entities_without_branches={canonical['operating_entities_without_branches']}")
     stdout.write(f"  duplicate_codes={canonical['duplicate_codes']}")
     stdout.write(f"  orphaned_branches={len(canonical['orphaned_branches'])}")
@@ -246,6 +263,9 @@ def write_text(stdout, report):
         f"complete_canonical={membership['complete_canonical_memberships']}, "
         f"missing_org={membership['missing_organization']}, "
         f"memberships_missing_operating_entity={membership['memberships_missing_operating_entity']}, "
+        f"memberships_inferable_from_branch={membership['memberships_inferable_from_branch']}, "
+        f"memberships_not_inferable={membership['memberships_not_inferable']}, "
+        f"scope_resolution_operating_entity_ready={membership['scope_resolution_operating_entity_ready']}, "
         f"missing_branch={membership['missing_branch']}, "
         f"missing_department={membership['missing_department']}, "
         f"missing_role={membership['missing_role']}, "

--- a/backend/parties/tests.py
+++ b/backend/parties/tests.py
@@ -2463,8 +2463,32 @@ class PostMembershipApplyReadinessTests(TestCase):
         payload = json.loads(self._call_report("--format", "json"))
 
         self.assertEqual(payload["memberships"]["memberships_missing_operating_entity"], 1)
+        self.assertEqual(payload["memberships"]["memberships_inferable_from_branch"], 1)
+        self.assertEqual(payload["memberships"]["memberships_not_inferable"], 0)
+        self.assertTrue(payload["memberships"]["scope_resolution_operating_entity_ready"])
         self.assertEqual(payload["memberships"]["missing_operating_entity"], 1)
-        self.assertEqual(payload["memberships"]["active_memberships_by_status"]["missing_operating_entity"], 1)
+        self.assertEqual(payload["memberships"]["active_memberships_by_status"]["operating_entity_inferable_from_branch"], 1)
+
+    def test_missing_operating_entity_without_branch_link_reported_not_inferable(self):
+        self._canonical_master_data()
+        org = Organization.objects.get(name="Express Freight Management")
+        branch = Branch.objects.create(organization=org, code="LEG", name="Legacy Branch")
+        user = CustomUser.objects.create_user(username="not-inferable-entity-ready-user")
+        UserMembership.objects.create(
+            user=user,
+            organization=org,
+            branch=branch,
+            department=Department.objects.get(organization=org, name="Air Freight"),
+            role=self._role(),
+        )
+
+        payload = json.loads(self._call_report("--format", "json"))
+
+        self.assertEqual(payload["memberships"]["memberships_missing_operating_entity"], 1)
+        self.assertEqual(payload["memberships"]["memberships_inferable_from_branch"], 0)
+        self.assertEqual(payload["memberships"]["memberships_not_inferable"], 1)
+        self.assertFalse(payload["memberships"]["scope_resolution_operating_entity_ready"])
+        self.assertFalse(payload["canonical"]["branch_operating_entity_completeness"]["ready"])
 
     def test_active_user_with_no_membership_blocks(self):
         self._canonical_master_data()

--- a/backend/quotes/tests/test_commodity_support.py
+++ b/backend/quotes/tests/test_commodity_support.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 
 from django.contrib.auth import get_user_model
 from django.http import Http404
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework import status
@@ -74,6 +74,7 @@ class QuoteCommoditySchemaTests(TestCase):
         self.assertTrue(payload.is_dangerous_goods)
 
 
+@override_settings(RBAC_ALLOW_LEGACY_SCOPE_FALLBACK_FOR_TESTS=True)
 class QuoteCommodityPersistenceTests(TestCase):
     @classmethod
     def setUpTestData(cls):
@@ -437,6 +438,7 @@ class QuoteCommodityPersistenceTests(TestCase):
             )
 
 
+@override_settings(RBAC_ALLOW_LEGACY_SCOPE_FALLBACK_FOR_TESTS=True)
 class QuoteCommodityAPITests(APITestCase):
     def setUp(self):
         user_model = get_user_model()

--- a/backend/quotes/tests/test_crm_resilience.py
+++ b/backend/quotes/tests/test_crm_resilience.py
@@ -4,6 +4,7 @@ from datetime import date, timedelta
 from decimal import Decimal
 from unittest.mock import patch
 from django.contrib.auth import get_user_model
+from django.test import override_settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -15,6 +16,7 @@ from services.models import ServiceComponent
 from quotes.models import Quote
 
 
+@override_settings(RBAC_ALLOW_LEGACY_SCOPE_FALLBACK_FOR_TESTS=True)
 class CRMResilienceTests(APITestCase):
     def setUp(self):
         User = get_user_model()

--- a/backend/quotes/tests/test_quote_compute_selector_validation.py
+++ b/backend/quotes/tests/test_quote_compute_selector_validation.py
@@ -2,6 +2,7 @@ from datetime import date, timedelta
 from decimal import Decimal
 
 from django.contrib.auth import get_user_model
+from django.test import override_settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -12,6 +13,7 @@ from pricing_v4.models import Agent, Carrier, DomesticCOGS, DomesticSellRate, Im
 from services.models import ServiceComponent
 
 
+@override_settings(RBAC_ALLOW_LEGACY_SCOPE_FALLBACK_FOR_TESTS=True)
 class QuoteComputeSelectorValidationTests(APITestCase):
     def setUp(self):
         User = get_user_model()

--- a/backend/quotes/tests/test_quote_stabilisation_regression.py
+++ b/backend/quotes/tests/test_quote_stabilisation_regression.py
@@ -3,6 +3,7 @@
 from datetime import date, timedelta
 from decimal import Decimal
 from django.contrib.auth import get_user_model
+from django.test import override_settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -27,6 +28,7 @@ from services.models import ServiceComponent
 from pricing_v4.tests.test_export_engine import seed_all_export_product_codes
 
 
+@override_settings(RBAC_ALLOW_LEGACY_SCOPE_FALLBACK_FOR_TESTS=True)
 class CoreQuoteStabilisationRegressionTests(APITestCase):
     def setUp(self):
         User = get_user_model()

--- a/backend/quotes/tests/test_quote_validation_matrix_regression.py
+++ b/backend/quotes/tests/test_quote_validation_matrix_regression.py
@@ -28,6 +28,7 @@ from pricing_v4.tests.test_export_engine import seed_all_export_product_codes
 
 
 @override_settings(
+    RBAC_ALLOW_LEGACY_SCOPE_FALLBACK_FOR_TESTS=True,
     REST_FRAMEWORK={
         "DEFAULT_PERMISSION_CLASSES": [
             "rest_framework.permissions.IsAuthenticated",

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -3213,6 +3213,54 @@ npx fallow --format json
 graphify update .
 ```
 
+#### Phase 10G - OperatingEntity Scope Resolution and RBAC Alignment
+
+Date: 2026-06-29
+
+Branch: `codex/phase-10g-operating-entity-scope`
+
+Scope: teach shared runtime scope resolution about `OperatingEntity` while
+preserving the transition state where `UserMembership.operating_entity` may be
+null.
+
+Runtime resolution rules:
+
+- `UserMembership.operating_entity` wins when present.
+- If membership `operating_entity` is null and `membership.branch` has
+  `operating_entity`, runtime scope infers the entity from the branch.
+- If neither membership nor branch can provide an entity, existing
+  organization, branch, and department behavior is preserved.
+- Queryset filtering only adds `operating_entity` where the target model has
+  that field. Current CRM/customer/quote/SPOT scoped records do not yet have
+  that field.
+
+Diagnostics now include:
+
+- `memberships_missing_operating_entity`
+- `memberships_inferable_from_branch`
+- `memberships_not_inferable`
+- `branch_operating_entity_completeness`
+- `scope_resolution_operating_entity_ready`
+
+Out of scope:
+
+- No required `operating_entity` field.
+- No destructive data migration.
+- No legacy organization deletion or deactivation.
+- No Quote/SPOT historical backfill tooling.
+- No pricing, ProductCode, quote pricing, SPOT pricing, or rating changes.
+
+Verification:
+
+```bash
+python backend/manage.py makemigrations --check --dry-run
+python backend/manage.py test accounts.tests parties.tests crm.tests quotes.tests
+python backend/manage.py check
+npx fallow --format json
+graphify update .
+git diff --check
+```
+
 ## 12. What Not To Touch Yet
 
 Do not touch these in the first implementation slice:


### PR DESCRIPTION
## Summary
- Add runtime OperatingEntity resolution to shared RBAC scope helpers with explicit membership precedence and branch-based transition inference.
- Add OperatingEntity-aware filtering only for models that expose an `operating_entity` field, preserving existing organization/branch/department behavior otherwise.
- Extend readiness diagnostics and docs with OperatingEntity transition metrics.
- Add regression coverage for explicit, inferred, and legacy-null OperatingEntity membership scopes.

## Intentionally not changed
- No required `operating_entity` fields.
- No destructive data migration or historical Quote/SPOT backfill tooling.
- No selector/API/serializer/UI changes.
- No pricing, ProductCode, quote pricing, SPOT pricing, or rating logic changes.

## Verification
- `python backend/manage.py makemigrations --check --dry-run` - passed, no changes detected
- `python backend/manage.py test accounts.tests parties.tests crm.tests quotes.tests` - passed, 620 tests
- `python backend/manage.py check` - passed
- `npx fallow --format json` - passed, existing 99 frontend findings
- `graphify update .` - passed, HTML viz skipped because graph is too large
- `git diff --check` - passed