### PR TITLE
Phase 13.1E — Air Freight dry-run seed plan

### DIFF
--- a/backend/quotes/management/commands/air_freight_pilot_seed_plan.py
+++ b/backend/quotes/management/commands/air_freight_pilot_seed_plan.py
@@ -1,0 +1,22 @@
+import json
+
+from django.core.management.base import BaseCommand
+
+from quotes.services.air_freight_pilot_seed_plan import (
+    build_air_freight_pilot_seed_plan,
+    render_air_freight_pilot_seed_plan_text,
+)
+
+
+class Command(BaseCommand):
+    help = "Dry-run-only Air Freight pilot seed plan. This command performs no writes."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--format", choices=["json", "text"], default="json")
+
+    def handle(self, *args, **options):
+        plan = build_air_freight_pilot_seed_plan()
+        if options["format"] == "text":
+            self.stdout.write(render_air_freight_pilot_seed_plan_text(plan), ending="")
+            return
+        self.stdout.write(json.dumps(plan, default=str, indent=2, sort_keys=True))

--- a/backend/quotes/services/air_freight_pilot_seed_plan.py
+++ b/backend/quotes/services/air_freight_pilot_seed_plan.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pricing_v4.models import ChargeAlias, ProductCode
+
+
+PRODUCT_CODE_CANDIDATES = [
+    {
+        "id": 2042,
+        "code": "IMP-HANDLE-DEST",
+        "description": "Import Destination Handling",
+        "domain": ProductCode.DOMAIN_IMPORT,
+        "category": ProductCode.CATEGORY_HANDLING,
+        "default_unit": ProductCode.UNIT_SHIPMENT,
+        "is_gst_applicable": True,
+        "gst_rate": "0.1000",
+        "gst_treatment": ProductCode.GST_TREATMENT_STANDARD,
+        "gl_revenue_code": "TBD-REV",
+        "gl_cost_code": "TBD-COS",
+    },
+    {
+        "id": 2043,
+        "code": "IMP-STORAGE-DEST",
+        "description": "Import Destination Storage / Warehouse",
+        "domain": ProductCode.DOMAIN_IMPORT,
+        "category": ProductCode.CATEGORY_HANDLING,
+        "default_unit": ProductCode.UNIT_SHIPMENT,
+        "is_gst_applicable": True,
+        "gst_rate": "0.1000",
+        "gst_treatment": ProductCode.GST_TREATMENT_STANDARD,
+        "gl_revenue_code": "TBD-REV",
+        "gl_cost_code": "TBD-COS",
+    },
+]
+
+ALIAS_CANDIDATES = [
+    ("freight", "EXPORT", "MAIN", "EXP-FRT-AIR"),
+    ("freight", "IMPORT", "MAIN", "IMP-FRT-AIR"),
+    ("freight", "DOMESTIC", "MAIN", "DOM-FRT-AIR"),
+    ("fuel surcharge", "EXPORT", "MAIN", "EXP-FSC-AIR"),
+    ("fuel surcharge", "IMPORT", "ORIGIN", "IMP-FSC-PICKUP"),
+    ("fuel surcharge", "IMPORT", "DESTINATION", "IMP-FSC-CARTAGE-DEST"),
+    ("security surcharge", "EXPORT", "ORIGIN", "EXP-SCREEN"),
+    ("security surcharge", "IMPORT", "ORIGIN", "IMP-SEC-ORIGIN"),
+    ("screening", "EXPORT", "ORIGIN", "EXP-SCREEN"),
+    ("screening", "IMPORT", "ORIGIN", "IMP-SEC-ORIGIN"),
+    ("awb", "EXPORT", "ORIGIN", "EXP-AWB"),
+    ("awb", "IMPORT", "ORIGIN", "IMP-AWB-ORIGIN"),
+    ("awb", "DOMESTIC", "ORIGIN", "DOM-AWB"),
+    ("export handling", "EXPORT", "ORIGIN", "EXP-HANDLE"),
+    ("import handling", "IMPORT", "DESTINATION", "IMP-HANDLE-DEST"),
+    ("storage", "IMPORT", "DESTINATION", "IMP-STORAGE-DEST"),
+]
+
+BLOCKED_DECISIONS = [
+    {
+        "item": "misc_recoveries",
+        "reason": "Phase 13.1D deferred broad miscellaneous recoveries to manual review.",
+    },
+    {
+        "item": "fsc ANY/ANY",
+        "reason": "Broad FSC alias is ambiguous across airline, pickup, cartage, and domestic fuel.",
+    },
+    {
+        "item": "handling generic",
+        "reason": "Generic handling is ambiguous across origin and destination handling.",
+    },
+]
+
+
+def build_air_freight_pilot_seed_plan() -> dict[str, Any]:
+    product_actions = [_product_code_action(row) for row in PRODUCT_CODE_CANDIDATES]
+    alias_actions = [_alias_action(*row) for row in ALIAS_CANDIDATES]
+    conflicts = [item for item in product_actions + alias_actions if item["action"] == "conflict"]
+    warnings = _placeholder_warnings(product_actions)
+    plan = {
+        "status": "blocked" if conflicts or BLOCKED_DECISIONS else "ready_for_dry_run_review",
+        "summary": {
+            "product_code_create": _count(product_actions, "create"),
+            "product_code_reuse": _count(product_actions, "reuse"),
+            "product_code_conflict": _count(product_actions, "conflict"),
+            "charge_alias_create": _count(alias_actions, "create"),
+            "charge_alias_skip": _count(alias_actions, "skip_existing"),
+            "charge_alias_blocked": _count(alias_actions, "blocked"),
+            "charge_alias_conflict": _count(alias_actions, "conflict"),
+            "blocked_count": len(BLOCKED_DECISIONS) + _count(alias_actions, "blocked"),
+            "warning_count": len(warnings),
+        },
+        "product_code_actions": product_actions,
+        "charge_alias_actions": alias_actions,
+        "conflicts": conflicts,
+        "blocked": BLOCKED_DECISIONS,
+        "warnings": warnings,
+        "recommended_next_actions": [
+            "Review GL placeholders and GST treatment before any apply-mode phase.",
+            "Resolve blocked broad aliases before adding any write command.",
+            "Keep Phase 13.1E dry-run only; no seed writes are available.",
+        ],
+    }
+    return plan
+
+
+def render_air_freight_pilot_seed_plan_text(plan: dict[str, Any]) -> str:
+    summary = plan["summary"]
+    lines = [
+        f"Air Freight pilot seed plan: {plan['status']}",
+        f"ProductCodes create/reuse/conflict: {summary['product_code_create']}/{summary['product_code_reuse']}/{summary['product_code_conflict']}",
+        f"ChargeAliases create/skip/blocked/conflict: {summary['charge_alias_create']}/{summary['charge_alias_skip']}/{summary['charge_alias_blocked']}/{summary['charge_alias_conflict']}",
+        f"Blocked: {summary['blocked_count']}",
+        f"Warnings: {summary['warning_count']}",
+        "",
+        "Recommended next actions:",
+    ]
+    lines.extend(f"- {item}" for item in plan["recommended_next_actions"])
+    return "\n".join(lines) + "\n"
+
+
+def _product_code_action(candidate: dict[str, Any]) -> dict[str, Any]:
+    existing_code = ProductCode.objects.filter(code=candidate["code"]).first()
+    existing_id = ProductCode.objects.filter(id=candidate["id"]).first()
+    validation = _validate_product_code_candidate(candidate)
+    if existing_code:
+        return {"action": "reuse", "candidate": candidate, "existing_id": existing_code.id, "validation": validation}
+    if existing_id:
+        return {
+            "action": "conflict",
+            "candidate": candidate,
+            "reason": f"id {candidate['id']} already belongs to {existing_id.code}",
+            "validation": validation,
+        }
+    return {"action": "create", "candidate": candidate, "validation": validation}
+
+
+def _alias_action(alias_text: str, mode_scope: str, direction_scope: str, product_code_code: str) -> dict[str, Any]:
+    normalized = ChargeAlias.normalize_alias_text_value(alias_text)
+    target = ProductCode.objects.filter(code=product_code_code).first()
+    action = {
+        "alias_text": alias_text,
+        "normalized_alias_text": normalized,
+        "match_type": ChargeAlias.MatchType.EXACT,
+        "mode_scope": mode_scope,
+        "direction_scope": direction_scope,
+        "product_code": product_code_code,
+    }
+    if not target:
+        return {**action, "action": "blocked", "reason": f"target ProductCode {product_code_code} does not exist yet"}
+
+    exact = ChargeAlias.objects.filter(
+        normalized_alias_text=normalized,
+        match_type=ChargeAlias.MatchType.EXACT,
+        mode_scope=mode_scope,
+        direction_scope=direction_scope,
+        product_code=target,
+    ).first()
+    if exact:
+        return {**action, "action": "skip_existing", "existing_id": exact.id}
+
+    conflict = ChargeAlias.objects.filter(
+        normalized_alias_text=normalized,
+        match_type=ChargeAlias.MatchType.EXACT,
+        mode_scope=mode_scope,
+        direction_scope=direction_scope,
+        is_active=True,
+    ).exclude(product_code=target).first()
+    if conflict:
+        return {
+            **action,
+            "action": "conflict",
+            "existing_id": conflict.id,
+            "reason": f"active scoped alias already targets ProductCode id {conflict.product_code_id}",
+        }
+    return {**action, "action": "create"}
+
+
+def _validate_product_code_candidate(candidate: dict[str, Any]) -> dict[str, Any]:
+    valid = []
+    errors = []
+    warnings = []
+    if 2000 <= candidate["id"] < 3000 and candidate["domain"] == ProductCode.DOMAIN_IMPORT:
+        valid.append("id_range")
+    else:
+        errors.append("id_range")
+    for field, allowed in [
+        ("domain", dict(ProductCode.DOMAIN_CHOICES)),
+        ("category", dict(ProductCode.CATEGORY_CHOICES)),
+        ("default_unit", dict(ProductCode.UNIT_CHOICES)),
+        ("gst_treatment", dict(ProductCode.GST_TREATMENT_CHOICES)),
+    ]:
+        (valid if candidate[field] in allowed else errors).append(field)
+    for field in ["gl_revenue_code", "gl_cost_code"]:
+        if candidate[field]:
+            valid.append(field)
+        else:
+            errors.append(field)
+        if str(candidate[field]).startswith("TBD"):
+            warnings.append(f"{field} is placeholder")
+    return {"valid": valid, "errors": errors, "warnings": warnings}
+
+
+def _placeholder_warnings(actions: list[dict[str, Any]]) -> list[str]:
+    warnings = []
+    for action in actions:
+        for warning in action["validation"]["warnings"]:
+            warnings.append(f"{action['candidate']['code']}: {warning}")
+    return warnings
+
+
+def _count(actions: list[dict[str, Any]], action: str) -> int:
+    return sum(1 for item in actions if item["action"] == action)

