### PR TITLE
Phase 12.5: Finalize Draft Quote review

### DIFF
--- a/backend/quotes/contracts/draft_quote_contract.py
+++ b/backend/quotes/contracts/draft_quote_contract.py
@@ -95,6 +95,20 @@ class TotalsValidationSchema(BaseModel):
     warnings: List[str] = Field(default_factory=list, description="Totals-related warnings")
 
 
+class DraftQuoteReviewSessionSchema(BaseModel):
+    status: str = Field("draft", description="Review status: draft, in_review, finalized")
+    finalized_by: Optional[int] = Field(None, description="User ID that finalized this review")
+    finalized_at: Optional[str] = Field(None, description="ISO timestamp when review was finalized")
+    remaining_blockers: int = Field(0, description="Critical blockers that must be cleared before finalization")
+    available_actions: List[str] = Field(default_factory=list, description="Available review session actions")
+
+    @model_validator(mode="after")
+    def validate_review_status(self) -> DraftQuoteReviewSessionSchema:
+        if self.status not in {"draft", "in_review", "finalized"}:
+            raise ValueError("Review status must be draft, in_review, or finalized.")
+        return self
+
+
 class DraftQuoteSchema(BaseModel):
     contract_version: str = Field(..., description="Version of the draft quote contract")
     quote_summary: str = Field(..., description="Summary overview of the draft quote")
@@ -110,6 +124,7 @@ class DraftQuoteSchema(BaseModel):
     review_queue: List[Dict[str, Any]] = Field(default_factory=list, description="Items queued for manual operator review")
     correction_actions: List[Dict[str, Any]] = Field(default_factory=list, description="Action descriptors to correct validation issues")
     metadata: Dict[str, Any] = Field(default_factory=dict, description="Metadata and sender-based memory placeholders")
+    review_session: DraftQuoteReviewSessionSchema = Field(default_factory=DraftQuoteReviewSessionSchema, description="Draft Quote review session state")
 
     @model_validator(mode="after")
     def validate_draft_quote(self) -> DraftQuoteSchema:
@@ -285,5 +300,29 @@ class DraftQuoteResolveResponseSchema(BaseModel):
         if self.status not in valid_statuses:
             raise ValueError(f"Invalid response status: {self.status}")
         return self
+
+
+class DraftQuoteFinalizeSchema(BaseModel):
+    idempotency_key: UUID = Field(..., description="UUID token ensuring finalize idempotency")
+    audit_metadata: Dict[str, Any] = Field(default_factory=dict, description="Operator audit metadata")
+
+
+class DraftQuoteFinalizeResponseSchema(BaseModel):
+    status: str = Field(..., description="accepted or rejected")
+    idempotency_key: UUID = Field(..., description="The finalize idempotency key")
+    envelope_id: UUID = Field(..., description="Target SPOT envelope ID")
+    review_status: str = Field(..., description="Current review status")
+    remaining_blockers: int = Field(..., description="Critical blockers remaining")
+    blockers: List[Dict[str, Any]] = Field(default_factory=list, description="Blocking items preventing finalization")
+    finalized_by: Optional[int] = Field(None, description="User ID that finalized this review")
+    finalized_at: Optional[str] = Field(None, description="ISO timestamp when review was finalized")
+    message: str = Field(..., description="Finalize result message")
+
+
+class DraftQuoteReopenResponseSchema(BaseModel):
+    status: str = Field(..., description="accepted or rejected")
+    envelope_id: UUID = Field(..., description="Target SPOT envelope ID")
+    review_status: str = Field(..., description="Current review status")
+    message: str = Field(..., description="Reopen result message")
 
 

--- a/backend/quotes/services/draft_quote_adapter.py
+++ b/backend/quotes/services/draft_quote_adapter.py
@@ -429,7 +429,7 @@ def build_draft_quote_payload(spe_db: SpotPricingEnvelopeDB) -> Dict[str, Any]:
         "user_audit_log": spe_db.conditions_json.get('user_audit_log', []) if isinstance(spe_db.conditions_json, dict) else []
     }
 
