### PR TITLE
Phase 13.1B — Safe staging seed audit command

### DIFF
--- a/backend/quotes/management/commands/air_freight_pilot_seed_audit.py
+++ b/backend/quotes/management/commands/air_freight_pilot_seed_audit.py
@@ -1,0 +1,22 @@
+import json
+
+from django.core.management.base import BaseCommand
+
+from quotes.services.air_freight_pilot_seed_audit import (
+    build_air_freight_pilot_seed_audit,
+    render_air_freight_pilot_seed_audit_text,
+)
+
+
+class Command(BaseCommand):
+    help = "Read-only Air Freight pilot reference-data readiness audit."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--format", choices=["json", "text"], default="json")
+
+    def handle(self, *args, **options):
+        audit = build_air_freight_pilot_seed_audit()
+        if options["format"] == "text":
+            self.stdout.write(render_air_freight_pilot_seed_audit_text(audit), ending="")
+            return
+        self.stdout.write(json.dumps(audit, default=str, indent=2, sort_keys=True))

--- a/backend/quotes/services/air_freight_pilot_seed_audit.py
+++ b/backend/quotes/services/air_freight_pilot_seed_audit.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+from typing import Any
+
+from django.apps import apps
+from django.db.models import Q
+
+
+CANONICAL_ORGANIZATION = "Express Freight Management"
+OPERATING_ENTITIES = [
+    {"code": "PNG", "name": "EFM PNG"},
+    {"code": "AUS", "name": "EFM Australia"},
+    {"code": "FJI", "name": "EFM Fiji"},
+    {"code": "SLB", "name": "EFM Solomon Islands"},
+]
+BRANCHES = [
+    {"code": "POM", "name": "Port Moresby"},
+    {"code": "LAE", "name": "Lae"},
+    {"code": "BNE", "name": "Brisbane"},
+    {"code": "SUV", "name": "Suva"},
+    {"code": "HIR", "name": "Honiara"},
+]
+DEPARTMENTS = [
+    {"code": "AIR", "name": "Air Freight"},
+    {"code": "SEA", "name": "Sea Freight"},
+    {"code": "CUS", "name": "Customs"},
+    {"code": "TRN", "name": "Transport"},
+]
+ROLES = ["admin", "manager", "sales", "finance"]
+PRODUCT_COVERAGE = [
+    {"key": "air_freight", "label": "Air Freight", "terms": ["air freight", "freight"]},
+    {"key": "fuel_surcharge", "label": "Fuel surcharge", "terms": ["fuel", "fsc"]},
+    {"key": "security_surcharge", "label": "Security surcharge", "terms": ["security"]},
+    {"key": "screening", "label": "Screening", "terms": ["screening"]},
+    {"key": "awb_docs", "label": "AWB / documentation", "terms": ["awb", "documentation", "docs"]},
+    {"key": "import_handling", "label": "Import handling", "terms": ["import handling"]},
+    {"key": "export_handling", "label": "Export handling", "terms": ["export handling"]},
+    {"key": "origin_handling", "label": "Origin handling", "terms": ["origin handling"]},
+    {"key": "destination_handling", "label": "Destination handling", "terms": ["destination handling"]},
+    {"key": "storage_warehouse", "label": "Storage / warehouse", "terms": ["storage", "warehouse"]},
+    {"key": "customs_pass_through", "label": "Customs pass-through", "terms": ["customs", "clearance"]},
+    {"key": "misc_recoveries", "label": "Miscellaneous recoveries", "terms": ["misc", "recovery", "recoveries"]},
+]
+ALIASES = [
+    "air freight",
+    "freight",
+    "fsc",
+    "fuel surcharge",
+    "security surcharge",
+    "screening",
+    "awb",
+    "documentation fee",
+    "terminal fee",
+    "handling",
+    "import handling",
+    "export handling",
+    "storage",
+]
+LOCATION_CODES = ["POM", "LAE", "BNE", "SYD", "SIN", "HKG", "NRT", "LAX", "AKL"]
+CURRENCY_CODES = ["PGK", "USD", "AUD", "SGD", "EUR"]
+
+
+def build_air_freight_pilot_seed_audit() -> dict[str, Any]:
+    audit = _empty_audit()
+    _audit_hierarchy(audit)
+    _audit_roles_memberships(audit)
+    _audit_product_codes(audit)
+    _audit_charge_aliases(audit)
+    _audit_locations(audit)
+    _audit_currencies(audit)
+    _audit_pilot_data(audit)
+    _finish(audit)
+    return audit
+
+
+def render_air_freight_pilot_seed_audit_text(audit: dict[str, Any]) -> str:
+    lines = [
+        f"Air Freight pilot seed audit: {audit['status']}",
+        f"Missing: {len(audit['missing'])}",
+        f"Conflicts: {len(audit['conflicts'])}",
+        f"Warnings: {len(audit['warnings'])}",
+        "",
+        "Recommended next actions:",
+    ]
+    lines.extend(f"- {item}" for item in audit["recommended_next_actions"])
+    return "\n".join(lines) + "\n"
+
+
+def _empty_audit() -> dict[str, Any]:
+    return {
+        "status": "not_ready",
+        "summary": {},
+        "hierarchy": {},
+        "roles_memberships": {},
+        "product_codes": {},
+        "charge_aliases": {},
+        "locations": {},
+        "currencies": {},
+        "pilot_data": {},
+        "conflicts": [],
+        "missing": [],
+        "warnings": [],
+        "recommended_next_actions": [],
+    }
+
+
+def _model(app_label: str, model_name: str, audit: dict[str, Any]):
+    try:
+        return apps.get_model(app_label, model_name)
+    except LookupError:
+        audit["warnings"].append(f"Model {app_label}.{model_name} is not available; skipped that audit section.")
+        return None
+
+
+def _audit_hierarchy(audit: dict[str, Any]) -> None:
+    Organization = _model("parties", "Organization", audit)
+    OperatingEntity = _model("parties", "OperatingEntity", audit)
+    Branch = _model("parties", "Branch", audit)
+    Department = _model("parties", "Department", audit)
+    if not all([Organization, OperatingEntity, Branch, Department]):
+        return
+
+    orgs = list(Organization.objects.filter(name=CANONICAL_ORGANIZATION).values("id", "name", "is_active"))
+    org = orgs[0] if len(orgs) == 1 else None
+    if not org:
+        _missing(audit, "hierarchy.organization", CANONICAL_ORGANIZATION)
+    if len(orgs) > 1:
+        _conflict(audit, "hierarchy.organization", f"Multiple organizations named {CANONICAL_ORGANIZATION}.")
+
+    org_id = org["id"] if org else None
+    org_active = bool(org and org["is_active"])
+    if org and not org_active:
+        _missing(audit, "hierarchy.organization", f"{CANONICAL_ORGANIZATION} active row")
+
+    audit["hierarchy"] = {
+        "organization": {"name": CANONICAL_ORGANIZATION, "exists": org_active, "is_active": org_active},
+        "operating_entities": _check_scoped_rows(OperatingEntity, org_id, OPERATING_ENTITIES, audit, "hierarchy.operating_entities"),
+        "branches": _check_scoped_rows(Branch, org_id, BRANCHES, audit, "hierarchy.branches"),
+        "departments": _check_scoped_rows(Department, org_id, DEPARTMENTS, audit, "hierarchy.departments"),
+    }
+
+
+def _check_scoped_rows(model, org_id, expected: list[dict[str, str]], audit: dict[str, Any], path: str) -> dict[str, Any]:
+    rows = []
+    if not org_id:
+        for item in expected:
+            _missing(audit, path, item["code"])
+            rows.append({**item, "exists": False})
+        return {"items": rows, "missing_count": len(expected)}
+
+    for item in expected:
+        matches = list(model.objects.filter(organization_id=org_id, code=item["code"]).values("id", "code", "name", "is_active"))
+        is_active = bool(matches and matches[0]["is_active"])
+        exists = len(matches) == 1 and is_active
+        if not exists:
+            _missing(audit, path, item["code"])
+        if len(matches) > 1:
+            _conflict(audit, path, f"Multiple {model.__name__} rows for code {item['code']}.")
+        rows.append({**item, "exists": exists, "is_active": is_active, "actual_name": matches[0]["name"] if matches else None})
+    return {"items": rows, "missing_count": sum(1 for row in rows if not row["exists"])}
+
+
+def _audit_roles_memberships(audit: dict[str, Any]) -> None:
+    Role = _model("accounts", "Role", audit)
+    UserMembership = _model("accounts", "UserMembership", audit)
+    if not all([Role, UserMembership]):
+        return
+
+    role_rows = []
+    for code in ROLES:
+        matches = list(Role.objects.filter(code__iexact=code, is_active=True).values("id", "code", "name", "is_system", "organization_id"))
+        if not matches:
+            _missing(audit, "roles_memberships.roles", code)
+        if len(matches) > 1:
+            _conflict(audit, "roles_memberships.roles", f"Multiple active roles match {code}.")
+        role_rows.append({"code": code, "exists": bool(matches), "matches": len(matches)})
+
+    active = UserMembership.objects.filter(is_active=True)
+    missing_primary = active.exclude(user_id__in=active.filter(is_primary=True).values("user_id")).values("user_id").distinct().count()
+    incomplete = {
+        "missing_organization": active.filter(organization__isnull=True).count(),
+        "missing_operating_entity": active.filter(operating_entity__isnull=True).count(),
+        "missing_branch": active.filter(branch__isnull=True).count(),
+        "missing_department": active.filter(department__isnull=True).count(),
+        "missing_role": active.filter(role__isnull=True).count(),
+        "missing_primary": missing_primary,
+    }
+    for key, count in incomplete.items():
+        if count:
+            audit["warnings"].append(f"{count} active membership(s) have {key.replace('_', ' ')}.")
+
+    audit["roles_memberships"] = {
+        "roles": role_rows,
+        "active_memberships": active.count(),
+        "primary_memberships": active.filter(is_primary=True).count(),
+        "incomplete_counts": incomplete,
+    }
+
+
+def _audit_product_codes(audit: dict[str, Any]) -> None:
+    ProductCode = _model("pricing_v4", "ProductCode", audit)
+    if not ProductCode:
+        return
+
+    rows = {}
+    for coverage in PRODUCT_COVERAGE:
+        query = Q()
+        for term in coverage["terms"]:
+            query |= Q(code__icontains=term) | Q(description__icontains=term)
+        matches = list(ProductCode.objects.filter(query).values("id", "code", "description", "domain", "category", "default_unit").order_by("id"))
+        if not matches:
+            _missing(audit, "product_codes", coverage["key"])
+        if len(matches) > 1:
+            _conflict(audit, "product_codes", f"{coverage['label']} has {len(matches)} possible ProductCodes; review mapping.")
+        rows[coverage["key"]] = {"label": coverage["label"], "exists": bool(matches), "matches": matches}
+
+    audit["product_codes"] = {"coverage": rows, "missing_count": sum(1 for row in rows.values() if not row["exists"])}
+
+
+def _audit_charge_aliases(audit: dict[str, Any]) -> None:
+    ChargeAlias = _model("pricing_v4", "ChargeAlias", audit)
+    if not ChargeAlias:
+        return
+
+    rows = {}
+    for alias in ALIASES:
+        normalized = ChargeAlias.normalize_alias_text_value(alias)
+        matches = list(
+            ChargeAlias.objects.filter(normalized_alias_text=normalized, is_active=True)
+            .values("id", "alias_text", "normalized_alias_text", "product_code_id", "match_type", "mode_scope", "direction_scope")
+            .order_by("id")
+        )
+        if not matches:
+            _missing(audit, "charge_aliases", alias)
+        if len({row["product_code_id"] for row in matches}) > 1:
+            _conflict(audit, "charge_aliases", f"Alias {alias!r} maps to multiple ProductCodes.")
+        rows[alias] = {"exists": bool(matches), "matches": matches}
+    audit["charge_aliases"] = {"aliases": rows, "missing_count": sum(1 for row in rows.values() if not row["exists"])}
+
+
+def _audit_locations(audit: dict[str, Any]) -> None:
+    Airport = _model("core", "Airport", audit)
+    Location = _model("core", "Location", audit)
+    if not all([Airport, Location]):
+        return
+
+    rows = {}
+    for code in LOCATION_CODES:
+        airport_exists = Airport.objects.filter(iata_code=code).exists()
+        locations = list(Location.objects.filter(code=code).values("id", "code", "name", "kind", "airport_id"))
+        exists = airport_exists or bool(locations)
+        if not exists:
+            _missing(audit, "locations", code)
+        if len(locations) > 1:
+            _conflict(audit, "locations", f"Multiple Location rows found for {code}.")
+        rows[code] = {"exists": exists, "airport_exists": airport_exists, "location_count": len(locations), "locations": locations}
+    audit["locations"] = {"items": rows, "missing_count": sum(1 for row in rows.values() if not row["exists"])}
+
+
+def _audit_currencies(audit: dict[str, Any]) -> None:
+    Currency = _model("core", "Currency", audit)
+    if not Currency:
+        return
+
+    rows = {}
+    for code in CURRENCY_CODES:
+        exists = Currency.objects.filter(code=code).exists()
+        if not exists:
+            _missing(audit, "currencies", code)
+        rows[code] = {"exists": exists}
+    audit["currencies"] = {"items": rows, "missing_count": sum(1 for row in rows.values() if not row["exists"])}
+
+
+def _audit_pilot_data(audit: dict[str, Any]) -> None:
+    Company = _model("parties", "Company", audit)
+    if not Company:
+        return
+
+    obvious = Company.objects.filter(Q(name__icontains="pilot") | Q(name__icontains="demo") | Q(name__icontains="sample"))
+    audit["pilot_data"] = {
+        "obvious_pilot_demo_company_count": obvious.count(),
+        "contains_sensitive_details": False,
+        "note": "Only counts are reported; customer/supplier names are intentionally omitted.",
+    }
+
+
+def _finish(audit: dict[str, Any]) -> None:
+    audit["summary"] = {
+        "missing_count": len(audit["missing"]),
+        "conflict_count": len(audit["conflicts"]),
+        "warning_count": len(audit["warnings"]),
+    }
+    if audit["conflicts"] or audit["missing"]:
+        audit["status"] = "not_ready"
+    elif audit["warnings"]:
+        audit["status"] = "ready_with_warnings"
+    else:
+        audit["status"] = "ready"
+
+    if audit["missing"]:
+        audit["recommended_next_actions"].append("Review missing reference data before Air Freight UAT.")
+    if audit["conflicts"]:
+        audit["recommended_next_actions"].append("Resolve conflicts before adding any seed/apply command.")
+    if not audit["missing"] and not audit["conflicts"]:
+        audit["recommended_next_actions"].append("Run this audit in staging and attach JSON output to the UAT gate.")
+
+
+def _missing(audit: dict[str, Any], section: str, item: str) -> None:
+    audit["missing"].append({"section": section, "item": item})
+
+
+def _conflict(audit: dict[str, Any], section: str, detail: str) -> None:
+    audit["conflicts"].append({"section": section, "detail": detail})

