### PR TITLE
chore(rbac): add final OperatingEntity readiness audit

### DIFF
--- a/backend/parties/management/commands/rbac_post_membership_apply_readiness.py
+++ b/backend/parties/management/commands/rbac_post_membership_apply_readiness.py
@@ -1,12 +1,16 @@
 import json
 from collections import Counter
+from pathlib import Path
 
+from django.apps import apps
 from django.core.management.base import BaseCommand
+from django.db import models
 
 from accounts.models import CustomUser, UserMembership
 from parties.models import Branch, Department, OperatingEntity, Organization
 
 
+ROOT = Path(__file__).resolve().parents[4]
 CANONICAL_ORGANIZATIONS = ("EFM PNG", "EFM Australia", "EFM Fiji", "EFM Solomon Islands")
 CANONICAL_TOP_ORGANIZATIONS = ("Express Freight Management",)
 CANONICAL_OPERATING_ENTITIES = ("EFM PNG", "EFM Australia", "EFM Fiji", "EFM Solomon Islands")
@@ -17,6 +21,13 @@ CANONICAL_BRANCHES = {
     "EFM Solomon Islands": ("Honiara",),
 }
 CANONICAL_DEPARTMENTS = ("Air Freight", "Sea Freight", "Customs", "Transport")
+LEGACY_EAC_NAMES = ("EAC", "EFM Express Air Cargo", "Express Air Cargo")
+STALE_ARTIFACTS = (
+    "backend/parties/management/commands/rbac_hierarchy_tooling_alignment_audit.py",
+    "docs/beta-readiness-efm.md",
+    "docs/tenant-model-beta.md",
+    "docs/rbac-organisation-audit-plan.md",
+)
 
 
 class Command(BaseCommand):
@@ -68,14 +79,28 @@ def build_report():
 
     canonical = canonical_report(organizations, operating_entities, branches, departments)
     membership = membership_report(memberships, active_users)
+    legacy = legacy_report()
+    stale_artifacts = stale_artifact_report()
     blockers = blockers_for(canonical, membership)
+    final_blockers = final_blockers_for(canonical, membership, legacy, stale_artifacts)
     return {
         "write_enabled": False,
         "canonical": canonical,
         "memberships": membership,
+        "legacy": legacy,
+        "stale_artifacts": stale_artifacts,
         "readiness": {
             "status": "READY_FOR_BACKFILL_PLANNING" if not blockers else "NOT_READY_FOR_BACKFILL_PLANNING",
             "blockers": blockers,
+        },
+        "final_readiness": {
+            "status": "READY" if not final_blockers else "NOT_READY",
+            "blockers": final_blockers,
+            "notes": [
+                "country-as-organization assumptions are obsolete",
+                "EAC is legacy Air Freight wording only",
+                "Quote/SPOT historical records remain DEV_TEST_LEGACY; no historical backfill is planned",
+            ],
         },
     }
 
