### PR TITLE
Phase 12.3: Apply high-value Draft Quote decisions

### DIFF
--- a/backend/quotes/contracts/draft_quote_contract.py
+++ b/backend/quotes/contracts/draft_quote_contract.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import Any, Dict, List, Optional
 from uuid import UUID
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class EvidenceSchema(BaseModel):
@@ -157,18 +157,34 @@ class IgnoreDetails(BaseModel):
 
 
 class ChargeValuesSchema(BaseModel):
-    amount: Decimal = Field(..., description="Monetary amount value")
-    currency: str = Field(..., description="3-letter currency code")
+    model_config = ConfigDict(extra="allow")
+
+    display_label: Optional[str] = Field(None, description="Human-friendly charge label")
+    description: Optional[str] = Field(None, description="Human-friendly charge description")
+    amount: Optional[Decimal] = Field(None, description="Monetary amount value")
+    currency: Optional[str] = Field(None, description="3-letter currency code")
     rate: Optional[Decimal] = Field(None, description="Monetary rate per unit")
     unit: Optional[str] = Field(None, description="Charge unit basis")
+    calculation_basis: Optional[str] = Field(None, description="Calculation basis")
+    minimum_charge: Optional[Decimal] = Field(None, description="Minimum charge limit")
+    include_in_totals: Optional[bool] = Field(None, description="Whether to include this charge in calculated totals")
+    conditions: Optional[List[str]] = Field(None, description="Charge conditions")
+    notes: Optional[str] = Field(None, description="Charge notes")
 
 
 class EditChargeDetails(BaseModel):
     original_values: ChargeValuesSchema = Field(..., description="Original field values")
     updated_values: ChargeValuesSchema = Field(..., description="Updated field values")
 
+    @model_validator(mode="after")
+    def validate_updated_values(self) -> EditChargeDetails:
+        if not self.updated_values.model_dump(exclude_none=True):
+            raise ValueError("edit_charge requires at least one updated value.")
+        return self
+
 
 class ClassifyUnclassifiedDetails(BaseModel):
+    classification: str = Field("charge", description="charge or ignored")
     bucket: str = Field(..., description="Target bucket for classification")
     display_label: str = Field(..., description="Display label for the new charge line")
     product_code: str = Field(..., description="Target product code for classification")
@@ -177,6 +193,12 @@ class ClassifyUnclassifiedDetails(BaseModel):
     rate: Optional[Decimal] = Field(None, description="Parsed rate")
     unit: Optional[str] = Field(None, description="Parsed unit")
     minimum_charge: Optional[Decimal] = Field(None, description="Parsed minimum limit")
+    reason: Optional[str] = Field(None, description="Operator reason")
+
+
+class IgnoreUnclassifiedDetails(BaseModel):
+    classification: str = Field(..., description="ignored/non-commercial classification")
+    reason: str = Field(..., description="Reason why item is ignored")
 
 
 class DecisionItemSchema(BaseModel):
@@ -213,7 +235,11 @@ class DecisionItemSchema(BaseModel):
         elif self.type == "edit_charge":
             EditChargeDetails(**self.details)
         elif self.type == "classify_unclassified":
-            ClassifyUnclassifiedDetails(**self.details)
+            classification = str(self.details.get("classification") or "charge").lower()
+            if classification in {"ignored", "ignore", "non_commercial", "non-commercial"}:
+                IgnoreUnclassifiedDetails(**self.details)
+            else:
+                ClassifyUnclassifiedDetails(**self.details)
         
         return self
 

--- a/backend/quotes/services/draft_quote_resolve_service.py
+++ b/backend/quotes/services/draft_quote_resolve_service.py
@@ -1,212 +1,335 @@
+import uuid
+import json
 from typing import List, Tuple
+
+from django.core.serializers.json import DjangoJSONEncoder
 from django.db import transaction
 from django.utils import timezone
