### PR TITLE
chore(rbac): add legacy organization cleanup tooling

### DIFF
--- a/backend/parties/management/commands/rbac_legacy_organization_cleanup_apply.py
+++ b/backend/parties/management/commands/rbac_legacy_organization_cleanup_apply.py
@@ -1,0 +1,35 @@
+import json
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from .rbac_legacy_organization_cleanup_plan import apply_cleanup
+
+
+class Command(BaseCommand):
+    help = "Guarded apply for legacy Organization cleanup. Dry-run by default."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--apply", action="store_true", help="Write safe planned changes. Defaults to dry-run.")
+        parser.add_argument("--format", choices=["text", "json"], default="text")
+
+    def handle(self, *args, **options):
+        with transaction.atomic():
+            report = apply_cleanup(apply=options["apply"])
+            if not options["apply"]:
+                transaction.set_rollback(True)
+        if options["format"] == "json":
+            self.stdout.write(json.dumps(report, indent=2, sort_keys=True))
+            return
+        write_text(self.stdout, report)
+
+
+def write_text(stdout, report):
+    summary = report["summary"]
+    stdout.write("RBAC legacy organization cleanup apply")
+    stdout.write("======================================")
+    stdout.write(f"Mode: {report['mode']}")
+    stdout.write(
+        f"Summary: planned={summary['planned']} applied={summary['applied']} "
+        f"unchanged={summary['unchanged']} blocked={summary['blocked']}"
+    )

