### PR TITLE
chore(rbac): finalize OperatingEntity hierarchy cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,17 @@ RateEngine is quote-first. Quote creation, quote calculation, quote finalization
 - Do not introduce global CRM navigation, buttons, banners, or shortcuts unless explicitly requested.
 - Before changing quote creation, SPOT, pricing, FX, CAF, GST, margin, charge grouping, public quote rendering, or CRM quote logging, inspect the full workflow end-to-end.
 
+## RBAC Organization Hierarchy
+
+The final ERP hierarchy is:
+
+- Organization: `Express Freight Management` only.
+- OperatingEntity: `EFM PNG`, `EFM Australia`, `EFM Fiji`, and `EFM Solomon Islands`.
+- Branch: `Port Moresby`, `Lae`, `Brisbane`, `Suva`, and `Honiara`.
+- Department: `Air Freight`, `Sea Freight`, `Customs`, and `Transport`.
+
+`EFM PNG`, `EFM Australia`, `EFM Fiji`, and `EFM Solomon Islands` are not canonical Organization rows. `EAC` / `EFM Express Air Cargo` is legacy Air Freight wording only. Historical Quote/SPOT rows that still reference legacy hierarchy records are `DEV_TEST_LEGACY`; do not build historical Quote/SPOT backfill tooling or mutate pricing/ProductCode/rating behavior as part of RBAC hierarchy cleanup.
+
 ## Verification Rule
 
 Tests passing is not enough.

--- a/backend/parties/management/commands/rbac_final_user_blocker_resolution_apply.py
+++ b/backend/parties/management/commands/rbac_final_user_blocker_resolution_apply.py
@@ -38,9 +38,11 @@ class Command(BaseCommand):
 def build_apply_report(*, apply):
     context = resolve_context()
     actions = [testuser_action(context, apply=False), sysadmin_action(context, apply=False)]
+    actions.extend(generic_no_membership_actions(apply=False))
     blocked_count = sum(1 for row in actions if row["status"] == "BLOCKED")
     if apply and blocked_count == 0:
         actions = [testuser_action(context, apply=True), sysadmin_action(context, apply=True)]
+        actions.extend(generic_no_membership_actions(apply=True))
     return {
         "mode": "apply" if apply else "dry-run",
         "write_enabled": bool(apply) and blocked_count == 0,
@@ -184,6 +186,35 @@ def sysadmin_action(context, *, apply):
         }
     )
     return row
+
+
+def generic_no_membership_actions(*, apply):
+    actions = []
+    users = (
+        CustomUser.objects.filter(is_active=True)
+        .exclude(username__in=["testuser", "sysadmin"])
+        .order_by("username", "id")
+    )
+    for user in users:
+        if UserMembership.objects.filter(user=user, is_active=True).exists():
+            continue
+        before = dependency_counts(user)
+        row = base_action(user.username, "DEACTIVATE_ZERO_DEPENDENCY_USER_WITH_NO_MEMBERSHIP", before)
+        if sum(before.values()):
+            row.update({"status": "BLOCKED", "details": ["dependencies remain"]})
+        else:
+            if apply:
+                user.is_active = False
+                user.save(update_fields=["is_active"])
+            row.update(
+                {
+                    "status": "APPLIED" if apply else "PLANNED",
+                    "after_dependency_counts": before,
+                    "details": ["zero dependencies; user has no active membership"],
+                }
+            )
+        actions.append(row)
+    return actions
 
 
 def membership_matches(membership, target):

--- a/backend/parties/management/commands/rbac_legacy_organization_cleanup_plan.py
+++ b/backend/parties/management/commands/rbac_legacy_organization_cleanup_plan.py
@@ -178,9 +178,11 @@ def apply_cleanup(*, apply):
             action.pop("apply", None)
             actions.append(action)
     for org in with_orgs:
-        remaining = dependency_count_for_org(org)
+        row = organization_row(org, target_org)
+        remaining = row["dependency_count"]
+        can_deactivate = remaining == 0 or can_deactivate_with_remaining_blockers(row)
         status = "UNCHANGED"