--- a/backend/quotes/tests/test_air_freight_pilot_seed_audit.py
+++ b/backend/quotes/tests/test_air_freight_pilot_seed_audit.py
@@ -1,0 +1,157 @@
+import json
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from accounts.models import Role, UserMembership
+from core.models import Airport, City, Country, Currency, Location
+from parties.models import Branch, Company, Department, OperatingEntity, Organization
+from pricing_v4.models import ChargeAlias, ProductCode
+
+
+class AirFreightPilotSeedAuditCommandTests(TestCase):
+    def call_audit(self, *args):
+        stdout = StringIO()
+        call_command("air_freight_pilot_seed_audit", *args, stdout=stdout)
+        return stdout.getvalue()
+
+    def payload(self):
+        return json.loads(self.call_audit("--format", "json"))
+
+    def test_command_performs_no_writes(self):
+        before = self.counts()
+        self.payload()
+        self.call_audit("--format", "text")
+        self.assertEqual(before, self.counts())
+
+    def test_missing_data_is_reported_as_missing(self):
+        payload = self.payload()
+        self.assertEqual(payload["status"], "not_ready")
+        self.assertIn({"section": "hierarchy.organization", "item": "Express Freight Management"}, payload["missing"])
+        self.assertIn({"section": "currencies", "item": "PGK"}, payload["missing"])
+
+    def test_existing_canonical_data_is_reported_as_existing(self):
+        self.create_hierarchy()
+        payload = self.payload()
+        self.assertTrue(payload["hierarchy"]["organization"]["exists"])
+        self.assertEqual(payload["hierarchy"]["branches"]["missing_count"], 0)
+        self.assertEqual(payload["hierarchy"]["departments"]["missing_count"], 0)
+        self.assertEqual(payload["hierarchy"]["operating_entities"]["missing_count"], 0)
+
+    def test_product_code_conflicts_are_reported(self):
+        self.product(1001, "AIRFRT", "Air Freight")
+        self.product(1002, "AIR-FREIGHT-ALT", "Air Freight alternate")
+        payload = self.payload()
+        self.assertTrue(any("Air Freight" in row["detail"] for row in payload["conflicts"]))
+
+    def test_missing_product_code_coverage_is_reported(self):
+        payload = self.payload()
+        self.assertIn({"section": "product_codes", "item": "fuel_surcharge"}, payload["missing"])
+        self.assertGreater(payload["product_codes"]["missing_count"], 0)
+
+    def test_missing_aliases_are_reported(self):
+        payload = self.payload()
+        self.assertIn({"section": "charge_aliases", "item": "fsc"}, payload["missing"])
+
+    def test_missing_locations_and_currencies_are_reported(self):
+        payload = self.payload()
+        self.assertIn({"section": "locations", "item": "POM"}, payload["missing"])
+        self.assertIn({"section": "currencies", "item": "USD"}, payload["missing"])
+
+    def test_json_output_is_valid_and_stable(self):
+        payload = self.payload()
+        self.assertEqual(
+            list(payload.keys()),
+            [
+                "charge_aliases",
+                "conflicts",
+                "currencies",
+                "hierarchy",
+                "locations",
+                "missing",
+                "pilot_data",
+                "product_codes",
+                "recommended_next_actions",
+                "roles_memberships",
+                "status",
+                "summary",
+                "warnings",
+            ],
+        )
+
+    def test_text_output_works(self):
+        output = self.call_audit("--format", "text")
+        self.assertIn("Air Freight pilot seed audit:", output)
+        self.assertIn("Recommended next actions:", output)
+
+    def test_existing_alias_and_location_currency_are_reported(self):
+        currency = Currency.objects.create(code="PGK", name="Papua New Guinea Kina")
+        country = Country.objects.create(code="PG", name="Papua New Guinea", currency=currency)
+        city = City.objects.create(country=country, name="Port Moresby")
+        airport = Airport.objects.create(iata_code="POM", name="Jacksons International", city=city)
+        Location.objects.create(code="POM", name="Port Moresby", kind=Location.Kind.AIRPORT, country=country, city=city, airport=airport)
+        product = self.product(1001, "AIRFRT", "Air Freight")
+        ChargeAlias.objects.create(
+            alias_text="air freight",
+            normalized_alias_text="air freight",
+            product_code=product,
+            is_active=True,
+            review_status=ChargeAlias.ReviewStatus.APPROVED,
+        )
+
+        payload = self.payload()
+        self.assertTrue(payload["currencies"]["items"]["PGK"]["exists"])
+        self.assertTrue(payload["locations"]["items"]["POM"]["exists"])
+        self.assertTrue(payload["charge_aliases"]["aliases"]["air freight"]["exists"])
+
+    def create_hierarchy(self):
+        org = Organization.objects.create(name="Express Freight Management", slug="express-freight-management")
+        entities = {
+            code: OperatingEntity.objects.create(organization=org, code=code, name=name, slug=code.lower(), country_code="PG")
+            for code, name in [
+                ("PNG", "EFM PNG"),
+                ("AUS", "EFM Australia"),
+                ("FJI", "EFM Fiji"),
+                ("SLB", "EFM Solomon Islands"),
+            ]
+        }
+        for code, name in [("POM", "Port Moresby"), ("LAE", "Lae"), ("BNE", "Brisbane"), ("SUV", "Suva"), ("HIR", "Honiara")]:
+            Branch.objects.create(organization=org, operating_entity=entities["PNG"], code=code, name=name)
+        for code, name in [("AIR", "Air Freight"), ("SEA", "Sea Freight"), ("CUS", "Customs"), ("TRN", "Transport")]:
+            Department.objects.create(organization=org, code=code, name=name)
+        for code in ["admin", "manager", "sales", "finance"]:
+            Role.objects.create(code=code, name=code.title(), is_system=True)
+        Company.objects.create(name="Demo Customer", is_customer=True, organization=org)
+        return org
+
+    def product(self, pk, code, description):
+        return ProductCode.objects.create(
+            id=pk,
+            code=code,
+            description=description,
+            domain=ProductCode.DOMAIN_EXPORT,
+            category=ProductCode.CATEGORY_FREIGHT,
+            is_gst_applicable=False,
+            gst_rate="0.0000",
+            gst_treatment=ProductCode.GST_TREATMENT_ZERO_RATED,
+            gl_revenue_code="REV",
+            gl_cost_code="COS",
+            default_unit=ProductCode.UNIT_SHIPMENT,
+        )
+
+    def counts(self):
+        return {
+            "organization": Organization.objects.count(),
+            "operating_entity": OperatingEntity.objects.count(),
+            "branch": Branch.objects.count(),
+            "department": Department.objects.count(),
+            "role": Role.objects.count(),
+            "membership": UserMembership.objects.count(),
+            "product_code": ProductCode.objects.count(),
+            "charge_alias": ChargeAlias.objects.count(),
+            "currency": Currency.objects.count(),
+            "airport": Airport.objects.count(),
+            "location": Location.objects.count(),
+            "company": Company.objects.count(),
+        }

