### PR TITLE
chore(rbac): consolidate duplicate hierarchy master data

### DIFF
--- a/backend/parties/management/commands/rbac_duplicate_master_data_consolidation_apply.py
+++ b/backend/parties/management/commands/rbac_duplicate_master_data_consolidation_apply.py
@@ -1,0 +1,35 @@
+import json
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from .rbac_duplicate_master_data_consolidation_plan import apply_consolidation
+
+
+class Command(BaseCommand):
+    help = "Guarded apply for duplicate Branch and Department master data consolidation. Dry-run by default."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--apply", action="store_true", help="Write safe planned changes. Defaults to dry-run.")
+        parser.add_argument("--format", choices=["text", "json"], default="text")
+
+    def handle(self, *args, **options):
+        with transaction.atomic():
+            report = apply_consolidation(apply=options["apply"])
+            if not options["apply"]:
+                transaction.set_rollback(True)
+        if options["format"] == "json":
+            self.stdout.write(json.dumps(report, indent=2, sort_keys=True))
+            return
+        write_text(self.stdout, report)
+
+
+def write_text(stdout, report):
+    summary = report["summary"]
+    stdout.write("RBAC duplicate master data consolidation apply")
+    stdout.write("==============================================")
+    stdout.write(f"Mode: {report['mode']}")
+    stdout.write(
+        f"Summary: planned={summary['planned']} applied={summary['applied']} "
+        f"unchanged={summary['unchanged']} blocked={summary['blocked']}"
+    )

