### PR TITLE
feat(spot): add live SPOT totals recalculation preview

### DIFF
--- a/frontend/src/app/quotes/spot/[speId]/page.tsx
+++ b/frontend/src/app/quotes/spot/[speId]/page.tsx
@@ -200,6 +200,14 @@ export default function SpotRateEntryPage() {
     const [primarySourceBatchId, setPrimarySourceBatchId] = useState<string | null>(null);
     const [intakeDirtyMap, setIntakeDirtyMap] = useState<Record<string, boolean>>({});
     const [standardPrefillCharges, setStandardPrefillCharges] = useState<SPEChargeLine[]>([]);
+    const [recalculatedTotals, setRecalculatedTotals] = useState<Record<string, Record<string, number>> | null>(null);
+    const [recalculatedWarnings, setRecalculatedWarnings] = useState<string[]>([]);
+    
+    const handleRecalculate = useCallback((totals: Record<string, Record<string, number>>, warnings: string[]) => {
+        setRecalculatedTotals(totals);
+        setRecalculatedWarnings(warnings);
+    }, []);
+
     // Guard ref: prevents the auto-detection useEffect from overriding
     // an explicit step transition (e.g. after analysis completes).
     const userAdvancedToReviewRef = useRef(false);

--- a/frontend/src/components/spot/ChargeBucketSection.tsx
+++ b/frontend/src/components/spot/ChargeBucketSection.tsx
@@ -15,6 +15,7 @@ import { useToast } from "@/context/toast-context";
 import { useConfirm } from "@/hooks/useConfirm";
 import type { SpotFormValues } from "@/lib/schemas/spotSchema";
 import type { SPEProductCodeSummary } from "@/lib/spot-types";
+import type { PreviewChargeLine } from "@/lib/spot-recalculation";
 import { COMMERCIAL_BUCKETS } from "@/lib/spot-commercial-buckets";
 
 import { ChargeNormalizationAudit } from "./ChargeNormalizationAudit";
@@ -29,6 +30,7 @@ interface ChargeBucketSectionProps {
     onOpenManualReview?: (chargeLine: SpotFormValues["charges"][number]) => void;
     activeChargeLineId?: string | null;
     duplicateIndices?: Set<number>;
+    previewCharges?: Record<number, PreviewChargeLine>;
 }
 
 const CHARGE_UNITS = [
@@ -96,6 +98,7 @@ export function ChargeBucketSection({
     onOpenManualReview,
     activeChargeLineId,
     duplicateIndices = new Set(),
+    previewCharges,
 }: ChargeBucketSectionProps) {
     const confirm = useConfirm();
     const { toast } = useToast();
@@ -186,6 +189,7 @@ export function ChargeBucketSection({
                                 }));
                             };
                             const chargeLine = watchedCharges?.[index];
+                            const preview = previewCharges?.[index];
                             const canOpenManualReview = Boolean(
                                 chargeLine?.charge_line_id &&
                                 chargeLine?.manual_resolution_status !== "RESOLVED" &&
@@ -284,36 +288,36 @@ export function ChargeBucketSection({
                                                 </div>
                                             </div>
                                             
-                                            {chargeLine?.unit === "percentage" ? (
-                                                <div className="flex flex-col sm:items-end justify-center min-w-[150px]">
-                                                    <div className="text-lg font-bold text-slate-900">
-                                                        {chargeLine?.percent ? `${parseFloat(String(chargeLine.percent)).toLocaleString()}%` : "0.00%"}
-                                                    </div>
-                                                    <div className="text-xs text-slate-500 flex items-center gap-1">
-                                                        <span>of</span>
-                                                        {chargeLine?.percent_basis ? (
-                                                            <span className="font-semibold text-slate-700 uppercase">{chargeLine.percent_basis}</span>
-                                                        ) : (
-                                                            <Badge variant="outline" className="border-red-200 bg-red-50 text-red-700 text-[10px] font-semibold py-0 px-1">
-                                                                Base charge missing
-                                                            </Badge>
-                                                        )}
-                                                    </div>
-                                                </div>
-                                            ) : (
-                                                <div className="flex flex-col sm:items-end justify-center min-w-[150px]">
-                                                    <div className="text-lg font-bold text-slate-900">
-                                                        {chargeLine?.currency} {chargeLine?.amount ? parseFloat(chargeLine.amount).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }) : "0.00"}
-                                                    </div>
-                                                    <div className="text-xs text-slate-500">
-                                                        {chargeLine?.unit === "min_or_per_kg" ? (
-                                                            <>Per KG (Min {chargeLine.currency} {chargeLine.min_charge || "0.00"})</>
-                                                        ) : (
-                                                            CHARGE_UNITS.find(u => u.value === chargeLine?.unit)?.label || chargeLine?.unit
-                                                        )}
-                                                    </div>
-                                                </div>
-                                            )}
+                                             <div className="flex flex-col sm:items-end justify-center min-w-[150px]">
+                                                 <div className="text-lg font-bold text-slate-900">
+                                                     {chargeLine?.currency} {preview?.display_amount || (chargeLine?.amount ? parseFloat(chargeLine.amount).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }) : "0.00")}
+                                                 </div>
+                                                 <div className="text-xs text-slate-500 flex flex-col sm:items-end">
+                                                     {chargeLine?.unit === "percentage" ? (
+                                                         <span className="text-slate-600 font-medium">
+                                                             {chargeLine?.percent ? `${parseFloat(String(chargeLine.percent)).toLocaleString()}%` : "0.00%"} of {chargeLine?.percent_basis || "base"}
+                                                         </span>
+                                                     ) : (
+                                                         <span>
+                                                             {chargeLine?.unit === "min_or_per_kg" ? (
+                                                                 <>Per KG (Min {chargeLine.currency} {chargeLine.min_charge || "0.00"})</>
+                                                             ) : (
+                                                                 CHARGE_UNITS.find(u => u.value === chargeLine?.unit)?.label || chargeLine?.unit
+                                                             )}
+                                                         </span>
+                                                     )}
+                                                     {preview?.calculation_preview && (
+                                                         <span className="text-[10px] text-slate-400 max-w-[200px] text-right truncate" title={preview.calculation_preview}>
+                                                             {preview.calculation_preview}
+                                                         </span>
+                                                     )}
+                                                     {preview?.warnings && preview.warnings.map((w: string, idx: number) => (
+                                                         <Badge key={idx} variant="outline" className="mt-1 border-amber-200 bg-amber-50 text-amber-800 text-[9px] font-semibold py-0 px-1">
+                                                             {w}
+                                                         </Badge>
+                                                     ))}
+                                                 </div>
+                                             </div>
 
                                             <div className="flex flex-wrap items-center gap-2 justify-end">
                                                 {canOpenManualReview && (

--- a/frontend/src/components/spot/SpotRateEntryForm.tsx
+++ b/frontend/src/components/spot/SpotRateEntryForm.tsx
@@ -14,10 +14,11 @@ import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Form } from "@/components/ui/form";
 
-import type { SPEChargeLine, SPEChargeBucket, SPEChargeUnit, ExtractedAssertion } from "@/lib/spot-types";
+import type { SPEChargeLine, SPEChargeBucket, SPEChargeUnit, ExtractedAssertion, SPEShipmentContext } from "@/lib/spot-types";
 import { spotFormSchema, type SpotFormInputValues, type SpotFormSubmitValues } from "@/lib/schemas/spotSchema";
 import { ChargeBucketSection } from "./ChargeBucketSection";
 import { SpotChargeLineManualReviewSheet } from "./SpotChargeLineManualReviewSheet";
+import { recalculateSpotCharges, type PreviewChargeLine } from "@/lib/spot-recalculation";
 import { getSpotChargeDisplayLabel } from "@/lib/spot-charge-display";
 import { getSpotChargeFormDisabledReason } from "@/lib/spot-charge-readiness";
 import {
@@ -54,6 +55,8 @@ interface SpotRateEntryFormProps {
     envelopeId?: string;
     reviewRequest?: ReviewRequest | null;
     filterType?: "all" | "matched" | "conditional";
+    shipmentContext?: SPEShipmentContext | null;
+    onRecalculate?: (totals: Record<string, Record<string, number>>, warnings: string[]) => void;
 }
 
 const normalizeSourceReference = (value?: string | null) => {
@@ -134,6 +137,8 @@ export function SpotRateEntryForm({
     envelopeId,
     reviewRequest,
     filterType = "all",
+    shipmentContext = null,
+    onRecalculate,
 }: SpotRateEntryFormProps) {
     const submitLockRef = useRef(false);
     const draftLockRef = useRef(false);
@@ -364,6 +369,56 @@ export function SpotRateEntryForm({
         name: "charges",
     });
     const memoizedWatchedFormCharges = useMemo(() => watchedFormCharges || [], [watchedFormCharges]);
+
+    // Dynamic Recalculation Memo
+    const currentRecalculation = useMemo(() => {
+        if (!watchedFormCharges) return null;
+        
+        // Map form values to SPEChargeLine format for recalculator
+        const visibleMapped: SPEChargeLine[] = watchedFormCharges.map((line) => {
+            return {
+                id: line.charge_line_id || undefined,
+                code: line.code || "",
+                description: line.description || "",
+                amount: line.amount || "0",
+                currency: line.currency || "USD",
+                unit: line.unit as SPEChargeUnit,
+                min_charge: line.min_charge ? parseFloat(line.min_charge) : undefined,
+                bucket: line.bucket,
+                is_primary_cost: line.is_primary_cost,
+                conditional: line.conditional,
+                conditional_acknowledged: line.conditional_acknowledged,
+                exclude_from_totals: line.exclude_from_totals,
+                percentage_basis: line.percentage_basis || undefined,
+                calculation_type: line.unit === "percentage" ? "percent_of" : (line.min_charge ? "min_or_per_unit" : "flat"),
+                percent: line.percent != null ? parseFloat(String(line.percent)) : undefined,
+                percent_basis: line.percent_basis || undefined,
+                min_amount: line.min_amount || undefined,
+                max_amount: line.max_amount || undefined,
+                reviewed_bucket: line.reviewed_bucket || undefined,
+                source_reference: "UI Edit",
+            };
+        });
+
+        return recalculateSpotCharges(visibleMapped, hiddenExistingCharges, shipmentContext);
+    }, [watchedFormCharges, hiddenExistingCharges, shipmentContext]);
+
+    // Notify parent component of recalculated totals
+    useEffect(() => {
+        if (currentRecalculation && onRecalculate) {
+            onRecalculate(currentRecalculation.bucketTotals, currentRecalculation.warnings);
+        }
+    }, [currentRecalculation, onRecalculate]);
+
+    // Map preview charges to index for ChargeBucketSection rendering
+    const previewChargesMap = useMemo(() => {
+        if (!currentRecalculation?.charges) return {};
+        const map: Record<number, PreviewChargeLine> = {};
+        currentRecalculation.charges.forEach((c, idx) => {
+            map[idx] = c;
+        });
+        return map;
+    }, [currentRecalculation]);
 
     const duplicateIndices = useMemo(() => {
         return getDuplicateChargeIndices(memoizedWatchedFormCharges);
@@ -724,6 +779,7 @@ export function SpotRateEntryForm({
                             onOpenManualReview={handleOpenManualReview}
                             activeChargeLineId={reviewRequest?.chargeLineId ?? null}
                             duplicateIndices={duplicateIndices}
+                            previewCharges={previewChargesMap}
                         />
                     );
                 })}

--- a/frontend/src/lib/spot-recalculation.test.ts
+++ b/frontend/src/lib/spot-recalculation.test.ts
@@ -1,0 +1,333 @@
+import assert from "assert";
+import { recalculateSpotCharges } from "./spot-recalculation";
+import { SPEChargeLine, SPEShipmentContext } from "./spot-types";
+
+// =============================================================================
+// TEST SUITE: SPOT Recalculation Engine
+// =============================================================================
+
+const mockShipment: SPEShipmentContext = {
+    origin_country: "PG",
+    destination_country: "AU",
+    origin_code: "POM",
+    destination_code: "SYD",
+    commodity: "GCR",
+    total_weight_kg: 500,
+    pieces: 5,
+};
+
+// 1. per_kg amount * weight
+function testPerKgCalculation() {
+    const visible: SPEChargeLine[] = [
+        {
+            id: "1",
+            code: "EXP-FREIGHT",
+            description: "Air Freight",
+            amount: "2.50",
+            currency: "USD",
+            unit: "per_kg",
+            bucket: "airfreight",
+            source_reference: "Test",
+        }
+    ];
+    
+    const result = recalculateSpotCharges(visible, [], mockShipment);
+    const charge = result.charges[0];
+    
+    assert.strictEqual(charge.calculated_amount, 1250.00); // 2.50 * 500
+    assert.strictEqual(charge.display_amount, "1250.00");
+    assert.strictEqual(charge.amount, "2.50"); // Original amount not mutated
+    assert.deepStrictEqual(result.bucketTotals.freight, { USD: 1250.00 });
+    console.log("✓ testPerKgCalculation passed");
+}
+
+// 2. min_or_per_kg floor
+function testMinOrPerKgFloor() {
+    const visible: SPEChargeLine[] = [
+        {
+            id: "1",
+            code: "EXP-FREIGHT",
+            description: "Air Freight Low",
+            amount: "0.10", // 0.10 * 500 = 50.00
+            min_charge: "150.00", // min floor is 150.00
+            currency: "USD",
+            unit: "min_or_per_kg",
+            bucket: "airfreight",
+            source_reference: "Test",
+        }
+    ];
+    
+    const result = recalculateSpotCharges(visible, [], mockShipment);
+    const charge = result.charges[0];
+    
+    assert.strictEqual(charge.calculated_amount, 150.00); // Floor clamped
+    assert.strictEqual(charge.display_amount, "150.00");
+    console.log("✓ testMinOrPerKgFloor passed");
+}
+
+// 3. percentage of freight
+function testPercentageOfFreight() {
+    const visible: SPEChargeLine[] = [
+        {
+            id: "1",
+            code: "EXP-FREIGHT",
+            description: "Air Freight",
+            amount: "1000.00",
+            currency: "USD",
+            unit: "flat",
+            bucket: "airfreight",
+            source_reference: "Test",
+        },
+        {
+            id: "2",
+            code: "EXP-FSC",
+            description: "Fuel Surcharge",
+            amount: "0.00",
+            percent: "22",
+            percent_basis: "freight",
+            currency: "USD",
+            unit: "percentage",
+            bucket: "airfreight",
+            source_reference: "Test",
+        }
+    ];
+    
+    const result = recalculateSpotCharges(visible, [], mockShipment);
+    const fsc = result.charges[1];
+    
+    assert.strictEqual(fsc.calculated_amount, 220.00); // 22% of 1000
+    assert.strictEqual(fsc.display_amount, "220.00");
+    assert.deepStrictEqual(result.bucketTotals.freight, { USD: 1220.00 }); // 1000 + 220
+    console.log("✓ testPercentageOfFreight passed");
+}
+
+// 4. pickup FSC percentage of pickup
+function testPickupFscPercentageOfPickup() {
+    const visible: SPEChargeLine[] = [
+        {
+            id: "1",
+            code: "EXP-PICKUP",
+            description: "Road Pickup",
+            amount: "500.00",
+            currency: "USD",
+            unit: "flat",
+            bucket: "origin_charges",
+            source_reference: "Test",
+        },
+        {
+            id: "2",
+            code: "EXP-PICKUP-FSC",
+            description: "Pickup Fuel Surcharge",
+            amount: "0.00",
+            percent: "15",
+            percent_basis: "EXP-PICKUP",
+            currency: "USD",
+            unit: "percentage",
+            bucket: "origin_charges",
+            source_reference: "Test",
+        }
+    ];
+    
+    const result = recalculateSpotCharges(visible, [], mockShipment);
+    const fsc = result.charges[1];
+    
+    assert.strictEqual(fsc.calculated_amount, 75.00); // 15% of 500
+    assert.strictEqual(fsc.display_amount, "75.00");
+    console.log("✓ testPickupFscPercentageOfPickup passed");
+}
+
+// 5. min_amount floor and max_amount cap
+function testMinMaxPercentageLimits() {
+    const visible: SPEChargeLine[] = [
+        {
+            id: "1",
+            code: "EXP-FREIGHT",
+            description: "Air Freight",
+            amount: "100.00",
+            currency: "USD",
+            unit: "flat",
+            bucket: "airfreight",
+            source_reference: "Test",
+        },
+        {
+            id: "2",
+            code: "EXP-FSC-LOW",
+            description: "Fuel Surcharge Floor",
+            amount: "0.00",
+            percent: "22", // 22% of 100 = 22.00
+            min_amount: "50.00", // min floor is 50.00
+            percent_basis: "freight",
+            currency: "USD",
+            unit: "percentage",
+            bucket: "airfreight",
+            source_reference: "Test",
+        },
+        {
+            id: "3",
+            code: "EXP-FSC-HIGH",
+            description: "Fuel Surcharge Cap",
+            amount: "0.00",
+            percent: "22", // 22% of 100 = 22.00
+            max_amount: "15.00", // max cap is 15.00
+            percent_basis: "freight",
+            currency: "USD",
+            unit: "percentage",
+            bucket: "airfreight",
+            source_reference: "Test",
+        }
+    ];
+    
+    const result = recalculateSpotCharges(visible, [], mockShipment);
+    const fscLow = result.charges[1];
+    const fscHigh = result.charges[2];
+    
+    assert.strictEqual(fscLow.calculated_amount, 50.00); // Min floor applied
+    assert.strictEqual(fscHigh.calculated_amount, 15.00); // Max cap applied
+    console.log("✓ testMinMaxPercentageLimits passed");
+}
+
+// 6. Excluded charges ignored
+function testExcludedChargesIgnored() {
+    const visible: SPEChargeLine[] = [
+        {
+            id: "1",
+            code: "EXP-FREIGHT",
+            description: "Air Freight",
+            amount: "1000.00",
+            currency: "USD",
+            unit: "flat",
+            bucket: "airfreight",
+            source_reference: "Test",
+        },
+        {
+            id: "2",
+            code: "EXP-DOC",
+            description: "Documentation Fee",
+            amount: "150.00",
+            currency: "USD",
+            unit: "flat",
+            bucket: "origin_charges",
+            exclude_from_totals: true, // excluded
+            source_reference: "Test",
+        }
+    ];
+    
+    const result = recalculateSpotCharges(visible, [], mockShipment);
+    const freight = result.charges[0];
+    const doc = result.charges[1];
+    
+    assert.strictEqual(freight.calculated_amount, 1000.00);
+    assert.strictEqual(doc.calculated_amount, 0); // Excluded is 0
+    assert.deepStrictEqual(result.bucketTotals.origin_charges || {}, {}); // Origin bucket has no totals
+    console.log("✓ testExcludedChargesIgnored passed");
+}
+
+// 7. Unacknowledged conditional charges ignored
+function testUnacknowledgedConditionalCharges() {
+    const visible: SPEChargeLine[] = [
+        {
+            id: "1",
+            code: "EXP-FREIGHT",
+            description: "Air Freight",
+            amount: "1000.00",
+            currency: "USD",
+            unit: "flat",
+            bucket: "airfreight",
+            source_reference: "Test",
+        },
+        {
+            id: "2",
+            code: "EXP-CONDITIONAL",
+            description: "Conditional Charge",
+            amount: "200.00",
+            currency: "USD",
+            unit: "flat",
+            bucket: "origin_charges",
+            conditional: true,
+            conditional_acknowledged: false, // not acknowledged
+            source_reference: "Test",
+        }
+    ];
+    
+    const result = recalculateSpotCharges(visible, [], mockShipment);
+    const cond = result.charges[1];
+    
+    assert.strictEqual(cond.calculated_amount, 0);
+    assert.deepStrictEqual(result.bucketTotals.origin_charges || {}, {});
+    console.log("✓ testUnacknowledgedConditionalCharges passed");
+}
+
+// 8. Mixed currency totals separated
+function testMixedCurrencyTotals() {
+    const visible: SPEChargeLine[] = [
+        {
+            id: "1",
+            code: "EXP-FREIGHT-USD",
+            description: "Air Freight USD",
+            amount: "1000.00",
+            currency: "USD",
+            unit: "flat",
+            bucket: "airfreight",
+            source_reference: "Test",
+        },
+        {
+            id: "2",
+            code: "EXP-FREIGHT-PGK",
+            description: "Air Freight PGK",
+            amount: "3000.00",
+            currency: "PGK",
+            unit: "flat",
+            bucket: "airfreight",
+            source_reference: "Test",
+        }
+    ];
+    
+    const result = recalculateSpotCharges(visible, [], mockShipment);
+    
+    assert.deepStrictEqual(result.bucketTotals.freight, { USD: 1000.00, PGK: 3000.00 });
+    console.log("✓ testMixedCurrencyTotals passed");
+}
+
+// 9. Percentage basis missing returns warning
+function testMissingPercentageBasis() {
+    const visible: SPEChargeLine[] = [
+        {
+            id: "1",
+            code: "EXP-FSC",
+            description: "Fuel Surcharge",
+            amount: "0.00",
+            percent: "22",
+            percent_basis: "", // Missing
+            currency: "USD",
+            unit: "percentage",
+            bucket: "airfreight",
+            source_reference: "Test",
+        }
+    ];
+    
+    const result = recalculateSpotCharges(visible, [], mockShipment);
+    const fsc = result.charges[0];
+    
+    assert.strictEqual(fsc.calculated_amount, 0);
+    assert.ok(fsc.warnings && fsc.warnings.includes("Missing applies-to basis"));
+    console.log("✓ testMissingPercentageBasis passed");
+}
+
+// RUN ALL TESTS
+try {
+    testPerKgCalculation();
+    testMinOrPerKgFloor();
+    testPercentageOfFreight();
+    testPickupFscPercentageOfPickup();
+    testMinMaxPercentageLimits();
+    testExcludedChargesIgnored();
+    testUnacknowledgedConditionalCharges();
+    testMixedCurrencyTotals();
+    testMissingPercentageBasis();
+    console.log("\n========================================================");
+    console.log("ALL SPOT RECALCULATION ENGINE TESTS PASSED SUCCESSFULLY!");
+    console.log("========================================================\n");
+} catch (error) {
+    console.error("Test execution failed:", error);
+    process.exit(1);
+}

--- a/frontend/src/lib/spot-recalculation.ts
+++ b/frontend/src/lib/spot-recalculation.ts
@@ -1,0 +1,254 @@
+import { SPEChargeLine, SPEShipmentContext } from "./spot-types";
+
+export interface PreviewChargeLine extends SPEChargeLine {
+    calculated_amount?: number;
+    display_amount?: string;
+    calculation_preview?: string;
+    warnings?: string[];
+}
+
+export interface RecalculationResult {
+    charges: PreviewChargeLine[];
+    bucketTotals: Record<string, Record<string, number>>; // bucketId -> currency -> sum
+    warnings: string[];
+}
+
+/** Normalize basis string to allow flexible matching */
+export function normalizeBasisKey(basis: string): string {
+    return (basis || "")
+        .trim()
+        .toLowerCase()
+        .replace(/[-]/g, "_");
+}
+
+export function recalculateSpotCharges(
+    visibleCharges: SPEChargeLine[],
+    hiddenCharges: SPEChargeLine[],
+    shipment: SPEShipmentContext | null
+): RecalculationResult {
+    const allCharges: PreviewChargeLine[] = [
+        ...hiddenCharges.map(c => ({ ...c })),
+        ...visibleCharges.map(c => ({ ...c }))
+    ];
+
+    const weight = shipment?.total_weight_kg || 0;
+
+    // Basis totals dictionary: targetKey -> currency -> amount
+    const basisTotals: Record<string, Record<string, number>> = {
+        freight: {},
+        origin: {},
+        destination: {},
+        total: {}
+    };
+
+    // Helper to add to a basis currency total
+    const addToBasis = (basisKey: string, currency: string, amount: number) => {
+        const normalizedKey = normalizeBasisKey(basisKey);
+        if (!basisTotals[normalizedKey]) {
+            basisTotals[normalizedKey] = {};
+        }
+        const cur = currency.toUpperCase();
+        basisTotals[normalizedKey][cur] = (basisTotals[normalizedKey][cur] || 0) + amount;
+    };
+
+    // PASS 1: Calculate non-percentage charges and accumulate basis totals
+    for (const charge of allCharges) {
+        const warnings: string[] = [];
+        charge.warnings = warnings;
+        
+        // Exclude unacknowledged conditional charges or explicit exclusions
+        const isExcluded = charge.exclude_from_totals || (charge.conditional && !charge.conditional_acknowledged);
+        if (isExcluded) {
+            charge.calculated_amount = 0;
+            charge.display_amount = "0.00";
+            charge.calculation_preview = charge.exclude_from_totals ? "Excluded from totals" : "Conditional (Not Acknowledged)";
+            continue;
+        }
+
+        const unit = (charge.unit || "").trim().toLowerCase();
+        if (unit === "percentage" || charge.calculation_type === "percent_of") {
+            // Percentage charge is calculated in Pass 2
+            continue;
+        }
+
+        const rate = parseFloat(charge.amount || "0");
+        if (isNaN(rate)) {
+            charge.calculated_amount = 0;
+            charge.display_amount = "0.00";
+            warnings.push("Invalid rate amount");
+            continue;
+        }
+
+        let calculated = 0;
+        let preview = "";
+
+        if (unit === "per_kg") {
+            calculated = rate * weight;
+            preview = `${rate.toFixed(2)} ${charge.currency}/KG × ${weight} KG`;
+        } else if (unit === "min_or_per_kg") {
+            const minCharge = parseFloat(String(charge.min_charge || "0"));
+            const calculatedPerKg = rate * weight;
+            calculated = Math.max(minCharge, calculatedPerKg);
+            preview = `Max(${minCharge.toFixed(2)} Min, ${rate.toFixed(2)}/KG × ${weight} KG)`;
+        } else if (["flat", "per_awb", "per_shipment", "per_trip", "per_set", "per_man"].includes(unit)) {
+            calculated = rate;
+            preview = `Flat rate`;
+        } else {
+            // Unknown or unsupported unit type
+            calculated = rate;
+            preview = `Flat rate (unknown unit: ${unit})`;
+            warnings.push(`Unknown or unsupported unit: ${unit}`);
+        }
+
+        charge.calculated_amount = calculated;
+        charge.display_amount = calculated.toFixed(2);
+        charge.calculation_preview = `${preview} = ${calculated.toFixed(2)} ${charge.currency}`;
+
+        // Accumulate basis totals
+        const currency = (charge.currency || "USD").toUpperCase();
+        addToBasis("total", currency, calculated);
+        
+        // Match code-specific basis (case-insensitive normalized)
+        if (charge.code) {
+            addToBasis(charge.code, currency, calculated);
+        }
+
+        const b = (charge.bucket || "").trim().toLowerCase();
+        if (b === "airfreight") {
+            addToBasis("freight", currency, calculated);
+        } else if (b === "origin_charges") {
+            addToBasis("origin", currency, calculated);
+        } else if (b === "destination_charges") {
+            addToBasis("destination", currency, calculated);
+        }
+    }
+
+    // PASS 2: Calculate percentage charges
+    for (const charge of allCharges) {
+        const isExcluded = charge.exclude_from_totals || (charge.conditional && !charge.conditional_acknowledged);
+        if (isExcluded) continue;
+
+        const unit = (charge.unit || "").trim().toLowerCase();
+        if (unit !== "percentage" && charge.calculation_type !== "percent_of") {
+            continue;
+        }
+
+        const warnings: string[] = [];
+        charge.warnings = warnings;
+
+        const percent = parseFloat(String(charge.percent || "0"));
+        const basisKey = normalizeBasisKey(charge.percent_basis || "");
+        const currency = (charge.currency || "USD").toUpperCase();
+
+        if (isNaN(percent)) {
+            charge.calculated_amount = 0;
+            charge.display_amount = "0.00";
+            warnings.push("Invalid percentage rate");
+            continue;
+        }
+
+        if (!basisKey) {
+            charge.calculated_amount = 0;
+            charge.display_amount = "0.00";
+            warnings.push("Missing applies-to basis");
+            continue;
+        }
+
+        // Retrieve base total for matching currency
+        const curBases = basisTotals[basisKey] || {};
+        const baseAmount = curBases[currency] || 0;
+
+        // Check if there are other currencies in this basis that were ignored
+        const otherCurrencies = Object.keys(curBases).filter(c => c !== currency);
+        if (otherCurrencies.length > 0) {
+            warnings.push(`Mixed currency base ignored: base has values in ${otherCurrencies.join(", ")}`);
+        }
+
+        if (baseAmount === 0 && !curBases[currency]) {
+            warnings.push(`No matching base charges found for basis '${charge.percent_basis}' in ${currency}`);
+        }
+
+        let calculated = baseAmount * (percent / 100);
+        let preview = `${percent.toFixed(2)}% of base ${charge.percent_basis} (${baseAmount.toFixed(2)} ${currency})`;
+
+        // Apply min/max caps
+        const minVal = charge.min_amount != null ? parseFloat(String(charge.min_amount)) : null;
+        const maxVal = charge.max_amount != null ? parseFloat(String(charge.max_amount)) : null;
+
+        if (minVal !== null && !isNaN(minVal) && calculated < minVal) {
+            calculated = minVal;
+            preview += ` (Floor clamp ${minVal.toFixed(2)} applied)`;
+            warnings.push(`Minimum floor clamp applied: ${minVal.toFixed(2)} ${currency}`);
+        }
+        if (maxVal !== null && !isNaN(maxVal) && calculated > maxVal) {
+            calculated = maxVal;
+            preview += ` (Cap clamp ${maxVal.toFixed(2)} applied)`;
+            warnings.push(`Maximum cap clamp applied: ${maxVal.toFixed(2)} ${currency}`);
+        }
+
+        charge.calculated_amount = calculated;
+        charge.display_amount = calculated.toFixed(2);
+        charge.calculation_preview = `${preview} = ${calculated.toFixed(2)} ${currency}`;
+
+        // Add to total basis so other calculations (or final totals) see it
+        addToBasis("total", currency, calculated);
+    }
+
+    // Compute Commercial Bucket Totals for display grouping (grouped by bucket -> currency -> sum)
+    const bucketTotals: Record<string, Record<string, number>> = {};
+    const globalWarnings: string[] = [];
+
+    // Helper to infer bucket if empty or to get reviewed bucket label
+    const getReviewedBucket = (c: SPEChargeLine): string => {
+        // Return bucket ID from our commercial categories
+        if (c.reviewed_bucket) return c.reviewed_bucket;
+        
+        // Fallback Heuristic
+        const codeLower = (c.code || "").toLowerCase();
+        const descLower = (c.description || "").toLowerCase();
+        
+        if (codeLower === "awb" || codeLower === "doc" || descLower.includes("awb") || descLower.includes("documentation") || descLower.includes("document")) {
+            return "origin_charges";
+        }
+        if (c.bucket === "airfreight") return "freight";
+        if (c.bucket === "destination_charges") return "destination_charges";
+        return "origin_charges";
+    };
+
+    for (const charge of allCharges) {
+        // Collect warnings
+        if (charge.warnings && charge.warnings.length > 0) {
+            globalWarnings.push(...charge.warnings.map(w => `${charge.description || charge.code}: ${w}`));
+        }
+
+        const isExcluded = charge.exclude_from_totals || (charge.conditional && !charge.conditional_acknowledged);
+        if (isExcluded) continue;
+
+        const bucketId = getReviewedBucket(charge);
+        const currency = (charge.currency || "USD").toUpperCase();
+        const amount = charge.calculated_amount || 0;
+
+        if (!bucketTotals[bucketId]) {
+            bucketTotals[bucketId] = {};
+        }
+        bucketTotals[bucketId][currency] = (bucketTotals[bucketId][currency] || 0) + amount;
+    }
+
+    // Only return the visible charges (with recalculated preview info attached) in the original order
+    const visibleResultCharges = visibleCharges.map(vc => {
+        const match = allCharges.find(ac => ac.id === vc.id || (ac.description === vc.description && ac.code === vc.code && ac.bucket === vc.bucket));
+        return {
+            ...vc,
+            calculated_amount: match?.calculated_amount,
+            display_amount: match?.display_amount,
+            calculation_preview: match?.calculation_preview,
+            warnings: match?.warnings
+        };
+    });
+
+    return {
+        charges: visibleResultCharges,
+        bucketTotals,
+        warnings: globalWarnings
+    };
+}


### PR DESCRIPTION
Adds frontend-only live SPOT charge recalculation preview with two-pass calculation logic, bucket totals, mixed-currency handling, and calculation warnings.

Backend pricing remains the source of truth.

Scope:
- Adds frontend/src/lib/spot-recalculation.ts
- Adds frontend/src/lib/spot-recalculation.test.ts
- Integrates live preview recalculation into the SPOT Rate Review UI
- Keeps currencies separate without frontend FX conversion
- Does not change backend pricing/finalisation logic