--- a/backend/parties/management/commands/rbac_legacy_organization_cleanup_plan.py
+++ b/backend/parties/management/commands/rbac_legacy_organization_cleanup_plan.py
@@ -1,0 +1,375 @@
+import json
+
+from django.apps import apps
+from django.core.management.base import BaseCommand
+from django.db import models
+
+from parties.models import Branch, Department, OperatingEntity, Organization
+
+
+TARGET_ORGANIZATION = "Express Freight Management"
+COUNTRY_ORGANIZATIONS = ("EFM PNG", "EFM Australia", "EFM Fiji", "EFM Solomon Islands")
+LEGACY_EAC_NAMES = ("EFM Express Air Cargo", "EAC", "Express Air Cargo")
+TEST_ORGANIZATION = "Test Org"
+LEGACY_ORGANIZATIONS = COUNTRY_ORGANIZATIONS + ("EFM Express Air Cargo", TEST_ORGANIZATION)
+QUOTE_SPOT_MODELS = {"quotes.Quote", "quotes.SpotPricingEnvelopeDB"}
+
+
+class Command(BaseCommand):
+    help = "Read-only plan for legacy Organization cleanup after OperatingEntity redesign."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--format", choices=["text", "json"], default="text")
+
+    def handle(self, *args, **options):
+        report = build_report()
+        if options["format"] == "json":
+            self.stdout.write(json.dumps(report, indent=2, sort_keys=True))
+            return
+        write_text(self.stdout, report)
+
+
+def build_report():
+    target_org = Organization.objects.filter(name=TARGET_ORGANIZATION).first()
+    legacy_orgs = list(Organization.objects.filter(name__in=LEGACY_ORGANIZATIONS).order_by("name", "id"))
+    rows = [organization_row(org, target_org) for org in legacy_orgs]
+    return {
+        "write_enabled": False,
+        "target_organization": label(target_org),
+        "quote_spot_historical_records": {
+            "classification": "DEV_TEST_LEGACY",
+            "historical_backfill_required": False,
+            "mutated_by_cleanup": False,
+        },
+        "summary": {
+            "organizations": len(rows),
+            "dependencies": sum(row["dependency_count"] for row in rows),
+            "auto_migratable_dependencies": sum(row["auto_migratable_dependency_count"] for row in rows),
+            "blocked_dependencies": sum(row["blocked_dependency_count"] for row in rows),
+        },
+        "organizations": rows,
+    }
+
+
+def organization_row(org, target_org):
+    dependencies = dependency_rows(org, target_org)
+    blockers = sorted({reason for row in dependencies for reason in row["blockers"]})
+    dependency_count = sum(row["count"] for row in dependencies)
+    auto_count = sum(row["count"] for row in dependencies if row["auto_migratable"])
+    blocked_count = dependency_count - auto_count
+    return {
+        "id": str(org.id),
+        "name": safe(org.name),
+        "slug": safe(org.slug),
+        "is_active": org.is_active,
+        "classification": classify_organization(org.name),
+        "dependencies": dependencies,
+        "dependency_count": dependency_count,
+        "auto_migratable_dependency_count": auto_count,
+        "blocked_dependency_count": blocked_count,
+        "target_organization": label(target_org),
+        "target_operating_entity": target_operating_entity_name(org.name, target_org),
+        "target_branch": None,
+        "target_department": "Air Freight" if org.name in LEGACY_EAC_NAMES else None,
+        "blockers": blockers,
+        "recommended_action": recommended_action(org.name, dependency_count, blockers, auto_count),
+    }
+
+
+def dependency_rows(org, target_org):
+    rows = []
+    for model in sorted(apps.get_models(), key=lambda item: item._meta.label):
+        for field in model._meta.fields:
+            if not isinstance(field, models.ForeignKey):
+                continue
+            if field.remote_field.model not in (Organization, Branch, Department):
+                continue
+            filters = dependency_filter(field, org)
+            if filters is None:
+                continue
+            queryset = model.objects.filter(**filters).order_by("pk")
+            count = queryset.count()
+            if not count:
+                continue
+            plan = field_plan(model, field, org, target_org)
+            rows.append(
+                {
+                    "model": model._meta.label,
+                    "field": field.name,
+                    "target_type": field.remote_field.model._meta.label,
+                    "count": count,
+                    "auto_migratable": plan["auto_migratable"],
+                    "target_organization": label(target_org) if plan["target_organization"] else None,
+                    "target_operating_entity": label(plan["target_operating_entity"]),
+                    "target_branch": label(plan["target_branch"]),
+                    "target_department": label(plan["target_department"]),
+                    "blockers": plan["blockers"],
+                    "sample_ids": [safe(obj.pk) for obj in queryset[:5]],
+                }
+            )
+    return rows
+
+
+def dependency_filter(field, org):
+    target = field.remote_field.model
+    if target is Organization:
+        return {field.name: org}
+    if target is Branch:
+        return {f"{field.name}__organization": org}
+    if target is Department:
+        return {f"{field.name}__organization": org}
+    return None
+
+
+def field_plan(model, field, org, target_org):
+    target = field.remote_field.model
+    blockers = []
+    target_entity = infer_operating_entity(org, target_org)
+    target_branch = None
+    target_department = None
+
+    if target_org is None:
+        blockers.append("target organization missing")
+    if isinstance(field, models.OneToOneField):
+        blockers.append("one-to-one dependency requires manual review")
+    if org.name == TEST_ORGANIZATION:
+        blockers.append("DEV_TEST_LEGACY manual review required")
+    if model._meta.label in QUOTE_SPOT_MODELS:
+        blockers.append("DEV_TEST_LEGACY quote/SPOT historical record")
+
+    if target is Organization:
+        target_department = eac_air_freight_department(org, target_org)
+        if org.name in COUNTRY_ORGANIZATIONS and target_entity is None:
+            blockers.append("target operating_entity missing")
+        if model is Branch:
+            blockers.extend(branch_reparent_blockers(org, target_org))
+        if model is Department:
+            blockers.extend(department_reparent_blockers(org, target_org))
+    elif target is Branch:
+        target_branch = canonical_branch_for_legacy_field(field, org, target_org)
+        target_entity = getattr(target_branch, "operating_entity", None) or target_entity
+        if target_branch is None:
+            blockers.append("target branch not inferable")
+    elif target is Department:
+        target_department = canonical_department_for_legacy_field(field, org, target_org)
+        if target_department is None:
+            blockers.append("target department not inferable")
+
+    return {
+        "auto_migratable": not blockers and target_org is not None,
+        "target_organization": target_org,
+        "target_operating_entity": target_entity,
+        "target_branch": target_branch,
+        "target_department": target_department,
+        "blockers": blockers,
+    }
+
+
+def apply_cleanup(*, apply):
+    before = build_report()
+    actions = []
+    with_orgs = Organization.objects.filter(name__in=LEGACY_ORGANIZATIONS).order_by("name", "id")
+    target_org = Organization.objects.filter(name=TARGET_ORGANIZATION).first()
+    for org in with_orgs:
+        for action in planned_updates_for_org(org, target_org):
+            if apply and action["status"] == "PLANNED":
+                action["apply"]()
+                action["status"] = "APPLIED"
+            action.pop("apply", None)
+            actions.append(action)
+    for org in with_orgs:
+        remaining = dependency_count_for_org(org)
+        status = "UNCHANGED"
+        if remaining == 0 and org.is_active:
+            status = "APPLIED" if apply else "PLANNED"
+            if apply:
+                org.is_active = False
+                org.save(update_fields=["is_active", "updated_at"])
+        actions.append(
+            {
+                "organization": safe(org.name),
+                "model": "parties.Organization",
+                "field": "is_active",
+                "count": 1,
+                "status": status if remaining == 0 else "BLOCKED",
+                "blockers": [] if remaining == 0 else [f"dependencies remain: {remaining}"],
+            }
+        )
+    after = build_report()
+    return {
+        "mode": "apply" if apply else "dry-run",
+        "write_enabled": bool(apply),
+        "before": before["summary"],
+        "after": after["summary"],
+        "summary": {
+            "planned": sum(1 for action in actions if action["status"] == "PLANNED"),
+            "applied": sum(1 for action in actions if action["status"] == "APPLIED"),
+            "unchanged": sum(1 for action in actions if action["status"] == "UNCHANGED"),
+            "blocked": sum(1 for action in actions if action["status"] == "BLOCKED"),
+        },
+        "actions": actions,
+    }
+
+
+def planned_updates_for_org(org, target_org):
+    actions = []
+    for model in sorted(apps.get_models(), key=lambda item: item._meta.label):
+        for field in model._meta.fields:
+            if not isinstance(field, models.ForeignKey):
+                continue
+            if field.remote_field.model not in (Organization, Branch, Department):
+                continue
+            plan = field_plan(model, field, org, target_org)
+            filters = dependency_filter(field, org)
+            if filters is None:
+                continue
+            queryset = model.objects.filter(**filters)
+            count = queryset.count()
+            if not count:
+                continue
+            status = "PLANNED" if plan["auto_migratable"] else "BLOCKED"
+            actions.append(
+                {
+                    "organization": safe(org.name),
+                    "model": model._meta.label,
+                    "field": field.name,
+                    "count": count,
+                    "status": status,
+                    "blockers": plan["blockers"],
+                    "apply": updater(queryset, model, field, plan),
+                }
+            )
+    return actions
+
+
+def updater(queryset, model, field, plan):
+    def run():
+        update = {}
+        if field.remote_field.model is Organization:
+            update[field.name] = plan["target_organization"]
+        elif field.remote_field.model is Branch:
+            update[field.name] = plan["target_branch"]
+        elif field.remote_field.model is Department:
+            update[field.name] = plan["target_department"]
+        if has_field(model, "organization"):
+            update["organization"] = plan["target_organization"]
+        if has_field(model, "operating_entity") and plan["target_operating_entity"] is not None:
+            update["operating_entity"] = plan["target_operating_entity"]
+        queryset.update(**{name: value for name, value in update.items() if value is not None})
+
+    return run
+
+
+def dependency_count_for_org(org):
+    total = 0
+    for model in apps.get_models():
+        for field in model._meta.fields:
+            if isinstance(field, models.ForeignKey) and field.remote_field.model in (Organization, Branch, Department):
+                filters = dependency_filter(field, org)
+                if filters:
+                    total += model.objects.filter(**filters).count()
+    return total
+
+
+def infer_operating_entity(org, target_org):
+    if target_org is None or org.name not in COUNTRY_ORGANIZATIONS:
+        return None
+    return OperatingEntity.objects.filter(organization=target_org, name=org.name).first()
+
+
+def canonical_branch_for_legacy_field(field, org, target_org):
+    sample = field.model.objects.filter(**dependency_filter(field, org)).select_related(field.name).first()
+    branch = getattr(sample, field.name, None)
+    if branch is None or target_org is None:
+        return None
+    return Branch.objects.filter(organization=target_org, name=branch.name).first()
+
+
+def canonical_department_for_legacy_field(field, org, target_org):
+    sample = field.model.objects.filter(**dependency_filter(field, org)).select_related(field.name).first()
+    department = getattr(sample, field.name, None)
+    if department is None or target_org is None:
+        return None
+    return Department.objects.filter(organization=target_org, name=department.name).first()
+
+
+def eac_air_freight_department(org, target_org):
+    if org.name not in LEGACY_EAC_NAMES or target_org is None:
+        return None
+    return Department.objects.filter(organization=target_org, name="Air Freight").first()
+
+
+def branch_reparent_blockers(org, target_org):
+    blockers = []
+    for branch in Branch.objects.filter(organization=org):
+        if Branch.objects.filter(organization=target_org, code=branch.code).exclude(pk=branch.pk).exists():
+            blockers.append(f"target branch code collision: {branch.code}")
+    return blockers
+
+
+def department_reparent_blockers(org, target_org):
+    blockers = []
+    for department in Department.objects.filter(organization=org):
+        if Department.objects.filter(organization=target_org, code=department.code).exclude(pk=department.pk).exists():
+            blockers.append(f"target department code collision: {department.code}")
+    return blockers
+
+
+def has_field(model, name):
+    return any(field.name == name for field in model._meta.fields)
+
+
+def target_operating_entity_name(name, target_org):
+    entity = infer_operating_entity(type("OrgName", (), {"name": name})(), target_org)
+    return label(entity)
+
+
+def classify_organization(name):
+    if name in COUNTRY_ORGANIZATIONS:
+        return "legacy_country_as_organization"
+    if name in LEGACY_EAC_NAMES:
+        return "legacy_air_freight_wording"
+    if name == TEST_ORGANIZATION:
+        return "DEV_TEST_LEGACY"
+    return "manual_review"
+
+
+def recommended_action(name, dependency_count, blockers, auto_count):
+    if dependency_count == 0:
+        return "dev_test_delete_candidate" if name == TEST_ORGANIZATION else "deactivate_after_zero_dependencies"
+    if name == TEST_ORGANIZATION:
+        return "manual_review_required"
+    if blockers:
+        return "manual_review_required"
+    if auto_count:
+        return "migrate_references"
+    return "manual_review_required"
+
+
+def label(value):
+    if value is None:
+        return None
+    return safe(getattr(value, "name", value))
+
+
+def safe(value):
+    if value is None:
+        return None
+    return str(value).encode("ascii", "replace").decode("ascii")
+
+
+def write_text(stdout, report):
+    stdout.write("RBAC legacy organization cleanup plan")
+    stdout.write("=====================================")
+    stdout.write("Mode: read-only diagnostics")
+    stdout.write(f"Target organization: {report['target_organization']}")
+    summary = report["summary"]
+    stdout.write(
+        f"Summary: organizations={summary['organizations']} dependencies={summary['dependencies']} "
+        f"auto_migratable={summary['auto_migratable_dependencies']} blocked={summary['blocked_dependencies']}"
+    )
+    for org in report["organizations"]:
+        stdout.write(
+            f"- {org['name']} action={org['recommended_action']} deps={org['dependency_count']} "
+            f"blocked={org['blocked_dependency_count']}"
+        )