--- a/backend/parties/management/commands/rbac_duplicate_master_data_consolidation_plan.py
+++ b/backend/parties/management/commands/rbac_duplicate_master_data_consolidation_plan.py
@@ -1,0 +1,257 @@
+import json
+
+from django.apps import apps
+from django.core.management.base import BaseCommand
+from django.db import models
+
+from parties.management.commands.rbac_legacy_organization_cleanup_plan import (
+    LEGACY_ORGANIZATIONS,
+    QUOTE_SPOT_MODELS,
+    TARGET_ORGANIZATION,
+    TEST_ORGANIZATION,
+    label,
+    safe,
+)
+from parties.models import Branch, Department, Organization
+
+CANONICAL_BRANCH_CODES = {"POM", "LAE", "BNE", "SUV", "HIR"}
+CANONICAL_DEPARTMENT_CODES = {"AIR", "SEA", "CUS", "TRN"}
+
+
+class Command(BaseCommand):
+    help = "Read-only plan for consolidating duplicate Branch and Department master data."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--format", choices=["text", "json"], default="text")
+
+    def handle(self, *args, **options):
+        report = build_report()
+        if options["format"] == "json":
+            self.stdout.write(json.dumps(report, indent=2, sort_keys=True))
+            return
+        write_text(self.stdout, report)
+
+
+def build_report():
+    target_org = Organization.objects.filter(name=TARGET_ORGANIZATION).first()
+    branch_rows = [branch_row(branch, target_org) for branch in legacy_duplicates(Branch)]
+    department_rows = [department_row(department, target_org) for department in legacy_duplicates(Department)]
+    rows = branch_rows + department_rows
+    return {
+        "write_enabled": False,
+        "target_organization": label(target_org),
+        "quote_spot_historical_records": {
+            "classification": "DEV_TEST_LEGACY",
+            "historical_backfill_required": False,
+            "mutated_by_cleanup": False,
+        },
+        "summary": {
+            "duplicate_branches": len(branch_rows),
+            "duplicate_departments": len(department_rows),
+            "dependencies": sum(row["dependency_count"] for row in rows),
+            "auto_repointable_dependencies": sum(row["auto_repointable_dependency_count"] for row in rows),
+            "blocked_dependencies": sum(row["blocked_dependency_count"] for row in rows),
+        },
+        "branches": branch_rows,
+        "departments": department_rows,
+    }
+
+
+def legacy_duplicates(model):
+    return list(
+        model.objects.filter(organization__name__in=LEGACY_ORGANIZATIONS, is_active=True)
+        .select_related("organization")
+        .order_by("organization__name", "code", "id")
+    )
+
+
+def branch_row(branch, target_org):
+    target = None
+    if target_org is not None and branch.code in CANONICAL_BRANCH_CODES:
+        target = Branch.objects.filter(organization=target_org, code=branch.code, is_active=True).exclude(pk=branch.pk).first()
+    return duplicate_row(branch, target, Branch)
+
+
+def department_row(department, target_org):
+    target = None
+    if target_org is not None and department.code in CANONICAL_DEPARTMENT_CODES:
+        target = Department.objects.filter(organization=target_org, code=department.code, is_active=True).exclude(pk=department.pk).first()
+    return duplicate_row(department, target, Department)
+
+
+def duplicate_row(source, target, target_model):
+    dependencies = dependency_rows(source, target, target_model)
+    blockers = sorted({reason for row in dependencies for reason in row["blockers"]})
+    if target is None:
+        blockers.append("canonical target missing")
+    if source.organization.name == TEST_ORGANIZATION:
+        blockers.append("DEV_TEST_LEGACY manual review required")
+    dependency_count = sum(row["count"] for row in dependencies)
+    auto_count = sum(row["count"] for row in dependencies if row["auto_repointable"])
+    return {
+        "id": safe(source.pk),
+        "organization": safe(source.organization.name),
+        "code": safe(source.code),
+        "name": safe(source.name),
+        "is_active": source.is_active,
+        "canonical_target": object_label(target),
+        "dependencies": dependencies,
+        "dependency_count": dependency_count,
+        "auto_repointable_dependency_count": auto_count,
+        "blocked_dependency_count": dependency_count - auto_count,
+        "blockers": blockers,
+        "recommended_action": recommended_action(source, target, dependency_count, blockers, auto_count),
+    }
+
+
+def dependency_rows(source, target, target_model):
+    rows = []
+    for model in sorted(apps.get_models(), key=lambda item: item._meta.label):
+        for field in model._meta.fields:
+            if not isinstance(field, models.ForeignKey) or field.remote_field.model is not target_model:
+                continue
+            queryset = model.objects.filter(**{field.name: source}).order_by("pk")
+            count = queryset.count()
+            if not count:
+                continue
+            blockers = dependency_blockers(model, source, target)
+            rows.append(
+                {
+                    "model": model._meta.label,
+                    "field": field.name,
+                    "count": count,
+                    "auto_repointable": not blockers,
+                    "target": object_label(target),
+                    "blockers": blockers,
+                    "sample_ids": [safe(obj.pk) for obj in queryset[:5]],
+                }
+            )
+    return rows
+
+
+def dependency_blockers(model, source, target):
+    blockers = []
+    if target is None:
+        blockers.append("canonical target missing")
+    if source.organization.name == TEST_ORGANIZATION:
+        blockers.append("DEV_TEST_LEGACY manual review required")
+    if model._meta.label in QUOTE_SPOT_MODELS:
+        blockers.append("DEV_TEST_LEGACY quote/SPOT historical record")
+    return blockers
+
+
+def apply_consolidation(*, apply):
+    before = build_report()
+    actions = []
+    for source, target_model in [
+        *[(branch, Branch) for branch in legacy_duplicates(Branch)],
+        *[(department, Department) for department in legacy_duplicates(Department)],
+    ]:
+        target = canonical_target(source, target_model)
+        row = duplicate_row(source, target, target_model)
+        for dep in row["dependencies"]:
+            status = "PLANNED" if dep["auto_repointable"] else "BLOCKED"
+            if apply and status == "PLANNED":
+                model = apps.get_model(dep["model"])
+                model.objects.filter(**{dep["field"]: source}).update(**{dep["field"]: target})
+                status = "APPLIED"
+            actions.append(
+                {
+                    "master_data_type": target_model._meta.label,
+                    "source": object_label(source),
+                    "model": dep["model"],
+                    "field": dep["field"],
+                    "count": dep["count"],
+                    "target": dep["target"],
+                    "status": status,
+                    "blockers": dep["blockers"],
+                }
+            )
+        source.refresh_from_db()
+        external_dependencies = external_dependency_count(source, target_model)
+        can_deactivate = external_dependencies == 0 and source.is_active and source.organization.name != TEST_ORGANIZATION
+        status = "PLANNED" if can_deactivate else "UNCHANGED"
+        if apply and can_deactivate:
+            source.is_active = False
+            source.save(update_fields=["is_active", "updated_at"])
+            status = "APPLIED"
+        actions.append(
+            {
+                "master_data_type": target_model._meta.label,
+                "source": object_label(source),
+                "model": target_model._meta.label,
+                "field": "is_active",
+                "count": 1,
+                "target": None,
+                "status": status,
+                "blockers": [] if external_dependencies == 0 else [f"dependencies remain: {external_dependencies}"],
+            }
+        )
+    after = build_report()
+    return {
+        "mode": "apply" if apply else "dry-run",
+        "write_enabled": bool(apply),
+        "before": before["summary"],
+        "after": after["summary"],
+        "summary": {
+            "planned": sum(1 for action in actions if action["status"] == "PLANNED"),
+            "applied": sum(1 for action in actions if action["status"] == "APPLIED"),
+            "unchanged": sum(1 for action in actions if action["status"] == "UNCHANGED"),
+            "blocked": sum(1 for action in actions if action["status"] == "BLOCKED"),
+        },
+        "actions": actions,
+    }
+
+
+def canonical_target(source, target_model):
+    target_org = Organization.objects.filter(name=TARGET_ORGANIZATION).first()
+    if target_org is None:
+        return None
+    if target_model is Branch and source.code not in CANONICAL_BRANCH_CODES:
+        return None
+    if target_model is Department and source.code not in CANONICAL_DEPARTMENT_CODES:
+        return None
+    return target_model.objects.filter(organization=target_org, code=source.code, is_active=True).exclude(pk=source.pk).first()
+
+
+def external_dependency_count(source, target_model):
+    count = 0
+    for model in apps.get_models():
+        for field in model._meta.fields:
+            if isinstance(field, models.ForeignKey) and field.remote_field.model is target_model:
+                count += model.objects.filter(**{field.name: source}).count()
+    return count
+
+
+def recommended_action(source, target, dependency_count, blockers, auto_count):
+    if source.organization.name == TEST_ORGANIZATION:
+        return "dev_test_manual_review"
+    if dependency_count == 0:
+        return "deactivate_after_zero_dependencies"
+    if target is None:
+        return "manual_review_required"
+    if auto_count:
+        return "repoint_references"
+    if blockers:
+        return "manual_review_required"
+    return "manual_review_required"
+
+
+def object_label(value):
+    if value is None:
+        return None
+    org = getattr(value, "organization", None)
+    prefix = f"{org.name}:" if org is not None else ""
+    return safe(f"{prefix}{value.code} {value.name}")
+
+
+def write_text(stdout, report):
+    summary = report["summary"]
+    stdout.write("RBAC duplicate master data consolidation plan")
+    stdout.write("=============================================")
+    stdout.write("Mode: read-only diagnostics")
+    stdout.write(
+        f"Summary: branches={summary['duplicate_branches']} departments={summary['duplicate_departments']} "
+        f"dependencies={summary['dependencies']} auto_repointable={summary['auto_repointable_dependencies']} "
+        f"blocked={summary['blocked_dependencies']}"
+    )