--- a/backend/quotes/tests/test_air_freight_pilot_seed_plan.py
+++ b/backend/quotes/tests/test_air_freight_pilot_seed_plan.py
@@ -1,0 +1,147 @@
+import json
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from pricing_v4.models import ChargeAlias, ProductCode
+
+
+class AirFreightPilotSeedPlanCommandTests(TestCase):
+    def call_plan(self, *args):
+        stdout = StringIO()
+        call_command("air_freight_pilot_seed_plan", *args, stdout=stdout)
+        return stdout.getvalue()
+
+    def payload(self):
+        return json.loads(self.call_plan("--format", "json"))
+
+    def test_command_performs_no_writes(self):
+        before = self.counts()
+        self.payload()
+        self.call_plan("--format", "text")
+        self.assertEqual(before, self.counts())
+
+    def test_json_output_is_stable(self):
+        payload = self.payload()
+        self.assertEqual(
+            list(payload.keys()),
+            [
+                "blocked",
+                "charge_alias_actions",
+                "conflicts",
+                "product_code_actions",
+                "recommended_next_actions",
+                "status",
+                "summary",
+                "warnings",
+            ],
+        )
+
+    def test_candidate_product_codes_are_create_actions_when_missing(self):
+        payload = self.payload()
+        create_codes = {
+            action["candidate"]["code"]
+            for action in payload["product_code_actions"]
+            if action["action"] == "create"
+        }
+        self.assertEqual(create_codes, {"IMP-HANDLE-DEST", "IMP-STORAGE-DEST"})
+
+    def test_existing_candidate_product_code_is_reused(self):
+        self.product(2042, "IMP-HANDLE-DEST", ProductCode.DOMAIN_IMPORT)
+        payload = self.payload()
+        action = self.action_for_code(payload, "IMP-HANDLE-DEST")
+        self.assertEqual(action["action"], "reuse")
+        self.assertEqual(action["existing_id"], 2042)
+
+    def test_product_code_id_conflict_is_reported(self):
+        self.product(2042, "IMP-OTHER", ProductCode.DOMAIN_IMPORT)
+        payload = self.payload()
+        action = self.action_for_code(payload, "IMP-HANDLE-DEST")
+        self.assertEqual(action["action"], "conflict")
+        self.assertIn("already belongs", action["reason"])
+
+    def test_alias_actions_block_until_target_product_code_exists(self):
+        payload = self.payload()
+        action = self.alias_action(payload, "import handling", "IMPORT", "DESTINATION")
+        self.assertEqual(action["action"], "blocked")
+        self.assertIn("IMP-HANDLE-DEST", action["reason"])
+
+    def test_alias_actions_skip_existing_scoped_alias(self):
+        product = self.product(1001, "EXP-FRT-AIR", ProductCode.DOMAIN_EXPORT)
+        ChargeAlias.objects.create(
+            alias_text="freight",
+            normalized_alias_text="freight",
+            match_type=ChargeAlias.MatchType.EXACT,
+            mode_scope=ChargeAlias.ModeScope.EXPORT,
+            direction_scope=ChargeAlias.DirectionScope.MAIN,
+            product_code=product,
+            is_active=True,
+            review_status=ChargeAlias.ReviewStatus.APPROVED,
+        )
+        payload = self.payload()
+        action = self.alias_action(payload, "freight", "EXPORT", "MAIN")
+        self.assertEqual(action["action"], "skip_existing")
+
+    def test_alias_scope_conflict_is_reported(self):
+        target = self.product(1001, "EXP-FRT-AIR", ProductCode.DOMAIN_EXPORT)
+        other = self.product(1002, "EXP-FRT-OTHER", ProductCode.DOMAIN_EXPORT)
+        ChargeAlias.objects.create(
+            alias_text="freight",
+            normalized_alias_text="freight",
+            match_type=ChargeAlias.MatchType.EXACT,
+            mode_scope=ChargeAlias.ModeScope.EXPORT,
+            direction_scope=ChargeAlias.DirectionScope.MAIN,
+            product_code=other,
+            is_active=True,
+            review_status=ChargeAlias.ReviewStatus.APPROVED,
+        )
+        self.assertEqual(target.code, "EXP-FRT-AIR")
+        payload = self.payload()
+        action = self.alias_action(payload, "freight", "EXPORT", "MAIN")
+        self.assertEqual(action["action"], "conflict")
+
+    def test_broad_ambiguous_items_are_blocked(self):
+        payload = self.payload()
+        blocked = {item["item"] for item in payload["blocked"]}
+        self.assertIn("misc_recoveries", blocked)
+        self.assertIn("fsc ANY/ANY", blocked)
+        self.assertIn("handling generic", blocked)
+
+    def test_text_output_works(self):
+        output = self.call_plan("--format", "text")
+        self.assertIn("Air Freight pilot seed plan:", output)
+        self.assertIn("Recommended next actions:", output)
+
+    def product(self, pk, code, domain):
+        return ProductCode.objects.create(
+            id=pk,
+            code=code,
+            description=code,
+            domain=domain,
+            category=ProductCode.CATEGORY_FREIGHT,
+            is_gst_applicable=False,
+            gst_rate="0.0000",
+            gst_treatment=ProductCode.GST_TREATMENT_ZERO_RATED,
+            gl_revenue_code="REV",
+            gl_cost_code="COS",
+            default_unit=ProductCode.UNIT_SHIPMENT,
+        )
+
+    def action_for_code(self, payload, code):
+        return next(action for action in payload["product_code_actions"] if action["candidate"]["code"] == code)
+
+    def alias_action(self, payload, alias_text, mode_scope, direction_scope):
+        return next(
+            action
+            for action in payload["charge_alias_actions"]
+            if action["alias_text"] == alias_text
+            and action["mode_scope"] == mode_scope
+            and action["direction_scope"] == direction_scope
+        )
+
+    def counts(self):
+        return {
+            "product_code": ProductCode.objects.count(),
+            "charge_alias": ChargeAlias.objects.count(),
+        }