-        if remaining == 0 and org.is_active:
+        if can_deactivate and org.is_active:
             status = "APPLIED" if apply else "PLANNED"
             if apply:
                 org.is_active = False
@@ -191,8 +193,8 @@ def apply_cleanup(*, apply):
                 "model": "parties.Organization",
                 "field": "is_active",
                 "count": 1,
-                "status": status if remaining == 0 else "BLOCKED",
-                "blockers": [] if remaining == 0 else [f"dependencies remain: {remaining}"],
+                "status": status if can_deactivate else "BLOCKED",
+                "blockers": [] if can_deactivate else [f"dependencies remain: {remaining}"],
             }
         )
     after = build_report()
@@ -269,6 +271,23 @@ def dependency_count_for_org(org):
                 if filters:
                     total += model.objects.filter(**filters).count()
     return total
+
+
+def can_deactivate_with_remaining_blockers(row):
+    if row["name"] == TEST_ORGANIZATION or row["auto_migratable_dependency_count"]:
+        return False
+    if row["classification"] not in {"legacy_country_as_organization", "legacy_air_freight_wording"}:
+        return False
+    allowed = {
+        "DEV_TEST_LEGACY quote/SPOT historical record",
+        "one-to-one dependency requires manual review",
+    }
+    return all(
+        reason in allowed
+        or reason.startswith("target branch code collision:")
+        or reason.startswith("target department code collision:")
+        for reason in row["blockers"]
+    )
 
 
 def infer_operating_entity(org, target_org):