--- a/backend/parties/management/commands/rbac_legacy_organization_cleanup_plan.py
+++ b/backend/parties/management/commands/rbac_legacy_organization_cleanup_plan.py
@@ -88,6 +88,8 @@ def dependency_rows(org, target_org):
             if filters is None:
                 continue
             queryset = model.objects.filter(**filters).order_by("pk")
+            if model in (Branch, Department) and field.name == "organization":
+                queryset = queryset.filter(is_active=True)
             count = queryset.count()
             if not count:
                 continue
@@ -226,6 +228,8 @@ def planned_updates_for_org(org, target_org):
             if filters is None:
                 continue
             queryset = model.objects.filter(**filters)
+            if model in (Branch, Department) and field.name == "organization":
+                queryset = queryset.filter(is_active=True)
             count = queryset.count()
             if not count:
                 continue
@@ -320,7 +324,7 @@ def eac_air_freight_department(org, target_org):
 
 def branch_reparent_blockers(org, target_org):
     blockers = []
-    for branch in Branch.objects.filter(organization=org):
+    for branch in Branch.objects.filter(organization=org, is_active=True):
         if Branch.objects.filter(organization=target_org, code=branch.code).exclude(pk=branch.pk).exists():
             blockers.append(f"target branch code collision: {branch.code}")
     return blockers
