### PR TITLE
Phase 8D.7.1: Fix invalid slate background class

### DIFF
--- a/frontend/src/app/quotes/spot/[speId]/exception-workspace/page.tsx
+++ b/frontend/src/app/quotes/spot/[speId]/exception-workspace/page.tsx
@@ -69,7 +69,7 @@ export default function ExceptionWorkspaceLivePage() {
 
   if (error) {
     return (
-      <div className="w-full min-h-screen bg-slate-955 flex flex-col items-center justify-center text-slate-200 p-6">
+      <div className="w-full min-h-screen bg-slate-950 flex flex-col items-center justify-center text-slate-200 p-6">
         <div className="bg-slate-900 border border-slate-800 rounded-2xl p-8 max-w-lg w-full shadow-2xl flex flex-col items-center text-center gap-6">
           <div className="bg-rose-950/40 border border-rose-900/60 p-4 rounded-full text-rose-400">
             <AlertCircle className="w-10 h-10" />

--- a/frontend/src/components/spot/ExceptionWorkspace.tsx
+++ b/frontend/src/components/spot/ExceptionWorkspace.tsx
@@ -309,7 +309,7 @@ export function ExceptionWorkspace({ initialData = hardCaseAirImportData, isLive
     }
 
     return (
-        <div className="min-h-screen bg-slate-955 text-slate-100 p-6 font-sans">
+        <div className="min-h-screen bg-slate-950 text-slate-100 p-6 font-sans">
             <div className="max-w-4xl mx-auto flex flex-col gap-6">
 
                 {isLive && (
@@ -688,7 +688,7 @@ export function ExceptionWorkspace({ initialData = hardCaseAirImportData, isLive
                         <h2 className="text-sm font-bold uppercase tracking-wider text-slate-400 mb-3">Review Decisions</h2>
                         <div className="flex flex-col gap-2 text-xs">
                             {decisions.map(d => (
-                                <div key={d.id} className="bg-slate-955 border border-slate-850 p-2.5 rounded-lg flex justify-between items-center">
+                                <div key={d.id} className="bg-slate-950 border border-slate-850 p-2.5 rounded-lg flex justify-between items-center">
                                     <span className="text-slate-300">✓ {d.description}</span>
                                     <div className="flex gap-2">
                                         <button


### PR DESCRIPTION
## Summary

Tiny cleanup after Phase 8D.7.

## Changes
- Replaces invalid `bg-slate-955` classes with `bg-slate-950`.
- Keeps Exception Workspace behaviour unchanged.

## Verification
- npm run typecheck
- npm run lint
- graphify update .

## Guardrails
- Styling cleanup only.
- No data-loading changes.
- No resolve or sync persistence.
- No backend changes.