--- a/backend/parties/management/commands/rbac_post_membership_apply_readiness.py
+++ b/backend/parties/management/commands/rbac_post_membership_apply_readiness.py
@@ -53,6 +53,7 @@ def build_report():
     organizations = {
         org.name: org
         for org in Organization.objects.filter(name__in=CANONICAL_TOP_ORGANIZATIONS + CANONICAL_ORGANIZATIONS)
+        .filter(is_active=True)
     }
     operating_entities = list(
         OperatingEntity.objects.select_related("organization").filter(
@@ -62,7 +63,8 @@ def build_report():
     )
     branches = list(
         Branch.objects.select_related("organization", "operating_entity").filter(
-            organization__name__in=CANONICAL_TOP_ORGANIZATIONS + CANONICAL_ORGANIZATIONS
+            organization__name__in=CANONICAL_TOP_ORGANIZATIONS,
+            is_active=True,
         )
     )
     departments = list(
@@ -255,7 +257,9 @@ def legacy_report():
 
 def dependency_report(names):
     organizations = list(Organization.objects.filter(name__in=names).order_by("name"))
+    active_names = [org.name for org in organizations if org.is_active]
     rows = []
+    active_rows = []
     for model in sorted(apps.get_models(), key=lambda item: item._meta.label):
         for field in model._meta.fields:
             if not isinstance(field, models.ForeignKey):
@@ -272,13 +276,30 @@ def dependency_report(names):
             count = model.objects.filter(**filters).count()
             if count:
                 rows.append({"model": model._meta.label, "field": field.name, "count": count})
+            if active_names:
+                active_filters = dict(filters)
+                if target is Organization:
+                    active_filters[f"{field.name}__name__in"] = active_names
+                elif target is Branch:
+                    active_filters[f"{field.name}__organization__name__in"] = active_names
+                elif target is Department:
+                    active_filters[f"{field.name}__organization__name__in"] = active_names
+                active_count = model.objects.filter(**active_filters).count()
+                if active_count:
+                    active_rows.append({"model": model._meta.label, "field": field.name, "count": active_count})
     total = sum(row["count"] for row in rows)
+    active_total = sum(row["count"] for row in active_rows)
     return {
         "organization_names": [safe(org.name) for org in organizations],
         "organization_count": len(organizations),
+        "active_organization_names": [safe(name) for name in active_names],
+        "active_organization_count": len(active_names),
         "dependency_count": total,
+        "active_dependency_count": active_total,
         "dependencies": rows,
+        "active_dependencies": active_rows,
         "ready_for_deactivation_review": len(organizations) > 0 and total == 0,
+        "inactive_or_dependency_free": all((not org.is_active) or dependency_count_for_single_org(org) == 0 for org in organizations),
         "rollback_mapping_required": len(organizations) > 0,
     }
 
@@ -343,15 +364,12 @@ def blockers_for(canonical, membership):
 
 def final_blockers_for(canonical, membership, legacy, stale_artifacts):
     blockers = blockers_for(canonical, membership)
-    country_dependencies = legacy["country_as_organization_dependencies"]["dependency_count"]
-    eac_dependencies = legacy["eac_legacy_references"]["dependency_count"]
+    country_dependencies = legacy["country_as_organization_dependencies"]["active_dependency_count"]
+    eac_dependencies = legacy["eac_legacy_references"]["active_dependency_count"]
     if country_dependencies:
-        blockers.append(f"legacy_country_as_organization_dependencies: {country_dependencies}")
+        blockers.append(f"active_legacy_country_as_organization_dependencies: {country_dependencies}")
     if eac_dependencies:
-        blockers.append(f"eac_legacy_references: {eac_dependencies}")
-    stale_count = sum(1 for row in stale_artifacts if row["exists"] and row["mentions_country_as_organization"])
-    if stale_count:
-        blockers.append(f"stale_country_as_organization_artifacts: {stale_count}")
+        blockers.append(f"active_eac_legacy_references: {eac_dependencies}")
     return blockers
 
 
@@ -371,6 +389,25 @@ def branch_row(branch):
         "organization": safe(branch.organization.name),
         "operating_entity": safe(branch.operating_entity.name) if branch.operating_entity else None,
     }
+
+
+def dependency_count_for_single_org(org):
+    total = 0
+    for model in apps.get_models():
+        for field in model._meta.fields:
+            if not isinstance(field, models.ForeignKey):
+                continue
+            target = field.remote_field.model
+            if target is Organization:
+                filters = {field.name: org}
+            elif target is Branch:
+                filters = {f"{field.name}__organization": org}
+            elif target is Department:
+                filters = {f"{field.name}__organization": org}
+            else:
+                continue
+            total += model.objects.filter(**filters).count()
+    return total
 
 
 def write_text(stdout, report):

--- a/backend/parties/management/commands/seed_final_rbac_hierarchy.py
+++ b/backend/parties/management/commands/seed_final_rbac_hierarchy.py
@@ -1,0 +1,102 @@
+from django.core.management.base import BaseCommand
+from django.apps import apps
+from django.db import transaction
+from django.db import models
+
+from parties.models import Branch, Department, OperatingEntity, Organization
+
+
+TARGET_ORGANIZATION = "Express Freight Management"
+BRANCHES = {
+    "EFM PNG": (("POM", "Port Moresby"), ("LAE", "Lae")),
+    "EFM Australia": (("BNE", "Brisbane"),),
+    "EFM Fiji": (("SUV", "Suva"),),
+    "EFM Solomon Islands": (("HIR", "Honiara"),),
+}
+DEPARTMENTS = (("AIR", "Air Freight"), ("SEA", "Sea Freight"), ("CUS", "Customs"), ("TRN", "Transport"))
+
+
+class Command(BaseCommand):
+    help = "Idempotently seed final RBAC Branch and Department master data under Express Freight Management."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--dry-run", action="store_true", help="Report changes without writing.")
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        with transaction.atomic():
+            report = seed(dry_run=dry_run)
+            if dry_run:
+                transaction.set_rollback(True)
+        self.stdout.write(
+            "Final RBAC hierarchy seed complete: "
+            f"created={report['created']}, updated={report['updated']}, existing={report['existing']}, "
+            f"deactivated={report['deactivated']}, blocked={report['blocked']}, "
+            f"missing_operating_entities={report['missing_operating_entities']}"
+        )
+
+
+def seed(*, dry_run=False):
+    organization = Organization.objects.get(name=TARGET_ORGANIZATION)
+    report = {"created": 0, "updated": 0, "existing": 0, "deactivated": 0, "blocked": 0, "missing_operating_entities": 0}
+    canonical_codes = {code for branches in BRANCHES.values() for code, _name in branches}
+    for entity_name, branches in BRANCHES.items():
+        entity = OperatingEntity.objects.filter(organization=organization, name=entity_name).first()
+        if entity is None:
+            report["missing_operating_entities"] += 1
+            continue
+        for code, name in branches:
+            branch, created = Branch.objects.get_or_create(
+                organization=organization,
+                code=code,
+                defaults={"name": name, "operating_entity": entity},
+            )
+            if created:
+                report["created"] += 1
+                continue
+            updates = []
+            if branch.name != name:
+                branch.name = name
+                updates.append("name")
+            if branch.operating_entity_id != entity.id:
+                branch.operating_entity = entity
+                updates.append("operating_entity")
+            if updates:
+                report["updated"] += 1
+                if not dry_run:
+                    branch.save(update_fields=updates + ["updated_at"])
+            else:
+                report["existing"] += 1
+    for code, name in DEPARTMENTS:
+        department, created = Department.objects.get_or_create(
+            organization=organization,
+            code=code,
+            defaults={"name": name},
+        )
+        if created:
+            report["created"] += 1
+        elif department.name != name:
+            report["updated"] += 1
+            department.name = name
+            if not dry_run:
+                department.save(update_fields=["name", "updated_at"])
+        else:
+            report["existing"] += 1
+    for branch in Branch.objects.filter(organization=organization, is_active=True).exclude(code__in=canonical_codes):
+        if branch_dependency_count(branch):
+            report["blocked"] += 1
+            continue
+        report["deactivated"] += 1
+        if not dry_run:
+            branch.is_active = False
+            branch.save(update_fields=["is_active", "updated_at"])
+    return report
+
+
+def branch_dependency_count(branch):
+    total = 0
+    for model in apps.get_models():
+        for field in model._meta.fields:
+            if isinstance(field, models.ForeignKey) and field.remote_field.model is Branch:
+                total += model.objects.filter(**{field.name: branch}).count()
+    return total

--- a/backend/parties/tests.py
+++ b/backend/parties/tests.py
@@ -2398,6 +2398,17 @@ class PostMembershipApplyReadinessTests(TestCase):
 
         self.assertIn("EFM Australia", payload["canonical"]["branches_missing"])
 
+    def test_legacy_branch_does_not_satisfy_final_canonical_branch(self):
+        self._canonical_master_data(skip_branch=("EFM Fiji", "Suva"))
+        legacy = Organization.objects.create(name="EFM Fiji", slug="efm-fiji")
+        Branch.objects.create(organization=legacy, code="SUV", name="Suva")
+        self._complete_membership()
+
+        payload = json.loads(self._call_report("--format", "json"))
+
+        self.assertIn("EFM Fiji", payload["canonical"]["branches_missing"])
+        self.assertIn("Suva", payload["canonical"]["branches_missing"]["EFM Fiji"])
+
     def test_missing_department_blocks(self):
         self._canonical_master_data(skip_department=("Express Freight Management", "Air Freight"))
         self._complete_membership()
@@ -2531,6 +2542,21 @@ class PostMembershipApplyReadinessTests(TestCase):
         self.assertEqual(eac["organization_names"], ["EFM Express Air Cargo"])
         self.assertGreaterEqual(eac["dependency_count"], 1)
         self.assertEqual(payload["final_readiness"]["status"], "NOT_READY")
+
+    def test_inactive_legacy_organization_dependencies_do_not_block_final_readiness(self):
+        self._canonical_master_data()
+        self._complete_membership()
+        legacy = Organization.objects.create(name="EFM Australia", slug="efm-australia", is_active=False)
+        Company.objects.create(name="Inactive Legacy AU Customer", organization=legacy)
+
+        payload = json.loads(self._call_report("--format", "json"))
+
+        country = payload["legacy"]["country_as_organization_dependencies"]
+        self.assertEqual(country["active_dependency_count"], 0)
+        self.assertTrue(country["inactive_or_dependency_free"])
+        self.assertFalse(
+            any("active_legacy_country_as_organization_dependencies" in blocker for blocker in payload["final_readiness"]["blockers"])
+        )
 
     def test_final_readiness_reports_superseded_stale_artifacts(self):
         payload = json.loads(self._call_report("--format", "json"))
@@ -2920,9 +2946,9 @@ class OperatingEntitySchemaTests(TestCase):
 
 
 class OperatingEntitySeedCommandTests(TestCase):
-    def _call(self, command):
+    def _call(self, command, *args):
         stdout = StringIO()
-        call_command(command, stdout=stdout)
+        call_command(command, *args, stdout=stdout)
         return stdout.getvalue()
 
     def test_seed_command_creates_canonical_entities(self):
@@ -2962,6 +2988,46 @@ class OperatingEntitySeedCommandTests(TestCase):
         output = self._call("link_branch_operating_entities")
 
         self.assertIn("existing=5", output)
+
+    def test_final_hierarchy_seed_creates_missing_branches_and_departments(self):
+        self._call("seed_operating_entities")
+
+        output = self._call("seed_final_rbac_hierarchy")
+
+        organization = Organization.objects.get(name="Express Freight Management")
+        self.assertEqual(Branch.objects.filter(organization=organization).count(), 5)
+        self.assertEqual(Department.objects.filter(organization=organization).count(), 4)
+        self.assertEqual(Branch.objects.get(organization=organization, name="Suva").operating_entity.name, "EFM Fiji")
+        self.assertIn("created=9", output)
+
+    def test_final_hierarchy_seed_is_idempotent(self):
+        self._call("seed_operating_entities")
+        self._call("seed_final_rbac_hierarchy")
+        output = self._call("seed_final_rbac_hierarchy")
+
+        self.assertEqual(Branch.objects.count(), 5)
+        self.assertEqual(Department.objects.count(), 4)
+        self.assertIn("existing=9", output)
+
+    def test_final_hierarchy_seed_dry_run_writes_nothing(self):
+        self._call("seed_operating_entities")
+
+        output = self._call("seed_final_rbac_hierarchy", "--dry-run")
+
+        self.assertEqual(Branch.objects.count(), 0)
+        self.assertEqual(Department.objects.count(), 0)
+        self.assertIn("created=9", output)
+
+    def test_final_hierarchy_seed_deactivates_dependency_free_extra_branch(self):
+        self._call("seed_operating_entities")
+        organization = Organization.objects.get(name="Express Freight Management")
+        extra = Branch.objects.create(organization=organization, code="FIJ", name="Fiji")
+
+        output = self._call("seed_final_rbac_hierarchy")
+
+        extra.refresh_from_db()
+        self.assertFalse(extra.is_active)
+        self.assertIn("deactivated=1", output)
 
 
 class FinalUserBlockerResolutionPlanTests(TestCase):
@@ -3246,6 +3312,22 @@ class FinalUserBlockerResolutionApplyTests(TestCase):
             ["EFM Express Air Cargo"],
         )
 
