### PR TITLE
feat(rbac): add frontend permission affordances

### DIFF
--- a/frontend/src/app/crm/opportunities/[id]/edit/page.tsx
+++ b/frontend/src/app/crm/opportunities/[id]/edit/page.tsx
@@ -11,9 +11,11 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { getOpportunity } from '@/lib/api/crm';
 import type { Opportunity } from '@/lib/types';
+import { usePermissions } from '@/hooks/usePermissions';
 
 export default function EditOpportunityPage() {
   const params = useParams<{ id: string }>();
+  const { canEditCRM } = usePermissions();
   const [opportunity, setOpportunity] = useState<Opportunity | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -63,7 +65,13 @@ export default function EditOpportunityPage() {
           </div>
         ) : null}
 
-        {loading ? (
+        {!canEditCRM ? (
+          <Card className="border-amber-200 bg-amber-50 shadow-sm">
+            <CardContent className="p-6 text-sm text-amber-900">
+              You do not have permission to edit CRM opportunities.
+            </CardContent>
+          </Card>
+        ) : loading ? (
           <Card className="border-slate-200 shadow-sm">
             <CardContent className="p-6 text-sm text-muted-foreground">Loading opportunity...</CardContent>
           </Card>

--- a/frontend/src/app/crm/opportunities/[id]/page.tsx
+++ b/frontend/src/app/crm/opportunities/[id]/page.tsx
@@ -43,6 +43,7 @@ import {
 } from '@/lib/api/crm';
 import type { CompanySearchResult, Interaction, Opportunity, Task, V3QuoteComputeResponse } from '@/lib/types';
 import { useToast } from '@/context/toast-context';
+import { usePermissions } from '@/hooks/usePermissions';
 
 const interactionLabels: Record<string, string> = {
   CALL: 'Call',
@@ -134,6 +135,7 @@ function TimelineItem({ interaction }: { interaction: Interaction }) {
 export default function OpportunityDetailPage() {
   const params = useParams<{ id: string }>();
   const { toast } = useToast();
+  const { canEditCRM, canEditQuotes } = usePermissions();
   const [opportunity, setOpportunity] = useState<Opportunity | null>(null);
   const [interactions, setInteractions] = useState<Interaction[]>([]);
   const [tasks, setTasks] = useState<Task[]>([]);
@@ -310,20 +312,22 @@ export default function OpportunityDetailPage() {
               <Button variant="outline" asChild>
                 <Link href="/crm/opportunities">Browse All</Link>
               </Button>
-              {opportunity && !isClosed && (
+              {canEditCRM && opportunity && !isClosed && (
                 <>
                   <Button variant="outline" asChild>
                     <Link href={`/crm/opportunities/${opportunity.id}/edit`}>Edit</Link>
                   </Button>
-                  <Button asChild>
-                    <Link href={createQuoteHref}>
-                      <PlusCircle className="mr-2 h-4 w-4" />
-                      Create Quote
-                    </Link>
-                  </Button>
+                  {canEditQuotes ? (
+                    <Button asChild>
+                      <Link href={createQuoteHref}>
+                        <PlusCircle className="mr-2 h-4 w-4" />
+                        Create Quote
+                      </Link>
+                    </Button>
+                  ) : null}
                 </>
               )}
-              {opportunity && (
+              {canEditCRM && opportunity && (
                 <Button type="button" onClick={() => setQuickLogOpen(true)}>
                   Log Activity
                 </Button>
@@ -345,7 +349,7 @@ export default function OpportunityDetailPage() {
         ) : opportunity ? (
           <>
             <div className="mb-6 flex flex-wrap gap-2">
-              {!isClosed && (
+              {canEditCRM && !isClosed && (
                 <>
                   {opportunity.status === 'NEW' && (
                     <Button variant="outline" size="sm" onClick={handleMarkQualified} disabled={Boolean(actionLoading)}>
@@ -358,9 +362,11 @@ export default function OpportunityDetailPage() {
                   <Button variant="outline" size="sm" onClick={() => setLostDialogOpen(true)} disabled={Boolean(actionLoading)} className="text-red-700 hover:text-red-800 hover:bg-red-50">
                     {actionLoading === 'lost' ? 'Saving...' : 'Mark Lost'}
                   </Button>
-                  <Button size="sm" asChild>
-                    <Link href={createQuoteHref}>Create Quote</Link>
-                  </Button>
+                  {canEditQuotes ? (
+                    <Button size="sm" asChild>
+                      <Link href={createQuoteHref}>Create Quote</Link>
+                    </Button>
+                  ) : null}
                 </>
               )}
             </div>
@@ -481,9 +487,11 @@ export default function OpportunityDetailPage() {
                       <CardTitle className="text-lg">Tasks</CardTitle>
                       <CardDescription>Basic tasks linked to this opportunity.</CardDescription>
                     </div>
-                    <Button type="button" variant="outline" size="sm" onClick={openCreateTaskDialog}>
-                      Create Task
-                    </Button>
+                    {canEditCRM ? (
+                      <Button type="button" variant="outline" size="sm" onClick={openCreateTaskDialog}>
+                        Create Task
+                      </Button>
+                    ) : null}
                   </CardHeader>
                   <CardContent className="px-6 pb-6 pt-2">
                     {tasks.length === 0 ? (
@@ -514,7 +522,7 @@ export default function OpportunityDetailPage() {
                                 <TableCell>{formatDate(task.due_date)}</TableCell>
                                 <TableCell>{task.status}</TableCell>
                                 <TableCell className="text-right">
-                                  {task.status === 'PENDING' ? (
+                                  {canEditCRM && task.status === 'PENDING' ? (
                                     <div className="flex justify-end gap-2">
                                       <Button variant="outline" size="sm" onClick={() => openEditTaskDialog(task)}>
                                         Edit

--- a/frontend/src/app/crm/opportunities/new/page.tsx
+++ b/frontend/src/app/crm/opportunities/new/page.tsx
@@ -6,8 +6,12 @@ import { OpportunityForm } from '@/components/crm/OpportunityForm';
 import ProtectedRoute from '@/components/protected-route';
 import { PageHeader, StandardPageContainer } from '@/components/layout/standard-page';
 import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { usePermissions } from '@/hooks/usePermissions';
 
 export default function NewOpportunityPage() {
+  const { canEditCRM } = usePermissions();
+
   return (
     <ProtectedRoute>
       <StandardPageContainer>
@@ -20,7 +24,15 @@ export default function NewOpportunityPage() {
             </Button>
           }
         />
-        <OpportunityForm mode="create" />
+        {canEditCRM ? (
+          <OpportunityForm mode="create" />
+        ) : (
+          <Card className="border-amber-200 bg-amber-50 shadow-sm">
+            <CardContent className="p-6 text-sm text-amber-900">
+              You do not have permission to create CRM opportunities.
+            </CardContent>
+          </Card>
+        )}
       </StandardPageContainer>
     </ProtectedRoute>
   );

--- a/frontend/src/app/crm/opportunities/page.tsx
+++ b/frontend/src/app/crm/opportunities/page.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/ui/table';
 import { listOpportunities } from '@/lib/api/crm';
 import type { Opportunity } from '@/lib/types';
+import { usePermissions } from '@/hooks/usePermissions';
 
 const statusOptions = ['NEW', 'QUALIFIED', 'QUOTED', 'WON', 'LOST'];
 const serviceTypeOptions = ['AIR', 'SEA', 'CUSTOMS', 'DOMESTIC', 'MULTIMODAL'];
@@ -61,6 +62,7 @@ function statusBadgeVariant(status: string) {
 
 export default function OpportunityListPage() {
   const router = useRouter();
+  const { canEditCRM } = usePermissions();
   const [opportunities, setOpportunities] = useState<Opportunity[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -130,11 +132,11 @@ export default function OpportunityListPage() {
         <PageHeader
           title="Opportunities"
           description="Review active and closed CRM opportunities by account, status, and service type."
-          actions={
+          actions={canEditCRM ? (
             <Button asChild>
               <Link href="/crm/opportunities/new">New Opportunity</Link>
             </Button>
-          }
+          ) : null}
         />
 
         <CrmSubNav />

--- a/frontend/src/app/crm/page.tsx
+++ b/frontend/src/app/crm/page.tsx
@@ -30,6 +30,7 @@ import {
 } from '@/lib/crm-engagement-health';
 import type { CompanySearchResult, Interaction, Opportunity, Task } from '@/lib/types';
 import { useToast } from '@/context/toast-context';
+import { usePermissions } from '@/hooks/usePermissions';
 
 const openStatuses = new Set(['NEW', 'QUALIFIED', 'QUOTED']);
 const taskOpenStatuses = new Set(['PENDING']);
@@ -138,6 +139,7 @@ function statusBadgeVariant(status: string) {
 
 export default function CrmOverviewPage() {
   const { toast } = useToast();
+  const { canEditCRM, canEditQuotes } = usePermissions();
   const [opportunities, setOpportunities] = useState<Opportunity[]>([]);
   const [tasks, setTasks] = useState<Task[]>([]);
   const [interactions, setInteractions] = useState<Interaction[]>([]);
@@ -327,14 +329,16 @@ export default function CrmOverviewPage() {
           title="CRM Overview"
           description="Pipeline, follow-ups, and recent CRM activity."
           actions={
-            <>
-              <Button type="button" variant="outline" onClick={() => setQuickLogOpen(true)}>
-                Log Activity
-              </Button>
-              <Button asChild>
-                <Link href="/crm/opportunities/new">New Opportunity</Link>
-              </Button>
-            </>
+            canEditCRM ? (
+              <>
+                <Button type="button" variant="outline" onClick={() => setQuickLogOpen(true)}>
+                  Log Activity
+                </Button>
+                <Button asChild>
+                  <Link href="/crm/opportunities/new">New Opportunity</Link>
+                </Button>
+              </>
+            ) : null
           }
         />
 
@@ -404,11 +408,13 @@ export default function CrmOverviewPage() {
                           <TableCell>{formatDateTime(opportunity.last_activity_at)}</TableCell>
                           <TableCell className="text-right">
                             <div className="flex items-center justify-end gap-1">
-                              <Button variant="ghost" size="sm" asChild title="Create Quote">
-                                <Link href={`/quotes/new?company=${opportunity.company}&opportunity=${opportunity.id}&service_type=${opportunity.service_type}&origin=${opportunity.origin}&destination=${opportunity.destination}`}>
-                                  <PlusCircle className="h-4 w-4" />
-                                </Link>
-                              </Button>
+                              {canEditQuotes ? (
+                                <Button variant="ghost" size="sm" asChild title="Create Quote">
+                                  <Link href={`/quotes/new?company=${opportunity.company}&opportunity=${opportunity.id}&service_type=${opportunity.service_type}&origin=${opportunity.origin}&destination=${opportunity.destination}`}>
+                                    <PlusCircle className="h-4 w-4" />
+                                  </Link>
+                                </Button>
+                              ) : null}
                               <Button variant="ghost" size="sm" asChild>
                                 <Link href={`/crm/opportunities/${opportunity.id}`}>View</Link>
                               </Button>
@@ -502,20 +508,24 @@ export default function CrmOverviewPage() {
                             <TableCell>{openOpportunityCounts.get(customer.id) || 0}</TableCell>
                             <TableCell className="text-right">
                               <div className="flex flex-wrap justify-end gap-2">
-                                <Button type="button" variant="outline" size="sm" onClick={() => handleOpenLogActivity(customer)}>
-                                  Log Activity
-                                </Button>
+                                {canEditCRM ? (
+                                  <Button type="button" variant="outline" size="sm" onClick={() => handleOpenLogActivity(customer)}>
+                                    Log Activity
+                                  </Button>
+                                ) : null}
                                 <Button asChild variant="outline" size="sm">
                                   <Link href={`/customers/${customer.id}/edit?returnTo=%2Fcrm`}>View Account</Link>
                                 </Button>
-                                <Button
-                                  type="button"
-                                  variant="outline"
-                                  size="sm"
-                                  onClick={() => openCreateTaskDialog(customer, days)}
-                                >
-                                  Create Task
-                                </Button>
+                                {canEditCRM ? (
+                                  <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => openCreateTaskDialog(customer, days)}
+                                  >
+                                    Create Task
+                                  </Button>
+                                ) : null}
                               </div>
                             </TableCell>
                           </TableRow>
@@ -600,17 +610,21 @@ export default function CrmOverviewPage() {
                               </div>
                             </div>
                             <div className="flex shrink-0 flex-wrap gap-2 lg:justify-end">
-                              <Button variant="outline" size="sm" onClick={() => openEditTaskDialog(task)}>
-                                Edit
-                              </Button>
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                onClick={() => handleCompleteTask(task.id)}
-                                disabled={completingTaskIds.has(task.id)}
-                              >
-                                {completingTaskIds.has(task.id) ? 'Saving...' : 'Done'}
-                              </Button>
+                              {canEditCRM ? (
+                                <>
+                                  <Button variant="outline" size="sm" onClick={() => openEditTaskDialog(task)}>
+                                    Edit
+                                  </Button>
+                                  <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => handleCompleteTask(task.id)}
+                                    disabled={completingTaskIds.has(task.id)}
+                                  >
+                                    {completingTaskIds.has(task.id) ? 'Saving...' : 'Done'}
+                                  </Button>
+                                </>
+                              ) : null}
                               {company ? (
                                 <Button variant="outline" size="sm" asChild>
                                   <Link href={`/customers/${company.id}/edit?returnTo=%2Fcrm`}>View Account</Link>

--- a/frontend/src/app/quotes/[id]/page.tsx
+++ b/frontend/src/app/quotes/[id]/page.tsx
@@ -47,9 +47,11 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
+import { usePermissions } from "@/hooks/usePermissions";
 
 export default function QuoteDetailPage() {
   const { user } = useAuth();
+  const { canEditQuotes, canUseSpotWorkspace } = usePermissions();
   const params = useParams();
   const router = useRouter();
   const id = params.id as string;
@@ -108,12 +110,12 @@ export default function QuoteDetailPage() {
   }, [id, user]);
 
   useEffect(() => {
-    if (!spotWorkflowHref || redirectingSpotRef.current) {
+    if (!canUseSpotWorkspace || !spotWorkflowHref || redirectingSpotRef.current) {
       return;
     }
     redirectingSpotRef.current = true;
     router.replace(spotWorkflowHref);
-  }, [router, spotWorkflowHref]);
+  }, [canUseSpotWorkspace, router, spotWorkflowHref]);
 
   useEffect(() => {
     if (!quote) {
@@ -330,7 +332,7 @@ export default function QuoteDetailPage() {
     }
   };
 
-  if (spotWorkflowHref) {
+  if (spotWorkflowHref && canUseSpotWorkspace) {
     return (
       <div className="container mx-auto max-w-3xl p-6">
         <Card className="border-slate-200">
@@ -406,7 +408,7 @@ export default function QuoteDetailPage() {
         </div>
         <div className="flex items-center gap-3">
           {/* Only show Back to Edit for editable quotes */}
-          {(!isArchived && (effectiveStatus === "DRAFT" || effectiveStatus === "INCOMPLETE")) && (
+          {canEditQuotes && !isArchived && (effectiveStatus === "DRAFT" || effectiveStatus === "INCOMPLETE") && (
             <Button
               variant="outline"
               onClick={() => router.push(buildQuoteEditHref(quote))}
@@ -416,15 +418,17 @@ export default function QuoteDetailPage() {
               Back to Edit
             </Button>
           )}
-          <QuoteStatusActions
-            quoteId={quote.id}
-            status={quote.status}
-            validUntil={quote.valid_until}
-            hasMissingRates={quote.latest_version?.totals?.has_missing_rates || false}
-            onStatusChange={() => {
-              getQuoteV3(id).then((data) => setQuote(data));
-            }}
-          />
+          {canEditQuotes ? (
+            <QuoteStatusActions
+              quoteId={quote.id}
+              status={quote.status}
+              validUntil={quote.valid_until}
+              hasMissingRates={quote.latest_version?.totals?.has_missing_rates || false}
+              onStatusChange={() => {
+                getQuoteV3(id).then((data) => setQuote(data));
+              }}
+            />
+          ) : null}
         </div>
       </div>
 
@@ -447,7 +451,7 @@ export default function QuoteDetailPage() {
         {isIncomplete ? (
           spotTriggerChecking || !spotTriggerChecked ? (
             <SpotTriggerCheckingCard quote={quote} />
-          ) : isSpotRequired ? (
+          ) : canEditQuotes && canUseSpotWorkspace && isSpotRequired ? (
             <SpotWorkflowRequiredCard
               quote={quote}
               spotLaunching={spotLaunching}
@@ -455,13 +459,19 @@ export default function QuoteDetailPage() {
               onLaunchSpot={handleLaunchSpotWorkflow}
               onReturnToEdit={() => router.push(`/quotes/${quote.id}/edit`)}
             />
-          ) : (
+          ) : canEditQuotes ? (
             <IncompleteQuoteCard
               quote={quote}
               triggerCheckError={spotTriggerCheckError}
               onRetryCheck={handleRetrySpotTriggerCheck}
               onReturnToEdit={() => router.push(`/quotes/${quote.id}/edit`)}
             />
+          ) : (
+            <Card className="border-slate-200 bg-slate-50/60">
+              <CardContent className="p-6 text-sm text-muted-foreground">
+                This quote is incomplete and cannot be edited by your current role.
+              </CardContent>
+            </Card>
           )
         ) : (
           /* Full-width Layout for Finalized Quotes */
@@ -478,6 +488,7 @@ export default function QuoteDetailPage() {
         displayCurrency={displayCurrency}
         displayAmount={displayAmount}
         canDownloadPDF={canDownloadPDF}
+        canEditQuote={canEditQuotes}
         pdfDownloading={pdfDownloading}
         onDownloadPDF={handleDownloadPDF}
         onEditQuote={() => router.push(buildQuoteEditHref(quote))}

--- a/frontend/src/app/quotes/new/page.tsx
+++ b/frontend/src/app/quotes/new/page.tsx
@@ -26,6 +26,7 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
+import { usePermissions } from "@/hooks/usePermissions";
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -44,6 +45,7 @@ const resolveLocationParam = async (value: string | null): Promise<LocationSearc
 
 function NewQuoteContent() {
   const { user } = useAuth();
+  const { canEditQuotes } = usePermissions();
   const router = useRouter();
   const searchParams = useSearchParams();
   const { toast } = useToast();
@@ -109,6 +111,20 @@ function NewQuoteContent() {
   useUnsavedChangesGuard(isFormDirty);
   const returnTo = useReturnTo();
   const pageCopy = getNewQuoteCopy(user?.role as "admin" | "manager" | "sales" | "finance" | undefined);
+
+  if (!canEditQuotes) {
+    return (
+      <div className="container mx-auto max-w-3xl p-4">
+        <PageBackButton fallbackHref="/quotes" returnTo="/quotes" className="mb-4 -ml-2 gap-2 px-2 text-slate-600 hover:text-slate-900" />
+        <div className="rounded-lg border border-amber-200 bg-amber-50 p-6">
+          <h1 className="text-lg font-semibold text-amber-950">Access Denied</h1>
+          <p className="mt-2 text-sm text-amber-900">
+            You do not have permission to create quotes.
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   const confirmLeave = async () => {
     if (!isFormDirty) {

--- a/frontend/src/app/quotes/page.tsx
+++ b/frontend/src/app/quotes/page.tsx
@@ -25,7 +25,7 @@ import { UnifiedQuote, formatCurrency, formatRoute, formatDate, getWeight, getCu
 
 export default function QuotesPage() {
   const { user } = useAuth();
-  const { isFinance } = usePermissions();
+  const { isFinance, canEditQuotes, canFinalizeQuotes, canUseSpotWorkspace } = usePermissions();
   const router = useRouter();
 
   const [loading, setLoading] = useState(true);
@@ -248,7 +248,7 @@ export default function QuotesPage() {
       cell: (item: UnifiedQuote) => (
         <div className="flex items-center gap-2">
           {getStatusBadge(item)}
-          {item.type === "STANDARD" && item.rawStatus === "SENT" && (
+          {canFinalizeQuotes && item.type === "STANDARD" && item.rawStatus === "SENT" && (
             <select
               defaultValue=""
               disabled={statusUpdatingId === item.id}
@@ -287,7 +287,7 @@ export default function QuotesPage() {
       header: "",
       cell: (item: UnifiedQuote) => (
         <div className="flex items-center justify-end gap-2">
-          {["DRAFT", "draft"].includes(item.rawStatus) && (
+          {canEditQuotes && ["DRAFT", "draft"].includes(item.rawStatus) && (
             <Button
               variant="outline"
               size="sm"
@@ -303,16 +303,18 @@ export default function QuotesPage() {
               Delete
             </Button>
           )}
-          <Button
-            variant="outline"
-            size="sm"
-            asChild
-            className="w-20 border-slate-200 hover:bg-slate-50 text-slate-700 h-8"
-          >
-            <Link href={item.actionLink}>
-              {["DRAFT", "draft"].includes(item.rawStatus) ? "Resume" : "View"}
-            </Link>
-          </Button>
+          {item.type !== "SPOT_DRAFT" || canUseSpotWorkspace ? (
+            <Button
+              variant="outline"
+              size="sm"
+              asChild
+              className="w-20 border-slate-200 hover:bg-slate-50 text-slate-700 h-8"
+            >
+              <Link href={item.actionLink}>
+                {canEditQuotes && ["DRAFT", "draft"].includes(item.rawStatus) ? "Resume" : "View"}
+              </Link>
+            </Button>
+          ) : null}
         </div>
       ),
       className: "text-right min-w-[120px]",
@@ -388,8 +390,8 @@ export default function QuotesPage() {
                 title="No quotes found"
                 description={searchQuery ? "No quotes match your search criteria." : "You haven't created any quotes yet."}
                 icon={FileText}
-                actionLabel={searchQuery ? "Clear Search" : "Create New Quote"}
-                onAction={searchQuery ? () => setSearchQuery("") : () => router.push("/quotes/new?returnTo=%2Fquotes")}
+                actionLabel={searchQuery ? "Clear Search" : canEditQuotes ? "Create New Quote" : undefined}
+                onAction={searchQuery ? () => setSearchQuery("") : canEditQuotes ? () => router.push("/quotes/new?returnTo=%2Fquotes") : undefined}
                 className="py-12 border-none"
               />
             }

--- a/frontend/src/app/quotes/spot/[speId]/page.tsx
+++ b/frontend/src/app/quotes/spot/[speId]/page.tsx
@@ -50,6 +50,7 @@ import {
 import PageBackButton from "@/components/navigation/PageBackButton";
 import PageCancelButton from "@/components/navigation/PageCancelButton";
 import { useUnsavedChangesGuard } from "@/hooks/useUnsavedChangesGuard";
+import { usePermissions } from "@/hooks/usePermissions";
 
 type Step = "intake" | "review";
 type DisplayStep = Step | "confirm";
@@ -128,6 +129,7 @@ export default function SpotRateEntryPage() {
     const params = useParams();
     const router = useRouter();
     const searchParams = useSearchParams();
+    const { canEditQuotes, canUseSpotWorkspace } = usePermissions();
 
     const speId = params.speId as string;
     const isNew = speId === "new";
@@ -720,7 +722,16 @@ export default function SpotRateEntryPage() {
         unresolvedReviewIssueCount,
         unresolvedReviewIssueLabels: reviewLines.affected.map((line) => line.label),
     });
-    const quoteSubmitDisabled = Boolean(quoteSubmitDisabledReason);
+    const quoteActionDisabledReason = !canEditQuotes
+        ? "You do not have permission to create or update quotes."
+        : !canUseSpotWorkspace
+            ? "You do not have permission to use the SPOT workspace."
+            : quoteSubmitDisabledReason;
+    const canMutateSpotWorkspace = canEditQuotes && canUseSpotWorkspace;
+    const accessError = state.error || finalizeError;
+    const isAccessError = Boolean(accessError && /permission|not available|not found|forbidden|403|404/i.test(accessError));
+    const effectiveSubmitDisabledReason = quoteActionDisabledReason;
+    const effectiveSubmitDisabled = Boolean(effectiveSubmitDisabledReason);
     const hasReviewActions =
         importedReviewCounts.unmapped > 0 ||
         importedReviewCounts.lowConfidence > 0 ||
@@ -733,8 +744,8 @@ export default function SpotRateEntryPage() {
         charges: Array<Omit<SPEChargeLine, 'id'> & { charge_line_id?: string }>
     ) => {
         if (state.spe) {
-            if (quoteSubmitDisabledReason) {
-                setFinalizeError(quoteSubmitDisabledReason);
+            if (effectiveSubmitDisabledReason) {
+                setFinalizeError(effectiveSubmitDisabledReason);
                 return;
             }
 
@@ -841,6 +852,10 @@ export default function SpotRateEntryPage() {
     );
 
     const handleReviewLine = useCallback((line: ImportedReviewLine) => {
+        if (!canMutateSpotWorkspace) {
+            setFinalizeError("You do not have permission to resolve SPOT review items.");
+            return;
+        }
         if (!line.chargeLineId) return;
         setReviewMode("allCharges");
         setActiveReviewRequest({
@@ -848,15 +863,19 @@ export default function SpotRateEntryPage() {
             openManualReview: line.canReviewInSheet,
             requestKey: Date.now(),
         });
-    }, []);
+    }, [canMutateSpotWorkspace]);
     const handleConditionalDecision = useCallback(async (
         line: ImportedReviewLine,
         action: "KEEP" | "REMOVE"
     ) => {
+        if (!canMutateSpotWorkspace) {
+            setFinalizeError("You do not have permission to resolve SPOT review items.");
+            return;
+        }
         if (!line.chargeLineId) return;
         await actions.resolveConditionalChargeLine(line.chargeLineId, action);
         setActiveIssueDetails(null);
-    }, [actions]);
+    }, [actions, canMutateSpotWorkspace]);
     const toggleIssueDetails = useCallback((key: string) => {
         void key;
     }, []);
@@ -1009,8 +1028,13 @@ export default function SpotRateEntryPage() {
 
             {/* Error display */}
             {(state.error || finalizeError) && (
-                <div className="mb-6 rounded-md border border-red-200 bg-red-50 p-4">
-                    <p className="text-sm font-medium text-red-800">{state.error || finalizeError}</p>
+                <div className={`mb-6 rounded-md border p-4 ${isAccessError ? "border-amber-200 bg-amber-50" : "border-red-200 bg-red-50"}`}>
+                    <p className={`text-sm font-medium ${isAccessError ? "text-amber-900" : "text-red-800"}`}>
+                        {isAccessError ? "This SPOT workspace is not available to your current role or scope." : state.error || finalizeError}
+                    </p>
+                    {isAccessError && accessError ? (
+                        <p className="mt-1 text-sm text-amber-800">{accessError}</p>
+                    ) : null}
                     {state.quoteResult?.has_missing_rates && (
                         <div className="mt-2 text-sm text-red-700">
                             {formatMissingComponents(state.quoteResult.missing_components)?.length ? (
@@ -1239,7 +1263,7 @@ export default function SpotRateEntryPage() {
                                                                                     type="button"
                                                                                     size="sm"
                                                                                     onClick={() => void handleConditionalDecision(line, "KEEP")}
-                                                                                    disabled={!line.chargeLineId || state.isLoading}
+                                                                                    disabled={!canMutateSpotWorkspace || !line.chargeLineId || state.isLoading}
                                                                                 >
                                                                                     Accept Conditional
                                                                                 </Button>
@@ -1248,7 +1272,7 @@ export default function SpotRateEntryPage() {
                                                                                     variant="outline"
                                                                                     size="sm"
                                                                                     onClick={() => void handleConditionalDecision(line, "REMOVE")}
-                                                                                    disabled={!line.chargeLineId || state.isLoading}
+                                                                                    disabled={!canMutateSpotWorkspace || !line.chargeLineId || state.isLoading}
                                                                                 >
                                                                                     Remove from Quote
                                                                                 </Button>
@@ -1259,7 +1283,7 @@ export default function SpotRateEntryPage() {
                                                                                 type="button"
                                                                                 size="sm"
                                                                                 onClick={() => handleReviewLine(line)}
-                                                                                disabled={!line.chargeLineId || state.isLoading}
+                                                                                disabled={!canMutateSpotWorkspace || !line.chargeLineId || state.isLoading}
                                                                             >
                                                                                 Resolve ProductCode
                                                                             </Button>
@@ -1331,11 +1355,11 @@ export default function SpotRateEntryPage() {
                                             serviceScope={serviceScope}
                                             missingComponents={missingComponents}
                                             submitLabel="Create Quote"
-                                            submitDisabled={quoteSubmitDisabled}
-                                            submitDisabledReason={quoteSubmitDisabledReason}
+                                            submitDisabled={effectiveSubmitDisabled}
+                                            submitDisabledReason={effectiveSubmitDisabledReason}
                                             allowEmptySubmit={Boolean(state.spe?.can_proceed)}
-                                            onSaveDraft={handleSaveDraft}
-                                            onManualResolveChargeLine={actions.manuallyResolveChargeLine}
+                                            onSaveDraft={canMutateSpotWorkspace ? handleSaveDraft : undefined}
+                                            onManualResolveChargeLine={canMutateSpotWorkspace ? actions.manuallyResolveChargeLine : undefined}
                                             productCodeDomain={resolvedShipmentType}
                                             envelopeId={state.spe?.id}
                                             reviewRequest={activeReviewRequest}
@@ -1405,9 +1429,9 @@ export default function SpotRateEntryPage() {
                                                     <span className="text-slate-700">Unresolved: <span className="font-semibold text-slate-900">{unresolvedReviewIssueCount}</span></span>
                                                 </div>
                                             </div>
-                                            {quoteSubmitDisabledReason ? (
+                                            {effectiveSubmitDisabledReason ? (
                                                 <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
-                                                    <span className="font-medium">Cannot create quote:</span> {quoteSubmitDisabledReason}
+                                                    <span className="font-medium">Cannot create quote:</span> {effectiveSubmitDisabledReason}
                                                 </div>
                                             ) : (
                                                 <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-900">
@@ -1517,7 +1541,7 @@ export default function SpotRateEntryPage() {
                                                                     type="button"
                                                                     size="sm"
                                                                     onClick={() => handleReviewLine(line)}
-                                                                    disabled={!line.chargeLineId}
+                                                                    disabled={!canMutateSpotWorkspace || !line.chargeLineId}
                                                                 >
                                                                     Review
                                                                 </Button>
@@ -1650,7 +1674,7 @@ export default function SpotRateEntryPage() {
                     <IssueDetailsSheet
                         open={Boolean(activeIssueDetails)}
                         activeIssueDetails={activeIssueDetails}
-                        isLoading={state.isLoading}
+                        isLoading={state.isLoading || !canMutateSpotWorkspace}
                         onOpenChange={(open) => !open && setActiveIssueDetails(null)}
                         onResolveConditional={handleConditionalDecision}
                         onReviewLine={(line) => {

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -9,7 +9,7 @@ import { usePermissions } from '@/hooks/usePermissions';
 import { getAdminHubCopy } from '@/lib/page-copy';
 
 export default function SettingsPage() {
-  const { canEditRateCards, isFinance, isAdmin } = usePermissions();
+  const { canEditRateCards, canReviewProductCodes, isFinance, isAdmin } = usePermissions();
   const pageCopy = getAdminHubCopy();
 
   if (!isAdmin) {
@@ -116,7 +116,7 @@ export default function SettingsPage() {
           </Card>
         )}
 
-        {isAdmin && (
+        {canReviewProductCodes && (
           <Card className="border-slate-200 shadow-sm">
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
@@ -136,7 +136,7 @@ export default function SettingsPage() {
         )}
       </div>
 
-      {!showPricingEngine && !canEditRateCards && !showBranding && !showUsers && (
+      {!showPricingEngine && !canEditRateCards && !showBranding && !showUsers && !canReviewProductCodes && (
         <Card className="border-slate-200 shadow-sm">
           <CardContent className="px-6 py-5 text-sm text-muted-foreground">
             No administrative modules are available for your role.

--- a/frontend/src/app/settings/product-code-requests/page.tsx
+++ b/frontend/src/app/settings/product-code-requests/page.tsx
@@ -32,7 +32,7 @@ import {
 } from "lucide-react";
 
 export default function ProductCodeRequestsPage() {
-  const { isAdmin } = usePermissions();
+  const { canReviewProductCodes } = usePermissions();
 
   const [requests, setRequests] = useState<ProductCodeRequestResponse[]>([]);
   const [loading, setLoading] = useState(true);
@@ -84,10 +84,10 @@ export default function ProductCodeRequestsPage() {
   }, [statusFilter]);
 
   useEffect(() => {
-    if (isAdmin) {
+    if (canReviewProductCodes) {
       void fetchRequests();
     }
-  }, [isAdmin, fetchRequests]);
+  }, [canReviewProductCodes, fetchRequests]);
 
   // Load product codes for linking
   const loadProductCodes = async () => {
@@ -352,7 +352,7 @@ export default function ProductCodeRequestsPage() {
     }
   };
 
-  if (!isAdmin) {
+  if (!canReviewProductCodes) {
     return (
       <StandardPageContainer>
         <PageHeader

--- a/frontend/src/components/app-header.tsx
+++ b/frontend/src/components/app-header.tsx
@@ -29,7 +29,7 @@ export default function AppHeader() {
   const pathname = usePathname();
   const router = useRouter();
   const { user, logout } = useAuth();
-  const { canEditRateCards, canEditFXRates, canEditQuotes, role, isAdmin, isFinance, isManager } = usePermissions();
+  const { canEditRateCards, canEditFXRates, canEditQuotes, canViewCRM, canReviewProductCodes, role, isAdmin, isManager } = usePermissions();
   const [open, setOpen] = useState(false);
   const brandName = user?.organization?.branding?.display_name || user?.organization?.name || 'RateEngine';
   const brandLogoUrl = user?.organization?.branding?.logo_url || null;
@@ -46,8 +46,7 @@ export default function AppHeader() {
     { href: '/quotes', label: 'Quotes', icon: FileText },
   ];
 
-  // Customers - only for non-Finance roles
-  if (!isFinance) {
+  if (canViewCRM) {
     navItems.push({ href: '/customers', label: 'Customers', icon: Users });
     navItems.push({ href: '/crm', label: 'CRM', icon: FileText });
   }
@@ -73,6 +72,10 @@ export default function AppHeader() {
   // Admin hub
   if (isAdmin) {
     moreItems.push({ href: '/settings', label: 'Admin Hub', icon: Settings });
+  }
+
+  if (canReviewProductCodes) {
+    moreItems.push({ href: '/settings/product-code-requests', label: 'ProductCode Governance', icon: Database });
   }
 
   // User Management (Manager/Admin only)

--- a/frontend/src/components/quotes/QuoteDetailFooter.tsx
+++ b/frontend/src/components/quotes/QuoteDetailFooter.tsx
@@ -9,6 +9,7 @@ export interface QuoteDetailFooterProps {
   displayCurrency: string;
   displayAmount: number;
   canDownloadPDF: boolean;
+  canEditQuote: boolean;
   pdfDownloading: boolean;
   onDownloadPDF: () => Promise<void>;
   onEditQuote: () => void;
@@ -21,6 +22,7 @@ export default function QuoteDetailFooter({
   displayCurrency,
   displayAmount,
   canDownloadPDF,
+  canEditQuote,
   pdfDownloading,
   onDownloadPDF,
   onEditQuote,
@@ -71,7 +73,7 @@ export default function QuoteDetailFooter({
               <CheckCircle className="h-4 w-4 text-emerald-600" />
               <span>Quote {effectiveStatus.toLowerCase()}</span>
             </div>
-          ) : effectiveStatus === "DRAFT" ? (
+          ) : canEditQuote && effectiveStatus === "DRAFT" ? (
             <>
               <Button
                 variant="outline"

--- a/frontend/src/components/spot/SpotChargeLineManualReviewSheet.tsx
+++ b/frontend/src/components/spot/SpotChargeLineManualReviewSheet.tsx
@@ -54,7 +54,7 @@ export function SpotChargeLineManualReviewSheet({
     saveError = null,
     onSave,
 }: SpotChargeLineManualReviewSheetProps) {
-    const { isAdmin } = usePermissions();
+    const { canRequestProductCodes, canReviewProductCodes } = usePermissions();
 
     const [productCodes, setProductCodes] = useState<ProductCodeOption[]>([]);
     const [loadingProducts, setLoadingProducts] = useState(false);
@@ -154,6 +154,10 @@ export function SpotChargeLineManualReviewSheet({
     );
 
     const handleSubmitRequest = async () => {
+        if (!canRequestProductCodes) {
+            setRequestErrorMessage("You do not have permission to request ProductCodes.");
+            return;
+        }
         setIsSubmittingRequest(true);
         setRequestErrorMessage(null);
         setRequestSuccessMessage(null);
@@ -364,7 +368,7 @@ export function SpotChargeLineManualReviewSheet({
                                             Resolve now with an existing ProductCode instead
                                         </Button>
 
-                                        {isAdmin && (
+                                        {canReviewProductCodes && (
                                             <Button
                                                 type="button"
                                                 variant="outline"
@@ -389,7 +393,11 @@ export function SpotChargeLineManualReviewSheet({
                                     </Alert>
                                 ) : null}
 
-                                {!showRequestForm ? (
+                                {!canRequestProductCodes ? (
+                                    <div className="rounded-2xl border border-slate-200 bg-slate-50/80 p-4 text-sm text-slate-600">
+                                        ProductCode requests are not available for your role.
+                                    </div>
+                                ) : !showRequestForm ? (
                                     <div className="pt-2">
                                         <Button
                                             type="button"

--- a/frontend/src/hooks/usePermissions.ts
+++ b/frontend/src/hooks/usePermissions.ts
@@ -17,6 +17,11 @@ import {
     canEditQuotes,
     canFinalizeQuotes,
     canUseAIIntake,
+    canUseSpotWorkspace,
+    canRequestProductCodes,
+    canReviewProductCodes,
+    canViewCRM,
+    canEditCRM,
     canEditRateCards,
     canEditFXRates,
     canManageUsers,
@@ -35,6 +40,11 @@ interface UsePermissionsReturn {
     canEditQuotes: boolean;
     canFinalizeQuotes: boolean;
     canUseAIIntake: boolean;
+    canUseSpotWorkspace: boolean;
+    canRequestProductCodes: boolean;
+    canReviewProductCodes: boolean;
+    canViewCRM: boolean;
+    canEditCRM: boolean;
     canEditRateCards: boolean;
     canEditFXRates: boolean;
     canManageUsers: boolean;
@@ -62,6 +72,11 @@ export function usePermissions(): UsePermissionsReturn {
         canEditQuotes: canEditQuotes(role),
         canFinalizeQuotes: canFinalizeQuotes(role),
         canUseAIIntake: canUseAIIntake(role),
+        canUseSpotWorkspace: canUseSpotWorkspace(role),
+        canRequestProductCodes: canRequestProductCodes(role),
+        canReviewProductCodes: canReviewProductCodes(role),
+        canViewCRM: canViewCRM(role),
+        canEditCRM: canEditCRM(role),
         canEditRateCards: canEditRateCards(role),
         canEditFXRates: canEditFXRates(role),
         canManageUsers: canManageUsers(role),

--- a/frontend/src/lib/permissions.ts
+++ b/frontend/src/lib/permissions.ts
@@ -27,6 +27,11 @@ export const PERMISSIONS = {
     EDIT_RATE_CARDS: 'edit_rate_cards',
     EDIT_FX_RATES: 'edit_fx_rates',
     USE_AI_INTAKE: 'use_ai_intake',
+    USE_SPOT_WORKSPACE: 'use_spot_workspace',
+    REQUEST_PRODUCT_CODES: 'request_product_codes',
+    REVIEW_PRODUCT_CODES: 'review_product_codes',
+    VIEW_CRM: 'view_crm',
+    EDIT_CRM: 'edit_crm',
     MANAGE_USERS: 'manage_users',
     SYSTEM_SETTINGS: 'system_settings',
     VIEW_AUDIT_LOGS: 'view_audit_logs',
@@ -47,6 +52,11 @@ const PERMISSION_MATRIX: Record<Permission, Role[]> = {
     [PERMISSIONS.EDIT_RATE_CARDS]: [ROLES.MANAGER, ROLES.ADMIN],
     [PERMISSIONS.EDIT_FX_RATES]: [ROLES.FINANCE, ROLES.ADMIN],
     [PERMISSIONS.USE_AI_INTAKE]: [ROLES.SALES, ROLES.MANAGER, ROLES.ADMIN],
+    [PERMISSIONS.USE_SPOT_WORKSPACE]: [ROLES.SALES, ROLES.MANAGER, ROLES.ADMIN],
+    [PERMISSIONS.REQUEST_PRODUCT_CODES]: [ROLES.SALES, ROLES.MANAGER, ROLES.ADMIN],
+    [PERMISSIONS.REVIEW_PRODUCT_CODES]: [ROLES.ADMIN],
+    [PERMISSIONS.VIEW_CRM]: [ROLES.SALES, ROLES.MANAGER, ROLES.ADMIN],
+    [PERMISSIONS.EDIT_CRM]: [ROLES.SALES, ROLES.MANAGER, ROLES.ADMIN],
     [PERMISSIONS.MANAGE_USERS]: [ROLES.MANAGER, ROLES.ADMIN],
     [PERMISSIONS.SYSTEM_SETTINGS]: [ROLES.ADMIN],
     [PERMISSIONS.VIEW_AUDIT_LOGS]: [ROLES.MANAGER, ROLES.FINANCE, ROLES.ADMIN],
@@ -94,6 +104,26 @@ export function canFinalizeQuotes(role: string | undefined): boolean {
  */
 export function canUseAIIntake(role: string | undefined): boolean {
     return hasPermission(role, PERMISSIONS.USE_AI_INTAKE);
+}
+
+export function canUseSpotWorkspace(role: string | undefined): boolean {
+    return hasPermission(role, PERMISSIONS.USE_SPOT_WORKSPACE);
+}
+
+export function canRequestProductCodes(role: string | undefined): boolean {
+    return hasPermission(role, PERMISSIONS.REQUEST_PRODUCT_CODES);
+}
+
+export function canReviewProductCodes(role: string | undefined): boolean {
+    return hasPermission(role, PERMISSIONS.REVIEW_PRODUCT_CODES);
+}
+
+export function canViewCRM(role: string | undefined): boolean {
+    return hasPermission(role, PERMISSIONS.VIEW_CRM);
+}
+
+export function canEditCRM(role: string | undefined): boolean {
+    return hasPermission(role, PERMISSIONS.EDIT_CRM);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add named frontend RBAC affordance permissions for SPOT workspace, ProductCode request/review, CRM view/edit, and quote actions.
- Hide or disable unauthorized CRM, quote, SPOT, and ProductCode UI actions while preserving backend enforcement as the source of truth.
- Add clean direct-route access denied states for quote creation and CRM opportunity create/edit paths, and avoid auto-opening SPOT workspaces for roles without SPOT access.

## Intentionally not changed
- No backend RBAC enforcement changes.
- No pricing logic, parser logic, ProductCode workflow behavior, quote/SPOT calculations, or historical Quote/SPOT mutation.
- No migrations.

## Verification
- `npm --prefix frontend run lint` passed with existing warnings only.
- `npm --prefix frontend run build` passed with existing warnings only.
- `python backend/manage.py rbac_backend_enforcement_audit --format json` passed; audit summary status `READY`.
- `python backend/manage.py check` passed; existing DRF Decimal warning emitted.
- `npx fallow --format json` exited 0; existing 104 findings remain.
- `graphify update .` completed; graph rebuilt with 12434 nodes / 34425 edges.
- `git diff --check` passed; Git emitted Windows line-ending warnings only.