### PR TITLE
Phase 8D.13: Consume approved ProductCodes in Exception Workspace

### DIFF
--- a/backend/quotes/contracts/draft_quote_contract.py
+++ b/backend/quotes/contracts/draft_quote_contract.py
@@ -24,6 +24,9 @@ class DraftChargeSchema(BaseModel):
     raw_label: str = Field(..., description="Raw text label from document")
     suggested_product_code: Optional[str] = Field(None, description="Inferred ERP product code")
     product_code_conflict: bool = Field(False, description="True if product code mapping is ambiguous")
+    approved_product_code: Optional[str] = Field(None, description="Approved ProductCode code from request")
+    approved_product_code_id: Optional[int] = Field(None, description="Approved ProductCode ID from request")
+    product_code_request_id: Optional[int] = Field(None, description="ID of the approved ProductCodeCreationRequest")
     bucket: str = Field(..., description="Category bucket: airfreight, origin_charges, destination_charges, or other/unclassified")
     currency: str = Field(..., description="3-letter currency code (e.g., USD)")
     amount: Decimal = Field(..., description="Charge monetary amount")
@@ -144,6 +147,11 @@ class RequestProductCodeDetails(BaseModel):
     reason: str = Field(..., description="Operator justification for request")
 
 
+class UseApprovedProductCodeDetails(BaseModel):
+    product_code_request_id: int = Field(..., description="ID of the approved ProductCodeCreationRequest")
+    product_code_id: int = Field(..., description="ID of the approved ProductCode")
+
+
 class IgnoreDetails(BaseModel):
     reason: str = Field(..., description="Reason why item is ignored (must not be empty)")
 
@@ -187,6 +195,7 @@ class DecisionItemSchema(BaseModel):
             "ignore",
             "edit_charge",
             "classify_unclassified",
+            "use_approved_product_code",
         }
         if self.type not in valid_types:
             raise ValueError(f"Invalid decision type: {self.type}")
@@ -195,6 +204,8 @@ class DecisionItemSchema(BaseModel):
             MapToProductCodeDetails(**self.details)
         elif self.type == "request_product_code":
             RequestProductCodeDetails(**self.details)
+        elif self.type == "use_approved_product_code":
+            UseApprovedProductCodeDetails(**self.details)
         elif self.type == "ignore":
             IgnoreDetails(**self.details)
             if not self.details.get("reason") or not str(self.details["reason"]).strip():

--- a/backend/quotes/services/draft_quote_adapter.py
+++ b/backend/quotes/services/draft_quote_adapter.py
@@ -101,14 +101,22 @@ def build_draft_quote_payload(spe_db: SpotPricingEnvelopeDB) -> Dict[str, Any]:
             req_obj = envelope_requests[str(req_id)]
             # Derive status directly from ProductCodeCreationRequest.status
             if req_obj.status == ProductCodeCreationRequest.STATUS_PENDING:
-                pending_targets[dec.target_id] = req_obj.suggested_name
+                pending_targets[dec.target_id] = {
+                    "proposed_code": req_obj.suggested_name,
+                    "request_id": req_obj.id
+                }
             elif req_obj.status == ProductCodeCreationRequest.STATUS_APPROVED:
                 approved_code = req_obj.approved_product_code.code if req_obj.approved_product_code else req_obj.suggested_name
-                approved_targets[dec.target_id] = approved_code
+                approved_targets[dec.target_id] = {
+                    "code": approved_code,
+                    "request_id": req_obj.id,
+                    "product_code_id": req_obj.approved_product_code_id
+                }
             elif req_obj.status == ProductCodeCreationRequest.STATUS_REJECTED:
                 rejected_targets[dec.target_id] = {
                     "proposed_code": req_obj.suggested_name,
-                    "reason": req_obj.rejection_reason or "No reason provided."
+                    "reason": req_obj.rejection_reason or "No reason provided.",
+                    "request_id": req_obj.id
                 }
 
     # 5. Suggested Charges