### PR DESCRIPTION
## Summary
- Add `air_freight_pilot_seed_plan` as a dry-run-only management command.
- Add a service-layer plan builder for Phase 13.1D ProductCode and ChargeAlias mapping decisions.
- Add focused tests proving the command performs no writes and reports create/reuse/skip/conflict/blocked actions.

## Scope confirmations
- Dry-run only: yes. There is no `--apply` flag and no write mode.
- No writes: yes. The command only queries `ProductCode` and `ChargeAlias` and returns a plan.
- No migrations: yes.
- No frontend changes: yes.
- No customer/supplier data: yes.
- Miscellaneous recoveries are not created; they are blocked/manual-review-only.
- Broad ambiguous aliases like generic `fsc` and `handling` are not created.

## Exact plan counts from current environment
- Status: `blocked`
- ProductCode actions: create `2`, reuse `0`, conflict `0`
- ChargeAlias actions: create `14`, skip `0`, blocked `2`, conflict `0`
- Total blocked items: `5`
- Warnings: `4`

## Verification
- `npx fallow --format json` ran; existing frontend findings only.
- `npx fallow dead-code --format json` ran; existing frontend dead-code findings, exits nonzero because findings exist.
- `npx fallow dupes --format json` ran; existing frontend duplication findings.
- `npx fallow health --format json` ran; existing frontend health findings, exits nonzero because findings exist.
- `python backend\manage.py air_freight_pilot_seed_plan --format json` passed.
- `python backend\manage.py air_freight_pilot_seed_plan --format text` passed.
- `python backend\manage.py test quotes.tests.test_air_freight_pilot_seed_audit quotes.tests.test_air_freight_pilot_seed_plan` passed: 20 tests OK.
- `python backend\manage.py check` passed: System check identified no issues.
- `git diff --check` passed.
- `graphify update .` passed: rebuilt 10942 nodes, 26805 edges, 928 communities.

## PR base
This PR is now based on `main` after Phase 13.1D was merged.