-from quotes.contracts.draft_quote_contract import DraftQuoteResolveSchema, DecisionItemSchema, DecisionResultSchema
-from quotes.spot_models import SpotPricingEnvelopeDB, SPEChargeLineDB, DraftQuoteDecisionDB
-import uuid
+
+from pricing_v4.models import ProductCode, ProductCodeCreationRequest
+from quotes.contracts.draft_quote_contract import (
+    DecisionItemSchema,
+    DecisionResultSchema,
+    DraftQuoteResolveSchema,
+)
+from quotes.spot_models import (
+    DraftQuoteDecisionDB,
+    SPEChargeLineDB,
+    SPESourceBatchDB,
+    SpotPricingEnvelopeDB,
+)
+
+
+APPLIED_DB_STATUSES = {"accepted": "applied", "skipped": "skipped", "rejected": "rejected"}
+EDITABLE_CHARGE_FIELDS = {
+    "display_label": "description",
+    "description": "description",
+    "amount": "amount",
+    "rate": "rate",
+    "currency": "currency",
+    "unit": "unit",
+    "calculation_basis": "calculation_basis",
+    "minimum_charge": "min_charge",
+    "include_in_totals": "include_in_totals",
+    "conditions": "note",
+    "notes": "note",
+}
+
+
+def _result(decision: DecisionItemSchema, status: str, message: str, error_code: str | None = None):
+    return DecisionResultSchema(
+        decision_id=decision.decision_id,
+        target_id=decision.target_id,
+        type=decision.type,
+        status=status,
+        message=message,
+        error_code=error_code,
+    )
+
+
+def _existing_result(decision: DraftQuoteDecisionDB):
+    return DecisionResultSchema(
+        decision_id=decision.decision_id,
+        target_id=decision.target_id,
+        type=decision.decision_type,
+        status=APPLIED_DB_STATUSES.get(decision.status, "applied"),
+        message=decision.message or "",
+        error_code=decision.error_code,
+    )
+
+
+def _persist(envelope, payload, decision, user, status, message, error_code=None):
+    details = json.loads(json.dumps(decision.details, cls=DjangoJSONEncoder))
+    return DraftQuoteDecisionDB.objects.create(
+        envelope=envelope,
+        idempotency_key=payload.idempotency_key,
+        decision_id=decision.decision_id,
+        decision_type=decision.type,
+        target_id=decision.target_id,
+        details_json=details,
+        client_audit_metadata_json=decision.audit_metadata.model_dump(),
+        server_user=user,
+        status=status,
+        error_code=error_code,
+        message=message,
+    )
+
+
+def _target_charge(envelope, target_id):
+    try:
+        return envelope.charge_lines.select_for_update().get(id=uuid.UUID(str(target_id)))
+    except (ValueError, TypeError, SPEChargeLineDB.DoesNotExist):
+        return None
+
+
+def _product_code(value):
+    query = ProductCode.objects
+    if isinstance(value, int) or str(value).isdigit():
+        return query.filter(id=int(value)).first()
+    return query.filter(code=str(value)).first()
+
+
+def _stamp_manual_resolution(charge_line, product_code, user, decision, payload):
+    charge_line.manual_resolved_product_code = product_code
+    charge_line.manual_resolution_status = SPEChargeLineDB.ManualResolutionStatus.RESOLVED
+    charge_line.manual_resolution_by = user
+    charge_line.manual_resolution_at = timezone.now()
+    rule_meta = dict(charge_line.rule_meta or {})
+    rule_meta["draft_quote_resolution"] = {
+        "decision_id": decision.decision_id,
+        "idempotency_key": str(payload.idempotency_key),
+        "decision_type": decision.type,
+        "operator_id": user.id,
+        "applied_at": charge_line.manual_resolution_at.isoformat(),
+    }
+    charge_line.rule_meta = rule_meta
+
+
+def _apply_product_code(charge_line, product_code, user, decision, payload):
+    _stamp_manual_resolution(charge_line, product_code, user, decision, payload)
+    charge_line.save(
+        update_fields=[
+            "manual_resolved_product_code",
+            "manual_resolution_status",
+            "manual_resolution_by",
+            "manual_resolution_at",
+            "rule_meta",
+        ]
+    )
+
+
+def _apply_edit_charge(charge_line, decision, payload, user):
+    updates = dict(decision.details.get("updated_values") or {})
+    before = {}
+    after = {}
+
+    for public_field in updates:
+        if public_field not in EDITABLE_CHARGE_FIELDS:
+            return "rejected", f"Field '{public_field}' is not editable.", "INVALID_FIELD"
+
+    for public_field, value in updates.items():
+        model_field = EDITABLE_CHARGE_FIELDS[public_field]
+        if public_field == "include_in_totals":
+            before[public_field] = not charge_line.exclude_from_totals
+            charge_line.exclude_from_totals = not bool(value)
+            after[public_field] = bool(value)
+        elif public_field == "conditions":
+            before[public_field] = [charge_line.note] if charge_line.note else []
+            charge_line.note = "; ".join(str(v) for v in (value or []))
+            after[public_field] = value or []
+        else:
+            before[public_field] = getattr(charge_line, model_field)
+            setattr(charge_line, model_field, value)
+            after[public_field] = value
+
+    rule_meta = dict(charge_line.rule_meta or {})
+    rule_meta["draft_quote_resolution"] = {
+        "decision_id": decision.decision_id,
+        "idempotency_key": str(payload.idempotency_key),
+        "decision_type": decision.type,
+        "operator_id": user.id,
+        "applied_at": timezone.now().isoformat(),
+    }
+    charge_line.rule_meta = rule_meta
+    decision.details["before"] = before
+    decision.details["after"] = after
+    charge_line.save()
+    return "accepted", "Charge edited successfully.", None
+
+
+def _unclassified_item(envelope, target_id):
+    for batch in envelope.source_batches.select_for_update():
+        summary = batch.analysis_summary_json if isinstance(batch.analysis_summary_json, dict) else {}
+        for item in summary.get("unclassified_items") or []:
+            if str(item.get("id")) == str(target_id):
+                return batch, item
+    return None, None
+
+
+def _ignore_unclassified(batch: SPESourceBatchDB, item: dict, reason: str):
+    summary = dict(batch.analysis_summary_json or {})
+    unclassified = [i for i in summary.get("unclassified_items") or [] if str(i.get("id")) != str(item.get("id"))]
+    ignored = list(summary.get("ignored_items") or [])
+    ignored.append(
+        {
+            "id": item.get("id"),
+            "raw_text": item.get("raw_text") or item.get("text") or "",
+            "ignored_reason": reason,
+            "evidence": item.get("evidence"),
+        }
+    )
+    summary["unclassified_items"] = unclassified
+    summary["ignored_items"] = ignored
+    batch.analysis_summary_json = summary
+    batch.save(update_fields=["analysis_summary_json", "updated_at"])
+
+
+def _create_classified_charge(envelope, batch, item, product_code, decision, payload, user):
+    details = decision.details
+    now = timezone.now()
+    charge_line = SPEChargeLineDB(
+        envelope=envelope,
+        source_batch=batch,
+        code=product_code.code,
+        description=details["display_label"],
+        amount=details["amount"],
+        currency=details["currency"],
+        unit=details.get("unit") or SPEChargeLineDB.Unit.FLAT,
+        bucket=details["bucket"],
+        rate=details.get("rate"),
+        min_charge=details.get("minimum_charge"),
+        source_label=item.get("raw_text") or item.get("text") or details["display_label"],
+        source_excerpt=item.get("raw_text") or item.get("text") or "",
+        source_reference=batch.file_name or batch.label or "draft quote unclassified item",
+        entered_by=user,
+        entered_at=now,
+    )
+    _stamp_manual_resolution(charge_line, product_code, user, decision, payload)
+    charge_line.save()
+    _ignore_unclassified(batch, item, details.get("reason") or "Classified as charge")
+
+
+def _apply_classify_unclassified(envelope, decision, payload, user):
+    batch, item = _unclassified_item(envelope, decision.target_id)
+    if not item:
+        return "rejected", "Target unclassified item was not found in this envelope.", "TARGET_NOT_FOUND"
+
+    classification = str(decision.details.get("classification") or "charge").lower()
+    if classification in {"ignored", "ignore", "non_commercial", "non-commercial"}:
+        _ignore_unclassified(batch, item, decision.details.get("reason") or "Classified as non-commercial")
+        return "accepted", "Unclassified item classified as ignored.", None
+
+    if classification != "charge":
+        return "rejected", "Unsupported unclassified classification.", "UNSUPPORTED_CLASSIFICATION"
+
+    product_code = _product_code(decision.details.get("product_code"))
+    if not product_code:
+        return "skipped", "Classifying this item as a charge requires an existing ProductCode.", "PRODUCT_CODE_REQUIRED"
+
+    _create_classified_charge(envelope, batch, item, product_code, decision, payload, user)
+    return "accepted", "Unclassified item classified as charge.", None
+
 
 def apply_draft_quote_decisions(
     envelope: SpotPricingEnvelopeDB,
     payload: DraftQuoteResolveSchema,
-    user
+    user,
 ) -> Tuple[List[DecisionResultSchema], List[DecisionResultSchema]]:
-    """
-    Persists and applies operator decisions to the draft quote.
-    Only applies low-risk decisions:
-      - accept_suggestion
-      - ignore
-    Other types (edit_charge, map_to_product_code, request_product_code, classify_unclassified)
-    are persisted but their DB side-effects are skipped.
-    
-    Returns:
-      (applied_decisions, rejected_decisions)
-    """
     applied: List[DecisionResultSchema] = []
     rejected: List[DecisionResultSchema] = []
 
     with transaction.atomic():
         for dec_item in payload.decisions:
-            decision_type = dec_item.type
-            target_id = dec_item.target_id
-            
-            # 1. Attempt to find target SPEChargeLineDB record if applicable
-            charge_line = None
-            try:
-                target_uuid = uuid.UUID(target_id)
-                charge_line = envelope.charge_lines.filter(id=target_uuid).first()
-            except (ValueError, TypeError):
-                charge_line = None
-                
-            if not charge_line and decision_type in ["accept_suggestion", "ignore", "edit_charge", "map_to_product_code", "use_approved_product_code"]:
-                # Unknown target_id returns rejected/skipped result
-                err_result = DecisionResultSchema(
-                    decision_id=dec_item.decision_id,
-                    target_id=target_id,
-                    type=decision_type,
-                    status="rejected",
-                    message="Target charge line ID not found in this envelope.",
-                    error_code="TARGET_NOT_FOUND"
-                )
-                rejected.append(err_result)
-                
-                # Persist the rejected decision for audit trail
-                DraftQuoteDecisionDB.objects.create(
-                    envelope=envelope,
-                    idempotency_key=payload.idempotency_key,
-                    decision_id=dec_item.decision_id,
-                    decision_type=decision_type,
-                    target_id=target_id,
-                    details_json=dec_item.details,
-                    client_audit_metadata_json=dec_item.audit_metadata.model_dump(),
-                    server_user=user,
-                    status="rejected",
-                    error_code="TARGET_NOT_FOUND",
-                    message="Target charge line ID not found in this envelope."
-                )
+            existing = DraftQuoteDecisionDB.objects.filter(
+                envelope=envelope,
+                idempotency_key=payload.idempotency_key,
+                decision_id=dec_item.decision_id,
+            ).first()
+            if existing:
+                result = _existing_result(existing)
+                (rejected if result.status == "rejected" else applied).append(result)
                 continue
 
-            # 2. Apply changes to DB for low-risk types if not already mutated
+            decision_type = dec_item.type
+            charge_line = _target_charge(envelope, dec_item.target_id)
+
             status_val = "accepted"
             message_val = "Decision persisted and applied successfully."
             error_code_val = None
-            response_status = "applied"
 
-            if decision_type == "accept_suggestion" and charge_line:
+            if decision_type in {"accept_suggestion", "ignore", "edit_charge", "map_to_product_code", "use_approved_product_code"} and not charge_line:
+                status_val = "rejected"
+                message_val = "Target charge line ID not found in this envelope."
+                error_code_val = "TARGET_NOT_FOUND"
+            elif decision_type == "accept_suggestion":
                 if charge_line.manual_resolution_status == SPEChargeLineDB.ManualResolutionStatus.RESOLVED:
                     message_val = "Decision logged. Target was already resolved in a prior transaction."
                 else:
                     charge_line.manual_resolution_status = SPEChargeLineDB.ManualResolutionStatus.RESOLVED
                     charge_line.manual_resolution_by = user
                     charge_line.manual_resolution_at = timezone.now()
-                    charge_line.save()
-            elif decision_type == "ignore" and charge_line:
-                if charge_line.exclude_from_totals:
-                    message_val = "Decision logged. Target was already ignored in a prior transaction."
+                    charge_line.save(update_fields=["manual_resolution_status", "manual_resolution_by", "manual_resolution_at"])
+            elif decision_type == "ignore":
+                charge_line.exclude_from_totals = True
+                charge_line.save(update_fields=["exclude_from_totals"])
+            elif decision_type == "map_to_product_code":
+                product_code = _product_code(dec_item.details.get("product_code"))
+                if not product_code:
+                    status_val = "rejected"
+                    message_val = "ProductCode was not found."
+                    error_code_val = "PRODUCT_CODE_NOT_FOUND"
                 else:
-                    charge_line.exclude_from_totals = True
-                    charge_line.save()
+                    _apply_product_code(charge_line, product_code, user, dec_item, payload)
+                    message_val = "ProductCode mapping applied successfully."
+            elif decision_type == "edit_charge":
+                status_val, message_val, error_code_val = _apply_edit_charge(charge_line, dec_item, payload, user)
+            elif decision_type == "classify_unclassified":
+                status_val, message_val, error_code_val = _apply_classify_unclassified(envelope, dec_item, payload, user)
             elif decision_type == "request_product_code":