--- a/backend/parties/tests.py
+++ b/backend/parties/tests.py
@@ -3309,6 +3309,191 @@ class FinalUserBlockerResolutionApplyTests(TestCase):
         self.assertEqual(payload["readiness"]["status"], "READY_FOR_BACKFILL_PLANNING")
 
 
+class LegacyOrganizationCleanupTests(TestCase):
+    def setUp(self):
+        UserMembership.objects.all().delete()
+        CustomUser.objects.all().delete()
+        Branch.objects.all().delete()
+        OperatingEntity.objects.all().delete()
+        Department.objects.all().delete()
+        Organization.objects.all().delete()
+
+    def _call_plan(self, *args):
+        stdout = StringIO()
+        call_command("rbac_legacy_organization_cleanup_plan", *args, stdout=stdout)
+        return stdout.getvalue()
+
+    def _call_apply(self, *args):
+        stdout = StringIO()
+        call_command("rbac_legacy_organization_cleanup_apply", *args, stdout=stdout)
+        return stdout.getvalue()
+
+    def _role(self):
+        role, _created = Role.objects.get_or_create(
+            code="sales",
+            organization=None,
+            defaults={"name": "Sales", "is_system": True},
+        )
+        return role
+
+    def _canonical_master_data(self):
+        org = Organization.objects.create(name="Express Freight Management", slug="express-freight-management")
+        for name, branches in {
+            "EFM PNG": ("Port Moresby", "Lae"),
+            "EFM Australia": ("Brisbane",),
+            "EFM Fiji": ("Suva",),
+            "EFM Solomon Islands": ("Honiara",),
+        }.items():
+            entity = OperatingEntity.objects.create(
+                organization=org,
+                code=name.split()[-1][:3].upper(),
+                name=name,
+                slug=name.lower().replace(" ", "-"),
+                country_code=name[:2].upper(),
+            )
+            for branch_name in branches:
+                Branch.objects.create(organization=org, operating_entity=entity, code=branch_name[:3].upper(), name=branch_name)
+        for department_name in ("Air Freight", "Sea Freight", "Customs", "Transport"):
+            Department.objects.create(organization=org, code=department_name[:3].upper(), name=department_name)
+        return org
+
+    def test_plan_command_is_read_only_and_detects_dependencies(self):
+        self._canonical_master_data()
+        legacy = Organization.objects.create(name="EFM Australia", slug="efm-australia")
+        company = Company.objects.create(name="Legacy AU Customer", organization=legacy)
+        before = (Organization.objects.count(), Company.objects.count())
+
+        payload = json.loads(self._call_plan("--format", "json"))
+
+        company.refresh_from_db()
+        row = next(item for item in payload["organizations"] if item["name"] == "EFM Australia")
+        self.assertFalse(payload["write_enabled"])
+        self.assertEqual(before, (Organization.objects.count(), Company.objects.count()))
+        self.assertEqual(company.organization, legacy)
+        self.assertGreaterEqual(row["dependency_count"], 1)
+
+    def test_country_organization_dependency_is_planned_for_safe_migration(self):
+        self._canonical_master_data()
+        legacy = Organization.objects.create(name="EFM Australia", slug="efm-australia")
+        Company.objects.create(name="Legacy AU Customer", organization=legacy)
+
+        payload = json.loads(self._call_plan("--format", "json"))
+
+        row = next(item for item in payload["organizations"] if item["name"] == "EFM Australia")
+        dep = next(item for item in row["dependencies"] if item["model"] == "parties.Company" and item["field"] == "organization")
+        self.assertEqual(row["recommended_action"], "migrate_references")
+        self.assertTrue(dep["auto_migratable"])
+        self.assertEqual(dep["target_organization"], "Express Freight Management")
+        self.assertEqual(dep["target_operating_entity"], "EFM Australia")
+
+    def test_non_inferable_branch_dependency_is_blocked(self):
+        self._canonical_master_data()
+        legacy = Organization.objects.create(name="EFM PNG", slug="efm-png-legacy")
+        branch = Branch.objects.create(organization=legacy, code="MAD", name="Madang")
+        Company.objects.create(name="Legacy Branch Customer", organization=legacy, branch=branch)
+
+        payload = json.loads(self._call_plan("--format", "json"))
+
+        row = next(item for item in payload["organizations"] if item["name"] == "EFM PNG")
+        dep = next(item for item in row["dependencies"] if item["model"] == "parties.Company" and item["field"] == "branch")
+        self.assertFalse(dep["auto_migratable"])
+        self.assertIn("target branch not inferable", dep["blockers"])
+        self.assertEqual(row["recommended_action"], "manual_review_required")
+
+    def test_dry_run_apply_writes_nothing(self):
+        self._canonical_master_data()
+        legacy = Organization.objects.create(name="EFM Fiji", slug="efm-fiji-legacy")
+        company = Company.objects.create(name="Legacy Fiji Customer", organization=legacy)
+
+        payload = json.loads(self._call_apply("--format", "json"))
+
+        company.refresh_from_db()
+        legacy.refresh_from_db()
+        self.assertEqual(payload["mode"], "dry-run")
+        self.assertEqual(company.organization, legacy)
+        self.assertTrue(legacy.is_active)
+
+    def test_apply_migrates_safe_records_and_is_idempotent(self):
+        org = self._canonical_master_data()
+        legacy = Organization.objects.create(name="EFM PNG", slug="efm-png-legacy")
+        branch = Branch.objects.get(organization=org, name="Port Moresby")
+        department = Department.objects.get(organization=org, name="Air Freight")
+        user = CustomUser.objects.create_user(username="legacy-png-user")
+        membership = UserMembership.objects.create(
+            user=user,
+            organization=legacy,
+            branch=branch,
+            department=department,
+            role=self._role(),
+        )
+        Company.objects.create(name="Legacy PNG Customer", organization=legacy)
+
+        first = json.loads(self._call_apply("--apply", "--format", "json"))
+        second = json.loads(self._call_apply("--apply", "--format", "json"))
+
+        membership.refresh_from_db()
+        legacy.refresh_from_db()
+        self.assertGreater(first["summary"]["applied"], 0)
+        self.assertGreaterEqual(second["summary"]["unchanged"], 1)
+        self.assertEqual(membership.organization.name, "Express Freight Management")
+        self.assertEqual(membership.operating_entity.name, "EFM PNG")
+        self.assertFalse(legacy.is_active)
+
+    def test_zero_dependency_legacy_organization_is_deactivated_only_after_apply(self):
+        self._canonical_master_data()
+        legacy = Organization.objects.create(name="EFM Solomon Islands", slug="efm-solomon-islands-legacy")
+
+        dry_run = json.loads(self._call_apply("--format", "json"))
+        legacy.refresh_from_db()
+        self.assertTrue(legacy.is_active)
+
+        applied = json.loads(self._call_apply("--apply", "--format", "json"))
+        legacy.refresh_from_db()
+        self.assertFalse(legacy.is_active)
+        self.assertGreaterEqual(dry_run["summary"]["planned"], 1)
+        self.assertGreaterEqual(applied["summary"]["applied"], 1)
+
+    def test_eac_is_legacy_air_freight_wording(self):
+        self._canonical_master_data()
+        legacy = Organization.objects.create(name="EFM Express Air Cargo", slug="efm-express-air-cargo")
+        user = CustomUser.objects.create_user(username="legacy-eac-user")
+        UserMembership.objects.create(user=user, organization=legacy, role=self._role())
+
+        payload = json.loads(self._call_plan("--format", "json"))
+
+        row = next(item for item in payload["organizations"] if item["name"] == "EFM Express Air Cargo")
+        dep = next(item for item in row["dependencies"] if item["model"] == "accounts.UserMembership")
+        self.assertEqual(row["classification"], "legacy_air_freight_wording")
+        self.assertEqual(dep["target_department"], "Air Freight")
+        self.assertIsNone(dep["target_operating_entity"])
+
+    def test_test_org_is_not_blindly_migrated(self):
+        self._canonical_master_data()
+        legacy = Organization.objects.create(name="Test Org", slug="test-org")
+        Company.objects.create(name="Test Org Customer", organization=legacy)
+
+        payload = json.loads(self._call_plan("--format", "json"))
+
+        row = next(item for item in payload["organizations"] if item["name"] == "Test Org")
+        self.assertEqual(row["classification"], "DEV_TEST_LEGACY")
+        self.assertEqual(row["recommended_action"], "manual_review_required")
+        self.assertIn("DEV_TEST_LEGACY manual review required", row["blockers"])
+
+    def test_quote_records_are_classified_not_mutated(self):
+        self._canonical_master_data()
+        legacy = Organization.objects.create(name="EFM Australia", slug="efm-australia")
+        company = Company.objects.create(name="Quote Legacy Customer", organization=legacy)
+        quote = Quote.objects.create(customer=company, organization=legacy)
+
+        payload = json.loads(self._call_apply("--apply", "--format", "json"))
+
+        quote.refresh_from_db()
+        self.assertEqual(quote.organization, legacy)
+        self.assertTrue(
+            any(action["model"] == "quotes.Quote" and "DEV_TEST_LEGACY quote/SPOT historical record" in action["blockers"] for action in payload["actions"])
+        )
+
+
 class CustomerListAPITests(APITestCase):
     def setUp(self):
         self.client = APIClient()

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -3322,6 +3322,75 @@ graphify update .
 git diff --check
 ```
 
+#### Phase 10I - Legacy Organization Cleanup Plan
+
+Date: 2026-06-30
+
+Branch: `codex/phase-10i-legacy-organization-cleanup`
+
+Scope: safe planning and guarded migration tooling for legacy `Organization`
+rows after the OperatingEntity redesign. This phase does not delete rows,
+does not backfill historical Quote/SPOT records, and does not touch pricing,
+ProductCode, rating, or UI behavior.
+
+Commands:
+
+- `python backend/manage.py rbac_legacy_organization_cleanup_plan`
+- `python backend/manage.py rbac_legacy_organization_cleanup_plan --format json`
+- `python backend/manage.py rbac_legacy_organization_cleanup_apply`
+- `python backend/manage.py rbac_legacy_organization_cleanup_apply --apply --format json`
+
+Safety rules:
+
+- `rbac_legacy_organization_cleanup_plan` is read-only.
+- `rbac_legacy_organization_cleanup_apply` is dry-run by default and only
+  writes with `--apply`.
+- Apply runs inside a transaction and only updates dependencies classified as
+  auto-migratable by the same planner.
+- Legacy organizations are only deactivated after dependency counts reach zero.
+- No command hard-deletes organizations.
+- `EFM Express Air Cargo` / `EAC` is treated as legacy Air Freight wording, not
+  a canonical organization.
+- `Test Org` is `DEV_TEST_LEGACY` and stays manual review unless it has zero
+  dependencies.
+- Quote/SPOT historical records are reported as `DEV_TEST_LEGACY` and are not
+  mutated by cleanup tooling.
+
+Mapping:
+
+- `EFM PNG` -> `Express Freight Management` + OperatingEntity `EFM PNG`
+- `EFM Australia` -> `Express Freight Management` + OperatingEntity
+  `EFM Australia`
+- `EFM Fiji` -> `Express Freight Management` + OperatingEntity `EFM Fiji`
+- `EFM Solomon Islands` -> `Express Freight Management` + OperatingEntity
+  `EFM Solomon Islands`
+- `EFM Express Air Cargo` -> `Express Freight Management` + Department
+  `Air Freight`; OperatingEntity only when inferable from a branch.
+- `Test Org` -> `DEV_TEST_LEGACY` / manual review.
+
+Manual runbook:
+
+1. Run the plan command in JSON mode and save the output with the release
+   evidence.
+2. Confirm `target_organization` is `Express Freight Management`.
+3. Review every dependency row with `auto_migratable=false`.
+4. Confirm Quote/SPOT rows are classified but not planned for mutation.
+5. Run apply without `--apply` and compare before/after counts.
+6. Run apply with `--apply` only after blockers are understood.
+7. Re-run the plan command. Legacy organizations are only eligible for
+   deactivation after dependency counts are zero.
+
+Verification:
+
+```bash
+python backend/manage.py makemigrations --check --dry-run
+python backend/manage.py test accounts.tests parties.tests crm.tests quotes.tests
+python backend/manage.py check
+npx fallow --format json
+graphify update .
+git diff --check
+```
+
 ## 12. What Not To Touch Yet
 
 Do not touch these in the first implementation slice:

--- a/frontend/src/components/quotes/ChargeCard.tsx
+++ b/frontend/src/components/quotes/ChargeCard.tsx
@@ -46,7 +46,7 @@ export default function ChargeCard({
 
     const buyAmountNum = Number(buyAmount || 0);
     const sellExGstNum = Number(sellExGst || 0);
-    const costPgk = Number(rawLine?.cost_pgk || (canonicalItem as any)?.cost_pgk || (buyCurrency === "PGK" ? buyAmount : 0) || 0);
+    const costPgk = Number(rawLine?.cost_pgk || canonicalItem?.cost_amount || (buyCurrency === "PGK" ? buyAmount : 0) || 0);
     
     let finalMarginAmount = line.margin_amount || rawLine?.margin_amount;
     let finalMarginPercent = line.margin_percent || rawLine?.margin_percent;


### PR DESCRIPTION
## Summary
- Add read-only legacy Organization cleanup planning command.
- Add guarded dry-run/apply command for auto-migratable legacy Organization references.
- Document Phase 10I safety rules and manual runbook.

## Verification
- python backend/manage.py makemigrations --check --dry-run
- python backend/manage.py test parties.tests.LegacyOrganizationCleanupTests
- python backend/manage.py test accounts.tests parties.tests crm.tests quotes.tests
- python backend/manage.py check
- npx fallow --format json
- graphify update .
- git diff --check

## Intentionally not changed
- No hard deletes.
- No quote/SPOT historical backfill or mutation.
- No pricing, ProductCode, rating, UI, selector, or API behavior changes.
- Generated tmp folders were left untracked.