@@ -167,23 +175,35 @@ def build_draft_quote_payload(spe_db: SpotPricingEnvelopeDB) -> Dict[str, Any]:
                 review_reason = "Currency inheritance warning: verify if currency is correct."
 
         # Check if there is a ProductCode request for this charge line and map state
-        pending_proposed_code = pending_targets.get(str(line.id))
-        approved_proposed_code = approved_targets.get(str(line.id))
+        pending_info = pending_targets.get(str(line.id))
+        approved_info = approved_targets.get(str(line.id))
         rejected_info = rejected_targets.get(str(line.id))
 
+        approved_product_code = None
+        approved_product_code_id = None
+        product_code_request_id = None
+
         correction_actions = []
-        if pending_proposed_code:
-            line_warnings.append(f"Pending ProductCode Creation Request: proposed code '{pending_proposed_code}'.")
-            review_reason = f"ProductCode creation request '{pending_proposed_code}' is pending admin approval."
+        if pending_info:
+            proposed_code = pending_info["proposed_code"]
+            line_warnings.append(f"Pending ProductCode Creation Request: proposed code '{proposed_code}'.")
+            review_reason = f"ProductCode creation request '{proposed_code}' is pending admin approval."
             correction_actions = ["PENDING_ADMIN_REVIEW"]
-        elif approved_proposed_code:
-            line_warnings.append(f"ProductCode Creation Request Approved: '{approved_proposed_code}' is available to apply.")
-            review_reason = f"ProductCode creation request approved: '{approved_proposed_code}' is available to apply."
+            product_code_request_id = pending_info["request_id"]
+        elif approved_info:
+            code = approved_info["code"]
+            line_warnings.append(f"ProductCode Creation Request Approved: '{code}' is available to apply.")
+            review_reason = f"ProductCode creation request approved: '{code}' is available to apply."
             correction_actions = ["APPROVED_PRODUCTCODE_AVAILABLE"]
+            approved_product_code = code
+            approved_product_code_id = approved_info["product_code_id"]
+            product_code_request_id = approved_info["request_id"]
         elif rejected_info:
-            line_warnings.append(f"ProductCode Creation Request Rejected: '{rejected_info['proposed_code']}'. Reason: {rejected_info['reason']}")
+            proposed_code = rejected_info["proposed_code"]
+            line_warnings.append(f"ProductCode Creation Request Rejected: '{proposed_code}'. Reason: {rejected_info['reason']}")
             review_reason = f"ProductCode creation request rejected: {rejected_info['reason']}"
             correction_actions = ["PRODUCTCODE_REJECTED"]
+            product_code_request_id = rejected_info["request_id"]
 
         # Evidence text must not be empty if status is 'suggested'
         source_text = line.source_excerpt or line.source_label or ""
@@ -210,6 +230,9 @@ def build_draft_quote_payload(spe_db: SpotPricingEnvelopeDB) -> Dict[str, Any]:
             "raw_label": line.source_label or line.description or "",
             "suggested_product_code": suggested_code,
             "product_code_conflict": product_code_conflict,
+            "approved_product_code": approved_product_code,
+            "approved_product_code_id": approved_product_code_id,
+            "product_code_request_id": product_code_request_id,
             "bucket": bucket_val,
             "currency": line.currency or "PGK",
             "amount": Decimal(str(line.amount or 0.00)),