--- a/backend/quotes/tests/test_air_freight_pilot_seed_audit.py
+++ b/backend/quotes/tests/test_air_freight_pilot_seed_audit.py
@@ -6,6 +6,7 @@ from django.test import TestCase
 
 from accounts.models import Role, UserMembership
 from core.models import Airport, City, Country, Currency, Location
+from core.tests.helpers import create_location
 from parties.models import Branch, Company, Department, OperatingEntity, Organization
 from pricing_v4.models import ChargeAlias, ProductCode
 
@@ -90,7 +91,7 @@ class AirFreightPilotSeedAuditCommandTests(TestCase):
         country = Country.objects.create(code="PG", name="Papua New Guinea", currency=currency)
         city = City.objects.create(country=country, name="Port Moresby")
         airport = Airport.objects.create(iata_code="POM", name="Jacksons International", city=city)
-        Location.objects.create(code="POM", name="Port Moresby", kind=Location.Kind.AIRPORT, country=country, city=city, airport=airport)
+        create_location(code="POM", name="Port Moresby", kind=Location.Kind.AIRPORT, country=country, city=city, airport=airport)
         product = self.product(1001, "AIRFRT", "Air Freight")
         ChargeAlias.objects.create(
             alias_text="air freight",

--- a/docs/pilot/staging-seed-audit.md
+++ b/docs/pilot/staging-seed-audit.md
@@ -267,3 +267,58 @@ python backend/manage.py air_freight_pilot_seed_audit --format json
 ```
 
 Apply-mode commands must not be run in staging until the dry-run output has been reviewed and explicitly approved.
+
+## 11. Phase 13.1B read-only audit command
+
+Phase 13.1B adds a dedicated read-only management command:
+
+```bash
+python backend/manage.py air_freight_pilot_seed_audit --format json
+python backend/manage.py air_freight_pilot_seed_audit --format text
+```
+
+The command does not create, update, delete, truncate, or overwrite database records. It has no apply mode, no reset mode, and no seed mode.
+
+Sample JSON shape:
+
+```json
+{
+  "status": "not_ready",
+  "summary": {
+    "missing_count": 3,
+    "conflict_count": 1,
+    "warning_count": 0
+  },
+  "hierarchy": {},
+  "roles_memberships": {},
+  "product_codes": {},
+  "charge_aliases": {},
+  "locations": {},
+  "currencies": {},
+  "pilot_data": {},
+  "conflicts": [
+    {
+      "section": "product_codes",
+      "detail": "Air Freight has 2 possible ProductCodes; review mapping."
+    }
+  ],
+  "missing": [
+    {
+      "section": "charge_aliases",
+      "item": "fsc"
+    }
+  ],
+  "warnings": [],
+  "recommended_next_actions": [
+    "Review missing reference data before Air Freight UAT."
+  ]
+}
+```
+
+Interpretation:
+
+- `ready`: no missing required reference data, no conflicts, and no warnings.
+- `ready_with_warnings`: required reference data is present, but non-blocking membership/model warnings need review.
+- `not_ready`: at least one required item is missing or at least one conflict needs human resolution.
+
+Use the JSON output for staging sign-off evidence. Use text output only for quick operator checks.


### PR DESCRIPTION
## Summary

Implements Phase 13.1B: a safe, read-only Air Freight pilot staging seed audit command.

This adds:

- `air_freight_pilot_seed_audit` management command
- service-layer audit logic
- focused command/service tests
- updated pilot staging seed audit documentation

## Scope / Guardrails

- Read-only only
- No migrations
- No frontend changes
- No database write mode
- No seed/apply behaviour
- No changes to existing quote or SPOT workflows

## Local Verification

Completed before commit/push:

```text
python backend\manage.py air_freight_pilot_seed_audit --format json
Result: passed; local status not_ready, missing_count=10, conflict_count=8

python backend\manage.py air_freight_pilot_seed_audit --format text
Result: passed

python backend\manage.py test quotes.tests.test_air_freight_pilot_seed_audit
Result: Ran 10 tests ... OK

python backend\manage.py check
Result: System check identified no issues (0 silenced).

pytest backend\quotes\tests
Result: 661 passed, 21 warnings in 1374.93s (0:22:54)

git diff --check
Result: passed; Windows LF/CRLF warning only for docs/pilot/staging-seed-audit.md

graphify update .
Result: rebuilt 10909 nodes, 26740 edges, 954 communities
```

## Notes

Pre-existing untracked folders were intentionally not included:

- `.qwen/`
- `tmp/`

This PR supports pilot readiness by allowing staging seed completeness/conflict checks before any future write/apply workflow is considered.