@@ -328,7 +332,7 @@ def branch_reparent_blockers(org, target_org):
 
 def department_reparent_blockers(org, target_org):
     blockers = []
-    for department in Department.objects.filter(organization=org):
+    for department in Department.objects.filter(organization=org, is_active=True):
         if Department.objects.filter(organization=target_org, code=department.code).exclude(pk=department.pk).exists():
             blockers.append(f"target department code collision: {department.code}")
     return blockers

--- a/backend/parties/tests.py
+++ b/backend/parties/tests.py
@@ -3598,6 +3598,144 @@ class LegacyOrganizationCleanupTests(TestCase):
         self.assertTrue(legacy.is_active)
 
 
+class DuplicateMasterDataConsolidationTests(TestCase):
+    def setUp(self):
+        UserMembership.objects.all().delete()
+        CustomUser.objects.all().delete()
+        Branch.objects.all().delete()
+        OperatingEntity.objects.all().delete()
+        Department.objects.all().delete()
+        Organization.objects.all().delete()
+
+    def _call_plan(self, *args):
+        stdout = StringIO()
+        call_command("rbac_duplicate_master_data_consolidation_plan", *args, stdout=stdout)
+        return stdout.getvalue()
+
+    def _call_apply(self, *args):
+        stdout = StringIO()
+        call_command("rbac_duplicate_master_data_consolidation_apply", *args, stdout=stdout)
+        return stdout.getvalue()
+
+    def _canonical_master_data(self):
+        org = Organization.objects.create(name="Express Freight Management", slug="express-freight-management")
+        entity = OperatingEntity.objects.create(
+            organization=org,
+            code="PNG",
+            name="EFM PNG",
+            slug="efm-png",
+            country_code="PG",
+        )
+        branch = Branch.objects.create(organization=org, operating_entity=entity, code="POM", name="Port Moresby")
+        department = Department.objects.create(organization=org, code="AIR", name="Air Freight")
+        return org, branch, department
+
+    def test_plan_is_read_only_and_detects_duplicate_master_data(self):
+        _org, branch, department = self._canonical_master_data()
+        legacy = Organization.objects.create(name="EFM PNG", slug="efm-png-legacy")
+        duplicate_branch = Branch.objects.create(organization=legacy, code="POM", name="Port Moresby")
+        duplicate_department = Department.objects.create(organization=legacy, code="AIR", name="Air Freight")
+        before = (duplicate_branch.is_active, duplicate_department.is_active)
+
+        payload = json.loads(self._call_plan("--format", "json"))
+
+        duplicate_branch.refresh_from_db()
+        duplicate_department.refresh_from_db()
+        self.assertFalse(payload["write_enabled"])
+        self.assertEqual(before, (duplicate_branch.is_active, duplicate_department.is_active))
+        self.assertEqual(payload["branches"][0]["canonical_target"], f"Express Freight Management:{branch.code} {branch.name}")
+        self.assertEqual(payload["departments"][0]["canonical_target"], f"Express Freight Management:{department.code} {department.name}")
+
+    def test_dry_run_writes_nothing(self):
+        self._canonical_master_data()
+        legacy = Organization.objects.create(name="EFM PNG", slug="efm-png-legacy")
+        duplicate_branch = Branch.objects.create(organization=legacy, code="POM", name="Port Moresby")
+        company = Company.objects.create(name="Legacy Branch Customer", organization=legacy, branch=duplicate_branch)
+
+        payload = json.loads(self._call_apply("--format", "json"))
+
+        company.refresh_from_db()
+        duplicate_branch.refresh_from_db()
+        self.assertEqual(payload["mode"], "dry-run")
+        self.assertEqual(company.branch, duplicate_branch)
+        self.assertTrue(duplicate_branch.is_active)
+
+    def test_apply_repoints_safe_branch_and_department_references(self):
+        _org, canonical_branch, canonical_department = self._canonical_master_data()
+        legacy = Organization.objects.create(name="EFM PNG", slug="efm-png-legacy")
+        duplicate_branch = Branch.objects.create(organization=legacy, code="POM", name="Port Moresby")
+        duplicate_department = Department.objects.create(organization=legacy, code="AIR", name="Air Freight")
+        company = Company.objects.create(
+            name="Legacy Scoped Customer",
+            organization=legacy,
+            branch=duplicate_branch,
+            department=duplicate_department,
+        )
+
+        payload = json.loads(self._call_apply("--apply", "--format", "json"))
+
+        company.refresh_from_db()
+        duplicate_branch.refresh_from_db()
+        duplicate_department.refresh_from_db()
+        self.assertGreaterEqual(payload["summary"]["applied"], 2)
+        self.assertEqual(company.branch, canonical_branch)
+        self.assertEqual(company.department, canonical_department)
+        self.assertFalse(duplicate_branch.is_active)
+        self.assertFalse(duplicate_department.is_active)
+
+    def test_quote_spot_historical_records_are_not_mutated(self):
+        self._canonical_master_data()
+        legacy = Organization.objects.create(name="EFM PNG", slug="efm-png-legacy")
+        duplicate_branch = Branch.objects.create(organization=legacy, code="POM", name="Port Moresby")
+        duplicate_department = Department.objects.create(organization=legacy, code="AIR", name="Air Freight")
+        company = Company.objects.create(name="Legacy Quote Customer", organization=legacy)
+        quote = Quote.objects.create(
+            customer=company,
+            organization=legacy,
+            branch=duplicate_branch,
+            department=duplicate_department,
+        )
+
+        payload = json.loads(self._call_apply("--apply", "--format", "json"))
+
+        quote.refresh_from_db()
+        duplicate_branch.refresh_from_db()
+        duplicate_department.refresh_from_db()
+        self.assertEqual(quote.branch, duplicate_branch)
+        self.assertEqual(quote.department, duplicate_department)
+        self.assertTrue(duplicate_branch.is_active)
+        self.assertTrue(duplicate_department.is_active)
+        self.assertTrue(any(action["model"] == "quotes.Quote" and action["status"] == "BLOCKED" for action in payload["actions"]))
+
+    def test_test_org_duplicate_departments_are_manual_review_only(self):
+        self._canonical_master_data()
+        test_org = Organization.objects.create(name="Test Org", slug="test-org")
+        duplicate_department = Department.objects.create(organization=test_org, code="AIR", name="Air Freight")
+
+        payload = json.loads(self._call_apply("--apply", "--format", "json"))
+
+        duplicate_department.refresh_from_db()
+        row = next(item for item in payload["actions"] if item["source"] == "Test Org:AIR Air Freight")
+        self.assertTrue(duplicate_department.is_active)
+        self.assertEqual(row["status"], "UNCHANGED")
+
+    def test_legacy_cleanup_plan_improves_after_consolidation(self):
+        self._canonical_master_data()
+        legacy = Organization.objects.create(name="EFM PNG", slug="efm-png-legacy")
+        Branch.objects.create(organization=legacy, code="POM", name="Port Moresby")
+        Department.objects.create(organization=legacy, code="AIR", name="Air Freight")
+        before = StringIO()
+        call_command("rbac_legacy_organization_cleanup_plan", "--format", "json", stdout=before)
+
+        self._call_apply("--apply", "--format", "json")
+        after = StringIO()
+        call_command("rbac_legacy_organization_cleanup_plan", "--format", "json", stdout=after)
+
+        before_row = next(item for item in json.loads(before.getvalue())["organizations"] if item["name"] == "EFM PNG")
+        after_row = next(item for item in json.loads(after.getvalue())["organizations"] if item["name"] == "EFM PNG")
+        self.assertGreater(before_row["blocked_dependency_count"], after_row["blocked_dependency_count"])
+
+
 class CustomerListAPITests(APITestCase):
     def setUp(self):
         self.client = APIClient()