--- a/backend/quotes/services/draft_quote_resolve_service.py
+++ b/backend/quotes/services/draft_quote_resolve_service.py
@@ -120,7 +120,7 @@ def apply_draft_quote_decisions(
                 response_status = "skipped"
                 message_val = "ProductCode request created and pending admin review."
             elif decision_type == "use_approved_product_code":
-                from pricing_v4.models import ProductCodeCreationRequest, ProductCode
+                from pricing_v4.models import ProductCodeCreationRequest
 
                 # Extract details
                 req_id = dec_item.details.get("product_code_request_id")

--- a/backend/quotes/services/draft_quote_resolve_service.py
+++ b/backend/quotes/services/draft_quote_resolve_service.py
@@ -37,7 +37,7 @@ def apply_draft_quote_decisions(
             except (ValueError, TypeError):
                 charge_line = None
                 
-            if not charge_line and decision_type in ["accept_suggestion", "ignore", "edit_charge", "map_to_product_code"]:
+            if not charge_line and decision_type in ["accept_suggestion", "ignore", "edit_charge", "map_to_product_code", "use_approved_product_code"]:
                 # Unknown target_id returns rejected/skipped result
                 err_result = DecisionResultSchema(
                     decision_id=dec_item.decision_id,
@@ -119,6 +119,64 @@ def apply_draft_quote_decisions(
                 status_val = "skipped"
                 response_status = "skipped"
                 message_val = "ProductCode request created and pending admin review."
+            elif decision_type == "use_approved_product_code":
+                from pricing_v4.models import ProductCodeCreationRequest, ProductCode
+
+                # Extract details
+                req_id = dec_item.details.get("product_code_request_id")
+                pc_id = dec_item.details.get("product_code_id")
+
+                pc_request = None
+                if req_id:
+                    try:
+                        pc_request = ProductCodeCreationRequest.objects.filter(id=req_id).first()
+                    except (ValueError, TypeError):
+                        pass
+
+                if not pc_request:
+                    status_val = "rejected"
+                    response_status = "rejected"
+                    error_code_val = "REQUEST_NOT_FOUND"
+                    message_val = f"ProductCodeCreationRequest with ID {req_id} not found."
+                elif str(pc_request.source_envelope_id) != str(envelope.id):
+                    status_val = "rejected"
+                    response_status = "rejected"
+                    error_code_val = "INVALID_REQUEST_SOURCE"
+                    message_val = "ProductCodeCreationRequest does not belong to the same envelope."
+                elif charge_line and pc_request.source_charge_line_id and str(pc_request.source_charge_line_id) != str(charge_line.id):
+                    status_val = "rejected"
+                    response_status = "rejected"
+                    error_code_val = "INVALID_REQUEST_SOURCE"
+                    message_val = "ProductCodeCreationRequest does not belong to the same charge line."
+                elif pc_request.status != ProductCodeCreationRequest.STATUS_APPROVED:
+                    status_val = "rejected"
+                    response_status = "rejected"
+                    error_code_val = "REQUEST_NOT_APPROVED"
+                    message_val = f"ProductCodeCreationRequest status is {pc_request.status}, must be APPROVED."
+                elif not pc_request.approved_product_code_id:
+                    status_val = "rejected"
+                    response_status = "rejected"
+                    error_code_val = "MISSING_APPROVED_PRODUCT_CODE"
+                    message_val = "ProductCodeCreationRequest does not have an approved product code."
+                elif pc_id and int(pc_id) != pc_request.approved_product_code_id:
+                    status_val = "rejected"
+                    response_status = "rejected"
+                    error_code_val = "PRODUCT_CODE_MISMATCH"
+                    message_val = f"Provided product_code_id {pc_id} does not match approved ProductCode ID {pc_request.approved_product_code_id}."
+                else:
+                    if charge_line:
+                        if charge_line.manual_resolution_status == SPEChargeLineDB.ManualResolutionStatus.RESOLVED and charge_line.manual_resolved_product_code_id == pc_request.approved_product_code_id:
+                            message_val = "Decision logged. Target was already resolved with the approved ProductCode."
+                        else:
+                            charge_line.manual_resolved_product_code = pc_request.approved_product_code
+                            charge_line.manual_resolution_status = SPEChargeLineDB.ManualResolutionStatus.RESOLVED
+                            charge_line.manual_resolution_by = user
+                            charge_line.manual_resolution_at = timezone.now()
+                            charge_line.save()
+                            message_val = "Approved ProductCode applied successfully."
+                    else:
+                        message_val = "Approved ProductCode validated, but target charge line was not found."
+
             elif decision_type in ["edit_charge", "map_to_product_code", "classify_unclassified"]:
                 # High-risk skipped decisions must remain status='skipped'
                 status_val = "skipped"
@@ -146,7 +204,8 @@ def apply_draft_quote_decisions(
                     target_id=target_id,
                     type=decision_type,
                     status=response_status,
-                    message=message_val
+                    message=message_val,
+                    error_code=error_code_val
                 )
             )
 

--- a/backend/quotes/tests/test_draft_quote_api.py
+++ b/backend/quotes/tests/test_draft_quote_api.py
@@ -657,6 +657,169 @@ def test_draft_quote_resolve_endpoint(transactional_db):
     assert DraftQuoteDecisionDB.objects.filter(idempotency_key="8e9b2520-22c5-4309-88cc-51e6b3648612").count() == 6
 
 
+@pytest.mark.django_db
+def test_resolve_use_approved_product_code():
+    from pricing_v4.models import ProductCodeCreationRequest, ProductCode
+    from quotes.spot_models import SpotPricingEnvelopeDB, SPEChargeLineDB, DraftQuoteDecisionDB
+    from quotes.contracts.draft_quote_contract import DraftQuoteResolveResponseSchema
+    from rest_framework.test import APIClient
+    from django.contrib.auth import get_user_model
+    import uuid
+
+    User = get_user_model()
+    user = User.objects.create_user(username="test_operator", password="password")
+    
+    envelope = SpotPricingEnvelopeDB.objects.create(
+        status=SpotPricingEnvelopeDB.Status.DRAFT,
+        shipment_context_json={
+            "origin_code": "SIN",
+            "destination_code": "POM",
+            "mode": "AIR",
+            "pieces": 3,
+            "actual_weight_kg": 150.0,
+            "chargeable_weight_kg": 200.0,
+            "commodity": "GCR",
+            "origin_country": "SG",
+            "destination_country": "PG",
+            "supplier_name": "Qantas Air Cargo"
+        },
+        shipment_context_hash="mock_hash_value_approved",
+        expires_at=timezone.now() + timezone.timedelta(days=7),
+        created_by=user
+    )
+    
+    charge_line = SPEChargeLineDB.objects.create(
+        envelope=envelope,
+        code="TEST-CHARGE",
+        description="Test Charge Line",
+        amount=100.00,
+        currency="USD",
+        unit="flat",
+        bucket="origin_charges",
+        entered_at=timezone.now()
+    )
+
+    product_code = ProductCode.objects.create(
+        id=9999,
+        code="APPROVED-PC-9999",
+        description="Approved Product Code",
+        domain=ProductCode.DOMAIN_IMPORT,
+        category=ProductCode.CATEGORY_SURCHARGE,
+        is_gst_applicable=False,
+        gl_revenue_code="4000",
+        gl_cost_code="5000",
+        default_unit=ProductCode.UNIT_SHIPMENT
+    )
+
+    # 1. Approved request setup
+    req_approved = ProductCodeCreationRequest.objects.create(
+        source_label="Test Charge Line",
+        suggested_name="TEST-CHARGE",
+        suggested_bucket="origin_charges",
+        suggested_basis="FLAT",
+        source_envelope=envelope,
+        source_charge_line=charge_line,
+        status=ProductCodeCreationRequest.STATUS_APPROVED,
+        approved_product_code=product_code,
+        created_by=user
+    )
+
+    # 2. Pending request setup
+    req_pending = ProductCodeCreationRequest.objects.create(
+        source_label="Test Charge Line 2",
+        suggested_name="TEST-CHARGE-2",
+        suggested_bucket="origin_charges",
+        suggested_basis="FLAT",
+        source_envelope=envelope,
+        source_charge_line=charge_line,
+        status=ProductCodeCreationRequest.STATUS_PENDING,
+        created_by=user
+    )
+
+    # 3. Rejected request setup
+    req_rejected = ProductCodeCreationRequest.objects.create(
+        source_label="Test Charge Line 3",
+        suggested_name="TEST-CHARGE-3",
+        suggested_bucket="origin_charges",
+        suggested_basis="FLAT",
+        source_envelope=envelope,
+        source_charge_line=charge_line,
+        status=ProductCodeCreationRequest.STATUS_REJECTED,
+        created_by=user
+    )
+
+    client = APIClient()
+    client.force_authenticate(user=user)
+    url = f"/api/v3/spot/envelopes/{envelope.id}/draft-quote/resolve/"
+
+    # Test pending request cannot be consumed
+    payload_pending = {
+        "idempotency_key": str(uuid.uuid4()),
+        "decisions": [{
+            "decision_id": "dec-pending",
+            "type": "use_approved_product_code",
+            "target_id": str(charge_line.id),
+            "details": {
+                "product_code_request_id": str(req_pending.id),
+                "product_code_id": product_code.id
+            },
+            "audit_metadata": {"user_id": user.id, "timestamp": "2026-07-03T00:00:00Z"}
+        }]
+    }
+    res = client.post(url, payload_pending, format="json")
+    assert res.status_code == 200
+    assert res.data["applied_decisions"][0]["error_code"] == "REQUEST_NOT_APPROVED"
+
+    # Test rejected request cannot be consumed
+    payload_rejected = {
+        "idempotency_key": str(uuid.uuid4()),
+        "decisions": [{
+            "decision_id": "dec-rejected",
+            "type": "use_approved_product_code",
+            "target_id": str(charge_line.id),
+            "details": {
+                "product_code_request_id": str(req_rejected.id),
+                "product_code_id": product_code.id
+            },
+            "audit_metadata": {"user_id": user.id, "timestamp": "2026-07-03T00:00:00Z"}
+        }]
+    }
+    res = client.post(url, payload_rejected, format="json")
+    assert res.status_code == 200
+    assert res.data["applied_decisions"][0]["error_code"] == "REQUEST_NOT_APPROVED"
+
+    # Test approved request can be consumed
+    ik = str(uuid.uuid4())
+    payload_approved = {
+        "idempotency_key": ik,
+        "decisions": [{
+            "decision_id": "dec-approved",
+            "type": "use_approved_product_code",
+            "target_id": str(charge_line.id),
+            "details": {
+                "product_code_request_id": str(req_approved.id),
+                "product_code_id": product_code.id
+            },
+            "audit_metadata": {"user_id": user.id, "timestamp": "2026-07-03T00:00:00Z"}
+        }]
+    }
+    res = client.post(url, payload_approved, format="json")
+    assert res.status_code == 200
+    assert len(res.data["applied_decisions"]) == 1
+    assert res.data["applied_decisions"][0]["status"] == "applied"
+
+    # Verify database updates
+    charge_line.refresh_from_db()
+    assert charge_line.manual_resolved_product_code == product_code
+    assert charge_line.manual_resolution_status == SPEChargeLineDB.ManualResolutionStatus.RESOLVED
+
+    # Test idempotent replay returns cached decision and does not mutate twice
+    res_replay = client.post(url, payload_approved, format="json")
+    assert res_replay.status_code == 200
+    assert "retrieved from database history" in res_replay.data["message"]
+
+
+
 
 
 

--- a/frontend/src/app/quotes/spot/[speId]/exception-workspace/page.tsx
+++ b/frontend/src/app/quotes/spot/[speId]/exception-workspace/page.tsx
@@ -124,7 +124,7 @@ export default function ExceptionWorkspaceLivePage() {
 
   return (
     <div className="w-full min-h-screen bg-slate-950">
-      <ExceptionWorkspace initialData={data} isLive={true} />
+      <ExceptionWorkspace initialData={data} isLive={true} envelopeId={speId} />
     </div>
   );
 }

--- a/frontend/src/components/spot/ExceptionWorkspace.tsx
+++ b/frontend/src/components/spot/ExceptionWorkspace.tsx
@@ -51,7 +51,7 @@ interface Decision {
     };
 }
 
-export function ExceptionWorkspace({ initialData = hardCaseAirImportData, isLive = false }: { initialData?: DraftQuote; isLive?: boolean }) {
+export function ExceptionWorkspace({ initialData = hardCaseAirImportData, isLive = false, envelopeId }: { initialData?: DraftQuote; isLive?: boolean; envelopeId?: string }) {
     // Single state containers for mock database updates
     const [draftQuote] = useState(initialData);
     const [explainTotals, setExplainTotals] = useState(false);
@@ -123,6 +123,57 @@ export function ExceptionWorkspace({ initialData = hardCaseAirImportData, isLive
             setSelectedActionType(null);
             setUnknownStep(1);
         }
+    };
+
+    const handleUseApprovedProductCode = async (chargeId: string, charge: DraftCharge) => {
+        const reqId = charge.product_code_request_id;
+        const pcId = charge.approved_product_code_id;
+        const code = charge.approved_product_code || charge.suggested_product_code || "";
+
+        if (!reqId || !pcId) {
+            setActionMessage("Missing approved ProductCode request metadata.");
+            return;
+        }
+
+        const decisionId = `dec-${Date.now()}`;
+        const newDecisionItem = {
+            decision_id: decisionId,
+            type: "use_approved_product_code",
+            target_id: chargeId,
+            details: {
+                product_code_request_id: Number(reqId),
+                product_code_id: Number(pcId)
+            },
+            audit_metadata: {
+                user_id: 1,
+                timestamp: new Date().toISOString()
+            }
+        };
+
+        if (isLive && envelopeId) {
+            try {
+                const { resolveDraftQuoteDecisions } = await import("../../lib/api");
+                const payload = {
+                    idempotency_key: crypto.randomUUID ? crypto.randomUUID() : "3b128522-a89e-4055-bf51-199eecc5628b",
+                    decisions: [newDecisionItem]
+                };
+                await resolveDraftQuoteDecisions(envelopeId, payload);
+            } catch (err) {
+                console.error("Failed to submit resolve decision:", err);
+                const errMsg = err instanceof Error ? err.message : String(err);
+                setActionMessage(`API error resolving mapping: ${errMsg}`);
+                return;
+            }
+        }
+
+        // Apply locally
+        captureSnapshot(chargeId, "map", `Used approved billing code ${code} for ${charge.display_label}`);
+        setSuggestedCharges(prev =>
+            prev.map(c => (c.id === chargeId ? { ...c, suggested_product_code: code, status: "accepted_by_user" as DraftChargeStatus } : c))
+        );
+        setReviewQueue(prev => prev.filter(q => q.id !== chargeId));
+        setActionMessage(`Approved billing code ${code} applied successfully to ${charge.display_label}.`);
+        setSelectedActionType(null);
     };
 
     // Action execution helpers
@@ -402,33 +453,58 @@ export function ExceptionWorkspace({ initialData = hardCaseAirImportData, isLive
                         {selectedActionType === null ? (
                             <div className="flex flex-col gap-4">
                                 {currentIssue.type === "review_item" && currentIssue.charge ? (
-                                    <div className="flex flex-wrap gap-2">
-                                        <button
-                                            onClick={() => setSelectedActionType("map_existing")}
-                                            className="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg text-xs font-semibold transition"
-                                        >
-                                            Map to Existing ProductCode
-                                        </button>
-                                        <button
-                                            onClick={() => handleOpenRequestProductCode(currentIssue.charge!)}
-                                            className="px-4 py-2 bg-slate-950 hover:bg-slate-900 border border-slate-800 text-slate-200 rounded-lg text-xs font-semibold transition"
-                                        >
-                                            Request New ProductCode
-                                        </button>
-                                        {currentIssue.charge.suggested_product_code && (
-                                            <button
-                                                onClick={() => handleAcceptSuggestedMapping(currentIssue.id, currentIssue.title, currentIssue.charge!.suggested_product_code!)}
-                                                className="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 text-white rounded-lg text-xs font-semibold transition"
-                                            >
-                                                Accept Suggested Mapping ({currentIssue.charge.suggested_product_code})
-                                            </button>
+                                    <div className="flex flex-col gap-4">
+                                        {currentIssue.charge.correction_actions?.includes("APPROVED_PRODUCTCODE_AVAILABLE") && (
+                                            <div className="bg-emerald-950/20 border border-emerald-900/60 p-4 rounded-xl text-xs flex flex-col gap-2 mb-2">
+                                                <div className="flex items-center gap-2 text-emerald-400 font-bold text-sm">
+                                                    <CheckCircle className="w-4 h-4" />
+                                                    <span>ProductCode Request Approved!</span>
+                                                </div>
+                                                <p className="text-slate-300">
+                                                    The requested billing code <strong className="font-mono text-indigo-300 bg-slate-950 px-1.5 py-0.5 rounded">{currentIssue.charge.approved_product_code}</strong> has been approved by admin. You can directly map and consume this approval.
+                                                </p>
+                                                <div className="text-[10px] text-slate-500 font-mono">
+                                                    Request Context ID: {currentIssue.charge.product_code_request_id}
+                                                </div>
+                                                <div className="mt-2">
+                                                    <button
+                                                        onClick={() => handleUseApprovedProductCode(currentIssue.id, currentIssue.charge!)}
+                                                        className="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 text-white rounded-lg font-semibold transition text-xs"
+                                                    >
+                                                        Use Approved ProductCode ({currentIssue.charge.approved_product_code})
+                                                    </button>
+                                                </div>
+                                            </div>
                                         )}
-                                        <button
-                                            onClick={() => handleIgnoreCharge(currentIssue.id, currentIssue.charge!)}
-                                            className="px-4 py-2 bg-slate-950 hover:bg-slate-900 border border-slate-800 text-red-400 rounded-lg text-xs font-semibold transition"
-                                        >
-                                            Ignore as Non-Commercial
-                                        </button>
+
+                                        <div className="flex flex-wrap gap-2">
+                                            <button
+                                                onClick={() => setSelectedActionType("map_existing")}
+                                                className="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg text-xs font-semibold transition"
+                                            >
+                                                Map to Existing ProductCode
+                                            </button>
+                                            <button
+                                                onClick={() => handleOpenRequestProductCode(currentIssue.charge!)}
+                                                className="px-4 py-2 bg-slate-950 hover:bg-slate-900 border border-slate-800 text-slate-200 rounded-lg text-xs font-semibold transition"
+                                            >
+                                                Request New ProductCode
+                                            </button>
+                                            {currentIssue.charge.suggested_product_code && !currentIssue.charge.correction_actions?.includes("APPROVED_PRODUCTCODE_AVAILABLE") && (
+                                                <button
+                                                    onClick={() => handleAcceptSuggestedMapping(currentIssue.id, currentIssue.title, currentIssue.charge!.suggested_product_code!)}
+                                                    className="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 text-white rounded-lg text-xs font-semibold transition"
+                                                >
+                                                    Accept Suggested Mapping ({currentIssue.charge.suggested_product_code})
+                                                </button>
+                                            )}
+                                            <button
+                                                onClick={() => handleIgnoreCharge(currentIssue.id, currentIssue.charge!)}
+                                                className="px-4 py-2 bg-slate-950 hover:bg-slate-900 border border-slate-800 text-red-400 rounded-lg text-xs font-semibold transition"
+                                            >
+                                                Ignore as Non-Commercial
+                                            </button>
+                                        </div>
                                     </div>
                                 ) : currentIssue.itemDetails ? (
                                     /* Unknown Charge Guided flow wizard */

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4,7 +4,7 @@ import { API_BASE_URL } from './config';
 import { getJson, sendJson } from './api/shared';
 import { mapQuoteDetailToComputeResult } from './quote-detail-mapping';
 import { ReplyAnalysisResult, SPEChargeLine, SPEConditions, SPECommodity } from './spot-types';
-import { DraftQuote } from './draft-quote-types';
+import { DraftQuote, DraftQuoteResolvePayload, DraftQuoteResolveResponse } from './draft-quote-types';
 import {
   LoginData,
   User,
@@ -810,8 +810,8 @@ export async function getDraftQuote(id: string): Promise<DraftQuote> {
  */
 export async function resolveDraftQuoteDecisions(
   envelopeId: string,
-  payload: { idempotency_key: string; decisions: any[] }
-): Promise<any> {
+  payload: DraftQuoteResolvePayload
+): Promise<DraftQuoteResolveResponse> {
   const url = API_BASE_URL + `/api/v3/spot/envelopes/${envelopeId}/draft-quote/resolve/`;
   const response = await fetch(url, {
     method: 'POST',
@@ -827,7 +827,7 @@ export async function resolveDraftQuoteDecisions(
     throw new Error(`Failed to resolve draft quote decisions: ${detail}`);
   }
 
-  return response.json();
+  return response.json() as Promise<DraftQuoteResolveResponse>;
 }
 
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -806,6 +806,32 @@ export async function getDraftQuote(id: string): Promise<DraftQuote> {
 
 
 /**
+ * Submit operator decisions to resolve exceptions for a draft quote.
+ */
+export async function resolveDraftQuoteDecisions(
+  envelopeId: string,
+  payload: { idempotency_key: string; decisions: any[] }
+): Promise<any> {
+  const url = API_BASE_URL + `/api/v3/spot/envelopes/${envelopeId}/draft-quote/resolve/`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Token ${resolveAuthToken()}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const detail = await parseErrorResponse(response);
+    throw new Error(`Failed to resolve draft quote decisions: ${detail}`);
+  }
+
+  return response.json();
+}
+
+
+/**
  * Submit Sales acknowledgement for SPE.
  */
 export async function acknowledgeSpotEnvelope(

--- a/frontend/src/lib/draft-quote-types.ts
+++ b/frontend/src/lib/draft-quote-types.ts
@@ -22,7 +22,7 @@ export interface DraftCharge {
     product_code_conflict: boolean;
     approved_product_code?: string | null;
     approved_product_code_id?: number | null;
-    product_code_request_id?: string | null;
+    product_code_request_id?: number | null;
     bucket: string; // airfreight, origin_charges, destination_charges, unclassified
     currency: string;
     amount: number;
@@ -122,4 +122,39 @@ export interface DraftQuote {
         historical_override_rules?: Record<string, unknown>;
         [key: string]: unknown;
     };
+}
+
+export interface AuditMetadata {
+    user_id: number;
+    timestamp: string;
+}
+
+export interface DecisionItem {
+    decision_id: string;
+    type: string;
+    target_id: string;
+    details: Record<string, unknown>;
+    audit_metadata: AuditMetadata;
+}
+
+export interface DraftQuoteResolvePayload {
+    idempotency_key: string;
+    decisions: DecisionItem[];
+}
+
+export interface DecisionResult {
+    decision_id: string;
+    target_id: string;
+    type: string;
+    status: 'applied' | 'rejected' | 'skipped';
+    message: string;
+    error_code?: string | null;
+}
+
+export interface DraftQuoteResolveResponse {
+    envelope_id: string;
+    status: 'accepted' | 'partially_accepted' | 'rejected';
+    message: string;
+    applied_decisions: DecisionResult[];
+    rejected_decisions: DecisionResult[];
 }

--- a/frontend/src/lib/draft-quote-types.ts
+++ b/frontend/src/lib/draft-quote-types.ts
@@ -20,6 +20,9 @@ export interface DraftCharge {
     raw_label: string;
     suggested_product_code: string | null;
     product_code_conflict: boolean;
+    approved_product_code?: string | null;
+    approved_product_code_id?: number | null;
+    product_code_request_id?: string | null;
     bucket: string; // airfreight, origin_charges, destination_charges, unclassified
     currency: string;
     amount: number;


### PR DESCRIPTION
## Summary
- Adds `use_approved_product_code` resolve decision.
- Surfaces approved ProductCode metadata in the Draft Quote payload.
- Allows operators to explicitly consume approved ProductCodes from the Exception Workspace.
- Applies approved ProductCode to the charge line with audit/idempotency protection.
- Updates frontend workspace action, API helper, and types.

## Verification
- Backend quote tests passed.
- `npm run typecheck` passed.
- `npm run test:spot-workspace-helpers` passed.
- `graphify update .` completed.

## Notes
- No silent auto-consumption.
- No ProductCode approval/creation logic changed.
- `backend/tmp/` intentionally not committed.