-                from pricing_v4.models import ProductCodeCreationRequest
-                
-                # Extract details
-                proposed_code = dec_item.details.get("proposed_code", "")
-                description = dec_item.details.get("description", "")
-                category = dec_item.details.get("category", "")
-                reason = dec_item.details.get("reason", "")
-                
-                source_label = description
-                if charge_line:
-                    source_label = charge_line.source_label or charge_line.description
-                
-                # Create pending ProductCodeCreationRequest
                 pc_request = ProductCodeCreationRequest.objects.create(
-                    source_label=source_label,
-                    suggested_name=proposed_code,
-                    suggested_bucket=category,
+                    source_label=(charge_line.source_label or charge_line.description) if charge_line else dec_item.details.get("description", ""),
+                    suggested_name=dec_item.details.get("proposed_code", ""),
+                    suggested_bucket=dec_item.details.get("category", ""),
                     suggested_basis="FLAT",
-                    suggested_reason=reason,
+                    suggested_reason=dec_item.details.get("reason", ""),
                     source_envelope=envelope,
                     source_charge_line=charge_line,
-                    source_quote=envelope.quote if hasattr(envelope, 'quote') else None,
+                    source_quote=envelope.quote if hasattr(envelope, "quote") else None,
                     source_context_json=dec_item.details,
                     created_by=user,
-                    status=ProductCodeCreationRequest.STATUS_PENDING
+                    status=ProductCodeCreationRequest.STATUS_PENDING,
                 )
-                
-                # Store the request ID in details for later lookup
                 dec_item.details["product_code_request_id"] = pc_request.id
-                
                 status_val = "skipped"
-                response_status = "skipped"
                 message_val = "ProductCode request created and pending admin review."
             elif decision_type == "use_approved_product_code":
-                from pricing_v4.models import ProductCodeCreationRequest
-
-                # Extract details
                 req_id = dec_item.details.get("product_code_request_id")
-                pc_id = dec_item.details.get("product_code_id")
-
-                pc_request = None
-                if req_id:
-                    try:
-                        pc_request = ProductCodeCreationRequest.objects.filter(id=req_id).first()
-                    except (ValueError, TypeError):
-                        pass
-
+                pc_request = ProductCodeCreationRequest.objects.filter(id=req_id).first() if req_id else None
                 if not pc_request:
-                    status_val = "rejected"
-                    response_status = "rejected"
-                    error_code_val = "REQUEST_NOT_FOUND"
+                    status_val, error_code_val = "rejected", "REQUEST_NOT_FOUND"
                     message_val = f"ProductCodeCreationRequest with ID {req_id} not found."
                 elif str(pc_request.source_envelope_id) != str(envelope.id):
-                    status_val = "rejected"
-                    response_status = "rejected"
-                    error_code_val = "INVALID_REQUEST_SOURCE"
+                    status_val, error_code_val = "rejected", "INVALID_REQUEST_SOURCE"
                     message_val = "ProductCodeCreationRequest does not belong to the same envelope."
-                elif charge_line and pc_request.source_charge_line_id and str(pc_request.source_charge_line_id) != str(charge_line.id):
-                    status_val = "rejected"
-                    response_status = "rejected"
-                    error_code_val = "INVALID_REQUEST_SOURCE"
+                elif pc_request.source_charge_line_id and pc_request.source_charge_line_id != charge_line.id:
+                    status_val, error_code_val = "rejected", "INVALID_REQUEST_SOURCE"
                     message_val = "ProductCodeCreationRequest does not belong to the same charge line."
                 elif pc_request.status != ProductCodeCreationRequest.STATUS_APPROVED:
-                    status_val = "rejected"
-                    response_status = "rejected"
-                    error_code_val = "REQUEST_NOT_APPROVED"
+                    status_val, error_code_val = "rejected", "REQUEST_NOT_APPROVED"
                     message_val = f"ProductCodeCreationRequest status is {pc_request.status}, must be APPROVED."
                 elif not pc_request.approved_product_code_id:
-                    status_val = "rejected"
-                    response_status = "rejected"
-                    error_code_val = "MISSING_APPROVED_PRODUCT_CODE"
+                    status_val, error_code_val = "rejected", "MISSING_APPROVED_PRODUCT_CODE"
                     message_val = "ProductCodeCreationRequest does not have an approved product code."
-                elif pc_id and int(pc_id) != pc_request.approved_product_code_id:
-                    status_val = "rejected"
-                    response_status = "rejected"
-                    error_code_val = "PRODUCT_CODE_MISMATCH"
-                    message_val = f"Provided product_code_id {pc_id} does not match approved ProductCode ID {pc_request.approved_product_code_id}."
+                elif dec_item.details.get("product_code_id") and int(dec_item.details["product_code_id"]) != pc_request.approved_product_code_id:
+                    status_val, error_code_val = "rejected", "PRODUCT_CODE_MISMATCH"
+                    message_val = "Provided product_code_id does not match approved ProductCode ID."
                 else:
-                    if charge_line:
-                        if charge_line.manual_resolution_status == SPEChargeLineDB.ManualResolutionStatus.RESOLVED and charge_line.manual_resolved_product_code_id == pc_request.approved_product_code_id:
-                            message_val = "Decision logged. Target was already resolved with the approved ProductCode."
-                        else:
-                            charge_line.manual_resolved_product_code = pc_request.approved_product_code
-                            charge_line.manual_resolution_status = SPEChargeLineDB.ManualResolutionStatus.RESOLVED
-                            charge_line.manual_resolution_by = user
-                            charge_line.manual_resolution_at = timezone.now()
-                            charge_line.save()
-                            message_val = "Approved ProductCode applied successfully."
-                    else:
-                        message_val = "Approved ProductCode validated, but target charge line was not found."
+                    _apply_product_code(charge_line, pc_request.approved_product_code, user, dec_item, payload)
+                    message_val = "Approved ProductCode applied successfully."
 