-    return {
+    payload = {
         "contract_version": "1.0.0",
         "quote_summary": quote_summary,
         "shipment_context": shipment_context,
@@ -445,6 +445,9 @@ def build_draft_quote_payload(spe_db: SpotPricingEnvelopeDB) -> Dict[str, Any]:
         "correction_actions": correction_actions,
         "metadata": metadata
     }
+    from quotes.services.draft_quote_review_service import review_session_payload
+    payload["review_session"] = review_session_payload(spe_db, DraftQuoteSchema(**payload))
+    return payload
 
 def get_validated_draft_quote(spe_db: SpotPricingEnvelopeDB) -> DraftQuoteSchema:
     payload = build_draft_quote_payload(spe_db)

--- a/backend/quotes/services/draft_quote_review_service.py
+++ b/backend/quotes/services/draft_quote_review_service.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from django.utils import timezone
+
+from quotes.contracts.draft_quote_contract import DraftQuoteSchema
+from quotes.spot_models import DraftQuoteDecisionDB, SpotPricingEnvelopeDB
+
+
+REVIEW_KEY = "draft_quote_review"
+
+
+def get_review_state(envelope: SpotPricingEnvelopeDB) -> dict[str, Any]:
+    conditions = envelope.conditions_json if isinstance(envelope.conditions_json, dict) else {}
+    state = dict(conditions.get(REVIEW_KEY) or {})
+    if state.get("status") == "finalized":
+        return state
+    if DraftQuoteDecisionDB.objects.filter(envelope=envelope).exists():
+        state["status"] = "in_review"
+    else:
+        state["status"] = "draft"
+    return state
+
+
+def is_finalized(envelope: SpotPricingEnvelopeDB) -> bool:
+    return get_review_state(envelope).get("status") == "finalized"
+
+
+def unresolved_blockers(draft_quote: DraftQuoteSchema) -> list[dict[str, Any]]:
+    charges_by_id = {charge.id: charge for charge in draft_quote.suggested_charges}
+    blockers: list[dict[str, Any]] = []
+    for item in draft_quote.review_queue:
+        item_id = str(item.get("id") or "")
+        charge = charges_by_id.get(item_id)
+        if charge and "PENDING_ADMIN_REVIEW" in (charge.correction_actions or []):
+            continue
+        blockers.append(item)
+    return blockers
+
+
+def review_session_payload(envelope: SpotPricingEnvelopeDB, draft_quote: DraftQuoteSchema) -> dict[str, Any]:
+    state = get_review_state(envelope)
+    blockers = unresolved_blockers(draft_quote)
+    status = state.get("status", "draft")
+    actions = []
+    if status == "finalized":
+        actions.append("reopen")
+    elif not blockers:
+        actions.append("finalize")
+    return {
+        "status": status,
+        "finalized_by": state.get("finalized_by"),
+        "finalized_at": state.get("finalized_at"),
+        "remaining_blockers": len(blockers),
+        "available_actions": actions,
+    }
+
+
+def finalize_review(envelope: SpotPricingEnvelopeDB, draft_quote: DraftQuoteSchema, user, idempotency_key: UUID) -> tuple[bool, dict[str, Any], list[dict[str, Any]]]:
+    state = get_review_state(envelope)
+    if state.get("status") == "finalized" and state.get("idempotency_key") == str(idempotency_key):
+        return True, state, []
+
+    blockers = unresolved_blockers(draft_quote)
+    if blockers:
+        return False, state, blockers
+
+    conditions = dict(envelope.conditions_json or {})
+    state = {
+        "status": "finalized",
+        "finalized_by": user.id,
+        "finalized_at": timezone.now().isoformat(),
+        "idempotency_key": str(idempotency_key),
+    }
+    conditions[REVIEW_KEY] = state
+    envelope.conditions_json = conditions
+    envelope.save(update_fields=["conditions_json"])
+    return True, state, []
+
+
+def reopen_review(envelope: SpotPricingEnvelopeDB, user) -> dict[str, Any]:
+    conditions = dict(envelope.conditions_json or {})
+    previous = dict(conditions.get(REVIEW_KEY) or {})
+    state = {
+        **previous,
+        "status": "in_review",
+        "reopened_by": user.id,
+        "reopened_at": timezone.now().isoformat(),
+    }
+    conditions[REVIEW_KEY] = state
+    envelope.conditions_json = conditions
+    envelope.save(update_fields=["conditions_json"])
+    return state

--- a/backend/quotes/spot_views.py
+++ b/backend/quotes/spot_views.py
@@ -33,7 +33,7 @@ from rest_framework.exceptions import PermissionDenied
 
 from django.shortcuts import get_object_or_404
 
-from accounts.permissions import CanUseAIIntake, CanEditQuotes
+from accounts.permissions import CanUseAIIntake, CanEditQuotes, CanFinalizeQuotes, IsManagerOrAdmin
 from core.security import validate_pdf_upload
 from core.business_rules import classify_png_shipment
 from pricing_v4.models import ChargeAlias, ProductCode
@@ -3404,6 +3404,13 @@ class SpotEnvelopeDraftQuoteResolveAPIView(APIView):
                 status=status.HTTP_200_OK
             )
 
