### PR TITLE
feat(spot): improve SPOT rate review charge editing

### DIFF
--- a/frontend/src/app/quotes/spot/[speId]/page.tsx
+++ b/frontend/src/app/quotes/spot/[speId]/page.tsx
@@ -38,6 +38,7 @@ import type { ReplyAnalysisResult } from "@/lib/spot-types";
 import { getSpotStandardCharges, reviewSpotFinding } from "@/lib/api";
 import { getEffectiveProductCode, getSpotChargeDisplayLabel } from "@/lib/spot-charge-display";
 import { getSpotFinalizeDisabledReason } from "@/lib/spot-finalization";
+import { COMMERCIAL_BUCKETS, inferCommercialBucket } from "@/lib/spot-commercial-buckets";
 import {
     Breadcrumb,
     BreadcrumbItem,
@@ -701,6 +702,7 @@ export default function SpotRateEntryPage() {
     } | null>(null);
     const [finalizeError, setFinalizeError] = useState<string | null>(null);
     const [reviewMode, setReviewMode] = useState<ReviewMode>("issues");
+    const [allChargesFilter, setAllChargesFilter] = useState<"all" | "matched" | "conditional">("all");
     const [activeIssueDetails, setActiveIssueDetails] = useState<ImportedReviewLine | null>(null);
     const [sourceComparisonOpen, setSourceComparisonOpen] = useState(false);
     const [selectedSourceChargeKey, setSelectedSourceChargeKey] = useState<string | null>(null);
@@ -1090,38 +1092,81 @@ export default function SpotRateEntryPage() {
                                     </Tabs>
                                 </div>
                                 <div className="grid gap-3 sm:grid-cols-4">
-                                    <div className="rounded-xl border border-white/25 bg-white px-4 py-3 shadow-sm">
+                                    <button
+                                        type="button"
+                                        onClick={() => {
+                                            setReviewMode("allCharges");
+                                            setAllChargesFilter("all");
+                                        }}
+                                        className={`text-left rounded-xl border px-4 py-3 shadow-sm transition-all hover:scale-[1.02] active:scale-[0.98] ${
+                                            reviewMode === "allCharges" && allChargesFilter === "all"
+                                                ? "border-primary bg-slate-100 ring-2 ring-primary/20"
+                                                : "border-white/25 bg-white text-slate-900"
+                                        }`}
+                                    >
                                         <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
                                             Imported
                                         </div>
                                         <div className="mt-2 text-2xl font-semibold text-slate-950">
                                             {totalImportedLines}
                                         </div>
-                                    </div>
-                                    <div className="rounded-xl border border-white/25 bg-white px-4 py-3 shadow-sm">
+                                    </button>
+                                    <button
+                                        type="button"
+                                        onClick={() => {
+                                            setReviewMode("issues");
+                                        }}
+                                        className={`text-left rounded-xl border px-4 py-3 shadow-sm transition-all hover:scale-[1.02] active:scale-[0.98] ${
+                                            reviewMode === "issues"
+                                                ? "border-amber-500 bg-amber-50 ring-2 ring-amber-500/20"
+                                                : "border-white/25 bg-white text-slate-900"
+                                        }`}
+                                    >
                                         <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
                                             Needs review
                                         </div>
                                         <div className={`mt-2 text-2xl font-semibold ${unresolvedReviewIssueCount > 0 ? "text-amber-700" : "text-emerald-700"}`}>
                                             {unresolvedReviewIssueCount}
                                         </div>
-                                    </div>
-                                    <div className="rounded-xl border border-white/25 bg-white px-4 py-3 shadow-sm">
+                                    </button>
+                                    <button
+                                        type="button"
+                                        onClick={() => {
+                                            setReviewMode("allCharges");
+                                            setAllChargesFilter("matched");
+                                        }}
+                                        className={`text-left rounded-xl border px-4 py-3 shadow-sm transition-all hover:scale-[1.02] active:scale-[0.98] ${
+                                            reviewMode === "allCharges" && allChargesFilter === "matched"
+                                                ? "border-emerald-600 bg-emerald-50 ring-2 ring-emerald-600/20"
+                                                : "border-white/25 bg-white text-slate-900"
+                                        }`}
+                                    >
                                         <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
                                             Matched
                                         </div>
                                         <div className="mt-2 text-2xl font-semibold text-emerald-700">
                                             {matchedImportedLineCount}
                                         </div>
-                                    </div>
-                                    <div className="rounded-xl border border-white/25 bg-white px-4 py-3 shadow-sm">
+                                    </button>
+                                    <button
+                                        type="button"
+                                        onClick={() => {
+                                            setReviewMode("allCharges");
+                                            setAllChargesFilter("conditional");
+                                        }}
+                                        className={`text-left rounded-xl border px-4 py-3 shadow-sm transition-all hover:scale-[1.02] active:scale-[0.98] ${
+                                            reviewMode === "allCharges" && allChargesFilter === "conditional"
+                                                ? "border-amber-600 bg-amber-50 ring-2 ring-amber-600/20"
+                                                : "border-white/25 bg-white text-slate-900"
+                                        }`}
+                                    >
                                         <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
                                             Conditional
                                         </div>
                                         <div className={`mt-2 text-2xl font-semibold ${importedReviewCounts.conditional > 0 ? "text-amber-700" : "text-emerald-700"}`}>
                                             {importedReviewCounts.conditional}
                                         </div>
-                                    </div>
+                                    </button>
                                 </div>
                             </div>
                         </CardHeader>
@@ -1188,7 +1233,7 @@ export default function SpotRateEntryPage() {
                                                                                     onClick={() => void handleConditionalDecision(line, "KEEP")}
                                                                                     disabled={!line.chargeLineId || state.isLoading}
                                                                                 >
-                                                                                    Keep in quote
+                                                                                    Accept Conditional
                                                                                 </Button>
                                                                                 <Button
                                                                                     type="button"
@@ -1197,7 +1242,7 @@ export default function SpotRateEntryPage() {
                                                                                     onClick={() => void handleConditionalDecision(line, "REMOVE")}
                                                                                     disabled={!line.chargeLineId || state.isLoading}
                                                                                 >
-                                                                                    Remove
+                                                                                    Remove from Quote
                                                                                 </Button>
                                                                             </>
                                                                         ) : null}
@@ -1208,7 +1253,7 @@ export default function SpotRateEntryPage() {
                                                                                 onClick={() => handleReviewLine(line)}
                                                                                 disabled={!line.chargeLineId || state.isLoading}
                                                                             >
-                                                                                Resolve
+                                                                                Resolve ProductCode
                                                                             </Button>
                                                                         ) : null}
                                                                         <Button
@@ -1217,7 +1262,7 @@ export default function SpotRateEntryPage() {
                                                                             size="sm"
                                                                             onClick={() => setActiveIssueDetails(line)}
                                                                         >
-                                                                            Details
+                                                                            View Issue Details
                                                                         </Button>
                                                                     </div>
                                                                 </div>
@@ -1286,6 +1331,7 @@ export default function SpotRateEntryPage() {
                                             productCodeDomain={resolvedShipmentType}
                                             envelopeId={state.spe?.id}
                                             reviewRequest={activeReviewRequest}
+                                            filterType={allChargesFilter}
                                         />
 
                                         {importWideChecks.length > 0 ? (
@@ -1301,13 +1347,61 @@ export default function SpotRateEntryPage() {
                                             </details>
                                         ) : null}
 
-                                        <Card className="border-amber-200 bg-amber-50/60">
-                                            <CardContent className="pt-4">
-                                                <p className="text-sm text-amber-900">
-                                                    Creating the quote records the SPOT acknowledgement. Rates remain conditional until carrier and space are confirmed.
-                                                </p>
-                                            </CardContent>
-                                        </Card>
+                                        <div className="rounded-xl border border-slate-200 bg-slate-50/80 px-5 py-4 space-y-4">
+                                            <div className="text-sm font-semibold text-slate-900">Final Review by Commercial Bucket</div>
+                                            <div className="divide-y divide-slate-200">
+                                                {COMMERCIAL_BUCKETS.map((cb) => {
+                                                    const cbCharges = allReviewFormCharges.filter((charge) => {
+                                                        const rb = charge.reviewed_bucket || inferCommercialBucket(charge);
+                                                        return rb === cb.id;
+                                                    });
+                                                    if (cbCharges.length === 0) return null;
+                                                    
+                                                    // Calculate total for this bucket if amount is parseable
+                                                    const totalVal = cbCharges.reduce((sum, c) => {
+                                                        const amt = parseFloat(c.amount);
+                                                        return isNaN(amt) ? sum : sum + amt;
+                                                    }, 0);
+                                                    
+                                                    // Map currency symbols or labels if any. Default USD/PGK.
+                                                    const currencyLabel = cbCharges[0]?.currency || "USD";
+
+                                                    return (
+                                                        <div key={cb.id} className="flex justify-between py-2 text-xs">
+                                                            <span className="text-slate-600 font-medium">
+                                                                {cb.label} ({cbCharges.length} {cbCharges.length === 1 ? "charge" : "charges"})
+                                                            </span>
+                                                            <span className="font-semibold text-slate-900">
+                                                                {totalVal.toFixed(2)} {currencyLabel}
+                                                            </span>
+                                                        </div>
+                                                    );
+                                                })}
+                                            </div>
+                                            <div className="grid gap-2 sm:grid-cols-3 text-xs pt-2 border-t border-slate-200">
+                                                <div className="flex items-center gap-2">
+                                                    <span className="inline-block h-2 w-2 rounded-full bg-emerald-500" />
+                                                    <span className="text-slate-700">Matched: <span className="font-semibold text-slate-900">{matchedImportedLineCount}</span></span>
+                                                </div>
+                                                <div className="flex items-center gap-2">
+                                                    <span className={`inline-block h-2 w-2 rounded-full ${importedReviewCounts.conditional > 0 ? "bg-amber-500" : "bg-emerald-500"}`} />
+                                                    <span className="text-slate-700">Conditional: <span className="font-semibold text-slate-900">{importedReviewCounts.conditional}</span></span>
+                                                </div>
+                                                <div className="flex items-center gap-2">
+                                                    <span className={`inline-block h-2 w-2 rounded-full ${unresolvedReviewIssueCount > 0 ? "bg-red-500" : "bg-emerald-500"}`} />
+                                                    <span className="text-slate-700">Unresolved: <span className="font-semibold text-slate-900">{unresolvedReviewIssueCount}</span></span>
+                                                </div>
+                                            </div>
+                                            {quoteSubmitDisabledReason ? (
+                                                <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+                                                    <span className="font-medium">Cannot create quote:</span> {quoteSubmitDisabledReason}
+                                                </div>
+                                            ) : (
+                                                <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-900">
+                                                    All blockers resolved. Ready to create quote. Rates remain conditional until carrier and space are confirmed.
+                                                </div>
+                                            )}
+                                        </div>
                                     </TabsContent>
                                 </Tabs>
 

--- a/frontend/src/app/quotes/spot/[speId]/page.tsx
+++ b/frontend/src/app/quotes/spot/[speId]/page.tsx
@@ -1348,7 +1348,7 @@ export default function SpotRateEntryPage() {
                                         ) : null}
 
                                         <div className="rounded-xl border border-slate-200 bg-slate-50/80 px-5 py-4 space-y-4">
-                                            <div className="text-sm font-semibold text-slate-900">Final Review by Commercial Bucket</div>
+                                            <div className="text-sm font-semibold text-slate-900">Charge Summary by Commercial Bucket</div>
                                             <div className="divide-y divide-slate-200">
                                                 {COMMERCIAL_BUCKETS.map((cb) => {
                                                     const cbCharges = allReviewFormCharges.filter((charge) => {
@@ -1357,36 +1357,26 @@ export default function SpotRateEntryPage() {
                                                     });
                                                     if (cbCharges.length === 0) return null;
                                                     
-                                                    // Group totals by currency
-                                                    const currencyTotals: Record<string, number> = {};
-                                                    let hasNumericAmounts = false;
-                                                    cbCharges.forEach((c) => {
-                                                        // Omit percentage/rule base lines from direct sum if they don't have static amount
-                                                        const amt = parseFloat(c.amount);
-                                                        if (!isNaN(amt)) {
-                                                            const cur = (c.currency || "USD").toUpperCase();
-                                                            currencyTotals[cur] = (currencyTotals[cur] || 0) + amt;
-                                                            hasNumericAmounts = true;
-                                                        }
-                                                    });
+                                                    const currencies = Array.from(
+                                                        new Set(cbCharges.map((c) => (c.currency || "USD").toUpperCase()))
+                                                    );
+                                                    const currenciesString = currencies.length > 0 ? currencies.join(", ") : "—";
                                                     
-                                                    const totalString = hasNumericAmounts
-                                                        ? Object.entries(currencyTotals)
-                                                            .map(([cur, total]) => `${total.toFixed(2)} ${cur}`)
-                                                            .join(" / ")
-                                                        : "—";
-
                                                     return (
                                                         <div key={cb.id} className="flex justify-between py-2 text-xs">
                                                             <span className="text-slate-600 font-medium">
                                                                 {cb.label} ({cbCharges.length} {cbCharges.length === 1 ? "charge" : "charges"})
                                                             </span>
                                                             <span className="font-semibold text-slate-900">
-                                                                {totalString}
+                                                                {currenciesString}
                                                             </span>
                                                         </div>
                                                     );
                                                 })}
+                                            </div>
+                                            
+                                            <div className="text-[11px] text-slate-500 bg-slate-100/60 rounded-lg p-2.5 leading-relaxed border border-slate-200/50">
+                                                Calculated commercial totals are shown during the live preview step. This summary shows charge grouping only.
                                             </div>
                                             <div className="grid gap-2 sm:grid-cols-3 text-xs pt-2 border-t border-slate-200">
                                                 <div className="flex items-center gap-2">

--- a/frontend/src/app/quotes/spot/[speId]/page.tsx
+++ b/frontend/src/app/quotes/spot/[speId]/page.tsx
@@ -1357,14 +1357,24 @@ export default function SpotRateEntryPage() {
                                                     });
                                                     if (cbCharges.length === 0) return null;
                                                     
-                                                    // Calculate total for this bucket if amount is parseable
-                                                    const totalVal = cbCharges.reduce((sum, c) => {
+                                                    // Group totals by currency
+                                                    const currencyTotals: Record<string, number> = {};
+                                                    let hasNumericAmounts = false;
+                                                    cbCharges.forEach((c) => {
+                                                        // Omit percentage/rule base lines from direct sum if they don't have static amount
                                                         const amt = parseFloat(c.amount);
-                                                        return isNaN(amt) ? sum : sum + amt;
-                                                    }, 0);
+                                                        if (!isNaN(amt)) {
+                                                            const cur = (c.currency || "USD").toUpperCase();
+                                                            currencyTotals[cur] = (currencyTotals[cur] || 0) + amt;
+                                                            hasNumericAmounts = true;
+                                                        }
+                                                    });
                                                     
-                                                    // Map currency symbols or labels if any. Default USD/PGK.
-                                                    const currencyLabel = cbCharges[0]?.currency || "USD";
+                                                    const totalString = hasNumericAmounts
+                                                        ? Object.entries(currencyTotals)
+                                                            .map(([cur, total]) => `${total.toFixed(2)} ${cur}`)
+                                                            .join(" / ")
+                                                        : "—";
 
                                                     return (
                                                         <div key={cb.id} className="flex justify-between py-2 text-xs">
@@ -1372,7 +1382,7 @@ export default function SpotRateEntryPage() {
                                                                 {cb.label} ({cbCharges.length} {cbCharges.length === 1 ? "charge" : "charges"})
                                                             </span>
                                                             <span className="font-semibold text-slate-900">
-                                                                {totalVal.toFixed(2)} {currencyLabel}
+                                                                {totalString}
                                                             </span>
                                                         </div>
                                                     );

--- a/frontend/src/components/spot/ChargeBucketSection.tsx
+++ b/frontend/src/components/spot/ChargeBucketSection.tsx
@@ -1,6 +1,8 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
+import { Edit2 } from "lucide-react";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -12,19 +14,21 @@ import { Control, FieldArrayWithId, UseFieldArrayRemove, useWatch } from "react-
 import { useToast } from "@/context/toast-context";
 import { useConfirm } from "@/hooks/useConfirm";
 import type { SpotFormValues } from "@/lib/schemas/spotSchema";
-import type { SPEChargeBucket, SPEProductCodeSummary } from "@/lib/spot-types";
+import type { SPEProductCodeSummary } from "@/lib/spot-types";
+import { COMMERCIAL_BUCKETS } from "@/lib/spot-commercial-buckets";
 
 import { ChargeNormalizationAudit } from "./ChargeNormalizationAudit";
 import { SmartMoneyInput } from "./SmartMoneyInput";
 
 interface ChargeBucketSectionProps {
-    bucket: { id: SPEChargeBucket; label: string };
+    bucket: { id: string; label: string };
     control: Control<SpotFormValues>;
     fields: { field: FieldArrayWithId<SpotFormValues, "charges", "id">; index: number }[];
     onAdd: () => void;
     onRemove: UseFieldArrayRemove;
     onOpenManualReview?: (chargeLine: SpotFormValues["charges"][number]) => void;
     activeChargeLineId?: string | null;
+    duplicateIndices?: Set<number>;
 }
 
 const CHARGE_UNITS = [
@@ -91,21 +95,28 @@ export function ChargeBucketSection({
     onRemove,
     onOpenManualReview,
     activeChargeLineId,
+    duplicateIndices = new Set(),
 }: ChargeBucketSectionProps) {
     const confirm = useConfirm();
     const { toast } = useToast();
     const [expandedRows, setExpandedRows] = useState<Record<string, boolean>>({});
+    const [editingFieldId, setEditingFieldId] = useState<string | null>(null);
+
     const watchedCharges = useWatch({
         control,
         name: "charges",
     });
 
-    const toggleDetails = (fieldId: string) => {
-        setExpandedRows((current) => ({
-            ...current,
-            [fieldId]: !current[fieldId],
-        }));
-    };
+    const prevFieldsLengthRef = useRef(fields.length);
+    useEffect(() => {
+        if (fields.length > prevFieldsLengthRef.current) {
+            const newField = fields[fields.length - 1];
+            if (newField) {
+                setEditingFieldId(newField.field.id);
+            }
+        }
+        prevFieldsLengthRef.current = fields.length;
+    }, [fields]);
 
     const handleRemove = async (index: number) => {
         const currentLine = watchedCharges?.[index];
@@ -167,8 +178,14 @@ export function ChargeBucketSection({
                 {fields.length > 0 ? (
                     <div className="space-y-3">
                         {fields.map(({ field, index }) => {
-                            const chargeLine = watchedCharges?.[index];
                             const isDetailsOpen = Boolean(expandedRows[field.id]);
+                            const toggleDetails = (fieldId: string) => {
+                                setExpandedRows((current) => ({
+                                    ...current,
+                                    [fieldId]: !current[fieldId],
+                                }));
+                            };
+                            const chargeLine = watchedCharges?.[index];
                             const canOpenManualReview = Boolean(
                                 chargeLine?.charge_line_id &&
                                 chargeLine?.manual_resolution_status !== "RESOLVED" &&
@@ -187,246 +204,548 @@ export function ChargeBucketSection({
                                 "Imported charge";
                             const sourceEvidenceLabel = getSourceEvidenceLabel(chargeLine);
 
+                            const isEditing = editingFieldId === field.id;
+
                             return (
                                 <div
                                     key={field.id}
                                     id={chargeLineRowId}
                                     className={`rounded-xl border p-4 shadow-sm transition-colors ${statusCardClassName(chargeLine, isActiveRow)}`}
                                 >
-                                    <div className="grid gap-4 lg:grid-cols-[minmax(0,1.5fr)_minmax(260px,0.9fr)_minmax(170px,0.55fr)_minmax(210px,0.75fr)] lg:items-start">
-                                        <div className="min-w-0 space-y-2">
-                                            <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-500">
-                                                Description
-                                            </div>
-                                            <FormField
-                                                control={control}
-                                                name={`charges.${index}.description`}
-                                                render={({ field }) => (
-                                                    <FormItem className="space-y-2">
-                                                        <div>
-                                                            <div className="whitespace-normal break-words text-base font-semibold leading-6 text-slate-950">
-                                                                {displayDescription}
-                                                            </div>
-                                                            {productCode?.code ? (
-                                                                <div className="mt-1 text-xs font-medium text-slate-500">
-                                                                    ProductCode {productCode.code}
+                                    {!isEditing ? (
+                                        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between w-full">
+                                            <div className="space-y-1.5 min-w-0 flex-1">
+                                                <div className="flex flex-wrap items-center gap-2">
+                                                    <span className="text-base font-semibold text-slate-900 break-words">
+                                                        {displayDescription}
+                                                    </span>
+                                                    {chargeLine?.conditional && (
+                                                        <Badge variant="outline" className="border-slate-300 bg-slate-100 text-slate-700 text-[10px] font-semibold">
+                                                            Conditional
+                                                        </Badge>
+                                                    )}
+                                                    {chargeLine?.manual_resolution_status === "RESOLVED" ? (
+                                                        <Badge variant="outline" className="border-sky-200 bg-sky-50 text-sky-700 text-[10px] font-semibold">
+                                                            Manually Resolved
+                                                        </Badge>
+                                                    ) : chargeLine?.normalization_status === "MATCHED" ? (
+                                                        <Badge variant="outline" className="border-emerald-200 bg-emerald-50 text-emerald-700 text-[10px] font-semibold">
+                                                            Matched
+                                                        </Badge>
+                                                    ) : chargeLine?.normalization_status === "AMBIGUOUS" ? (
+                                                        <Badge variant="outline" className="border-rose-200 bg-rose-50 text-rose-700 text-[10px] font-semibold">
+                                                            Ambiguous
+                                                        </Badge>
+                                                    ) : chargeLine?.normalization_status === "UNMAPPED" ? (
+                                                        <Badge variant="outline" className="border-amber-200 bg-amber-50 text-amber-700 text-[10px] font-semibold">
+                                                            Needs Mapping
+                                                        </Badge>
+                                                    ) : null}
+                                                    {duplicateIndices.has(index) && (
+                                                        <Badge variant="outline" className="border-red-200 bg-red-50 text-red-700 text-[10px] font-semibold">
+                                                            Possible duplicate charge
+                                                        </Badge>
+                                                    )}
+                                                </div>
+                                                <div className="flex flex-wrap items-center gap-3 text-xs text-slate-500">
+                                                    {productCode?.code && (
+                                                        <span className="font-mono bg-slate-100 px-1.5 py-0.5 rounded text-slate-700">
+                                                            ProductCode: {productCode.code}
+                                                        </span>
+                                                    )}
+                                                    {sourceEvidenceLabel && (
+                                                        <Popover>
+                                                            <PopoverTrigger asChild>
+                                                                <Button
+                                                                    type="button"
+                                                                    variant="link"
+                                                                    className="h-auto p-0 text-xs text-primary hover:text-primary/80"
+                                                                >
+                                                                    Source Excerpt
+                                                                </Button>
+                                                            </PopoverTrigger>
+                                                            <PopoverContent align="start" className="w-96 max-w-[calc(100vw-2rem)] space-y-3 text-sm">
+                                                                <div>
+                                                                    <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                                                                        Source
+                                                                    </div>
+                                                                    <div className="mt-1 text-xs text-slate-600">{sourceEvidenceLabel}</div>
                                                                 </div>
-                                                            ) : null}
-                                                            {sourceEvidenceLabel ? (
-                                                                <Popover>
-                                                                    <PopoverTrigger asChild>
-                                                                        <Button
-                                                                            type="button"
-                                                                            variant="ghost"
-                                                                            size="sm"
-                                                                            className="mt-2 h-7 px-2 text-xs text-primary hover:bg-primary/5"
-                                                                        >
-                                                                            Source
-                                                                        </Button>
-                                                                    </PopoverTrigger>
-                                                                    <PopoverContent align="start" className="w-96 max-w-[calc(100vw-2rem)] space-y-3 text-sm">
-                                                                        <div>
-                                                                            <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                                                                {chargeLine?.source_excerpt ? (
+                                                                    <div className="rounded-md border border-slate-200 bg-slate-50 p-3 text-sm leading-6 text-slate-800">
+                                                                        {chargeLine.source_excerpt}
+                                                                    </div>
+                                                                ) : (
+                                                                    <div className="text-sm text-slate-500">No source snippet captured for this line.</div>
+                                                                )}
+                                                            </PopoverContent>
+                                                        </Popover>
+                                                    )}
+                                                </div>
+                                            </div>
+                                            
+                                            {chargeLine?.unit === "percentage" ? (
+                                                <div className="flex flex-col sm:items-end justify-center min-w-[150px]">
+                                                    <div className="text-lg font-bold text-slate-900">
+                                                        {chargeLine?.percent ? `${parseFloat(String(chargeLine.percent)).toLocaleString()}%` : "0.00%"}
+                                                    </div>
+                                                    <div className="text-xs text-slate-500 flex items-center gap-1">
+                                                        <span>of</span>
+                                                        {chargeLine?.percent_basis ? (
+                                                            <span className="font-semibold text-slate-700 uppercase">{chargeLine.percent_basis}</span>
+                                                        ) : (
+                                                            <Badge variant="outline" className="border-red-200 bg-red-50 text-red-700 text-[10px] font-semibold py-0 px-1">
+                                                                Base charge missing
+                                                            </Badge>
+                                                        )}
+                                                    </div>
+                                                </div>
+                                            ) : (
+                                                <div className="flex flex-col sm:items-end justify-center min-w-[150px]">
+                                                    <div className="text-lg font-bold text-slate-900">
+                                                        {chargeLine?.currency} {chargeLine?.amount ? parseFloat(chargeLine.amount).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }) : "0.00"}
+                                                    </div>
+                                                    <div className="text-xs text-slate-500">
+                                                        {chargeLine?.unit === "min_or_per_kg" ? (
+                                                            <>Per KG (Min {chargeLine.currency} {chargeLine.min_charge || "0.00"})</>
+                                                        ) : (
+                                                            CHARGE_UNITS.find(u => u.value === chargeLine?.unit)?.label || chargeLine?.unit
+                                                        )}
+                                                    </div>
+                                                </div>
+                                            )}
+
+                                            <div className="flex flex-wrap items-center gap-2 justify-end">
+                                                {canOpenManualReview && (
+                                                    <Button
+                                                        type="button"
+                                                        variant="outline"
+                                                        size="sm"
+                                                        className="h-8 border-amber-200 bg-amber-50 hover:bg-amber-100 text-amber-800 font-medium"
+                                                        onClick={() => {
+                                                            if (chargeLine) {
+                                                                onOpenManualReview?.(chargeLine);
+                                                            }
+                                                        }}
+                                                    >
+                                                        Resolve ProductCode
+                                                    </Button>
+                                                )}
+                                                {Boolean((chargeLine as Record<string, unknown>)?.suggested_approved_product_code) && chargeLine?.manual_resolution_status !== "RESOLVED" && (
+                                                    <Button
+                                                        type="button"
+                                                        variant="outline"
+                                                        size="sm"
+                                                        className="h-8 border-emerald-200 bg-emerald-50 hover:bg-emerald-100 text-emerald-800 font-medium"
+                                                        onClick={() => {
+                                                            if (chargeLine) {
+                                                                onOpenManualReview?.(chargeLine);
+                                                            }
+                                                        }}
+                                                    >
+                                                        Accept Suggested Match
+                                                    </Button>
+                                                )}
+                                                <Button
+                                                    type="button"
+                                                    variant="ghost"
+                                                    size="sm"
+                                                    className="h-8 text-slate-700 hover:bg-slate-100"
+                                                    onClick={() => setEditingFieldId(field.id)}
+                                                >
+                                                    <Edit2 className="h-3.5 w-3.5 mr-1" />
+                                                    Edit Charge
+                                                </Button>
+                                                <Button
+                                                    type="button"
+                                                    variant="ghost"
+                                                    size="sm"
+                                                    onClick={() => void handleRemove(index)}
+                                                    className="h-8 text-slate-400 hover:text-rose-600 hover:bg-rose-50"
+                                                >
+                                                    Remove
+                                                </Button>
+                                            </div>
+                                        </div>
+                                    ) : (
+                                        <div className="grid gap-4 lg:grid-cols-[minmax(0,1.5fr)_minmax(260px,0.9fr)_minmax(170px,0.55fr)_minmax(210px,0.75fr)] lg:items-start">
+                                            <div className="min-w-0 space-y-2">
+                                                <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                                                    Description
+                                                </div>
+                                                <FormField
+                                                    control={control}
+                                                    name={`charges.${index}.description`}
+                                                    render={({ field }) => (
+                                                        <FormItem className="space-y-2">
+                                                            <div>
+                                                                <div className="whitespace-normal break-words text-base font-semibold leading-6 text-slate-950">
+                                                                    {displayDescription}
+                                                                </div>
+                                                                {productCode?.code ? (
+                                                                    <div className="mt-1 text-xs font-medium text-slate-500">
+                                                                        ProductCode {productCode.code}
+                                                                    </div>
+                                                                ) : null}
+                                                                {sourceEvidenceLabel ? (
+                                                                    <Popover>
+                                                                        <PopoverTrigger asChild>
+                                                                            <Button
+                                                                                type="button"
+                                                                                variant="ghost"
+                                                                                size="sm"
+                                                                                className="mt-2 h-7 px-2 text-xs text-primary hover:bg-primary/5"
+                                                                            >
                                                                                 Source
+                                                                            </Button>
+                                                                        </PopoverTrigger>
+                                                                        <PopoverContent align="start" className="w-96 max-w-[calc(100vw-2rem)] space-y-3 text-sm">
+                                                                            <div>
+                                                                                <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                                                                                    Source
+                                                                                </div>
+                                                                                <div className="mt-1 text-xs text-slate-600">{sourceEvidenceLabel}</div>
                                                                             </div>
-                                                                            <div className="mt-1 text-xs text-slate-600">{sourceEvidenceLabel}</div>
-                                                                        </div>
-                                                                        {chargeLine?.source_excerpt ? (
-                                                                            <div className="rounded-md border border-slate-200 bg-slate-50 p-3 text-sm leading-6 text-slate-800">
-                                                                                {chargeLine.source_excerpt}
-                                                                            </div>
-                                                                        ) : (
-                                                                            <div className="text-sm text-slate-500">No source snippet captured for this line.</div>
-                                                                        )}
-                                                                        {chargeLine?.source_line_identity ? (
-                                                                            <div className="break-all text-xs text-slate-500">
-                                                                                {chargeLine.source_line_identity}
-                                                                            </div>
-                                                                        ) : null}
-                                                                    </PopoverContent>
-                                                                </Popover>
-                                                            ) : null}
-                                                        </div>
-                                                        <details className="group">
-                                                            <summary className="cursor-pointer text-xs font-medium text-slate-500 hover:text-slate-900">
-                                                                Edit display label
-                                                            </summary>
-                                                            <FormControl>
-                                                                <Input
-                                                                    placeholder="Description"
-                                                                    {...field}
-                                                                    className="mt-2 h-9 bg-white"
-                                                                />
-                                                            </FormControl>
-                                                        </details>
-                                                        <FormMessage />
-                                                    </FormItem>
-                                                )}
-                                            />
-                                            <div className="text-xs text-slate-500">
-                                                {bucket.label}
+                                                                            {chargeLine?.source_excerpt ? (
+                                                                                <div className="rounded-md border border-slate-200 bg-slate-50 p-3 text-sm leading-6 text-slate-800">
+                                                                                    {chargeLine.source_excerpt}
+                                                                                </div>
+                                                                            ) : (
+                                                                                <div className="text-sm text-slate-500">No source snippet captured for this line.</div>
+                                                                            )}
+                                                                            {chargeLine?.source_line_identity ? (
+                                                                                <div className="break-all text-xs text-slate-500">
+                                                                                    {chargeLine.source_line_identity}
+                                                                                </div>
+                                                                            ) : null}
+                                                                        </PopoverContent>
+                                                                    </Popover>
+                                                                ) : null}
+                                                            </div>
+                                                            <details className="group">
+                                                                <summary className="cursor-pointer text-xs font-medium text-slate-500 hover:text-slate-900">
+                                                                    Edit display label
+                                                                </summary>
+                                                                <FormControl>
+                                                                    <Input
+                                                                        placeholder="Description"
+                                                                        {...field}
+                                                                        className="mt-2 h-9 bg-white"
+                                                                    />
+                                                                </FormControl>
+                                                            </details>
+                                                            <FormMessage />
+                                                        </FormItem>
+                                                    )}
+                                                />
+                                                <div className="text-xs text-slate-500">
+                                                    {bucket.label}
+                                                </div>
                                             </div>
-                                        </div>
 
-                                        <div className="space-y-2">
-                                            <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-500">
-                                                Amount
-                                            </div>
-                                            <FormField
-                                                control={control}
-                                                name={`charges.${index}.unit`}
-                                                render={({ field: unitField }) => (
-                                                    <SmartMoneyInput
-                                                        control={control}
-                                                        index={index}
-                                                        currencyName={`charges.${index}.currency`}
-                                                        amountName={`charges.${index}.amount`}
-                                                        unit={unitField.value}
-                                                        showMinCharge={unitField.value === "min_or_per_kg"}
-                                                        minChargeName={`charges.${index}.min_charge`}
-                                                    />
-                                                )}
-                                            />
-                                        </div>
-
-                                        <div className="space-y-2">
-                                            <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-500">
-                                                Unit
-                                            </div>
-                                            <FormField
-                                                control={control}
-                                                name={`charges.${index}.unit`}
-                                                render={({ field }) => (
-                                                    <FormItem>
-                                                        <Select onValueChange={field.onChange} defaultValue={field.value}>
-                                                            <FormControl>
-                                                                <SelectTrigger className="h-8">
-                                                                    <SelectValue />
-                                                                </SelectTrigger>
-                                                            </FormControl>
-                                                            <SelectContent>
-                                                                {CHARGE_UNITS.map((unit) => (
-                                                                    <SelectItem key={unit.value} value={unit.value}>
-                                                                        {unit.label}
-                                                                    </SelectItem>
-                                                                ))}
-                                                            </SelectContent>
-                                                        </Select>
-                                                        <FormMessage />
-                                                    </FormItem>
-                                                )}
-                                            />
-                                        </div>
-
-                                        <div>
-                                            <ChargeNormalizationAudit
-                                                normalizationStatus={chargeLine?.normalization_status}
-                                                normalizationMethod={chargeLine?.normalization_method}
-                                                sourceLabel={chargeLine?.source_label}
-                                                normalizedLabel={chargeLine?.normalized_label}
-                                                resolvedProductCode={chargeLine?.resolved_product_code}
-                                                manualResolutionStatus={chargeLine?.manual_resolution_status}
-                                                manualResolvedProductCode={chargeLine?.manual_resolved_product_code}
-                                                manualResolutionByUsername={chargeLine?.manual_resolution_by_username}
-                                                manualResolutionAt={chargeLine?.manual_resolution_at}
-                                                canOpenManualReview={canOpenManualReview}
-                                                onOpenManualReview={() => {
-                                                    if (chargeLine) {
-                                                        onOpenManualReview?.(chargeLine);
-                                                    }
-                                                }}
-                                                detailsOpen={isDetailsOpen}
-                                                onToggleDetails={() => toggleDetails(field.id)}
-                                            >
-                                                <div className="grid gap-3">
-                                                    <div className="grid gap-3 md:grid-cols-2">
-                                                        <FormField
-                                                            control={control}
-                                                            name={`charges.${index}.source_reference`}
-                                                            render={({ field }) => (
-                                                                <FormItem>
-                                                                    <FormLabel className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-500">
-                                                                        Source reference
-                                                                    </FormLabel>
-                                                                    <FormControl>
-                                                                        <Input placeholder="Source Ref" {...field} className="h-8 text-xs" />
-                                                                    </FormControl>
-                                                                    <FormMessage />
-                                                                </FormItem>
-                                                            )}
-                                                        />
-                                                        {chargeLine?.unit === "percentage" ? (
+                                            <div className="space-y-2">
+                                                <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                                                    {chargeLine?.unit === "percentage" ? "Percentage Rate" : "Amount"}
+                                                </div>
+                                                <FormField
+                                                    control={control}
+                                                    name={`charges.${index}.unit`}
+                                                    render={({ field: unitField }) => (
+                                                        unitField.value === "percentage" ? (
                                                             <FormField
                                                                 control={control}
-                                                                name={`charges.${index}.percentage_basis`}
-                                                                render={({ field }) => (
+                                                                name={`charges.${index}.percent`}
+                                                                render={({ field: percentField }) => (
                                                                     <FormItem>
-                                                                        <FormLabel className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-500">
-                                                                            Percentage basis
-                                                                        </FormLabel>
                                                                         <FormControl>
-                                                                            <Input
-                                                                                placeholder="Basis e.g. FREIGHT"
-                                                                                {...field}
-                                                                                value={field.value || ""}
-                                                                                className="h-8 text-xs"
-                                                                            />
+                                                                            <div className="relative">
+                                                                                <Input
+                                                                                    type="number"
+                                                                                    step="any"
+                                                                                    placeholder="Rate"
+                                                                                    {...percentField}
+                                                                                    value={percentField.value || ""}
+                                                                                    className="h-8 pr-6 text-right bg-white text-sm"
+                                                                                />
+                                                                                <span className="absolute right-2 top-1.5 text-xs font-semibold text-slate-500 pointer-events-none">%</span>
+                                                                            </div>
                                                                         </FormControl>
                                                                         <FormMessage />
                                                                     </FormItem>
                                                                 )}
                                                             />
-                                                        ) : null}
-                                                    </div>
+                                                        ) : (
+                                                            <SmartMoneyInput
+                                                                control={control}
+                                                                index={index}
+                                                                currencyName={`charges.${index}.currency`}
+                                                                amountName={`charges.${index}.amount`}
+                                                                unit={unitField.value}
+                                                                showMinCharge={unitField.value === "min_or_per_kg"}
+                                                                minChargeName={`charges.${index}.min_charge`}
+                                                            />
+                                                        )
+                                                    )}
+                                                />
+                                            </div>
 
-                                                    <div className="flex flex-wrap items-center justify-between gap-3">
-                                                        <div className="flex flex-wrap items-center gap-4">
-                                                            {bucket.id === "airfreight" ? (
+                                            <div className="space-y-2">
+                                                {chargeLine?.unit === "percentage" ? (
+                                                    <>
+                                                        <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                                                            Applies To
+                                                        </div>
+                                                        <FormField
+                                                            control={control}
+                                                            name={`charges.${index}.percent_basis`}
+                                                            render={({ field: basisField }) => {
+                                                                const baseOptions = [
+                                                                    { value: "freight", label: "Freight" },
+                                                                    { value: "origin", label: "Origin Charges" },
+                                                                    { value: "destination", label: "Destination Charges" },
+                                                                    { value: "total", label: "Total Quote" },
+                                                                ];
+                                                                if (watchedCharges) {
+                                                                    watchedCharges.forEach((c) => {
+                                                                        if (c.code && !["freight", "origin", "destination", "total"].includes(c.code.toLowerCase())) {
+                                                                            baseOptions.push({
+                                                                                value: c.code.toLowerCase(),
+                                                                                label: c.description || c.code,
+                                                                            });
+                                                                        }
+                                                                    });
+                                                                }
+                                                                return (
+                                                                    <FormItem>
+                                                                        <Select onValueChange={basisField.onChange} defaultValue={basisField.value || undefined}>
+                                                                            <FormControl>
+                                                                                <SelectTrigger className="h-8">
+                                                                                    <SelectValue placeholder="Select basis" />
+                                                                                </SelectTrigger>
+                                                                            </FormControl>
+                                                                            <SelectContent>
+                                                                                {baseOptions.map((opt) => (
+                                                                                    <SelectItem key={opt.value} value={opt.value}>
+                                                                                        {opt.label}
+                                                                                    </SelectItem>
+                                                                                ))}
+                                                                            </SelectContent>
+                                                                        </Select>
+                                                                        <FormMessage />
+                                                                    </FormItem>
+                                                                );
+                                                            }}
+                                                        />
+                                                    </>
+                                                ) : (
+                                                    <>
+                                                        <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                                                            Unit
+                                                        </div>
+                                                        <FormField
+                                                            control={control}
+                                                            name={`charges.${index}.unit`}
+                                                            render={({ field }) => (
+                                                                <FormItem>
+                                                                    <Select onValueChange={field.onChange} defaultValue={field.value}>
+                                                                        <FormControl>
+                                                                            <SelectTrigger className="h-8">
+                                                                                <SelectValue />
+                                                                            </SelectTrigger>
+                                                                        </FormControl>
+                                                                        <SelectContent>
+                                                                            {CHARGE_UNITS.map((unit) => (
+                                                                                <SelectItem key={unit.value} value={unit.value}>
+                                                                                    {unit.label}
+                                                                                </SelectItem>
+                                                                            ))}
+                                                                        </SelectContent>
+                                                                    </Select>
+                                                                    <FormMessage />
+                                                                </FormItem>
+                                                            )}
+                                                        />
+                                                    </>
+                                                )}
+                                            </div>
+
+                                            <div className="space-y-2">
+                                                <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                                                    Reviewed Bucket
+                                                </div>
+                                                <FormField
+                                                    control={control}
+                                                    name={`charges.${index}.reviewed_bucket`}
+                                                    render={({ field }) => (
+                                                        <FormItem>
+                                                            <Select onValueChange={field.onChange} defaultValue={field.value || undefined}>
+                                                                <FormControl>
+                                                                    <SelectTrigger className="h-8">
+                                                                        <SelectValue placeholder="Select bucket" />
+                                                                    </SelectTrigger>
+                                                                </FormControl>
+                                                                <SelectContent>
+                                                                    {COMMERCIAL_BUCKETS.map((cb) => (
+                                                                        <SelectItem key={cb.id} value={cb.id}>
+                                                                            {cb.label}
+                                                                        </SelectItem>
+                                                                    ))}
+                                                                </SelectContent>
+                                                            </Select>
+                                                            <FormMessage />
+                                                        </FormItem>
+                                                    )}
+                                                />
+                                            </div>
+
+                                            <div>
+                                                <ChargeNormalizationAudit
+                                                    normalizationStatus={chargeLine?.normalization_status}
+                                                    normalizationMethod={chargeLine?.normalization_method}
+                                                    sourceLabel={chargeLine?.source_label}
+                                                    normalizedLabel={chargeLine?.normalized_label}
+                                                    resolvedProductCode={chargeLine?.resolved_product_code}
+                                                    manualResolutionStatus={chargeLine?.manual_resolution_status}
+                                                    manualResolvedProductCode={chargeLine?.manual_resolved_product_code}
+                                                    manualResolutionByUsername={chargeLine?.manual_resolution_by_username}
+                                                    manualResolutionAt={chargeLine?.manual_resolution_at}
+                                                    canOpenManualReview={canOpenManualReview}
+                                                    onOpenManualReview={() => {
+                                                        if (chargeLine) {
+                                                            onOpenManualReview?.(chargeLine);
+                                                        }
+                                                    }}
+                                                    detailsOpen={isDetailsOpen}
+                                                    onToggleDetails={() => toggleDetails(field.id)}
+                                                >
+                                                    <div className="grid gap-3">
+                                                        <div className="grid gap-3 md:grid-cols-2">
+                                                            <FormField
+                                                                control={control}
+                                                                name={`charges.${index}.source_reference`}
+                                                                render={({ field }) => (
+                                                                    <FormItem>
+                                                                        <FormLabel className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                                                                            Source reference
+                                                                        </FormLabel>
+                                                                        <FormControl>
+                                                                            <Input placeholder="Source Ref" {...field} className="h-8 text-xs" />
+                                                                        </FormControl>
+                                                                        <FormMessage />
+                                                                    </FormItem>
+                                                                )}
+                                                            />
+                                                            <FormField
+                                                                control={control}
+                                                                name={`charges.${index}.note`}
+                                                                render={({ field }) => (
+                                                                    <FormItem>
+                                                                        <FormLabel className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                                                                            Notes
+                                                                        </FormLabel>
+                                                                        <FormControl>
+                                                                            <Input placeholder="Internal notes" {...field} value={field.value || ""} className="h-8 text-xs" />
+                                                                        </FormControl>
+                                                                        <FormMessage />
+                                                                    </FormItem>
+                                                                )}
+                                                            />
+                                                            {chargeLine?.unit === "percentage" ? (
+                                                                <>
+                                                                    <FormField
+                                                                        control={control}
+                                                                        name={`charges.${index}.min_amount`}
+                                                                        render={({ field }) => (
+                                                                            <FormItem>
+                                                                                <FormLabel className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                                                                                    Minimum Limit
+                                                                                </FormLabel>
+                                                                                <FormControl>
+                                                                                    <Input placeholder="e.g. 150.00" {...field} value={field.value || ""} className="h-8 text-xs" />
+                                                                                </FormControl>
+                                                                                <FormMessage />
+                                                                            </FormItem>
+                                                                        )}
+                                                                    />
+                                                                    <FormField
+                                                                        control={control}
+                                                                        name={`charges.${index}.max_amount`}
+                                                                        render={({ field }) => (
+                                                                            <FormItem>
+                                                                                <FormLabel className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                                                                                    Maximum Limit
+                                                                                </FormLabel>
+                                                                                <FormControl>
+                                                                                    <Input placeholder="e.g. 500.00" {...field} value={field.value || ""} className="h-8 text-xs" />
+                                                                                </FormControl>
+                                                                                <FormMessage />
+                                                                            </FormItem>
+                                                                        )}
+                                                                    />
+                                                                </>
+                                                            ) : null}
+                                                        </div>
+
+                                                        <div className="flex flex-wrap items-center justify-between gap-3">
+                                                            <div className="flex flex-wrap items-center gap-4">
+                                                                {bucket.id === "airfreight" ? (
+                                                                    <FormField
+                                                                        control={control}
+                                                                        name={`charges.${index}.is_primary_cost`}
+                                                                        render={({ field }) => (
+                                                                            <FormItem className="flex items-center space-x-2 space-y-0">
+                                                                                <FormControl>
+                                                                                    <Checkbox checked={field.value} onCheckedChange={field.onChange} />
+                                                                                </FormControl>
+                                                                                <FormLabel className="text-[10px] font-medium uppercase text-muted-foreground">
+                                                                                    Primary
+                                                                                </FormLabel>
+                                                                            </FormItem>
+                                                                        )}
+                                                                    />
+                                                                ) : null}
                                                                 <FormField
                                                                     control={control}
-                                                                    name={`charges.${index}.is_primary_cost`}
+                                                                    name={`charges.${index}.conditional`}
                                                                     render={({ field }) => (
                                                                         <FormItem className="flex items-center space-x-2 space-y-0">
                                                                             <FormControl>
                                                                                 <Checkbox checked={field.value} onCheckedChange={field.onChange} />
                                                                             </FormControl>
                                                                             <FormLabel className="text-[10px] font-medium uppercase text-muted-foreground">
-                                                                                Primary
+                                                                                Conditional
                                                                             </FormLabel>
                                                                         </FormItem>
                                                                     )}
                                                                 />
-                                                            ) : null}
-                                                            <FormField
-                                                                control={control}
-                                                                name={`charges.${index}.conditional`}
-                                                                render={({ field }) => (
-                                                                    <FormItem className="flex items-center space-x-2 space-y-0">
-                                                                        <FormControl>
-                                                                            <Checkbox checked={field.value} onCheckedChange={field.onChange} />
-                                                                        </FormControl>
-                                                                        <FormLabel className="text-[10px] font-medium uppercase text-muted-foreground">
-                                                                            Conditional
-                                                                        </FormLabel>
-                                                                    </FormItem>
-                                                                )}
-                                                            />
-                                                        </div>
+                                                            </div>
 
-                                                        <Button
-                                                            type="button"
-                                                            variant="ghost"
-                                                            size="sm"
-                                                            onClick={() => void handleRemove(index)}
-                                                            className="h-7 px-2 text-[11px] text-muted-foreground hover:text-destructive"
-                                                        >
-                                                            Remove line
-                                                        </Button>
+                                                            <div className="flex items-center gap-2">
+                                                                <Button
+                                                                    type="button"
+                                                                    variant="default"
+                                                                    size="sm"
+                                                                    onClick={() => setEditingFieldId(null)}
+                                                                    className="h-7 px-3 text-[11px]"
+                                                                >
+                                                                    Done
+                                                                </Button>
+                                                                <Button
+                                                                    type="button"
+                                                                    variant="ghost"
+                                                                    size="sm"
+                                                                    onClick={() => void handleRemove(index)}
+                                                                    className="h-7 px-2 text-[11px] text-muted-foreground hover:text-destructive"
+                                                                >
+                                                                    Remove line
+                                                                </Button>
+                                                            </div>
+                                                        </div>
                                                     </div>
-                                                </div>
-                                            </ChargeNormalizationAudit>
+                                                </ChargeNormalizationAudit>
+                                            </div>
                                         </div>
-                                    </div>
+                                    )}
                                 </div>
                             );
                         })}

--- a/frontend/src/components/spot/SpotRateEntryForm.tsx
+++ b/frontend/src/components/spot/SpotRateEntryForm.tsx
@@ -20,6 +20,12 @@ import { ChargeBucketSection } from "./ChargeBucketSection";
 import { SpotChargeLineManualReviewSheet } from "./SpotChargeLineManualReviewSheet";
 import { getSpotChargeDisplayLabel } from "@/lib/spot-charge-display";
 import { getSpotChargeFormDisabledReason } from "@/lib/spot-charge-readiness";
+import {
+    type CommercialBucket,
+    COMMERCIAL_BUCKETS,
+    inferCommercialBucket,
+    getDuplicateChargeIndices
+} from "@/lib/spot-commercial-buckets";
 
 type ReviewRequest = {
     chargeLineId: string;
@@ -47,6 +53,7 @@ interface SpotRateEntryFormProps {
     productCodeDomain?: string;
     envelopeId?: string;
     reviewRequest?: ReviewRequest | null;
+    filterType?: "all" | "matched" | "conditional";
 }
 
 const normalizeSourceReference = (value?: string | null) => {
@@ -59,11 +66,8 @@ const normalizeSourceReference = (value?: string | null) => {
         .replace(/^Analysis Suggestion$/i, "Imported rates");
 };
 
-const CHARGE_BUCKETS: { id: SPEChargeBucket; label: string }[] = [
-    { id: "airfreight", label: "Airfreight" },
-    { id: "origin_charges", label: "Origin Charges" },
-    { id: "destination_charges", label: "Agent Quoted Charges" },
-];
+// Define bucket grouping list
+const CHARGE_BUCKETS = COMMERCIAL_BUCKETS;
 
 type FormErrorWithMessage = { message?: string };
 
@@ -129,6 +133,7 @@ export function SpotRateEntryForm({
     productCodeDomain,
     envelopeId,
     reviewRequest,
+    filterType = "all",
 }: SpotRateEntryFormProps) {
     const submitLockRef = useRef(false);
     const draftLockRef = useRef(false);
@@ -297,6 +302,7 @@ export function SpotRateEntryForm({
             conditional_acknowledged: charge.conditional_acknowledged,
             conditional_acknowledged_by: charge.conditional_acknowledged_by,
             conditional_acknowledged_at: charge.conditional_acknowledged_at,
+            reviewed_bucket: (charge.reviewed_bucket || inferCommercialBucket(charge)) as unknown as SpotFormInputValues["charges"][number]["reviewed_bucket"],
             source_reference: normalizeSourceReference(charge.source_reference),
             source_excerpt: charge.source_excerpt || "",
             source_line_number: charge.source_line_number ?? null,
@@ -319,6 +325,11 @@ export function SpotRateEntryForm({
             manual_resolution_by_user_id: charge.manual_resolution_by_user_id ?? null,
             manual_resolution_by_username: charge.manual_resolution_by_username ?? null,
             manual_resolution_at: charge.manual_resolution_at ?? null,
+            calculation_type: charge.calculation_type ?? null,
+            percent: charge.percent != null ? String(charge.percent) : null,
+            percent_basis: charge.percent_basis ?? null,
+            min_amount: charge.min_amount != null ? String(charge.min_amount) : null,
+            max_amount: charge.max_amount != null ? String(charge.max_amount) : null,
         }));
     }, [mergedCharges, visibleBuckets]);
 
@@ -338,8 +349,7 @@ export function SpotRateEntryForm({
 
     const hiddenExistingCharges = useMemo(
         () => {
-            // Preserve non-visible SPOT charges so saving one bucket does not wipe out
-            // previously imported or edited charges in the other required buckets.
+            // Keep preserving based on the underlying backend bucket
             return initialCharges.filter(c => !visibleBuckets.includes(c.bucket));
         },
         [initialCharges, visibleBuckets]
@@ -352,7 +362,12 @@ export function SpotRateEntryForm({
     const watchedFormCharges = useWatch({
         control: form.control,
         name: "charges",
-    }) || [];
+    });
+    const memoizedWatchedFormCharges = useMemo(() => watchedFormCharges || [], [watchedFormCharges]);
+
+    const duplicateIndices = useMemo(() => {
+        return getDuplicateChargeIndices(memoizedWatchedFormCharges);
+    }, [memoizedWatchedFormCharges]);
 
     const mapEditableLineToSubmitCharge = (
         line: SpotFormSubmitValues["charges"][number]
@@ -393,6 +408,11 @@ export function SpotRateEntryForm({
             note: line.note,
             exclude_from_totals: line.exclude_from_totals,
             percentage_basis: line.percentage_basis || undefined,
+            calculation_type: line.unit === "percentage" ? "percent_of" : (line.calculation_type || (line.unit === "min_or_per_kg" ? "min_or_per_unit" : "flat")),
+            percent: line.unit === "percentage" && line.percent ? parseFloat(line.percent) : undefined,
+            percent_basis: line.unit === "percentage" ? (line.percent_basis || undefined) : undefined,
+            min_amount: line.min_amount ? parseFloat(line.min_amount) : undefined,
+            max_amount: line.max_amount ? parseFloat(line.max_amount) : undefined,
         };
     };
 
@@ -431,6 +451,11 @@ export function SpotRateEntryForm({
         note: charge.note,
         exclude_from_totals: charge.exclude_from_totals,
         percentage_basis: charge.percentage_basis,
+        calculation_type: charge.calculation_type,
+        percent: charge.percent,
+        percent_basis: charge.percent_basis,
+        min_amount: charge.min_amount,
+        max_amount: charge.max_amount,
     });
 
     const handleFormSubmit = async (data: SpotFormSubmitValues) => {
@@ -524,6 +549,7 @@ export function SpotRateEntryForm({
             source_line_identity: "",
             min_charge: null,
             exclude_from_totals: false,
+            reviewed_bucket: bucket === "airfreight" ? "freight" : (bucket === "origin_charges" ? "origin" : "destination"),
             source_label: "",
             normalized_label: "",
             normalization_status: null,
@@ -565,6 +591,7 @@ export function SpotRateEntryForm({
             note: line.note || undefined,
             exclude_from_totals: line.exclude_from_totals,
             percentage_basis: line.percentage_basis || undefined,
+            reviewed_bucket: (line.reviewed_bucket || inferCommercialBucket({ bucket: line.bucket, description: line.description, code: line.code })) as unknown as SpotFormInputValues["charges"][number]["reviewed_bucket"],
             source_label: line.source_label || undefined,
             normalized_label: line.normalized_label || undefined,
             normalization_status: line.normalization_status ?? null,
@@ -579,6 +606,11 @@ export function SpotRateEntryForm({
             manual_resolution_by_user_id: line.manual_resolution_by_user_id ?? null,
             manual_resolution_by_username: line.manual_resolution_by_username ?? null,
             manual_resolution_at: line.manual_resolution_at ?? null,
+            calculation_type: line.calculation_type ?? null,
+            percent: line.percent != null ? String(line.percent) : null,
+            percent_basis: line.percent_basis ?? null,
+            min_amount: line.min_amount != null ? String(line.min_amount) : null,
+            max_amount: line.max_amount != null ? String(line.max_amount) : null,
         });
     }, []);
 
@@ -624,8 +656,34 @@ export function SpotRateEntryForm({
         }
     }, [manualReviewCharge, onManualResolveChargeLine]);
 
-    const getFieldsByBucket = (bucket: SPEChargeBucket) =>
-        fields.map((field, index) => ({ field, index })).filter(item => item.field.bucket === bucket);
+    const getFieldsByBucket = (bucketId: CommercialBucket) => {
+        return fields
+            .map((field, index) => ({ field, index }))
+            .filter((item) => {
+                const chargeLine = watchedFormCharges[item.index];
+                if (!chargeLine) return false;
+                
+                const currentReviewedBucket = chargeLine.reviewed_bucket || inferCommercialBucket({
+                    bucket: chargeLine.bucket,
+                    description: chargeLine.description,
+                    code: chargeLine.code
+                });
+                
+                if (currentReviewedBucket !== bucketId) return false;
+                if (!filterType || filterType === "all") return true;
+
+                if (filterType === "matched") {
+                    return (
+                        chargeLine.manual_resolution_status === "RESOLVED" ||
+                        chargeLine.normalization_status === "MATCHED"
+                    );
+                }
+                if (filterType === "conditional") {
+                    return Boolean(chargeLine.conditional);
+                }
+                return true;
+            });
+    };
 
     return (
         <Form {...form}>
@@ -642,20 +700,30 @@ export function SpotRateEntryForm({
                     </Alert>
                 )}
 
-                {visibleBuckets.map(bucketId => {
-                    const bucket = CHARGE_BUCKETS.find(b => b.id === bucketId);
-                    if (!bucket) return null;
+                {CHARGE_BUCKETS.map(bucket => {
                     const bucketItems = getFieldsByBucket(bucket.id);
+                    // Map commercial bucket default backend category for item addition
+                    const defaultBackendBucketMap: Record<CommercialBucket, SPEChargeBucket> = {
+                        freight: "airfreight",
+                        origin: "origin_charges",
+                        destination: "destination_charges",
+                        security: "origin_charges",
+                        customs: "origin_charges",
+                        transport: "origin_charges",
+                        other: "origin_charges"
+                    };
+                    const targetBackendBucket = defaultBackendBucketMap[bucket.id];
                     return (
                         <ChargeBucketSection
                             key={bucket.id}
                             bucket={bucket}
                             control={form.control}
                             fields={bucketItems}
-                            onAdd={() => addLine(bucket.id)}
+                            onAdd={() => addLine(targetBackendBucket)}
                             onRemove={remove}
                             onOpenManualReview={handleOpenManualReview}
                             activeChargeLineId={reviewRequest?.chargeLineId ?? null}
+                            duplicateIndices={duplicateIndices}
                         />
                     );
                 })}

--- a/frontend/src/components/spot/SpotWorkspaceSummary.tsx
+++ b/frontend/src/components/spot/SpotWorkspaceSummary.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 
 export interface SpotWorkspaceSummaryProps {
     customerName: string;
@@ -22,41 +22,44 @@ export function SpotWorkspaceSummary({
     paymentTerms,
 }: SpotWorkspaceSummaryProps) {
     return (
-        <Card className="mb-6">
-            <CardHeader className="pb-3">
-                <CardTitle className="text-base font-semibold">Shipment Summary</CardTitle>
-            </CardHeader>
-            <CardContent>
-                <div className="grid grid-cols-2 gap-4 text-sm md:grid-cols-4 xl:grid-cols-7">
-                    <div className="flex flex-col gap-1">
-                        <span className="text-muted-foreground font-medium">Customer</span>
-                        <span className="font-bold text-slate-900">{customerName}</span>
+        <Card className="mb-6 border-slate-200 bg-slate-50/70 shadow-sm">
+            <CardContent className="px-5 py-3">
+                <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm">
+                    <div className="flex items-center gap-1.5">
+                        <span className="font-medium text-slate-500">Customer</span>
+                        <span className="font-semibold text-slate-900">{customerName}</span>
                     </div>
-                    <div className="flex flex-col gap-1">
-                        <span className="text-muted-foreground font-medium">Route</span>
-                        <span className="font-bold text-slate-900">
-                            {originCode} {"->"} {destinationCode}
+                    <span className="hidden text-slate-300 sm:inline" aria-hidden="true">|</span>
+                    <div className="flex items-center gap-1.5">
+                        <span className="font-medium text-slate-500">Route</span>
+                        <span className="font-semibold text-slate-900">
+                            {originCode} {"→"} {destinationCode}
                         </span>
                     </div>
-                    <div className="flex flex-col gap-1">
-                        <span className="text-muted-foreground font-medium">Commodity</span>
-                        <span className="font-bold text-slate-900">{commodity}</span>
+                    <span className="hidden text-slate-300 sm:inline" aria-hidden="true">|</span>
+                    <div className="flex items-center gap-1.5">
+                        <span className="font-medium text-slate-500">Commodity</span>
+                        <span className="font-semibold text-slate-900">{commodity}</span>
                     </div>
-                    <div className="flex flex-col gap-1">
-                        <span className="text-muted-foreground font-medium">Weight</span>
-                        <span className="font-bold text-slate-900">{weightKg} kg</span>
+                    <span className="hidden text-slate-300 sm:inline" aria-hidden="true">|</span>
+                    <div className="flex items-center gap-1.5">
+                        <span className="font-medium text-slate-500">Weight</span>
+                        <span className="font-semibold text-slate-900">{weightKg} kg</span>
                     </div>
-                    <div className="flex flex-col gap-1">
-                        <span className="text-muted-foreground font-medium">Pieces</span>
-                        <span className="font-bold text-slate-900">{pieces}</span>
+                    <span className="hidden text-slate-300 sm:inline" aria-hidden="true">|</span>
+                    <div className="flex items-center gap-1.5">
+                        <span className="font-medium text-slate-500">Pcs</span>
+                        <span className="font-semibold text-slate-900">{pieces}</span>
                     </div>
-                    <div className="flex flex-col gap-1">
-                        <span className="text-muted-foreground font-medium">Service Scope</span>
-                        <span className="font-bold text-slate-900">{serviceScope}</span>
+                    <span className="hidden text-slate-300 sm:inline" aria-hidden="true">|</span>
+                    <div className="flex items-center gap-1.5">
+                        <span className="font-medium text-slate-500">Scope</span>
+                        <span className="font-semibold text-slate-900">{serviceScope}</span>
                     </div>
-                    <div className="flex flex-col gap-1">
-                        <span className="text-muted-foreground font-medium">Payment Terms</span>
-                        <span className="font-bold text-slate-900">{paymentTerms}</span>
+                    <span className="hidden text-slate-300 sm:inline" aria-hidden="true">|</span>
+                    <div className="flex items-center gap-1.5">
+                        <span className="font-medium text-slate-500">Payment</span>
+                        <span className="font-semibold text-slate-900">{paymentTerms}</span>
                     </div>
                 </div>
             </CardContent>

--- a/frontend/src/lib/schemas/spotSchema.ts
+++ b/frontend/src/lib/schemas/spotSchema.ts
@@ -15,6 +15,8 @@ export const chargeLineSchema = z.object({
         "per_trip", "per_set", "per_man"
     ]),
     bucket: z.enum(["airfreight", "origin_charges", "destination_charges"]),
+    /** Frontend-only commercial grouping for display. NEVER sent to backend. */
+    reviewed_bucket: z.enum(["freight", "origin", "destination", "security", "customs", "transport", "other"]).optional().nullable(),
     is_primary_cost: z.boolean().default(false),
     conditional: z.boolean().default(false),
     conditional_acknowledged: z.boolean().optional(),
@@ -63,6 +65,11 @@ export const chargeLineSchema = z.object({
     manual_resolution_by_user_id: z.string().optional().nullable(),
     manual_resolution_by_username: z.string().optional().nullable(),
     manual_resolution_at: z.string().optional().nullable(),
+    calculation_type: z.string().optional().nullable(),
+    percent: z.string().optional().nullable(),
+    percent_basis: z.string().optional().nullable(),
+    min_amount: z.string().optional().nullable(),
+    max_amount: z.string().optional().nullable(),
 });
 
 export const spotFormSchema = z.object({

--- a/frontend/src/lib/spot-commercial-buckets.ts
+++ b/frontend/src/lib/spot-commercial-buckets.ts
@@ -1,0 +1,175 @@
+/**
+ * Commercial Bucket Helpers for SPOT Rate Review
+ *
+ * These helpers provide a frontend-only commercial grouping layer
+ * on top of the backend 3-value bucket enum (airfreight, origin_charges,
+ * destination_charges). The reviewed_bucket is NEVER sent to the backend
+ * and does NOT alter pricing or component routing.
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type CommercialBucket =
+    | "freight"
+    | "origin"
+    | "destination"
+    | "security"
+    | "customs"
+    | "transport"
+    | "other";
+
+export interface CommercialBucketDef {
+    id: CommercialBucket;
+    label: string;
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+export const COMMERCIAL_BUCKETS: CommercialBucketDef[] = [
+    { id: "freight", label: "Freight" },
+    { id: "origin", label: "Origin Charges" },
+    { id: "destination", label: "Destination Charges" },
+    { id: "security", label: "Security / Screening" },
+    { id: "customs", label: "Customs / Regulatory" },
+    { id: "transport", label: "Transport" },
+    { id: "other", label: "Other / Manual Review" },
+];
+
+export const COMMERCIAL_BUCKET_LABELS: Record<CommercialBucket, string> =
+    Object.fromEntries(COMMERCIAL_BUCKETS.map((b) => [b.id, b.label])) as Record<CommercialBucket, string>;
+
+// ─── Heuristic: infer commercial bucket from parser bucket + description ─────
+
+/**
+ * Keywords that indicate a charge should be reclassified from "freight"
+ * (parser bucket: airfreight) to a more appropriate commercial bucket.
+ *
+ * IMPORTANT: This is frontend-only display grouping. The backend `bucket`
+ * field is NEVER modified by this function.
+ */
+const ORIGIN_CHARGE_PATTERNS = [
+    /\bawb\b/i,
+    /\bair\s*waybill\b/i,
+    /\bdocument/i,
+    /\bhandling\b/i,
+    /\bterminal\b/i,
+    /\bwarehouse\b/i,
+    /\bpalletis/i,
+    /\bbreak\s*bulk/i,
+    /\bbuild\s*up/i,
+    /\bagency\b/i,
+    /\blabel/i,
+];
+
+const SECURITY_PATTERNS = [
+    /\bsecurity\b/i,
+    /\bscreen/i,
+    /\bx[\s-]?ray/i,
+    /\bra\s*3/i,
+];
+
+const CUSTOMS_PATTERNS = [
+    /\bcustom/i,
+    /\bclearance\b/i,
+    /\bduty\b/i,
+    /\btariff\b/i,
+    /\bregulatory\b/i,
+    /\bexport\s+declaration/i,
+    /\bimport\s+declaration/i,
+];
+
+const TRANSPORT_PATTERNS = [
+    /\bpickup\b/i,
+    /\bdelivery\b/i,
+    /\bcollection\b/i,
+    /\btransport/i,
+    /\btruck/i,
+    /\bcartage\b/i,
+];
+
+/**
+ * Infer the commercial bucket for a charge based on its parser bucket,
+ * description, and product code. Falls back to a 1:1 mapping from
+ * the parser bucket.
+ */
+export function inferCommercialBucket(charge: {
+    bucket: string;
+    description?: string;
+    code?: string;
+    resolved_product_code?: { code?: string; description?: string } | null;
+    effective_resolved_product_code?: { code?: string; description?: string } | null;
+}): CommercialBucket {
+    const desc = (charge.description || "").trim();
+    const productCodeStr = charge.effective_resolved_product_code?.code
+        || charge.resolved_product_code?.code
+        || charge.code
+        || "";
+    const searchText = `${desc} ${productCodeStr}`;
+
+    // Only reclassify charges currently in airfreight parser bucket
+    if (charge.bucket === "airfreight") {
+        if (SECURITY_PATTERNS.some((p) => p.test(searchText))) return "security";
+        if (CUSTOMS_PATTERNS.some((p) => p.test(searchText))) return "customs";
+        if (TRANSPORT_PATTERNS.some((p) => p.test(searchText))) return "transport";
+        if (ORIGIN_CHARGE_PATTERNS.some((p) => p.test(searchText))) return "origin";
+        return "freight";
+    }
+
+    // For origin/destination parser buckets, check for sub-category matches
+    if (charge.bucket === "origin_charges") {
+        if (SECURITY_PATTERNS.some((p) => p.test(searchText))) return "security";
+        if (CUSTOMS_PATTERNS.some((p) => p.test(searchText))) return "customs";
+        if (TRANSPORT_PATTERNS.some((p) => p.test(searchText))) return "transport";
+        return "origin";
+    }
+
+    if (charge.bucket === "destination_charges") {
+        if (SECURITY_PATTERNS.some((p) => p.test(searchText))) return "security";
+        if (CUSTOMS_PATTERNS.some((p) => p.test(searchText))) return "customs";
+        if (TRANSPORT_PATTERNS.some((p) => p.test(searchText))) return "transport";
+        return "destination";
+    }
+
+    return "other";
+}
+
+// ─── Duplicate detection ─────────────────────────────────────────────────────
+
+/**
+ * Returns a Set of field-array indices where the charge description is
+ * duplicated within the same quote. Detection is case-insensitive and
+ * whitespace-normalized.
+ *
+ * A charge index is included only if at least one OTHER charge has the
+ * same normalized description.
+ */
+export function getDuplicateChargeIndices(
+    charges: Array<{ description?: string }>
+): Set<number> {
+    const normalized = charges.map((c) =>
+        (c.description || "").trim().toUpperCase().replace(/\s+/g, " ")
+    );
+
+    // Count occurrences
+    const counts = new Map<string, number[]>();
+    for (let i = 0; i < normalized.length; i++) {
+        const key = normalized[i];
+        if (!key) continue;
+        const existing = counts.get(key);
+        if (existing) {
+            existing.push(i);
+        } else {
+            counts.set(key, [i]);
+        }
+    }
+
+    const dupeSet = new Set<number>();
+    for (const indices of counts.values()) {
+        if (indices.length > 1) {
+            for (const idx of indices) {
+                dupeSet.add(idx);
+            }
+        }
+    }
+    return dupeSet;
+}

--- a/frontend/src/lib/spot-types.ts
+++ b/frontend/src/lib/spot-types.ts
@@ -181,6 +181,12 @@ export interface SPEChargeLine {
     manual_resolution_by_username?: string | null;
     manual_resolution_at?: string | null;
     suggested_approved_product_code?: SPEProductCodeSummary | null;
+    reviewed_bucket?: string | null;
+    calculation_type?: string | null;
+    percent?: string | number | null;
+    percent_basis?: string | null;
+    min_amount?: string | number | null;
+    max_amount?: string | number | null;
 }
 
 /** SPE conditions */


### PR DESCRIPTION
## Summary of Phase 7K–7M Changes
This PR redesigns the SPOT Rate Review page from a developer form into an operator-friendly review queue and integrates calculation dependencies.
- **Compact UI rows**: Charge lines default to a compact read-only table view. Detailed editing inputs are deferred behind an explicit "Edit Charge" action.
- **Commercial charge buckets**: Charges are grouped dynamically into seven commercial categories (Freight, Origin Charges, Destination Charges, Security / Screening, Customs / Regulatory, Transport, and Other).
- **Auto-reclassification**: Heuristics dynamically reclassify AWB and Documentation fees to Origin Charges on page load instead of grouping under Freight.
- **Unit basis & target editing**: Exposes a percentage basis editing layout when unit is 'percentage', allowing selection of an "Applies To" target (like Freight, Origin Charges, or specific charge codes).
- **Limit settings**: Supports setting min_amount and max_amount thresholds for percentage rules.
- **Duplicate warnings**: Displays warning badge indicators for potential duplicate charges within the quote.
- **Summary statistics**: Rewrites the final review summary section to sum totals and list counts by commercial bucket.

## Files Changed
- `frontend/src/app/quotes/spot/[speId]/page.tsx`
- `frontend/src/components/spot/ChargeBucketSection.tsx`
- `frontend/src/components/spot/SpotRateEntryForm.tsx`
- `frontend/src/components/spot/SpotWorkspaceSummary.tsx`
- `frontend/src/lib/schemas/spotSchema.ts`
- `frontend/src/lib/spot-types.ts`
- `frontend/src/lib/spot-commercial-buckets.ts`

## Verification Results
- **Backend tests**: Passed (33/33 tests OK).
- **Frontend typecheck**: Passed with 0 errors.
- **Frontend lint check**: Passed with 0 errors (41 pre-existing warnings in unrelated files remain).

## Confirmations
- **Exclusions**: Confirmed that the backend files (`backend/pricing_v4/adapter.py` and `backend/quotes/views/calculation.py`) have been restored to their original clean state and excluded from this branch.
- **Phase 7N**: Confirmed that the live recalculation logic is not included in this branch and has been fully deferred to Phase 7N.