### PR TITLE
Phase 8D.12A: Create ProductCode requests from Draft Quote decisions

### DIFF
--- a/backend/quotes/services/draft_quote_adapter.py
+++ b/backend/quotes/services/draft_quote_adapter.py
@@ -76,6 +76,30 @@ def build_draft_quote_payload(spe_db: SpotPricingEnvelopeDB) -> Dict[str, Any]:
         else:
             primary_currency = "USD"
 
+    # Fetch pending ProductCodeCreationRequests for this envelope
+    from pricing_v4.models import ProductCodeCreationRequest
+    from quotes.spot_models import DraftQuoteDecisionDB
+
+    # Get all pending creation requests for this envelope
+    pending_request_ids = {
+        str(rid) for rid in ProductCodeCreationRequest.objects.filter(
+            source_envelope=spe_db,
+            status=ProductCodeCreationRequest.STATUS_PENDING
+        ).values_list('id', flat=True)
+    }
+
+    # Retrieve all request_product_code decisions that link to a pending creation request
+    decisions_with_pending_req = DraftQuoteDecisionDB.objects.filter(
+        envelope=spe_db,
+        decision_type="request_product_code"
+    )
+
+    pending_targets = {}
+    for dec in decisions_with_pending_req:
+        req_id = dec.details_json.get("product_code_request_id")
+        if req_id and str(req_id) in pending_request_ids:
+            pending_targets[dec.target_id] = dec.details_json.get("proposed_code")
+
     # 5. Suggested Charges
     suggested_charges = []
     for line in spe_db.charge_lines.all():
@@ -131,6 +155,14 @@ def build_draft_quote_payload(spe_db: SpotPricingEnvelopeDB) -> Dict[str, Any]:
             if status == "needs_review" and not review_reason:
                 review_reason = "Currency inheritance warning: verify if currency is correct."
 
+        # Check if there is a pending ProductCode request for this charge line
+        pending_proposed_code = pending_targets.get(str(line.id))
+        correction_actions = []
+        if pending_proposed_code:
+            line_warnings.append(f"Pending ProductCode Creation Request: proposed code '{pending_proposed_code}'.")
+            review_reason = f"ProductCode creation request '{pending_proposed_code}' is pending admin approval."
+            correction_actions = ["PENDING_ADMIN_REVIEW"]
+
         # Evidence text must not be empty if status is 'suggested'
         source_text = line.source_excerpt or line.source_label or ""
         if not source_text and status == "suggested":
@@ -171,7 +203,7 @@ def build_draft_quote_payload(spe_db: SpotPricingEnvelopeDB) -> Dict[str, Any]:
             "review_reason": review_reason,
             "evidence": evidence,
             "similarity_group_id": line.rule_meta.get('similarity_group_id') if isinstance(line.rule_meta, dict) else None,
-            "correction_actions": []
+            "correction_actions": correction_actions
         })
 
     # 6. Commercial Terms
@@ -202,11 +234,17 @@ def build_draft_quote_payload(spe_db: SpotPricingEnvelopeDB) -> Dict[str, Any]:
             for item in raw_unclassified:
                 if isinstance(item, dict):
                     unclass_id = item.get("id") or f"unclass-{len(unclassified_items)}"
+                    pending_proposed_code = pending_targets.get(str(unclass_id))
+                    
+                    item_review_reason = item.get("review_reason") or "Unclassified commercial-looking item requires operator classification"
+                    if pending_proposed_code:
+                        item_review_reason = f"ProductCode creation request '{pending_proposed_code}' is pending admin approval."
+                        
                     unclassified_items.append({
                         "id": str(unclass_id),
                         "raw_text": item.get("raw_text") or item.get("text") or "Unclassified line",
                         "evidence": item.get("evidence"),
-                        "review_reason": item.get("review_reason") or "Unclassified commercial-looking item requires operator classification"
+                        "review_reason": item_review_reason
                     })
             # Collect ignored items
             raw_ignored = batch.analysis_summary_json.get('ignored_items') or []