-            elif decision_type in ["edit_charge", "map_to_product_code", "classify_unclassified"]:
-                # High-risk skipped decisions must remain status='skipped'
-                status_val = "skipped"
-                response_status = "skipped"
-                message_val = "Decision persisted but database side-effects are pending implementation."
-            
-            # 4. Create decision audit record
-            DraftQuoteDecisionDB.objects.create(
-                envelope=envelope,
-                idempotency_key=payload.idempotency_key,
-                decision_id=dec_item.decision_id,
-                decision_type=decision_type,
-                target_id=target_id,
-                details_json=dec_item.details,
-                client_audit_metadata_json=dec_item.audit_metadata.model_dump(),
-                server_user=user,
-                status=status_val,
-                error_code=error_code_val,
-                message=message_val
-            )
-            
-            applied.append(
-                DecisionResultSchema(
-                    decision_id=dec_item.decision_id,
-                    target_id=target_id,
-                    type=decision_type,
-                    status=response_status,
-                    message=message_val,
-                    error_code=error_code_val
-                )
-            )
+            _persist(envelope, payload, dec_item, user, status_val, message_val, error_code_val)
+            response_status = APPLIED_DB_STATUSES.get(status_val, "applied")
+            result = _result(dec_item, response_status, message_val, error_code_val)
+            (rejected if response_status == "rejected" else applied).append(result)
 
     return applied, rejected

--- a/backend/quotes/services/draft_quote_resolve_service.py
+++ b/backend/quotes/services/draft_quote_resolve_service.py
@@ -1,5 +1,6 @@
 import uuid
 import json
+from decimal import Decimal, InvalidOperation
 from typing import List, Tuple
 
 from django.core.serializers.json import DjangoJSONEncoder
@@ -28,12 +29,17 @@ EDITABLE_CHARGE_FIELDS = {
     "rate": "rate",
     "currency": "currency",
     "unit": "unit",
-    "calculation_basis": "calculation_basis",
+    "calculation_basis": "unit_type",
     "minimum_charge": "min_charge",
     "include_in_totals": "include_in_totals",
     "conditions": "note",
     "notes": "note",
 }
+NUMERIC_CHARGE_FIELDS = {"amount", "rate", "minimum_charge"}
+
+
+def _valid_choice_values(choices):
+    return {choice for choice, _ in choices}
 
 
 def _result(decision: DecisionItemSchema, status: str, message: str, error_code: str | None = None):
@@ -123,9 +129,26 @@ def _apply_edit_charge(charge_line, decision, payload, user):
     before = {}
     after = {}
 
-    for public_field in updates:
+    for public_field, value in updates.items():
         if public_field not in EDITABLE_CHARGE_FIELDS:
             return "rejected", f"Field '{public_field}' is not editable.", "INVALID_FIELD"
+        if public_field == "currency":
+            currency = str(value or "").strip().upper()
+            if len(currency) != 3 or not currency.isalpha():
+                return "rejected", "Currency must be a 3-letter ISO code.", "INVALID_CURRENCY"
+            updates[public_field] = currency
+        elif public_field == "unit" and value not in _valid_choice_values(SPEChargeLineDB.Unit.choices):
+            return "rejected", "Unit is not supported for SPOT charge lines.", "INVALID_UNIT"
+        elif public_field == "calculation_basis" and value not in _valid_choice_values(SPEChargeLineDB.UnitType.choices):
+            return "rejected", "Calculation basis is not supported for SPOT charge lines.", "INVALID_CALCULATION_BASIS"
+        elif public_field in NUMERIC_CHARGE_FIELDS:
+            try:
+                numeric_value = Decimal(str(value))
+            except (InvalidOperation, TypeError, ValueError):
+                return "rejected", f"{public_field} must be numeric.", "INVALID_NUMERIC_VALUE"
+            if numeric_value < 0:
+                return "rejected", f"{public_field} cannot be negative.", "NEGATIVE_NUMERIC_VALUE"
+            updates[public_field] = numeric_value
 
     for public_field, value in updates.items():
         model_field = EDITABLE_CHARGE_FIELDS[public_field]

--- a/backend/quotes/tests/test_draft_quote_api.py
+++ b/backend/quotes/tests/test_draft_quote_api.py
@@ -333,7 +333,7 @@ def test_draft_quote_resolve_endpoint(transactional_db):
     applied_map = {d.decision_id: d for d in resp_schema.applied_decisions}
     assert applied_map["dec-001"].status == "applied"
     assert applied_map["dec-002"].status == "applied"
-    assert applied_map["dec-003"].status == "skipped"  # edit_charge is persisted but not applied yet
+    assert applied_map["dec-003"].status == "applied"
 
     # Verify decision is persisted in DB with correct status
     from quotes.spot_models import DraftQuoteDecisionDB
@@ -348,7 +348,7 @@ def test_draft_quote_resolve_endpoint(transactional_db):
 
     db_record_3 = DraftQuoteDecisionDB.objects.get(envelope=envelope, decision_id="dec-003")
     assert db_record_3.decision_type == "edit_charge"
-    assert db_record_3.status == "skipped"  # High-risk stored as skipped
+    assert db_record_3.status == "accepted"
 
     # Verify charge lines were actually updated for low-risk decisions
     line_suggested.refresh_from_db()
@@ -358,9 +358,9 @@ def test_draft_quote_resolve_endpoint(transactional_db):
     line_ignore.refresh_from_db()
     assert line_ignore.exclude_from_totals is True
 
-    # Verify charge line for edit_charge was NOT mutated yet (guardrail check)
+    # Verify charge line for edit_charge was safely mutated.
     line_edit.refresh_from_db()
-    assert float(line_edit.amount) == 200.00
+    assert float(line_edit.amount) == 250.00
 
     # Verify idempotency retry doesn't re-apply, duplicate records, or overwrite metadata
     original_at = line_suggested.manual_resolution_at
@@ -373,9 +373,9 @@ def test_draft_quote_resolve_endpoint(transactional_db):
     assert "Idempotent resolution" in resp_retry_schema.message
     assert DraftQuoteDecisionDB.objects.filter(envelope=envelope).count() == 3
 
-    # Assert skipped status remains skipped on retry
+    # Assert applied status remains applied on retry
     retry_applied_map = {d.decision_id: d for d in resp_retry_schema.applied_decisions}
-    assert retry_applied_map["dec-003"].status == "skipped"
+    assert retry_applied_map["dec-003"].status == "applied"
 
     # Assert charge line metadata remains untouched
     line_suggested.refresh_from_db()