--- a/docs/rbac-organisation-audit-plan.md
+++ b/docs/rbac-organisation-audit-plan.md
@@ -3498,6 +3498,74 @@ graphify update .
 git diff --check
 ```
 
+#### Phase 10K - Duplicate Branch/Department Master Data Consolidation
+
+Date: 2026-07-01
+
+Branch: `codex/consolidate-duplicate-hierarchy-master-data`
+
+Scope: consolidate duplicate Branch and Department master data left under
+legacy organizations after the final OperatingEntity hierarchy cleanup. This
+phase is guarded, dry-run by default, transactional, and idempotent. It does
+not hard-delete records and does not mutate Quote/SPOT historical records,
+pricing, ProductCode, rating, selectors, APIs, or UI.
+
+Added commands:
+
+```bash
+python backend/manage.py rbac_duplicate_master_data_consolidation_plan --format json
+python backend/manage.py rbac_duplicate_master_data_consolidation_apply --format json
+python backend/manage.py rbac_duplicate_master_data_consolidation_apply --apply --format json
+```
+
+Behavior:
+
+- The plan reports active duplicate Branch and Department rows under legacy
+  organizations, their canonical target when one exists, FK dependency counts,
+  blocked dependencies, and recommended action.
+- The apply command repoints only safe non-Quote/SPOT FK references to the
+  canonical Branch or Department.
+- Duplicate Branch/Department rows are deactivated only after their FK
+  dependency count is zero.
+- `Test Org` duplicate master data remains `DEV_TEST_LEGACY` manual review and
+  is not blindly migrated or deactivated by this command.
+- Quote/SPOT historical rows remain classified as `DEV_TEST_LEGACY` and are
+  never repointed by this command.
+- The legacy organization cleanup planner now ignores inactive Branch and
+  Department master rows so the guarded cleanup apply cannot attempt a unique
+  code collision against deactivated duplicates.
+
+Development database result:
+
+- `rbac_duplicate_master_data_consolidation_apply --apply --format json`
+  applied 28 safe deactivations, blocked 6 Quote/SPOT historical dependency
+  groups, and left 8 Test Org/protected rows unchanged.
+- Active duplicate master-data report now shows only protected active
+  Quote/SPOT-linked duplicates plus Test Org manual-review departments.
+- `rbac_legacy_organization_cleanup_plan --format json` improved from 252
+  dependencies to 224 after consolidation.
+- `rbac_post_membership_apply_readiness --format json` remained
+  `final_readiness.status=READY`.
+
+Stop conditions:
+
+- Any Quote/SPOT row planned for repointing instead of
+  `DEV_TEST_LEGACY` blocking.
+- Any `Test Org` row planned for automatic migration or deactivation.
+- Any duplicate Branch/Department deactivation planned while FK dependencies
+  remain.
+- Any canonical target outside the final active Branch/Department code set.
+
+Runbook:
+
+```bash
+python backend/manage.py rbac_duplicate_master_data_consolidation_plan --format json
+python backend/manage.py rbac_duplicate_master_data_consolidation_apply --format json
+python backend/manage.py rbac_duplicate_master_data_consolidation_apply --apply --format json
+python backend/manage.py rbac_legacy_organization_cleanup_plan --format json
+python backend/manage.py rbac_post_membership_apply_readiness --format json
+```
+
 ## 12. What Not To Touch Yet
 
 Do not touch these in the first implementation slice:


### PR DESCRIPTION
## Summary
- Added read-only and guarded apply commands for duplicate Branch/Department master-data consolidation.
- Repoint safe non-Quote/SPOT FK references to canonical Branch/Department records and deactivate duplicate master rows only after zero dependencies.
- Kept Test Org manual-review only and preserved Quote/SPOT historical rows as DEV_TEST_LEGACY.
- Updated the legacy organization cleanup planner so inactive duplicate Branch/Department rows are not treated as active collision blockers or auto-migratable organization dependencies.
- Documented the Phase 10K runbook and stop conditions.

## Dev DB cleanup result
- Ran `rbac_duplicate_master_data_consolidation_apply --apply --format json`.
- Applied 28 safe deactivations.
- Blocked 6 protected Quote/SPOT historical dependency groups.
- Left Test Org/manual-review rows unchanged.
- `rbac_legacy_organization_cleanup_plan --format json` improved from 252 dependencies to 224 after consolidation.
- `rbac_post_membership_apply_readiness --format json` remained `final_readiness.status=READY`.

## Verification
- `python backend/manage.py makemigrations --check --dry-run`
- `python backend/manage.py test parties.tests.DuplicateMasterDataConsolidationTests parties.tests.LegacyOrganizationCleanupTests parties.tests.PostMembershipApplyReadinessTests`
- `python backend/manage.py test accounts.tests parties.tests crm.tests quotes.tests`
- `python backend/manage.py check`
- `npx fallow --format json` (existing 104 frontend findings)
- `graphify update .`
- `git diff --check`