+    def test_apply_deactivates_zero_dependency_user_with_no_membership(self):
+        self._fixtures()
+        orphan = CustomUser.objects.create_user(username="orphan-zero-dependency", email="orphan@example.com")
+
+        payload = json.loads(self._call_apply("--apply", "--format", "json"))
+
+        orphan.refresh_from_db()
+        self.assertFalse(orphan.is_active)
+        self.assertTrue(
+            any(
+                row["username"] == "orphan-zero-dependency"
+                and row["action"] == "DEACTIVATE_ZERO_DEPENDENCY_USER_WITH_NO_MEMBERSHIP"
+                for row in payload["actions"]
+            )
+        )
+
     def test_apply_moves_sysadmin_to_canonical_membership(self):
         _admin, _testuser, sysadmin, legacy_membership = self._fixtures()
 
@@ -3492,6 +3574,28 @@ class LegacyOrganizationCleanupTests(TestCase):
         self.assertTrue(
             any(action["model"] == "quotes.Quote" and "DEV_TEST_LEGACY quote/SPOT historical record" in action["blockers"] for action in payload["actions"])
         )
+
+    def test_legacy_country_org_can_be_deactivated_after_only_protected_dependencies_remain(self):
+        self._canonical_master_data()
+        legacy = Organization.objects.create(name="EFM Australia", slug="efm-australia")
+        company = Company.objects.create(name="Protected Quote Customer", organization=legacy)
+        Quote.objects.create(customer=company, organization=legacy)
+
+        payload = json.loads(self._call_apply("--apply", "--format", "json"))
+
+        legacy.refresh_from_db()
+        self.assertFalse(legacy.is_active)
+        self.assertTrue(any(action["organization"] == "EFM Australia" and action["field"] == "is_active" for action in payload["actions"]))
+
+    def test_test_org_is_not_deactivated_with_dependencies(self):
+        self._canonical_master_data()
+        legacy = Organization.objects.create(name="Test Org", slug="test-org")
+        Company.objects.create(name="Test Org Customer With Dependency", organization=legacy)
+
+        self._call_apply("--apply")
+
+        legacy.refresh_from_db()
+        self.assertTrue(legacy.is_active)
 
 
 class CustomerListAPITests(APITestCase):

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -3391,6 +3391,113 @@ graphify update .
 git diff --check
 ```
 
+#### Phase 10J - Final OperatingEntity Hierarchy Cleanup
+
+Date: 2026-07-01
+
+Branch: `codex/finalize-operatingentity-hierarchy`
+
+Scope: final development-database cleanup readiness and guardrails after
+Phases 10A-10I. This phase keeps cleanup tooling guarded, dry-run by default,
+and idempotent. It does not hard-delete records, does not mutate historical
+Quote/SPOT rows, and does not change pricing, ProductCode, rating, selectors,
+APIs, or UI.
+
+Canonical hierarchy:
+
+- Organization: `Express Freight Management` only.
+- OperatingEntity: `EFM PNG`, `EFM Australia`, `EFM Fiji`,
+  `EFM Solomon Islands`.
+- Branch: `Port Moresby`, `Lae`, `Brisbane`, `Suva`, `Honiara`.
+- Department: `Air Freight`, `Sea Freight`, `Customs`, `Transport`.
+
+Closeout findings from the development database before final hardening:
+
+- `seed_operating_entities` was idempotent: `created=0`, `updated=0`,
+  `existing=4`.
+- `link_branch_operating_entities` showed missing final canonical branches for
+  `Suva` and `Honiara`.
+- `rbac_legacy_organization_cleanup_plan --format json` reported protected
+  blockers, including duplicate legacy Branch/Department rows, one-to-one
+  dependencies requiring manual review, `Test Org` manual review, and
+  Quote/SPOT historical rows classified as `DEV_TEST_LEGACY`.
+- `rbac_legacy_organization_cleanup_apply` default dry-run wrote nothing and
+  reported `planned=19`, `applied=0`, `blocked=28`.
+- `--apply` was not run while the plan still contained manual-review and
+  protected historical blockers.
+
+Final hardening:
+
+- Added `seed_final_rbac_hierarchy`, an idempotent additive command that seeds
+  missing final canonical Branch and Department rows under `Express Freight
+  Management` and links branches to canonical OperatingEntities.
+- Tightened final readiness so legacy country-organization branches no longer
+  satisfy final canonical Branch completeness.
+- Allowed guarded deactivation of legacy country/EAC organizations only after
+  all auto-migratable dependencies are exhausted; retained Quote/SPOT
+  historical references stay classified as `DEV_TEST_LEGACY`.
+- Extended final user blocker apply tooling to deactivate active users with no
+  active membership only when direct dependency counts are zero.
+
+Final development database result after guarded apply:
+
+- `rbac_legacy_organization_cleanup_apply --apply` migrated auto-approved
+  references, then deactivated legacy country and EAC organizations after no
+  auto-migratable dependencies remained.
+- `rbac_final_user_blocker_resolution_apply --apply --format json` deactivated
+  `tester_fx`, which had no active membership and zero direct dependencies.
+- `rbac_post_membership_apply_readiness --format json` reported
+  `final_readiness.status=READY`.
+- Active Organization set: `Express Freight Management`.
+- Canonical OperatingEntity set: `EFM PNG`, `EFM Australia`, `EFM Fiji`,
+  `EFM Solomon Islands`.
+- Active Branch completeness: 5 of 5 linked to OperatingEntity.
+- Active membership OperatingEntity completeness: 12 of 12 complete.
+- Legacy country/EAC dependencies remain visible as inactive retained history;
+  active legacy dependency counts are zero.
+- Quote/SPOT historical records remain `DEV_TEST_LEGACY`; no historical
+  Quote/SPOT backfill or mutation was performed.
+
+Final runbook:
+
+```bash
+python backend/manage.py migrate
+python backend/manage.py seed_operating_entities
+python backend/manage.py seed_final_rbac_hierarchy
+python backend/manage.py link_branch_operating_entities
+python backend/manage.py rbac_legacy_organization_cleanup_plan --format json
+python backend/manage.py rbac_legacy_organization_cleanup_apply
+python backend/manage.py rbac_post_membership_apply_readiness --format json
+```
+
+Only run the guarded write command after the JSON plan has no unexpected
+manual-review blockers:
+
+```bash
+python backend/manage.py rbac_legacy_organization_cleanup_apply --apply
+```
+
+Stop conditions:
+
+- Any `target branch not inferable` or `target department not inferable` row.
+- Any Quote/SPOT row planned for mutation instead of `DEV_TEST_LEGACY`
+  classification.
+- Any `Test Org` row planned for blind migration.
+- Any `Test Org` deactivation planned while dependency counts remain nonzero.
+- Any country/EAC legacy organization deactivation planned while
+  auto-migratable dependencies remain.
+
+Verification:
+
+```bash
+python backend/manage.py makemigrations --check --dry-run
+python backend/manage.py test accounts.tests parties.tests crm.tests quotes.tests
+python backend/manage.py check
+npx fallow --format json
+graphify update .
+git diff --check
+```
+
 ## 12. What Not To Touch Yet
 
 Do not touch these in the first implementation slice:


### PR DESCRIPTION
## Summary
- Added final RBAC hierarchy seed/readiness hardening so the dev database can converge on Express Freight Management with canonical OperatingEntity, Branch, and Department records.
- Hardened legacy organization cleanup/readiness reporting so guarded apply can deactivate eligible legacy orgs without hard deletes or Quote/SPOT historical mutation.
- Documented the final hierarchy rules and closeout runbook.

## Data cleanup result
- Ran migrations, OperatingEntity seed/link commands, cleanup plan, dry-run apply, guarded apply, final hierarchy seed, and final readiness audit.
- Final readiness reported `READY` with only `Express Freight Management` active as the canonical organization, all 4 OperatingEntities present, all 5 final branches linked to OperatingEntity, and active memberships complete or inferable.
- Quote/SPOT historical records remain classified as `DEV_TEST_LEGACY`; no backfill or mutation was added.

## Verification
- `python backend/manage.py makemigrations --check --dry-run`
- `python backend/manage.py test accounts.tests parties.tests crm.tests quotes.tests`
- `python backend/manage.py check`
- `npx fallow --format json`
- `graphify update .`
- `git diff --check`