@@ -768,7 +768,7 @@ def test_resolve_use_approved_product_code():
     }
     res = client.post(url, payload_pending, format="json")
     assert res.status_code == 200
-    assert res.data["applied_decisions"][0]["error_code"] == "REQUEST_NOT_APPROVED"
+    assert res.data["rejected_decisions"][0]["error_code"] == "REQUEST_NOT_APPROVED"
 
     # Test rejected request cannot be consumed
     payload_rejected = {
@@ -786,7 +786,7 @@ def test_resolve_use_approved_product_code():
     }
     res = client.post(url, payload_rejected, format="json")
     assert res.status_code == 200
-    assert res.data["applied_decisions"][0]["error_code"] == "REQUEST_NOT_APPROVED"
+    assert res.data["rejected_decisions"][0]["error_code"] == "REQUEST_NOT_APPROVED"
 
     # Test approved request can be consumed
     ik = str(uuid.uuid4())

--- a/backend/quotes/tests/test_draft_quote_resolve.py
+++ b/backend/quotes/tests/test_draft_quote_resolve.py
@@ -1,0 +1,257 @@
+import uuid
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from accounts.models import Role, UserMembership
+from parties.models import Branch, Department, Organization
+from pricing_v4.models import ProductCode, ProductCodeCreationRequest
+from quotes.spot_models import DraftQuoteDecisionDB, SPEChargeLineDB, SPESourceBatchDB, SpotPricingEnvelopeDB
+
+
+class DraftQuoteResolveHighValueTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.org = Organization.objects.create(name="Test Org", slug="test-org")
+        self.other_org = Organization.objects.create(name="Other Org", slug="other-org")
+        self.branch = Branch.objects.create(organization=self.org, code="POM", name="Port Moresby")
+        self.other_branch = Branch.objects.create(organization=self.other_org, code="BNE", name="Brisbane")
+        self.department = Department.objects.create(organization=self.org, branch=self.branch, code="AIR", name="Air Freight")
+        self.other_department = Department.objects.create(organization=self.other_org, branch=self.other_branch, code="SEA", name="Sea Freight")
+        User = get_user_model()
+        self.sales = User.objects.create_user(username="sales_resolve", password="x", role=User.ROLE_SALES)
+        self.finance = User.objects.create_user(username="finance_resolve", password="x", role=User.ROLE_FINANCE)
+        self.other_sales = User.objects.create_user(username="other_sales_resolve", password="x", role=User.ROLE_SALES)
+        self._membership(self.sales, self.org, self.branch, self.department, "sales")
+        self._membership(self.finance, self.org, self.branch, self.department, "finance")
+        self._membership(self.other_sales, self.other_org, self.other_branch, self.other_department, "sales")
+        self.envelope = SpotPricingEnvelopeDB.objects.create(
+            status=SpotPricingEnvelopeDB.Status.DRAFT,
+            shipment_context_json={"origin_country": "SG", "destination_country": "PG", "mode": "AIR"},
+            spot_trigger_reason_code="TEST",
+            spot_trigger_reason_text="Test",
+            expires_at=timezone.now() + timezone.timedelta(days=7),
+            organization=self.org,
+            branch=self.branch,
+            department=self.department,
+            owner=self.sales,
+            created_by=self.sales,
+        )
+        self.batch = SPESourceBatchDB.objects.create(
+            envelope=self.envelope,
+            source_kind=SPESourceBatchDB.SourceKind.AGENT,
+            source_type=SPESourceBatchDB.SourceType.TEXT,
+            label="Agent reply",
+            file_name="agent.txt",
+            analysis_summary_json={
+                "unclassified_items": [
+                    {"id": "unclass-1", "raw_text": "Documentation fee USD 25", "evidence": {"source_text": "Documentation fee USD 25"}},
+                    {"id": "unclass-2", "raw_text": "Have a nice day"},
+                ]
+            },
+        )
+        self.product_code = ProductCode.objects.create(
+            id=2001,
+            code="IMP-DOC-FEE",
+            description="Import documentation fee",
+            domain=ProductCode.DOMAIN_IMPORT,
+            category=ProductCode.CATEGORY_DOCUMENTATION,
+            is_gst_applicable=False,
+            gl_revenue_code="4000",
+            gl_cost_code="5000",
+            default_unit=ProductCode.UNIT_SHIPMENT,
+        )
+        self.charge = SPEChargeLineDB.objects.create(
+            envelope=self.envelope,
+            source_batch=self.batch,
+            code="RAW-DOC",
+            description="Raw documentation fee",
+            amount=Decimal("10.00"),
+            currency="USD",
+            unit=SPEChargeLineDB.Unit.FLAT,
+            bucket=SPEChargeLineDB.Bucket.DESTINATION_CHARGES,
+            normalization_status=SPEChargeLineDB.NormalizationStatus.UNMAPPED,
+            source_label="DOC FEE",
+            source_excerpt="DOC FEE USD 10",
+            source_reference="agent.txt",
+            entered_by=self.sales,
+            entered_at=timezone.now(),
+        )
+
+    def _membership(self, user, organization, branch, department, role_code):
+        role, _ = Role.objects.get_or_create(code=role_code, defaults={"name": role_code.title()})
+        UserMembership.objects.create(user=user, organization=organization, branch=branch, department=department, role=role, is_active=True, is_primary=True)
+
+    def _post(self, decisions, key=None, user=None):
+        self.client.force_authenticate(user=user or self.sales)
+        return self.client.post(
+            f"/api/v3/spot/envelopes/{self.envelope.id}/draft-quote/resolve/",
+            {"idempotency_key": str(key or uuid.uuid4()), "decisions": decisions},
+            format="json",
+        )
+
+    def _decision(self, decision_type, target_id=None, details=None, decision_id="dec-1"):
+        return {
+            "decision_id": decision_id,
+            "type": decision_type,
+            "target_id": str(target_id or self.charge.id),
+            "details": details or {},
+            "audit_metadata": {"user_id": self.sales.id, "timestamp": "2026-07-06T00:00:00Z"},
+        }
+
+    def test_map_to_product_code_applies_to_charge_line_and_read_queue(self):
+        res = self._post([self._decision("map_to_product_code", details={"product_code": self.product_code.code})])
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data["applied_decisions"][0]["status"], "applied")
+        self.charge.refresh_from_db()
+        self.assertEqual(self.charge.manual_resolved_product_code_id, self.product_code.id)
+        self.assertEqual(self.charge.manual_resolution_status, SPEChargeLineDB.ManualResolutionStatus.RESOLVED)
+        self.assertEqual(self.charge.source_excerpt, "DOC FEE USD 10")
+        self.assertEqual(res.data["unresolved_items_remaining"], 2)
+
+    def test_map_to_product_code_rejects_invalid_product_code(self):
+        res = self._post([self._decision("map_to_product_code", details={"product_code": "NOPE"})])
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data["rejected_decisions"][0]["error_code"], "PRODUCT_CODE_NOT_FOUND")
+        self.charge.refresh_from_db()
+        self.assertIsNone(self.charge.manual_resolved_product_code_id)
+
+    def test_map_to_product_code_replay_is_idempotent(self):
+        key = uuid.uuid4()
+        decision = self._decision("map_to_product_code", details={"product_code": self.product_code.code})
+        self._post([decision], key=key)
+        self._post([decision], key=key)
+        self.assertEqual(DraftQuoteDecisionDB.objects.filter(idempotency_key=key).count(), 1)
+
+    def test_edit_charge_updates_allowed_fields_and_preserves_evidence(self):
+        res = self._post([
+            self._decision(
+                "edit_charge",
+                details={"original_values": {}, "updated_values": {"description": "Edited fee", "amount": "12.50", "include_in_totals": False}},
+            )
+        ])
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data["applied_decisions"][0]["status"], "applied")
+        self.charge.refresh_from_db()
+        self.assertEqual(self.charge.description, "Edited fee")
+        self.assertEqual(self.charge.amount, Decimal("12.50"))
+        self.assertTrue(self.charge.exclude_from_totals)
+        self.assertEqual(self.charge.source_label, "DOC FEE")
+        decision = DraftQuoteDecisionDB.objects.get(decision_type="edit_charge")
+        self.assertEqual(decision.details_json["before"]["description"], "Raw documentation fee")
+        self.assertEqual(decision.details_json["after"]["amount"], "12.50")
+
+    def test_edit_charge_rejects_unknown_field(self):
+        res = self._post([self._decision("edit_charge", details={"original_values": {}, "updated_values": {"source_excerpt": "rewrite raw"}})])
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data["rejected_decisions"][0]["error_code"], "INVALID_FIELD")
+        self.charge.refresh_from_db()
+        self.assertEqual(self.charge.source_excerpt, "DOC FEE USD 10")
+
+    def test_classify_unclassified_as_charge_creates_charge_line(self):
+        res = self._post([
+            self._decision(
+                "classify_unclassified",
+                target_id="unclass-1",
+                details={
+                    "classification": "charge",
+                    "bucket": SPEChargeLineDB.Bucket.DESTINATION_CHARGES,
+                    "display_label": "Documentation fee",
+                    "product_code": self.product_code.code,
+                    "amount": "25.00",
+                    "currency": "USD",
+                    "unit": SPEChargeLineDB.Unit.FLAT,
+                },
+            )
+        ])
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data["applied_decisions"][0]["status"], "applied")
+        created = SPEChargeLineDB.objects.get(description="Documentation fee")
+        self.assertEqual(created.manual_resolved_product_code_id, self.product_code.id)
+        self.assertEqual(created.source_excerpt, "Documentation fee USD 25")
+        self.batch.refresh_from_db()
+        self.assertEqual([i["id"] for i in self.batch.analysis_summary_json["unclassified_items"]], ["unclass-2"])
+        self.assertEqual(self.batch.analysis_summary_json["ignored_items"][0]["raw_text"], "Documentation fee USD 25")
+
+    def test_classify_unclassified_without_product_code_is_skipped(self):
+        res = self._post([
+            self._decision(
+                "classify_unclassified",
+                target_id="unclass-1",
+                details={
+                    "classification": "charge",
+                    "bucket": SPEChargeLineDB.Bucket.DESTINATION_CHARGES,
+                    "display_label": "Documentation fee",
+                    "product_code": "MISSING",
+                    "amount": "25.00",
+                    "currency": "USD",
+                },
+            )
+        ])
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data["applied_decisions"][0]["status"], "skipped")
+        self.assertEqual(res.data["applied_decisions"][0]["error_code"], "PRODUCT_CODE_REQUIRED")
+
+    def test_classify_unclassified_as_ignored_preserves_text(self):
+        res = self._post([self._decision("classify_unclassified", target_id="unclass-2", details={"classification": "ignored", "reason": "Greeting"})])
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data["applied_decisions"][0]["status"], "applied")
+        self.batch.refresh_from_db()
+        self.assertEqual(self.batch.analysis_summary_json["ignored_items"][0]["raw_text"], "Have a nice day")
+
+    def test_finance_and_cross_scope_users_cannot_resolve_high_value_decisions(self):
+        decision = self._decision("map_to_product_code", details={"product_code": self.product_code.code})
+        self.assertEqual(self._post([decision], user=self.finance).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn(self._post([decision], user=self.other_sales).status_code, (status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND))
+
+    def test_low_risk_and_product_code_request_flows_still_pass(self):
+        res = self._post([
+            self._decision("accept_suggestion", decision_id="accept"),
+            self._decision("ignore", decision_id="ignore", details={"reason": "Not commercial"}),
+        ])
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual([d["status"] for d in res.data["applied_decisions"]], ["applied", "applied"])
+
+        request_res = self._post([
+            self._decision(
+                "request_product_code",
+                decision_id="request",
+                details={
+                    "proposed_code": "IMP-NEW",
+                    "description": "New import fee",
+                    "category": "destination_charges",
+                    "domain": "IMPORT",
+                    "reason": "Supplier added new fee",
+                },
+            )
+        ])
+        self.assertEqual(request_res.status_code, status.HTTP_200_OK)
+        self.assertEqual(request_res.data["applied_decisions"][0]["status"], "skipped")
+        self.assertEqual(ProductCodeCreationRequest.objects.filter(source_envelope=self.envelope).count(), 1)
+
+    def test_approved_product_code_consumption_still_passes(self):
+        req = ProductCodeCreationRequest.objects.create(
+            source_label="DOC FEE",
+            suggested_name="IMP-DOC-FEE",
+            suggested_bucket="destination_charges",
+            suggested_basis="FLAT",
+            source_envelope=self.envelope,
+            source_charge_line=self.charge,
+            status=ProductCodeCreationRequest.STATUS_APPROVED,
+            approved_product_code=self.product_code,
+            created_by=self.sales,
+        )
+        res = self._post([
+            self._decision(
+                "use_approved_product_code",
+                details={"product_code_request_id": req.id, "product_code_id": self.product_code.id},
+            )
+        ])
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data["applied_decisions"][0]["status"], "applied")
+        self.charge.refresh_from_db()
+        self.assertEqual(self.charge.manual_resolved_product_code_id, self.product_code.id)