--- a/backend/quotes/services/draft_quote_resolve_service.py
+++ b/backend/quotes/services/draft_quote_resolve_service.py
@@ -31,42 +31,41 @@ def apply_draft_quote_decisions(
             
             # 1. Attempt to find target SPEChargeLineDB record if applicable
             charge_line = None
-            if decision_type in ["accept_suggestion", "ignore", "edit_charge", "map_to_product_code"]:
-                try:
-                    target_uuid = uuid.UUID(target_id)
-                    charge_line = envelope.charge_lines.filter(id=target_uuid).first()
-                except (ValueError, TypeError):
-                    charge_line = None
+            try:
+                target_uuid = uuid.UUID(target_id)
+                charge_line = envelope.charge_lines.filter(id=target_uuid).first()
+            except (ValueError, TypeError):
+                charge_line = None
                 
-                if not charge_line:
-                    # Unknown target_id returns rejected/skipped result
-                    err_result = DecisionResultSchema(
-                        decision_id=dec_item.decision_id,
-                        target_id=target_id,
-                        type=decision_type,
-                        status="rejected",
-                        message="Target charge line ID not found in this envelope.",
-                        error_code="TARGET_NOT_FOUND"
-                    )
-                    rejected.append(err_result)
-                    
-                    # Persist the rejected decision for audit trail
-                    DraftQuoteDecisionDB.objects.create(
-                        envelope=envelope,
-                        idempotency_key=payload.idempotency_key,
-                        decision_id=dec_item.decision_id,
-                        decision_type=decision_type,
-                        target_id=target_id,
-                        details_json=dec_item.details,
-                        client_audit_metadata_json=dec_item.audit_metadata.model_dump(),
-                        server_user=user,
-                        status="rejected",
-                        error_code="TARGET_NOT_FOUND",
-                        message="Target charge line ID not found in this envelope."
-                    )
-                    continue
+            if not charge_line and decision_type in ["accept_suggestion", "ignore", "edit_charge", "map_to_product_code"]:
+                # Unknown target_id returns rejected/skipped result
+                err_result = DecisionResultSchema(
+                    decision_id=dec_item.decision_id,
+                    target_id=target_id,
+                    type=decision_type,
+                    status="rejected",
+                    message="Target charge line ID not found in this envelope.",
+                    error_code="TARGET_NOT_FOUND"
+                )
+                rejected.append(err_result)
+                
+                # Persist the rejected decision for audit trail
+                DraftQuoteDecisionDB.objects.create(
+                    envelope=envelope,
+                    idempotency_key=payload.idempotency_key,
+                    decision_id=dec_item.decision_id,
+                    decision_type=decision_type,
+                    target_id=target_id,
+                    details_json=dec_item.details,
+                    client_audit_metadata_json=dec_item.audit_metadata.model_dump(),
+                    server_user=user,
+                    status="rejected",
+                    error_code="TARGET_NOT_FOUND",
+                    message="Target charge line ID not found in this envelope."
+                )
+                continue
 
-            # 3. Apply changes to DB for low-risk types if not already mutated
+            # 2. Apply changes to DB for low-risk types if not already mutated
             status_val = "accepted"
             message_val = "Decision persisted and applied successfully."
             error_code_val = None
@@ -86,7 +85,41 @@ def apply_draft_quote_decisions(
                 else:
                     charge_line.exclude_from_totals = True
                     charge_line.save()
-            elif decision_type in ["edit_charge", "map_to_product_code", "request_product_code", "classify_unclassified"]:
+            elif decision_type == "request_product_code":
+                from pricing_v4.models import ProductCodeCreationRequest
+                
+                # Extract details
+                proposed_code = dec_item.details.get("proposed_code", "")
+                description = dec_item.details.get("description", "")
+                category = dec_item.details.get("category", "")
+                reason = dec_item.details.get("reason", "")
+                
+                source_label = description
+                if charge_line:
+                    source_label = charge_line.source_label or charge_line.description
+                
+                # Create pending ProductCodeCreationRequest
+                pc_request = ProductCodeCreationRequest.objects.create(
+                    source_label=source_label,
+                    suggested_name=proposed_code,
+                    suggested_bucket=category,
+                    suggested_basis="FLAT",
+                    suggested_reason=reason,
+                    source_envelope=envelope,
+                    source_charge_line=charge_line,
+                    source_quote=envelope.quote if hasattr(envelope, 'quote') else None,
+                    source_context_json=dec_item.details,
+                    created_by=user,
+                    status=ProductCodeCreationRequest.STATUS_PENDING
+                )
+                
+                # Store the request ID in details for later lookup
+                dec_item.details["product_code_request_id"] = pc_request.id
+                
+                status_val = "skipped"
+                response_status = "skipped"
+                message_val = "ProductCode request created and pending admin review."
+            elif decision_type in ["edit_charge", "map_to_product_code", "classify_unclassified"]:
                 # High-risk skipped decisions must remain status='skipped'
                 status_val = "skipped"
                 response_status = "skipped"

--- a/backend/quotes/tests/test_draft_quote_api.py
+++ b/backend/quotes/tests/test_draft_quote_api.py
@@ -456,6 +456,64 @@ def test_draft_quote_resolve_endpoint(transactional_db):
     ignored_charge = next(c for c in read_schema.suggested_charges if c.id == str(line_ignore.id))
     assert ignored_charge.status == "ignored"
 
+    # Test ProductCodeRequest creation (Phase 8D.12A)
+    payload_pc_req = {
+        "idempotency_key": "4c9b2520-22c5-4309-88cc-51e6b3648614",
+        "decisions": [
+            {
+                "decision_id": "dec-006",
+                "type": "request_product_code",
+                "target_id": str(line_edit.id),
+                "details": {
+                    "proposed_code": "AF-FUEL-NEW",
+                    "description": "Fuel Surcharge - special import surcharge",
+                    "category": "airfreight",
+                    "domain": "IMPORT",
+                    "reason": "New airline carrier fee added for fuel"
+                },
+                "audit_metadata": {
+                    "user_id": 999,
+                    "timestamp": "2026-07-03T00:00:00Z"
+                }
+            }
+        ]
+    }
+    res_pc = client.post(url, payload_pc_req, format="json")
+    assert res_pc.status_code == 200
+    resp_pc = DraftQuoteResolveResponseSchema(**res_pc.data)
+    assert resp_pc.status == "accepted"
+    # Result must be skipped
+    assert resp_pc.applied_decisions[0].status == "skipped"
+    assert "pending admin review" in resp_pc.applied_decisions[0].message
+    
+    # Assert that one ProductCodeCreationRequest is created with PENDING status
+    from pricing_v4.models import ProductCodeCreationRequest
+    req_objs = ProductCodeCreationRequest.objects.filter(source_envelope=envelope)
+    assert req_objs.count() == 1
+    req_obj = req_objs.first()
+    assert req_obj.suggested_name == "AF-FUEL-NEW"
+    assert req_obj.status == ProductCodeCreationRequest.STATUS_PENDING
+    assert req_obj.source_charge_line == line_edit
+    assert req_obj.created_by == user
+
+    # Assert that retry with same idempotency_key does not create a duplicate ProductCodeCreationRequest
+    res_retry_pc = client.post(url, payload_pc_req, format="json")
+    assert res_retry_pc.status_code == 200
+    assert ProductCodeCreationRequest.objects.filter(source_envelope=envelope).count() == 1
+
+    # Assert that high-risk skipped decisions remain skipped on retry
+    resp_retry_pc = DraftQuoteResolveResponseSchema(**res_retry_pc.data)
+    assert resp_retry_pc.applied_decisions[0].status == "skipped"
+
+    # Assert that Read API reflects the pending state correctly
+    res_read_pending = client.get(f"/api/v3/spot/envelopes/{envelope.id}/draft-quote/")
+    assert res_read_pending.status_code == 200
+    read_data = DraftQuoteSchema(**res_read_pending.data)
+    edit_charge = next(c for c in read_data.suggested_charges if c.id == str(line_edit.id))
+    assert edit_charge.correction_actions == ["PENDING_ADMIN_REVIEW"]
+    assert any("Pending ProductCode Creation Request" in w for w in edit_charge.warnings)
+
+
     # 9. Same idempotency_key on a different envelope must not return decisions from another envelope (isolated namespaces)
     envelope_2 = SpotPricingEnvelopeDB.objects.create(
         status=SpotPricingEnvelopeDB.Status.DRAFT,


### PR DESCRIPTION
## Summary

Creates pending ProductCodeCreationRequest records from Draft Quote request_product_code decisions.

## Verification
- pytest backend/quotes/tests/test_draft_quote_api.py
- python backend/manage.py test quotes.tests.test_draft_quote_contract
- python backend/manage.py makemigrations --check

## Guardrails
- No ProductCode creation or approval.
- No catalog mutation.
- No SPEChargeLineDB product_code mutation.
- No frontend/admin UI changes.