@@ -102,8 +127,18 @@ def canonical_report(organizations, operating_entities, branches, departments):
     return {
         "organizations_present": sorted(organizations),
         "organizations_missing": [name for name in CANONICAL_TOP_ORGANIZATIONS if name not in organizations],
+        "organization_completeness": {
+            "present": len([name for name in CANONICAL_TOP_ORGANIZATIONS if name in organizations]),
+            "expected": len(CANONICAL_TOP_ORGANIZATIONS),
+            "ready": all(name in organizations for name in CANONICAL_TOP_ORGANIZATIONS),
+        },
         "operating_entities_present": sorted(entity_names),
         "operating_entities_missing": [name for name in CANONICAL_OPERATING_ENTITIES if name not in entity_names],
+        "operating_entity_completeness": {
+            "present": len(entity_names),
+            "expected": len(CANONICAL_OPERATING_ENTITIES),
+            "ready": all(name in entity_names for name in CANONICAL_OPERATING_ENTITIES),
+        },
         "branches_missing": {org: names for org, names in missing_branches.items() if names},
         "branches_missing_operating_entity": [branch_row(branch) for branch in branches if branch.operating_entity_id is None],
         "branch_operating_entity_completeness": {
@@ -156,6 +191,12 @@ def membership_report(memberships, active_users):
         "active_users": len(active_users),
         "active_memberships": len(memberships),
         "complete_canonical_memberships": sum(1 for membership in memberships if membership_is_complete_canonical(membership)),
+        "membership_operating_entity_completeness": {
+            "total": len(memberships),
+            "with_operating_entity": len(memberships) - len(missing_operating_entity),
+            "missing_operating_entity": len(missing_operating_entity),
+            "ready": len(not_inferable) == 0,
+        },
         "missing_organization": sum(1 for membership in memberships if membership.organization_id is None),
         "missing_branch": sum(1 for membership in memberships if membership.branch_id is None),
         "memberships_missing_operating_entity": len(missing_operating_entity),
@@ -204,17 +245,113 @@ def membership_status(membership):
     return "complete_canonical"
 
 
+def legacy_report():
+    return {
+        "country_as_organization_dependencies": dependency_report(CANONICAL_ORGANIZATIONS),
+        "eac_legacy_references": dependency_report(LEGACY_EAC_NAMES),
+        "quote_spot_historical_records": quote_spot_legacy_report(),
+    }
+
+
+def dependency_report(names):
+    organizations = list(Organization.objects.filter(name__in=names).order_by("name"))
+    rows = []
+    for model in sorted(apps.get_models(), key=lambda item: item._meta.label):
+        for field in model._meta.fields:
+            if not isinstance(field, models.ForeignKey):
+                continue
+            target = field.remote_field.model
+            if target is Organization:
+                filters = {f"{field.name}__name__in": names}
+            elif target is Branch:
+                filters = {f"{field.name}__organization__name__in": names}
+            elif target is Department:
+                filters = {f"{field.name}__organization__name__in": names}
+            else:
+                continue
+            count = model.objects.filter(**filters).count()
+            if count:
+                rows.append({"model": model._meta.label, "field": field.name, "count": count})
+    total = sum(row["count"] for row in rows)
+    return {
+        "organization_names": [safe(org.name) for org in organizations],
+        "organization_count": len(organizations),
+        "dependency_count": total,
+        "dependencies": rows,
+        "ready_for_deactivation_review": len(organizations) > 0 and total == 0,
+        "rollback_mapping_required": len(organizations) > 0,
+    }
+
+
+def quote_spot_legacy_report():
+    quote_model = apps.get_model("quotes", "Quote")
+    spot_model = apps.get_model("quotes", "SpotPricingEnvelopeDB")
+    return {
+        "classification": "DEV_TEST_LEGACY",
+        "historical_backfill_required": False,
+        "build_historical_backfill_tooling": False,
+        "quote_count": quote_model.objects.count(),
+        "spot_count": spot_model.objects.count(),
+    }
+
+
+def stale_artifact_report():
+    rows = []
+    for relative_path in STALE_ARTIFACTS:
+        source = read_source(relative_path)
+        rows.append(
+            {
+                "path": relative_path,
+                "exists": source is not None,
+                "mentions_country_as_organization": bool(source and all(name in source for name in CANONICAL_ORGANIZATIONS)),
+                "mentions_legacy_eac": bool(source and any(name in source for name in LEGACY_EAC_NAMES)),
+                "status": "superseded_legacy_reference",
+                "note": "country-as-organization assumptions are obsolete; EAC is legacy Air Freight wording only",
+            }
+        )
+    return rows
+
+
+def read_source(relative_path):
+    path = ROOT / relative_path
+    if not path.exists():
+        return None
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
 def blockers_for(canonical, membership):
     blockers = []
+    if canonical["organizations_missing"]:
+        blockers.append(f"missing canonical organization: {canonical['organizations_missing']}")
+    if canonical["operating_entities_missing"]:
+        blockers.append(f"missing operating entities: {canonical['operating_entities_missing']}")
     if canonical["branches_missing"]:
         blockers.append(f"missing canonical branches: {canonical['branches_missing']}")
+    if canonical["branches_missing_operating_entity"]:
+        blockers.append(f"branches_missing_operating_entity: {len(canonical['branches_missing_operating_entity'])}")
+    if canonical["operating_entities_without_branches"]:
+        blockers.append(f"operating_entities_without_branches: {canonical['operating_entities_without_branches']}")
     if any(canonical["duplicate_codes"].values()):
         blockers.append(f"duplicate_codes: {canonical['duplicate_codes']}")
     if canonical["departments_missing"]:
         blockers.append(f"missing canonical departments: {canonical['departments_missing']}")
-    for key in ("legacy_non_canonical_organization_memberships", "missing_organization", "missing_branch", "missing_department", "missing_role", "users_with_no_active_membership", "users_with_multiple_active_memberships"):
+    for key in ("legacy_non_canonical_organization_memberships", "missing_organization", "memberships_not_inferable", "missing_branch", "missing_department", "missing_role", "users_with_no_active_membership", "users_with_multiple_active_memberships"):
         if membership[key]:
             blockers.append(f"{key}: {membership[key]}")
+    return blockers
+
+
+def final_blockers_for(canonical, membership, legacy, stale_artifacts):
+    blockers = blockers_for(canonical, membership)
+    country_dependencies = legacy["country_as_organization_dependencies"]["dependency_count"]
+    eac_dependencies = legacy["eac_legacy_references"]["dependency_count"]
+    if country_dependencies:
+        blockers.append(f"legacy_country_as_organization_dependencies: {country_dependencies}")
+    if eac_dependencies:
+        blockers.append(f"eac_legacy_references: {eac_dependencies}")
+    stale_count = sum(1 for row in stale_artifacts if row["exists"] and row["mentions_country_as_organization"])
+    if stale_count:
+        blockers.append(f"stale_country_as_organization_artifacts: {stale_count}")
     return blockers
 
 
@@ -244,8 +381,11 @@ def write_text(stdout, report):
     stdout.write("====================================")
     stdout.write("Mode: read-only diagnostics")
     stdout.write(f"Readiness: {readiness['status']}")
+    stdout.write(f"Final readiness: {report['final_readiness']['status']}")
     stdout.write("")
     stdout.write("Canonical master data:")
+    stdout.write(f"  organization_completeness={canonical['organization_completeness']}")
+    stdout.write(f"  operating_entity_completeness={canonical['operating_entity_completeness']}")
     stdout.write(f"  organizations_missing={canonical['organizations_missing']}")
     stdout.write(f"  operating_entities_missing={canonical['operating_entities_missing']}")
     stdout.write(f"  branches_missing={canonical['branches_missing']}")
@@ -261,6 +401,7 @@ def write_text(stdout, report):
         f"active_users={membership['active_users']}, "
         f"active_memberships={membership['active_memberships']}, "
         f"complete_canonical={membership['complete_canonical_memberships']}, "
+        f"membership_operating_entity_completeness={membership['membership_operating_entity_completeness']}, "
         f"missing_org={membership['missing_organization']}, "
         f"memberships_missing_operating_entity={membership['memberships_missing_operating_entity']}, "
         f"memberships_inferable_from_branch={membership['memberships_inferable_from_branch']}, "
@@ -274,10 +415,24 @@ def write_text(stdout, report):
         f"users_multiple_memberships={membership['users_with_multiple_active_memberships']}"
     )
     stdout.write(f"  by_status={membership['active_memberships_by_status']}")
+    legacy = report["legacy"]
+    stdout.write("")
+    stdout.write(
+        "Legacy dependencies: "
+        f"country_as_organization={legacy['country_as_organization_dependencies']['dependency_count']}, "
+        f"eac_legacy_references={legacy['eac_legacy_references']['dependency_count']}, "
+        f"quote_spot={legacy['quote_spot_historical_records']['classification']}"
+    )
+    stdout.write(f"Stale artifacts={len(report['stale_artifacts'])}")
     if readiness["blockers"]:
         stdout.write("")
         stdout.write("Blockers:")
         for blocker in readiness["blockers"]:
+            stdout.write(f"  - {blocker}")
+    if report["final_readiness"]["blockers"]:
+        stdout.write("")
+        stdout.write("Final blockers:")
+        for blocker in report["final_readiness"]["blockers"]:
             stdout.write(f"  - {blocker}")
 
 

--- a/backend/parties/tests.py
+++ b/backend/parties/tests.py
@@ -2380,6 +2380,8 @@ class PostMembershipApplyReadinessTests(TestCase):
 
         self.assertEqual(payload["readiness"]["status"], "READY_FOR_BACKFILL_PLANNING")
         self.assertEqual(payload["memberships"]["complete_canonical_memberships"], 1)
+        self.assertTrue(payload["canonical"]["organization_completeness"]["ready"])
+        self.assertTrue(payload["canonical"]["operating_entity_completeness"]["ready"])
 
     def test_missing_canonical_org_blocks(self):
         self._canonical_master_data(skip_org="Express Freight Management")
@@ -2466,6 +2468,7 @@ class PostMembershipApplyReadinessTests(TestCase):
         self.assertEqual(payload["memberships"]["memberships_inferable_from_branch"], 1)
         self.assertEqual(payload["memberships"]["memberships_not_inferable"], 0)
         self.assertTrue(payload["memberships"]["scope_resolution_operating_entity_ready"])
+        self.assertTrue(payload["memberships"]["membership_operating_entity_completeness"]["ready"])
         self.assertEqual(payload["memberships"]["missing_operating_entity"], 1)
         self.assertEqual(payload["memberships"]["active_memberships_by_status"]["operating_entity_inferable_from_branch"], 1)
 
@@ -2488,7 +2491,55 @@ class PostMembershipApplyReadinessTests(TestCase):
         self.assertEqual(payload["memberships"]["memberships_inferable_from_branch"], 0)
         self.assertEqual(payload["memberships"]["memberships_not_inferable"], 1)
         self.assertFalse(payload["memberships"]["scope_resolution_operating_entity_ready"])
+        self.assertFalse(payload["memberships"]["membership_operating_entity_completeness"]["ready"])
         self.assertFalse(payload["canonical"]["branch_operating_entity_completeness"]["ready"])
+        self.assertEqual(payload["final_readiness"]["status"], "NOT_READY")
+        self.assertTrue(any("memberships_not_inferable" in blocker for blocker in payload["final_readiness"]["blockers"]))
+
+    def test_final_readiness_command_is_read_only(self):
+        self._canonical_master_data()
+        membership = self._complete_membership()
+        before = (Organization.objects.count(), Branch.objects.count(), UserMembership.objects.count())
+
+        payload = json.loads(self._call_report("--format", "json"))
+
+        membership.refresh_from_db()
+        self.assertFalse(payload["write_enabled"])
+        self.assertEqual((Organization.objects.count(), Branch.objects.count(), UserMembership.objects.count()), before)
+        self.assertTrue(membership.is_active)
+
+    def test_final_readiness_detects_missing_operating_entity_links(self):
+        self._canonical_master_data()
+        branch = Branch.objects.get(name="Port Moresby")
+        branch.operating_entity = None
+        branch.save(update_fields=["operating_entity"])
+
+        payload = json.loads(self._call_report("--format", "json"))
+
+        self.assertEqual(payload["canonical"]["branch_operating_entity_completeness"]["missing_operating_entity"], 1)
+        self.assertFalse(payload["canonical"]["branch_operating_entity_completeness"]["ready"])
+        self.assertEqual(payload["final_readiness"]["status"], "NOT_READY")
+
+    def test_final_readiness_reports_legacy_organization_dependencies(self):
+        self._canonical_master_data()
+        legacy = Organization.objects.create(name="EFM Express Air Cargo", slug="efm-express-air-cargo")
+        Company.objects.create(name="Legacy EAC Customer", organization=legacy)
+
+        payload = json.loads(self._call_report("--format", "json"))
+
+        eac = payload["legacy"]["eac_legacy_references"]
+        self.assertEqual(eac["organization_names"], ["EFM Express Air Cargo"])
+        self.assertGreaterEqual(eac["dependency_count"], 1)
+        self.assertEqual(payload["final_readiness"]["status"], "NOT_READY")
+
+    def test_final_readiness_reports_superseded_stale_artifacts(self):
+        payload = json.loads(self._call_report("--format", "json"))
+
+        self.assertTrue(payload["stale_artifacts"])
+        self.assertTrue(all(row["status"] == "superseded_legacy_reference" for row in payload["stale_artifacts"]))
+        self.assertTrue(
+            any("Quote/SPOT historical records remain DEV_TEST_LEGACY" in note for note in payload["final_readiness"]["notes"])
+        )
 
     def test_active_user_with_no_membership_blocks(self):
         self._canonical_master_data()

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -3071,8 +3071,9 @@ Risks:
 - `OrganizationBranding` is one-to-one with `Organization`; country-specific
   branding requires a separate design.
 - Membership semantics change and must not be inferred without a migration map.
-- Older readiness/reassignment commands still contain country-as-organization
-  assumptions.
+- Superseded legacy diagnostics/docs may still mention country-as-organization
+  history; Phase 10H readiness reports these as obsolete references, not target
+  design.
 - Rollback requires old Organization id to new OperatingEntity id mappings
   before any apply phase.
 
@@ -3249,6 +3250,66 @@ Out of scope:
 - No legacy organization deletion or deactivation.
 - No Quote/SPOT historical backfill tooling.
 - No pricing, ProductCode, quote pricing, SPOT pricing, or rating changes.
+
+Verification:
+
+```bash
+python backend/manage.py makemigrations --check --dry-run
+python backend/manage.py test accounts.tests parties.tests crm.tests quotes.tests
+python backend/manage.py check
+npx fallow --format json
+graphify update .
+git diff --check
+```
+
+#### Phase 10H - Final OperatingEntity Readiness Audit
+
+Date: 2026-06-29
+
+Branch: `codex/phase-10h-operating-entity-readiness`
+
+Scope: final read-only readiness validation for the OperatingEntity RBAC
+hierarchy. No destructive cleanup, no legacy organization deactivation, no
+Quote/SPOT historical backfill.
+
+Command:
+
+- `python backend/manage.py rbac_post_membership_apply_readiness`
+- `python backend/manage.py rbac_post_membership_apply_readiness --format json`
+
+Final readiness now reports:
+
+- `organization_completeness`
+- `operating_entity_completeness`
+- `branch_operating_entity_completeness`
+- `membership_operating_entity_completeness`
+- `memberships_inferable_from_branch`
+- `memberships_not_inferable`
+- `legacy.country_as_organization_dependencies`
+- `legacy.eac_legacy_references`
+- `stale_artifacts`
+- `final_readiness.status`: `READY` or `NOT_READY`
+
+Final transition rules:
+
+- Country-as-organization assumptions are obsolete.
+- `EAC` / `EFM Express Air Cargo` is legacy Air Freight wording only, not a
+  live target organization.
+- Historical Quote/SPOT records remain `DEV_TEST_LEGACY`; no historical
+  backfill tooling should be built for them.
+- Legacy organizations must not be deleted or deactivated unless diagnostics
+  prove zero dependencies and a rollback mapping exists.
+
+Final roadmap:
+
+1. Run final readiness in production-like data.
+2. Resolve any missing OperatingEntity, Branch, Department, or membership
+   completeness blockers.
+3. Review legacy country-as-organization and EAC dependency counts.
+4. Only after zero-dependency proof and rollback mapping, consider a separate
+   legacy organization deactivation PR.
+5. Keep Quote/SPOT historical cleanup separate from OperatingEntity RBAC
+   readiness.
 
 Verification:
 


### PR DESCRIPTION
Adds final OperatingEntity readiness diagnostics, legacy hierarchy blocker reporting, tests, and Phase 10H documentation.

Verification:
- python backend/manage.py makemigrations --check --dry-run
- python backend/manage.py test parties.tests.PostMembershipApplyReadinessTests
- python backend/manage.py test accounts.tests parties.tests crm.tests quotes.tests
- python backend/manage.py check
- npx fallow --format json
- graphify update .
- git diff --check