--- a/backend/quotes/tests/test_draft_quote_resolve.py
+++ b/backend/quotes/tests/test_draft_quote_resolve.py
@@ -152,6 +152,46 @@ class DraftQuoteResolveHighValueTests(TestCase):
         self.charge.refresh_from_db()
         self.assertEqual(self.charge.source_excerpt, "DOC FEE USD 10")
 
+    def test_edit_charge_maps_calculation_basis_to_unit_type(self):
+        res = self._post([
+            self._decision(
+                "edit_charge",
+                details={"original_values": {}, "updated_values": {"calculation_basis": SPEChargeLineDB.UnitType.KG}},
+            )
+        ])
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data["applied_decisions"][0]["status"], "applied")
+        self.charge.refresh_from_db()
+        self.assertEqual(self.charge.unit_type, SPEChargeLineDB.UnitType.KG)
+        self.assertIsNone(self.charge.calculation_basis)
+
+    def test_edit_charge_rejects_invalid_currency(self):
+        res = self._post([
+            self._decision("edit_charge", details={"original_values": {}, "updated_values": {"currency": "USDX"}})
+        ])
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data["rejected_decisions"][0]["error_code"], "INVALID_CURRENCY")
+        self.charge.refresh_from_db()
+        self.assertEqual(self.charge.currency, "USD")
+
+    def test_edit_charge_rejects_invalid_unit(self):
+        res = self._post([
+            self._decision("edit_charge", details={"original_values": {}, "updated_values": {"unit": "per_container"}})
+        ])
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data["rejected_decisions"][0]["error_code"], "INVALID_UNIT")
+        self.charge.refresh_from_db()
+        self.assertEqual(self.charge.unit, SPEChargeLineDB.Unit.FLAT)
+
+    def test_edit_charge_rejects_negative_numeric_value(self):
+        res = self._post([
+            self._decision("edit_charge", details={"original_values": {}, "updated_values": {"amount": "-0.01"}})
+        ])
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data["rejected_decisions"][0]["error_code"], "NEGATIVE_NUMERIC_VALUE")
+        self.charge.refresh_from_db()
+        self.assertEqual(self.charge.amount, Decimal("10.00"))
+
     def test_classify_unclassified_as_charge_creates_charge_line(self):
         res = self._post([
             self._decision(


### PR DESCRIPTION
## Summary
- Applies high-value Draft Quote resolve decisions to SPOT charge-line state.
- Extends resolve contract validation for safe editable charge fields and unclassified classification.
- Corrects `edit_charge.calculation_basis` application to update `SPEChargeLineDB.unit_type`, not the diagnostic `calculation_basis` field.
- Validates editable currency, unit, calculation basis, and non-negative numeric charge values before mutating charge lines.
- Adds focused backend tests for mapping, editing, classification, validation, idempotency, RBAC, ProductCode request, and approved ProductCode consumption.

## Decision types implemented
- `map_to_product_code`
- `edit_charge`
- `classify_unclassified`

## Decision types intentionally not implemented
- Rejected ProductCode UX
- Final quote locking/finalization
- Controlled learning
- Frontend redesign
- Bulk operations
- Autonomous AI behaviour
- Parser rewrite

## Data fields changed
- `SPEChargeLineDB.manual_resolved_product_code`
- `SPEChargeLineDB.manual_resolution_status`
- `SPEChargeLineDB.manual_resolution_by`
- `SPEChargeLineDB.manual_resolution_at`
- Safe editable charge fields: description, amount, rate, currency, unit, unit_type via `calculation_basis`, min_charge, exclude_from_totals, note
- `SPEChargeLineDB.rule_meta["draft_quote_resolution"]` for decision/idempotency/operator audit context
- `SPESourceBatchDB.analysis_summary_json` for classified ignored/unclassified items
- `DraftQuoteDecisionDB.details_json` preserves edit before/after metadata

## Idempotency behaviour
- Existing envelope/idempotency_key/decision_id records are replayed from `DraftQuoteDecisionDB`.
- Replays do not duplicate ProductCode requests, charge lines, or audit records.
- A new idempotency key can log a new decision without overwriting an already resolved charge-line operator/timestamp.

## Tests run
- `python backend\manage.py test quotes.tests.test_draft_quote_resolve`
- `python backend\manage.py test quotes.tests.test_draft_quote_contract`
- `pytest backend\quotes\tests\test_draft_quote_api.py`
- `python backend\manage.py check`
- `graphify update .`
- `git diff --check`

## Known risks / follow-ups
- `ProductCode` has no active/inactive field in the current model, so active validation is effectively existence validation for now.
- `classify_unclassified` supports safe charge creation only when an existing ProductCode is supplied; missing ProductCode is skipped with `PRODUCT_CODE_REQUIRED` rather than guessed.
- Graphify skipped HTML generation because the graph exceeds the local 5,000-node visualization limit; JSON/report were updated.