+        from quotes.services.draft_quote_review_service import is_finalized
+        if is_finalized(spe_db):
+            return Response(
+                {"error": "Draft Quote review is finalized and locked.", "error_code": "DRAFT_QUOTE_FINALIZED"},
+                status=status.HTTP_409_CONFLICT,
+            )
+
         # 2. Persist and apply new decisions atomically using resolve service
         from quotes.services.draft_quote_resolve_service import apply_draft_quote_decisions
         applied, rejected = apply_draft_quote_decisions(spe_db, payload, request.user)
@@ -3441,6 +3448,60 @@ class SpotEnvelopeDraftQuoteResolveAPIView(APIView):
         )
 
 
+class SpotEnvelopeDraftQuoteFinalizeAPIView(APIView):
+    permission_classes = [IsAuthenticated, CanFinalizeQuotes]
+
+    @transaction.atomic
+    def post(self, request, envelope_id):
+        spe_db = _get_spe_or_404(request.user, envelope_id, _spe_queryset())
+
+        from pydantic import ValidationError
+        from quotes.contracts.draft_quote_contract import DraftQuoteFinalizeSchema, DraftQuoteFinalizeResponseSchema
+        from quotes.services.draft_quote_adapter import get_validated_draft_quote
+        from quotes.services.draft_quote_review_service import finalize_review
+
+        try:
+            payload = DraftQuoteFinalizeSchema(**request.data)
+        except ValidationError as err:
+            return Response(
+                {"error": "Validation failed", "details": [f"{'.'.join(str(l) for l in e['loc'])}: {e['msg']}" for e in err.errors()]},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        draft_quote = get_validated_draft_quote(spe_db)
+        accepted, state, blockers = finalize_review(spe_db, draft_quote, request.user, payload.idempotency_key)
+        response_payload = DraftQuoteFinalizeResponseSchema(
+            status="accepted" if accepted else "rejected",
+            idempotency_key=payload.idempotency_key,
+            envelope_id=spe_db.id,
+            review_status=state.get("status", "draft"),
+            remaining_blockers=len(blockers),
+            blockers=blockers,
+            finalized_by=state.get("finalized_by"),
+            finalized_at=state.get("finalized_at"),
+            message="Draft Quote review finalized." if accepted else "Draft Quote review has critical blockers.",
+        )
+        return Response(response_payload.model_dump(mode="json"), status=status.HTTP_200_OK if accepted else status.HTTP_400_BAD_REQUEST)
+
+
+class SpotEnvelopeDraftQuoteReopenAPIView(APIView):
+    permission_classes = [IsAuthenticated, IsManagerOrAdmin]
+
+    @transaction.atomic
+    def post(self, request, envelope_id):
+        spe_db = _get_spe_or_404(request.user, envelope_id, _spe_queryset())
+
+        from quotes.contracts.draft_quote_contract import DraftQuoteReopenResponseSchema
+        from quotes.services.draft_quote_review_service import reopen_review
+
+        state = reopen_review(spe_db, request.user)
+        response_payload = DraftQuoteReopenResponseSchema(
+            status="accepted",
+            envelope_id=spe_db.id,
+            review_status=state.get("status", "in_review"),
+            message="Draft Quote review reopened.",
+        )
+        return Response(response_payload.model_dump(mode="json"), status=status.HTTP_200_OK)
 
 
 

--- a/backend/quotes/tests/test_draft_quote_resolve.py
+++ b/backend/quotes/tests/test_draft_quote_resolve.py
@@ -24,9 +24,11 @@ class DraftQuoteResolveHighValueTests(TestCase):
         self.other_department = Department.objects.create(organization=self.other_org, branch=self.other_branch, code="SEA", name="Sea Freight")
         User = get_user_model()
         self.sales = User.objects.create_user(username="sales_resolve", password="x", role=User.ROLE_SALES)
+        self.manager = User.objects.create_user(username="manager_resolve", password="x", role=User.ROLE_MANAGER)
         self.finance = User.objects.create_user(username="finance_resolve", password="x", role=User.ROLE_FINANCE)
         self.other_sales = User.objects.create_user(username="other_sales_resolve", password="x", role=User.ROLE_SALES)
         self._membership(self.sales, self.org, self.branch, self.department, "sales")
+        self._membership(self.manager, self.org, self.branch, self.department, "manager")
         self._membership(self.finance, self.org, self.branch, self.department, "finance")
         self._membership(self.other_sales, self.other_org, self.other_branch, self.other_department, "sales")
         self.envelope = SpotPricingEnvelopeDB.objects.create(
@@ -137,6 +139,27 @@ class DraftQuoteResolveHighValueTests(TestCase):
         res = self.client.get(f"/api/v3/spot/envelopes/{self.envelope.id}/draft-quote/")
         self.assertEqual(res.status_code, status.HTTP_200_OK)
         return next(c for c in res.data["suggested_charges"] if c["id"] == str(self.charge.id))
+
+    def _finalize(self, key=None, user=None):
+        self.client.force_authenticate(user=user or self.sales)
+        return self.client.post(
+            f"/api/v3/spot/envelopes/{self.envelope.id}/draft-quote/finalize/",
+            {"idempotency_key": str(key or uuid.uuid4()), "audit_metadata": {"user_id": (user or self.sales).id}},
+            format="json",
+        )
+
+    def _reopen(self, user=None):
+        self.client.force_authenticate(user=user or self.manager)
+        return self.client.post(f"/api/v3/spot/envelopes/{self.envelope.id}/draft-quote/reopen/", {}, format="json")
+
+    def _resolve_all_blockers(self):
+        res = self._post([
+            self._decision("map_to_product_code", details={"product_code": self.product_code.code}, decision_id="map-finalize"),
+            self._decision("classify_unclassified", target_id="unclass-1", details={"classification": "ignored", "reason": "Not billable"}, decision_id="ignore-u1"),
+            self._decision("classify_unclassified", target_id="unclass-2", details={"classification": "ignored", "reason": "Greeting"}, decision_id="ignore-u2"),
+        ])
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data["rejected_decisions"], [])
 
     def test_map_to_product_code_applies_to_charge_line_and_read_queue(self):
         res = self._post([self._decision("map_to_product_code", details={"product_code": self.product_code.code})])
@@ -426,3 +449,81 @@ class DraftQuoteResolveHighValueTests(TestCase):
         self.assertEqual(res.data["applied_decisions"][0]["status"], "applied")
         self.charge.refresh_from_db()
         self.assertEqual(self.charge.manual_resolved_product_code_id, self.product_code.id)
+
+    def test_finalize_succeeds_when_blockers_resolved_and_read_reflects_state(self):
+        self._resolve_all_blockers()
+        key = uuid.uuid4()
+
+        res = self._finalize(key=key)
+
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data["status"], "accepted")
+        self.assertEqual(res.data["review_status"], "finalized")
+        self.assertEqual(res.data["remaining_blockers"], 0)
+        self.assertEqual(res.data["finalized_by"], self.sales.id)
+        self.assertIsNotNone(res.data["finalized_at"])
+
+        self.client.force_authenticate(user=self.sales)
+        read_res = self.client.get(f"/api/v3/spot/envelopes/{self.envelope.id}/draft-quote/")
+        self.assertEqual(read_res.status_code, status.HTTP_200_OK)
+        self.assertEqual(read_res.data["review_session"]["status"], "finalized")
+        self.assertEqual(read_res.data["review_session"]["remaining_blockers"], 0)
+        self.assertEqual(read_res.data["review_session"]["available_actions"], ["reopen"])
+
+    def test_finalize_fails_when_critical_blockers_remain(self):
+        res = self._finalize()
+
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(res.data["status"], "rejected")
+        self.assertGreaterEqual(res.data["remaining_blockers"], 1)
+        self.assertEqual(res.data["review_status"], "draft")
+
+    def test_finalize_replay_is_idempotent(self):
+        self._resolve_all_blockers()
+        key = uuid.uuid4()
+
+        first = self._finalize(key=key)
+        second = self._finalize(key=key)
+
+        self.assertEqual(first.status_code, status.HTTP_200_OK)
+        self.assertEqual(second.status_code, status.HTTP_200_OK)
+        self.assertEqual(second.data["review_status"], "finalized")
+        self.assertEqual(second.data["finalized_at"], first.data["finalized_at"])
+
+    def test_finalized_workspace_blocks_further_resolve_decisions(self):
+        self._resolve_all_blockers()
+        self.assertEqual(self._finalize().status_code, status.HTTP_200_OK)
+
+        res = self._post([
+            self._decision("edit_charge", details={"original_values": {}, "updated_values": {"amount": "11.00"}}, decision_id="edit-after-final")
+        ])
+
+        self.assertEqual(res.status_code, status.HTTP_409_CONFLICT)
+        self.assertEqual(res.data["error_code"], "DRAFT_QUOTE_FINALIZED")
+        self.charge.refresh_from_db()
+        self.assertEqual(self.charge.amount, Decimal("10.00"))
+
+    def test_manager_can_reopen_finalized_review_and_resolve_can_continue(self):
+        self._resolve_all_blockers()
+        self.assertEqual(self._finalize().status_code, status.HTTP_200_OK)
+
+        reopen = self._reopen(user=self.manager)
+        self.assertEqual(reopen.status_code, status.HTTP_200_OK)
+        self.assertEqual(reopen.data["review_status"], "in_review")
+
+        res = self._post([
+            self._decision("edit_charge", details={"original_values": {}, "updated_values": {"amount": "11.00"}}, decision_id="edit-after-reopen")
+        ])
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data["applied_decisions"][0]["status"], "applied")
+
+    def test_finance_and_cross_scope_users_cannot_finalize_or_reopen(self):
+        self._resolve_all_blockers()
+
+        self.assertEqual(self._finalize(user=self.finance).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn(self._finalize(user=self.other_sales).status_code, (status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND))
+
+        self.assertEqual(self._finalize(user=self.sales).status_code, status.HTTP_200_OK)
+        self.assertEqual(self._reopen(user=self.sales).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self._reopen(user=self.finance).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn(self._reopen(user=self.other_sales).status_code, (status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND))

--- a/backend/quotes/urls.py
+++ b/backend/quotes/urls.py
@@ -37,6 +37,8 @@ from .spot_views import (
     SpotTemplateValidationMaintenanceInsightsAPIView,
     SpotEnvelopeDraftQuoteAPIView,
     SpotEnvelopeDraftQuoteResolveAPIView,
+    SpotEnvelopeDraftQuoteFinalizeAPIView,
+    SpotEnvelopeDraftQuoteReopenAPIView,
 )
 
 app_name = 'quotes'
@@ -82,4 +84,6 @@ urlpatterns = [
     path('v3/spot/template-validation/maintenance-insights/', SpotTemplateValidationMaintenanceInsightsAPIView.as_view(), name='spot-validation-maintenance-insights'),
     path('v3/spot/envelopes/<uuid:envelope_id>/draft-quote/', SpotEnvelopeDraftQuoteAPIView.as_view(), name='spot-envelope-draft-quote'),
     path('v3/spot/envelopes/<uuid:envelope_id>/draft-quote/resolve/', SpotEnvelopeDraftQuoteResolveAPIView.as_view(), name='spot-envelope-draft-quote-resolve'),
+    path('v3/spot/envelopes/<uuid:envelope_id>/draft-quote/finalize/', SpotEnvelopeDraftQuoteFinalizeAPIView.as_view(), name='spot-envelope-draft-quote-finalize'),
+    path('v3/spot/envelopes/<uuid:envelope_id>/draft-quote/reopen/', SpotEnvelopeDraftQuoteReopenAPIView.as_view(), name='spot-envelope-draft-quote-reopen'),
 ]

--- a/frontend/src/components/spot/ExceptionWorkspace.tsx
+++ b/frontend/src/components/spot/ExceptionWorkspace.tsx
@@ -60,6 +60,13 @@ export function ExceptionWorkspace({ initialData = hardCaseAirImportData, isLive
     const [unclassifiedItems, setUnclassifiedItems] = useState(initialData.unclassified_items);
     const [ignoredItems, setIgnoredItems] = useState<Array<{ id: string; raw_text: string; ignored_reason: string; evidence: Evidence | null }>>(initialData.ignored_items || []);
     const [decisions, setDecisions] = useState<Decision[]>([]);
+    const [reviewSession, setReviewSession] = useState(initialData.review_session || {
+        status: "draft" as const,
+        finalized_by: null,
+        finalized_at: null,
+        remaining_blockers: initialData.review_queue.length,
+        available_actions: [] as string[]
+    });
 
     // Guided resolving workflow states
     const [activeIssueId, setActiveIssueId] = useState<string | null>(initialData.review_queue?.[0]?.id || null);
@@ -132,6 +139,9 @@ export function ExceptionWorkspace({ initialData = hardCaseAirImportData, isLive
         details: Record<string, unknown>;
         audit_metadata: { user_id: number; timestamp: string };
     }) => {
+        if (reviewSession.status === "finalized") {
+            throw new Error("Draft Quote review is finalized and locked.");
+        }
         if (!isLive || !envelopeId) {
             return;
         }
@@ -140,6 +150,39 @@ export function ExceptionWorkspace({ initialData = hardCaseAirImportData, isLive
             idempotency_key: crypto.randomUUID ? crypto.randomUUID() : "3b128522-a89e-4055-bf51-199eecc5628b",
             decisions: [decisionItem]
         });
+    };
+
+    const handleFinalizeReview = async () => {
+        if (!canFinishReview || reviewSession.status === "finalized") {
+            return;
+        }
+        if (isLive && envelopeId) {
+            try {
+                const { finalizeDraftQuoteReview } = await import("../../lib/api");
+                const result = await finalizeDraftQuoteReview(envelopeId, crypto.randomUUID ? crypto.randomUUID() : "47c7fa2d-8a4f-4cdb-9fbf-a396ed7f7f88");
+                setReviewSession(prev => ({
+                    ...prev,
+                    status: result.review_status,
+                    finalized_by: result.finalized_by ?? null,
+                    finalized_at: result.finalized_at ?? null,
+                    remaining_blockers: result.remaining_blockers,
+                    available_actions: ["reopen"]
+                }));
+            } catch (err) {
+                const errMsg = err instanceof Error ? err.message : String(err);
+                setActionMessage(`API error finalizing review: ${errMsg}`);
+                return;
+            }
+        } else {
+            setReviewSession(prev => ({
+                ...prev,
+                status: "finalized",
+                finalized_at: new Date().toISOString(),
+                remaining_blockers: 0,
+                available_actions: ["reopen"]
+            }));
+        }
+        setActionMessage("Draft Quote review finalized and locked.");
     };
 
     const handleUseApprovedProductCode = async (chargeId: string, charge: DraftCharge) => {
@@ -256,6 +299,7 @@ export function ExceptionWorkspace({ initialData = hardCaseAirImportData, isLive
     };
 
     const handleAcceptSuggestedMapping = (chargeId: string, displayLabel: string, suggestedCode: string) => {
+        if (isReviewLocked) return;
         captureSnapshot(chargeId, "accept", `Accepted code ${suggestedCode} for ${displayLabel}`);
         setSuggestedCharges(prev =>
             prev.map(c => (c.id === chargeId ? { ...c, status: "accepted_by_user" as DraftChargeStatus } : c))
@@ -302,6 +346,7 @@ export function ExceptionWorkspace({ initialData = hardCaseAirImportData, isLive
     };
 
     const handleIgnoreUnknownCharge = (itemId: string, rawText: string) => {
+        if (isReviewLocked) return;
         captureSnapshot(itemId, "ignore", "Ignored unknown text block");
         setIgnoredItems(prev => [
             ...prev,
@@ -319,6 +364,7 @@ export function ExceptionWorkspace({ initialData = hardCaseAirImportData, isLive
     };
 
     const handleAddUnknownAsCharge = (itemId: string) => {
+        if (isReviewLocked) return;
         const newChargeId = `chg-new-${Date.now()}`;
         const newCharge: DraftCharge = {
             id: newChargeId,
@@ -366,6 +412,7 @@ export function ExceptionWorkspace({ initialData = hardCaseAirImportData, isLive
     };
 
     const toggleIncludeInTotals = (chargeId: string) => {
+        if (isReviewLocked) return;
         setSuggestedCharges(prev =>
             prev.map(c => (c.id === chargeId ? { ...c, include_in_totals: !c.include_in_totals } : c))
         );
@@ -414,6 +461,7 @@ export function ExceptionWorkspace({ initialData = hardCaseAirImportData, isLive
         .every(c => c.suggested_product_code !== null && c.status !== ("pending_product_code" as any));
 
     const canFinishReview = checklistIssuesResolved && checklistNoUnknown && checklistProductCodesVerified;
+    const isReviewLocked = reviewSession.status === "finalized";
 
     // Direct Next-Step instructions guidance
     let nextStepGuidance = "Review the remaining commercial term before finishing.";
@@ -434,6 +482,13 @@ export function ExceptionWorkspace({ initialData = hardCaseAirImportData, isLive
                     <div className="bg-yellow-950/40 border border-yellow-900/60 text-yellow-300 p-4 rounded-xl text-xs flex items-center gap-3">
                         <Info className="w-5 h-5 text-yellow-400 shrink-0" />
                         <span className="font-medium">Live draft data loaded. Operator decisions are saved when you apply each action.</span>
+                    </div>
+                )}
+
+                {isReviewLocked && (
+                    <div className="bg-emerald-950/30 border border-emerald-900/60 text-emerald-200 p-4 rounded-xl text-xs flex items-center gap-3">
+                        <CheckCircle className="w-5 h-5 text-emerald-400 shrink-0" />
+                        <span className="font-medium">Draft Quote review finalized and locked{reviewSession.finalized_at ? ` at ${reviewSession.finalized_at}` : ""}.</span>
                     </div>
                 )}
 
@@ -914,6 +969,7 @@ export function ExceptionWorkspace({ initialData = hardCaseAirImportData, isLive
                                                 type="checkbox"
                                                 checked={charge.include_in_totals}
                                                 onChange={() => toggleIncludeInTotals(charge.id)}
+                                                disabled={isReviewLocked}
                                                 className="rounded bg-slate-950 border-slate-800 text-indigo-600 focus:ring-indigo-500 w-4 h-4"
                                             />
                                             <div>
@@ -1128,11 +1184,11 @@ export function ExceptionWorkspace({ initialData = hardCaseAirImportData, isLive
                         </div>
 
                         <button
-                            disabled={!canFinishReview && !prototypeOverride}
-                            onClick={() => alert("Review Complete! The quote suggestions have been finalized locally.")}
+                            disabled={isReviewLocked || (!canFinishReview && !prototypeOverride)}
+                            onClick={handleFinalizeReview}
                             className="px-8 py-3 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 disabled:hover:bg-indigo-600 text-white rounded-xl font-bold text-sm shadow-xl shadow-indigo-900/40 w-full sm:w-auto text-center transition"
                         >
-                            Finish Review
+                            {isReviewLocked ? "Review Finalized" : "Finalize Review"}
                         </button>
                     </div>
                     

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4,7 +4,7 @@ import { API_BASE_URL } from './config';
 import { getJson, sendJson } from './api/shared';
 import { mapQuoteDetailToComputeResult } from './quote-detail-mapping';
 import { ReplyAnalysisResult, SPEChargeLine, SPEConditions, SPECommodity } from './spot-types';
-import { DraftQuote, DraftQuoteResolvePayload, DraftQuoteResolveResponse } from './draft-quote-types';
+import { DraftQuote, DraftQuoteFinalizeResponse, DraftQuoteResolvePayload, DraftQuoteResolveResponse } from './draft-quote-types';
 import {
   LoginData,
   User,
@@ -828,6 +828,30 @@ export async function resolveDraftQuoteDecisions(
   }
 
   return response.json() as Promise<DraftQuoteResolveResponse>;
+}
+
+export async function finalizeDraftQuoteReview(
+  envelopeId: string,
+  idempotencyKey: string
+): Promise<DraftQuoteFinalizeResponse> {
+  const url = API_BASE_URL + `/api/v3/spot/envelopes/${envelopeId}/draft-quote/finalize/`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Token ${resolveAuthToken()}`,
+    },
+    body: JSON.stringify({
+      idempotency_key: idempotencyKey,
+      audit_metadata: { timestamp: new Date().toISOString() },
+    }),
+  });
+
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data?.message || data?.error || 'Failed to finalize draft quote review.');
+  }
+  return data as DraftQuoteFinalizeResponse;
 }
 
 

--- a/frontend/src/lib/draft-quote-types.ts
+++ b/frontend/src/lib/draft-quote-types.ts
@@ -126,6 +126,13 @@ export interface DraftQuote {
         historical_override_rules?: Record<string, unknown>;
         [key: string]: unknown;
     };
+    review_session?: {
+        status: 'draft' | 'in_review' | 'finalized';
+        finalized_by: number | null;
+        finalized_at: string | null;
+        remaining_blockers: number;
+        available_actions: string[];
+    };
 }
 
 export interface AuditMetadata {
@@ -161,4 +168,14 @@ export interface DraftQuoteResolveResponse {
     message: string;
     applied_decisions: DecisionResult[];
     rejected_decisions: DecisionResult[];
+}
+
+export interface DraftQuoteFinalizeResponse {
+    envelope_id: string;
+    status: 'accepted' | 'rejected';
+    review_status: 'draft' | 'in_review' | 'finalized';
+    remaining_blockers: number;
+    finalized_by?: number | null;
+    finalized_at?: string | null;
+    message: string;
 }


### PR DESCRIPTION
## Summary
- Adds a Draft Quote review finalization endpoint and read-payload review session status.
- Locks finalized Draft Quote review sessions against further resolve mutations, while preserving idempotent replay.
- Adds a manager/admin reopen endpoint and frontend locked-state affordance for the Exception Workspace.

## Decision types implemented
- Finalize Draft Quote review session.
- Reopen finalized Draft Quote review session for manager/admin users.

## Decision types intentionally not implemented
- PDF generation changes.
- Email workflow.
- Controlled learning.
- Bulk operations.
- Parser changes.
- Deployment scripts.

## Data fields changed
- Draft Quote read payload now includes `review_session` with `status`, `finalized_by`, `finalized_at`, `remaining_blockers`, and `available_actions`.
- Finalization state is persisted under the envelope `conditions_json.draft_quote_review` metadata key.

## Idempotency behaviour
- Replaying the same finalize idempotency key after successful finalization returns the existing finalized state without creating duplicate audit state.
- Resolve endpoint idempotent replay remains available, but new resolve mutations are rejected once the review is finalized.

## Tests run
- `python backend\manage.py test quotes.tests.test_draft_quote_resolve`
- `python backend\manage.py test quotes.tests.test_draft_quote_contract`
- `pytest backend/quotes/tests/test_draft_quote_api.py`
- `npm --prefix frontend run typecheck`
- `npm --prefix frontend run lint`
- `python backend\manage.py check`
- `graphify update .`
- `git diff --check`

## Known risks / follow-ups
- Review lock state is stored on the existing envelope JSON metadata rather than a new table, to keep this phase migration-free.
- The frontend shows the finalized locked state and disables mutations; manager/admin reopen is implemented on the backend but not exposed as a dedicated frontend CTA in this PR.