### PR TITLE
Phase 13.1F: Review and harden Air Freight dry-run seed plan

### DIFF
--- a/backend/quotes/services/air_freight_pilot_seed_plan.py
+++ b/backend/quotes/services/air_freight_pilot_seed_plan.py
@@ -71,7 +71,12 @@ BLOCKED_DECISIONS = [
 
 def build_air_freight_pilot_seed_plan() -> dict[str, Any]:
     product_actions = [_product_code_action(row) for row in PRODUCT_CODE_CANDIDATES]
-    alias_actions = [_alias_action(*row) for row in ALIAS_CANDIDATES]
+    planned_product_codes = {
+        action["candidate"]["code"]
+        for action in product_actions
+        if action["action"] == "create"
+    }
+    alias_actions = [_alias_action(*row, planned_product_codes) for row in ALIAS_CANDIDATES]
     conflicts = [item for item in product_actions + alias_actions if item["action"] == "conflict"]
     warnings = _placeholder_warnings(product_actions)
     plan = {
@@ -81,6 +86,7 @@ def build_air_freight_pilot_seed_plan() -> dict[str, Any]:
             "product_code_reuse": _count(product_actions, "reuse"),
             "product_code_conflict": _count(product_actions, "conflict"),
             "charge_alias_create": _count(alias_actions, "create"),
+            "charge_alias_create_after_product_code": _count(alias_actions, "create_after_product_code"),
             "charge_alias_skip": _count(alias_actions, "skip_existing"),
             "charge_alias_blocked": _count(alias_actions, "blocked"),
             "charge_alias_conflict": _count(alias_actions, "conflict"),
@@ -106,7 +112,7 @@ def render_air_freight_pilot_seed_plan_text(plan: dict[str, Any]) -> str:
     lines = [
         f"Air Freight pilot seed plan: {plan['status']}",
         f"ProductCodes create/reuse/conflict: {summary['product_code_create']}/{summary['product_code_reuse']}/{summary['product_code_conflict']}",
-        f"ChargeAliases create/skip/blocked/conflict: {summary['charge_alias_create']}/{summary['charge_alias_skip']}/{summary['charge_alias_blocked']}/{summary['charge_alias_conflict']}",
+        f"ChargeAliases create/dependent/skip/blocked/conflict: {summary['charge_alias_create']}/{summary['charge_alias_create_after_product_code']}/{summary['charge_alias_skip']}/{summary['charge_alias_blocked']}/{summary['charge_alias_conflict']}",
         f"Blocked: {summary['blocked_count']}",
         f"Warnings: {summary['warning_count']}",
         "",
@@ -132,7 +138,13 @@ def _product_code_action(candidate: dict[str, Any]) -> dict[str, Any]:
     return {"action": "create", "candidate": candidate, "validation": validation}
 
 
-def _alias_action(alias_text: str, mode_scope: str, direction_scope: str, product_code_code: str) -> dict[str, Any]:
+def _alias_action(
+    alias_text: str,
+    mode_scope: str,
+    direction_scope: str,
+    product_code_code: str,
+    planned_product_codes: set[str],
+) -> dict[str, Any]:
     normalized = ChargeAlias.normalize_alias_text_value(alias_text)
     target = ProductCode.objects.filter(code=product_code_code).first()
     action = {
@@ -144,6 +156,12 @@ def _alias_action(alias_text: str, mode_scope: str, direction_scope: str, produc
         "product_code": product_code_code,
     }
     if not target:
+        if product_code_code in planned_product_codes:
+            return {
+                **action,
+                "action": "create_after_product_code",
+                "depends_on_product_code": product_code_code,
+            }
         return {**action, "action": "blocked", "reason": f"target ProductCode {product_code_code} does not exist yet"}
 
     exact = ChargeAlias.objects.filter(

--- a/backend/quotes/tests/test_air_freight_pilot_seed_plan.py
+++ b/backend/quotes/tests/test_air_freight_pilot_seed_plan.py
@@ -61,11 +61,11 @@ class AirFreightPilotSeedPlanCommandTests(TestCase):
         self.assertEqual(action["action"], "conflict")
         self.assertIn("already belongs", action["reason"])
 
-    def test_alias_actions_block_until_target_product_code_exists(self):
+    def test_alias_actions_track_planned_product_code_dependency(self):
         payload = self.payload()
         action = self.alias_action(payload, "import handling", "IMPORT", "DESTINATION")
-        self.assertEqual(action["action"], "blocked")
-        self.assertIn("IMP-HANDLE-DEST", action["reason"])
+        self.assertEqual(action["action"], "create_after_product_code")
+        self.assertEqual(action["depends_on_product_code"], "IMP-HANDLE-DEST")
 
     def test_alias_actions_skip_existing_scoped_alias(self):
         product = self.product(1001, "EXP-FRT-AIR", ProductCode.DOMAIN_EXPORT)

--- a/docs/pilot/staging-seed-audit.md
+++ b/docs/pilot/staging-seed-audit.md
@@ -482,3 +482,47 @@ Recommended Phase 13.1E dry-run seed-plan scope:
 5. Do not overwrite existing aliases. Report existing scoped aliases as `skip_existing`.
 6. Report broad or ambiguous existing aliases, especially `fsc`, as `conflict_requires_review`.
 7. Keep apply mode out of Phase 13.1E unless a later phase explicitly approves writes.
+
+## 14. Phase 13.1F dry-run seed plan review
+
+Phase 13.1F reran the merged dry-run seed plan from latest `main`. The command remained read-only: no apply mode, no database writes, no migrations, no frontend changes, and no ProductCode or ChargeAlias creation.
+
+Commands run:
+
+```bash
+python backend/manage.py air_freight_pilot_seed_plan --format json
+python backend/manage.py air_freight_pilot_seed_plan --format text
+```
+
+Reviewed plan status:
+
+- Status: `blocked`
+- ProductCode actions: create `2`, reuse `0`, conflict `0`
+- ChargeAlias actions after hardening: create `14`, create after planned ProductCode `2`, skip `0`, blocked `0`, conflict `0`
+- Blocked business decisions: `3`
+- Warnings: `4`
+
+Safety findings:
+
+- The dry-run command is safe to keep as a prerequisite for future apply-mode work because it has no write path and no `--apply` flag.
+- The plan correctly limits ProductCode create candidates to `IMP-HANDLE-DEST` and `IMP-STORAGE-DEST`.
+- The plan does not create miscellaneous recoveries.
+- The plan does not create broad ambiguous aliases such as generic `fsc` or generic `handling`.
+- Phase 13.1F hardened alias planning so aliases targeting ProductCodes planned in the same dry-run are reported as `create_after_product_code`, not as false blocked items.
+- GL values remain placeholders: `TBD-REV` and `TBD-COS` for both ProductCode candidates.
+
+Remaining blockers before apply mode:
+
+1. Replace placeholder GL revenue and cost codes for `IMP-HANDLE-DEST`.
+2. Replace placeholder GL revenue and cost codes for `IMP-STORAGE-DEST`.
+3. Confirm GST treatment and GST applicability for both import destination handling and import destination storage.
+4. Keep `misc_recoveries` manual-review-only until specific commercial categories are approved.
+5. Keep broad `fsc ANY/ANY` and generic `handling` out of apply scope unless business signs off a deterministic scoped mapping.
+
+Recommended Phase 13.1G scope:
+
+1. Add an apply-mode command only after GL and GST values are approved.
+2. Keep dry-run as the default behavior and require an explicit `--apply` flag for writes.
+3. Apply ProductCodes before dependent ChargeAliases in one transaction.
+4. Refuse to apply if the current dry-run output has conflicts, blocked business decisions, placeholder GL codes, or validation errors.
+5. Preserve existing ProductCodes and ChargeAliases; use additive creates only and skip existing scoped aliases.


### PR DESCRIPTION
## Summary
- Rerun and review the merged Air Freight dry-run seed plan from latest `main`.
- Harden alias planning so aliases targeting ProductCodes planned in the same dry-run are reported as `create_after_product_code` instead of false blocked items.
- Document the Phase 13.1F review result and remaining apply-mode blockers.

## Scope confirmations
- No apply mode added.
- No database writes.
- No migrations.
- No frontend changes.
- No ProductCode or ChargeAlias creation.
- Changes are limited to dry-run planning logic, its focused test, and pilot documentation.

## Plan status and counts
- Status: `blocked`
- ProductCode actions: create `2`, reuse `0`, conflict `0`
- ChargeAlias actions: create `14`, create after planned ProductCode `2`, skip `0`, blocked `0`, conflict `0`
- Blocked business decisions: `3`
- Warnings: `4`

## Safety findings
- The dry-run command remains safe as a prerequisite for apply-mode work: no write path and no `--apply` flag.
- Remaining blockers are placeholder GL codes, GST confirmation, and intentionally blocked broad decisions for `misc_recoveries`, `fsc ANY/ANY`, and generic `handling`.

## Verification
- `python backend\manage.py air_freight_pilot_seed_plan --format json` passed.
- `python backend\manage.py air_freight_pilot_seed_plan --format text` passed.
- `python backend\manage.py test quotes.tests.test_air_freight_pilot_seed_audit quotes.tests.test_air_freight_pilot_seed_plan` passed: 20 tests OK.
- `python backend\manage.py check` passed: System check identified no issues.
- `git diff --check` passed.
- `graphify update .` passed: rebuilt 10945 nodes, 26810 edges, 934 communities.