### PR TITLE
test: disable DRF throttling during pytest runs

### DIFF
--- a/backend/rate_engine/test_settings.py
+++ b/backend/rate_engine/test_settings.py
@@ -2,3 +2,10 @@ from .settings import *
 
 SECURE_SSL_REDIRECT = False
 RBAC_ALLOW_LEGACY_SCOPE_FALLBACK_FOR_TESTS = True
+
+# Disable throttling globally for tests (prevents HTTP 429 errors in pytest bulk runs)
+REST_FRAMEWORK = {
+    **REST_FRAMEWORK,
+    'DEFAULT_THROTTLE_CLASSES': [],
+}
+


### PR DESCRIPTION
Disables DRF throttling in test settings so full pytest runs do not fail with HTTP 429 from accumulated throttle state.

Production throttling is unchanged.

Verified:
- pytest: 1183 passed, 0 failed