### PR TITLE
Phase 13.1H: Add guarded Air Freight seed apply mode

### DIFF
--- a/backend/quotes/management/commands/air_freight_pilot_seed_plan.py
+++ b/backend/quotes/management/commands/air_freight_pilot_seed_plan.py
@@ -3,19 +3,21 @@ import json
 from django.core.management.base import BaseCommand
 
 from quotes.services.air_freight_pilot_seed_plan import (
+    apply_air_freight_pilot_seed_plan,
     build_air_freight_pilot_seed_plan,
     render_air_freight_pilot_seed_plan_text,
 )
 
 
 class Command(BaseCommand):
-    help = "Dry-run-only Air Freight pilot seed plan. This command performs no writes."
+    help = "Air Freight pilot seed plan. Dry-run by default; --apply creates approved records."
 
     def add_arguments(self, parser):
         parser.add_argument("--format", choices=["json", "text"], default="json")
+        parser.add_argument("--apply", action="store_true", help="Create approved missing ProductCodes and ChargeAliases.")
 
     def handle(self, *args, **options):
-        plan = build_air_freight_pilot_seed_plan()
+        plan = apply_air_freight_pilot_seed_plan() if options["apply"] else build_air_freight_pilot_seed_plan()
         if options["format"] == "text":
             self.stdout.write(render_air_freight_pilot_seed_plan_text(plan), ending="")
             return

--- a/backend/quotes/services/air_freight_pilot_seed_plan.py
+++ b/backend/quotes/services/air_freight_pilot_seed_plan.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+from decimal import Decimal
 from typing import Any
+
+from django.core.exceptions import ValidationError
+from django.db import transaction
+from django.db.utils import IntegrityError
 
 from pricing_v4.models import ChargeAlias, ProductCode
 
@@ -16,8 +21,8 @@ PRODUCT_CODE_CANDIDATES = [
         "is_gst_applicable": True,
         "gst_rate": "0.1000",
         "gst_treatment": ProductCode.GST_TREATMENT_STANDARD,
-        "gl_revenue_code": "TBD-REV",
-        "gl_cost_code": "TBD-COS",
+        "gl_revenue_code": "4400",
+        "gl_cost_code": "5400",
     },
     {
         "id": 2043,
@@ -29,8 +34,8 @@ PRODUCT_CODE_CANDIDATES = [
         "is_gst_applicable": True,
         "gst_rate": "0.1000",
         "gst_treatment": ProductCode.GST_TREATMENT_STANDARD,
-        "gl_revenue_code": "TBD-REV",
-        "gl_cost_code": "TBD-COS",
+        "gl_revenue_code": "4400",
+        "gl_cost_code": "5400",
     },
 ]
 
@@ -57,14 +62,17 @@ BLOCKED_DECISIONS = [
     {
         "item": "misc_recoveries",
         "reason": "Phase 13.1D deferred broad miscellaneous recoveries to manual review.",
+        "apply_scope": False,
     },
     {
         "item": "fsc ANY/ANY",
         "reason": "Broad FSC alias is ambiguous across airline, pickup, cartage, and domestic fuel.",
+        "apply_scope": False,
     },
     {
         "item": "handling generic",
         "reason": "Generic handling is ambiguous across origin and destination handling.",
+        "apply_scope": False,
     },
 ]
 
@@ -79,8 +87,9 @@ def build_air_freight_pilot_seed_plan() -> dict[str, Any]:
     alias_actions = [_alias_action(*row, planned_product_codes) for row in ALIAS_CANDIDATES]
     conflicts = [item for item in product_actions + alias_actions if item["action"] == "conflict"]
     warnings = _placeholder_warnings(product_actions)
+    apply_blockers = _apply_blockers(product_actions, alias_actions, conflicts, warnings)
     plan = {
-        "status": "blocked" if conflicts or BLOCKED_DECISIONS else "ready_for_dry_run_review",
+        "status": "blocked" if apply_blockers else "ready_for_apply",
         "summary": {
             "product_code_create": _count(product_actions, "create"),
             "product_code_reuse": _count(product_actions, "reuse"),
@@ -91,20 +100,76 @@ def build_air_freight_pilot_seed_plan() -> dict[str, Any]:
             "charge_alias_blocked": _count(alias_actions, "blocked"),
             "charge_alias_conflict": _count(alias_actions, "conflict"),
             "blocked_count": len(BLOCKED_DECISIONS) + _count(alias_actions, "blocked"),
+            "apply_blocker_count": len(apply_blockers),
             "warning_count": len(warnings),
         },
         "product_code_actions": product_actions,
         "charge_alias_actions": alias_actions,
         "conflicts": conflicts,
+        "apply_blockers": apply_blockers,
         "blocked": BLOCKED_DECISIONS,
         "warnings": warnings,
         "recommended_next_actions": [
-            "Review GL placeholders and GST treatment before any apply-mode phase.",
-            "Resolve blocked broad aliases before adding any write command.",
-            "Keep Phase 13.1E dry-run only; no seed writes are available.",
+            "Run dry-run first and review product_code_actions, charge_alias_actions, conflicts, and apply_blockers.",
+            "Use --apply only in the approved environment after dry-run output is ready_for_apply.",
+            "Keep miscellaneous recoveries, broad fsc, and generic handling out of apply scope.",
         ],
     }
     return plan
+
+
+def apply_air_freight_pilot_seed_plan() -> dict[str, Any]:
+    plan = build_air_freight_pilot_seed_plan()
+    if plan["apply_blockers"]:
+        return {**plan, "status": "apply_aborted", "applied": _empty_apply_summary("apply blockers present")}
+
+    created_product_codes = []
+    created_charge_aliases = []
+    try:
+        with transaction.atomic():
+            for action in plan["product_code_actions"]:
+                if action["action"] != "create":
+                    continue
+                candidate = action["candidate"]
+                product_code = ProductCode(**{**candidate, "gst_rate": Decimal(candidate["gst_rate"])})
+                product_code.full_clean()
+                product_code.save(force_insert=True)
+                created_product_codes.append(product_code.code)
+
+            for action in plan["charge_alias_actions"]:
+                if action["action"] not in {"create", "create_after_product_code"}:
+                    continue
+                product_code = ProductCode.objects.filter(code=action["product_code"]).first()
+                if not product_code:
+                    raise RuntimeError(f"target ProductCode {action['product_code']} is missing")
+                alias = ChargeAlias(
+                    alias_text=action["alias_text"],
+                    normalized_alias_text=action["normalized_alias_text"],
+                    match_type=action["match_type"],
+                    mode_scope=action["mode_scope"],
+                    direction_scope=action["direction_scope"],
+                    product_code=product_code,
+                    alias_source=ChargeAlias.AliasSource.SEED,
+                    review_status=ChargeAlias.ReviewStatus.APPROVED,
+                    is_active=True,
+                    notes="Phase 13.1H Air Freight pilot seed apply",
+                )
+                alias.full_clean()
+                alias.save(force_insert=True)
+                created_charge_aliases.append(alias.alias_text)
+    except (IntegrityError, RuntimeError, ValidationError) as exc:
+        return {**build_air_freight_pilot_seed_plan(), "status": "apply_aborted", "applied": _empty_apply_summary(str(exc))}
+
+    return {
+        **build_air_freight_pilot_seed_plan(),
+        "status": "applied",
+        "applied": {
+            "product_codes_created": len(created_product_codes),
+            "charge_aliases_created": len(created_charge_aliases),
+            "created_product_codes": created_product_codes,
+            "created_charge_aliases": created_charge_aliases,
+        },
+    }
 
 
 def render_air_freight_pilot_seed_plan_text(plan: dict[str, Any]) -> str:
@@ -114,6 +179,7 @@ def render_air_freight_pilot_seed_plan_text(plan: dict[str, Any]) -> str:
         f"ProductCodes create/reuse/conflict: {summary['product_code_create']}/{summary['product_code_reuse']}/{summary['product_code_conflict']}",
         f"ChargeAliases create/dependent/skip/blocked/conflict: {summary['charge_alias_create']}/{summary['charge_alias_create_after_product_code']}/{summary['charge_alias_skip']}/{summary['charge_alias_blocked']}/{summary['charge_alias_conflict']}",
         f"Blocked: {summary['blocked_count']}",
+        f"Apply blockers: {summary['apply_blocker_count']}",
         f"Warnings: {summary['warning_count']}",
         "",
         "Recommended next actions:",
@@ -127,6 +193,15 @@ def _product_code_action(candidate: dict[str, Any]) -> dict[str, Any]:
     existing_id = ProductCode.objects.filter(id=candidate["id"]).first()
     validation = _validate_product_code_candidate(candidate)
     if existing_code:
+        mismatches = _product_code_mismatches(existing_code, candidate)
+        if mismatches:
+            return {
+                "action": "conflict",
+                "candidate": candidate,
+                "existing_id": existing_code.id,
+                "reason": f"existing ProductCode differs on {', '.join(mismatches)}",
+                "validation": validation,
+            }
         return {"action": "reuse", "candidate": candidate, "existing_id": existing_code.id, "validation": validation}
     if existing_id:
         return {
@@ -172,6 +247,13 @@ def _alias_action(
         product_code=target,
     ).first()
     if exact:
+        if not exact.is_active or exact.review_status != ChargeAlias.ReviewStatus.APPROVED:
+            return {
+                **action,
+                "action": "conflict",
+                "existing_id": exact.id,
+                "reason": "existing scoped alias is not active and approved",
+            }
         return {**action, "action": "skip_existing", "existing_id": exact.id}
 
     conflict = ChargeAlias.objects.filter(
@@ -222,6 +304,50 @@ def _placeholder_warnings(actions: list[dict[str, Any]]) -> list[str]:
         for warning in action["validation"]["warnings"]:
             warnings.append(f"{action['candidate']['code']}: {warning}")
     return warnings
+
+
+def _product_code_mismatches(existing: ProductCode, candidate: dict[str, Any]) -> list[str]:
+    fields = [
+        "id",
+        "description",
+        "domain",
+        "category",
+        "default_unit",
+        "is_gst_applicable",
+        "gst_treatment",
+        "gl_revenue_code",
+        "gl_cost_code",
+    ]
+    mismatches = [field for field in fields if getattr(existing, field) != candidate[field]]
+    if existing.gst_rate != Decimal(candidate["gst_rate"]):
+        mismatches.append("gst_rate")
+    return mismatches
+
+
+def _apply_blockers(
+    product_actions: list[dict[str, Any]],
+    alias_actions: list[dict[str, Any]],
+    conflicts: list[dict[str, Any]],
+    warnings: list[str],
+) -> list[dict[str, Any]]:
+    blockers = [{"type": "conflict", "item": item} for item in conflicts]
+    for action in product_actions:
+        for error in action["validation"]["errors"]:
+            blockers.append({"type": "validation_error", "product_code": action["candidate"]["code"], "field": error})
+    blockers.extend({"type": "placeholder_gl", "item": warning} for warning in warnings)
+    blockers.extend({"type": "missing_target", "item": item} for item in alias_actions if item["action"] == "blocked")
+    blockers.extend({"type": "blocked_decision", "item": item} for item in BLOCKED_DECISIONS if item.get("apply_scope", True))
+    return blockers
+
+
+def _empty_apply_summary(reason: str) -> dict[str, Any]:
+    return {
+        "product_codes_created": 0,
+        "charge_aliases_created": 0,
+        "created_product_codes": [],
+        "created_charge_aliases": [],
+        "reason": reason,
+    }
 
 
 def _count(actions: list[dict[str, Any]], action: str) -> int:

--- a/backend/quotes/tests/test_air_freight_pilot_seed_plan.py
+++ b/backend/quotes/tests/test_air_freight_pilot_seed_plan.py
@@ -1,10 +1,12 @@
 import json
 from io import StringIO
+from unittest import mock
 
 from django.core.management import call_command
 from django.test import TestCase
 
 from pricing_v4.models import ChargeAlias, ProductCode
+from quotes.services import air_freight_pilot_seed_plan as seed_plan
 
 
 class AirFreightPilotSeedPlanCommandTests(TestCase):
@@ -27,6 +29,7 @@ class AirFreightPilotSeedPlanCommandTests(TestCase):
         self.assertEqual(
             list(payload.keys()),
             [
+                "apply_blockers",
                 "blocked",
                 "charge_alias_actions",
                 "conflicts",
@@ -48,7 +51,7 @@ class AirFreightPilotSeedPlanCommandTests(TestCase):
         self.assertEqual(create_codes, {"IMP-HANDLE-DEST", "IMP-STORAGE-DEST"})
 
     def test_existing_candidate_product_code_is_reused(self):
-        self.product(2042, "IMP-HANDLE-DEST", ProductCode.DOMAIN_IMPORT)
+        self.product_candidate(seed_plan.PRODUCT_CODE_CANDIDATES[0])
         payload = self.payload()
         action = self.action_for_code(payload, "IMP-HANDLE-DEST")
         self.assertEqual(action["action"], "reuse")
@@ -108,6 +111,74 @@ class AirFreightPilotSeedPlanCommandTests(TestCase):
         self.assertIn("fsc ANY/ANY", blocked)
         self.assertIn("handling generic", blocked)
 
+    def test_apply_creates_expected_product_codes(self):
+        self.seed_alias_targets()
+        payload = json.loads(self.call_plan("--apply", "--format", "json"))
+        self.assertEqual(payload["status"], "applied")
+        self.assertEqual(payload["applied"]["product_codes_created"], 2)
+        handling = ProductCode.objects.get(code="IMP-HANDLE-DEST")
+        storage = ProductCode.objects.get(code="IMP-STORAGE-DEST")
+        self.assertEqual(handling.gl_revenue_code, "4400")
+        self.assertEqual(handling.gl_cost_code, "5400")
+        self.assertEqual(storage.gst_treatment, ProductCode.GST_TREATMENT_STANDARD)
+        self.assertTrue(storage.is_gst_applicable)
+
+    def test_apply_creates_dependent_aliases_after_product_codes(self):
+        self.seed_alias_targets()
+        payload = json.loads(self.call_plan("--apply", "--format", "json"))
+        self.assertEqual(payload["applied"]["charge_aliases_created"], 16)
+        alias = ChargeAlias.objects.get(alias_text="import handling")
+        self.assertEqual(alias.product_code.code, "IMP-HANDLE-DEST")
+        self.assertEqual(alias.alias_source, ChargeAlias.AliasSource.SEED)
+
+    def test_apply_is_idempotent(self):
+        self.seed_alias_targets()
+        first = json.loads(self.call_plan("--apply", "--format", "json"))
+        second = json.loads(self.call_plan("--apply", "--format", "json"))
+        self.assertEqual(first["applied"]["product_codes_created"], 2)
+        self.assertEqual(first["applied"]["charge_aliases_created"], 16)
+        self.assertEqual(second["applied"]["product_codes_created"], 0)
+        self.assertEqual(second["applied"]["charge_aliases_created"], 0)
+        self.assertEqual(ProductCode.objects.filter(code__in=["IMP-HANDLE-DEST", "IMP-STORAGE-DEST"]).count(), 2)
+
+    def test_apply_aborts_on_conflicts_without_writes(self):
+        self.seed_alias_targets()
+        other = self.product(1099, "EXP-FRT-OTHER", ProductCode.DOMAIN_EXPORT)
+        ChargeAlias.objects.create(
+            alias_text="freight",
+            normalized_alias_text="freight",
+            match_type=ChargeAlias.MatchType.EXACT,
+            mode_scope=ChargeAlias.ModeScope.EXPORT,
+            direction_scope=ChargeAlias.DirectionScope.MAIN,
+            product_code=other,
+            is_active=True,
+            review_status=ChargeAlias.ReviewStatus.APPROVED,
+        )
+        payload = json.loads(self.call_plan("--apply", "--format", "json"))
+        self.assertEqual(payload["status"], "apply_aborted")
+        self.assertFalse(ProductCode.objects.filter(code="IMP-HANDLE-DEST").exists())
+
+    def test_apply_aborts_on_placeholder_gl_codes(self):
+        candidates = [{**item} for item in seed_plan.PRODUCT_CODE_CANDIDATES]
+        candidates[0]["gl_revenue_code"] = "TBD-REV"
+        with mock.patch.object(seed_plan, "PRODUCT_CODE_CANDIDATES", candidates):
+            payload = json.loads(self.call_plan("--apply", "--format", "json"))
+        self.assertEqual(payload["status"], "apply_aborted")
+        self.assertIn("placeholder_gl", {item["type"] for item in payload["apply_blockers"]})
+
+    def test_apply_aborts_on_blocked_decisions_in_apply_scope(self):
+        self.seed_alias_targets()
+        blocked = [{"item": "generic handling", "reason": "test", "apply_scope": True}]
+        with mock.patch.object(seed_plan, "BLOCKED_DECISIONS", blocked):
+            payload = json.loads(self.call_plan("--apply", "--format", "json"))
+        self.assertEqual(payload["status"], "apply_aborted")
+        self.assertFalse(ProductCode.objects.filter(code="IMP-HANDLE-DEST").exists())
+
+    def test_apply_aborts_when_target_product_codes_are_missing(self):
+        payload = json.loads(self.call_plan("--apply", "--format", "json"))
+        self.assertEqual(payload["status"], "apply_aborted")
+        self.assertIn("missing_target", {item["type"] for item in payload["apply_blockers"]})
+
     def test_text_output_works(self):
         output = self.call_plan("--format", "text")
         self.assertIn("Air Freight pilot seed plan:", output)
@@ -145,3 +216,35 @@ class AirFreightPilotSeedPlanCommandTests(TestCase):
             "product_code": ProductCode.objects.count(),
             "charge_alias": ChargeAlias.objects.count(),
         }
+
+    def seed_alias_targets(self):
+        for pk, code, domain in [
+            (1001, "EXP-FRT-AIR", ProductCode.DOMAIN_EXPORT),
+            (1002, "EXP-FSC-AIR", ProductCode.DOMAIN_EXPORT),
+            (1011, "EXP-AWB", ProductCode.DOMAIN_EXPORT),
+            (1032, "EXP-HANDLE", ProductCode.DOMAIN_EXPORT),
+            (1040, "EXP-SCREEN", ProductCode.DOMAIN_EXPORT),
+            (2001, "IMP-FRT-AIR", ProductCode.DOMAIN_IMPORT),
+            (2002, "IMP-FSC-PICKUP", ProductCode.DOMAIN_IMPORT),
+            (2003, "IMP-FSC-CARTAGE-DEST", ProductCode.DOMAIN_IMPORT),
+            (2004, "IMP-SEC-ORIGIN", ProductCode.DOMAIN_IMPORT),
+            (2005, "IMP-AWB-ORIGIN", ProductCode.DOMAIN_IMPORT),
+            (3001, "DOM-FRT-AIR", ProductCode.DOMAIN_DOMESTIC),
+            (3002, "DOM-AWB", ProductCode.DOMAIN_DOMESTIC),
+        ]:
+            self.product(pk, code, domain)
+
+    def product_candidate(self, candidate):
+        return ProductCode.objects.create(
+            id=candidate["id"],
+            code=candidate["code"],
+            description=candidate["description"],
+            domain=candidate["domain"],
+            category=candidate["category"],
+            is_gst_applicable=candidate["is_gst_applicable"],
+            gst_rate=candidate["gst_rate"],
+            gst_treatment=candidate["gst_treatment"],
+            gl_revenue_code=candidate["gl_revenue_code"],
+            gl_cost_code=candidate["gl_cost_code"],
+            default_unit=candidate["default_unit"],
+        )

--- a/docs/pilot/staging-seed-audit.md
+++ b/docs/pilot/staging-seed-audit.md
@@ -564,3 +564,41 @@ Updated dry-run/apply readiness checklist:
 Recommendation for Phase 13.1H:
 
 Phase 13.1H may add guarded apply mode only after the dry-run plan constants are updated to the approved GL/GST values in this section. The apply command should keep dry-run as the default, require an explicit `--apply`, run in a transaction, create ProductCodes before dependent ChargeAliases, skip exact existing records, and abort on conflicts, placeholder GL codes, or any non-deferred blocked decision.
+
+## 16. Phase 13.1H guarded apply mode
+
+Phase 13.1H adds an explicit apply path to the existing Air Freight pilot seed-plan command. Dry-run remains the default.
+
+Usage:
+
+```bash
+python backend/manage.py air_freight_pilot_seed_plan --format json
+python backend/manage.py air_freight_pilot_seed_plan --format text
+python backend/manage.py air_freight_pilot_seed_plan --apply --format json
+python backend/manage.py air_freight_pilot_seed_plan --apply --format text
+```
+
+Approved ProductCode values encoded for apply:
+
+| ProductCode | GST applicable | GST rate | GST treatment | Revenue GL | Cost GL |
+| --- | --- | --- | --- | --- | --- |
+| `IMP-HANDLE-DEST` | Yes | `0.1000` | `STANDARD` | `4400` | `5400` |
+| `IMP-STORAGE-DEST` | Yes | `0.1000` | `STANDARD` | `4400` | `5400` |
+
+Apply safety rules:
+
+- `--apply` is required for writes; without it the command only reports the plan.
+- Apply uses one database transaction.
+- ProductCodes are created before dependent ChargeAliases.
+- Apply is additive only: it creates missing approved records and skips exact existing records.
+- Apply never deletes, overwrites, deactivates, resets, or updates existing ProductCodes or ChargeAliases.
+- Apply aborts before writing if conflicts, validation errors, placeholder GL codes, missing alias target ProductCodes, or in-scope blocked decisions are present.
+- Deferred decisions remain out of apply scope: `misc_recoveries`, broad `fsc ANY/ANY`, and generic `handling`.
+
+Expected Phase 13.1H apply scope:
+
+| Object type | Create scope |
+| --- | --- |
+| ProductCodes | `IMP-HANDLE-DEST`, `IMP-STORAGE-DEST` |
+| ChargeAliases | Approved scoped aliases only, including dependent `import handling` and `storage` after ProductCode creation |
+| Excluded | Customer data, supplier data, miscellaneous recoveries, broad `fsc`, generic `handling`, migrations, frontend changes |


### PR DESCRIPTION
## Summary
- Add explicit `--apply` support to `air_freight_pilot_seed_plan`; dry-run remains the default.
- Encode Phase 13.1G GL/GST decisions for `IMP-HANDLE-DEST` and `IMP-STORAGE-DEST`.
- Create ProductCodes before dependent ChargeAliases in a single transaction.
- Keep apply additive-only: create missing approved records, skip exact existing records, never update/delete/deactivate/reset.
- Add focused tests for dry-run no writes, apply creation, dependent alias ordering, idempotency, and abort paths.
- Update `docs/pilot/staging-seed-audit.md` with apply usage and safety rules.

## Safety checks added
- Abort apply on conflicts.
- Abort apply on validation errors.
- Abort apply on placeholder GL codes.
- Abort apply on missing alias target ProductCodes.
- Abort apply on blocked decisions marked in apply scope.
- Treat existing ProductCode code with mismatched canonical fields as conflict, not reuse.
- Treat inactive/unapproved scoped alias duplicates as conflict, not ready.

## Counts
- Dry-run before local apply: ProductCodes create `2`, reuse `0`, conflict `0`; ChargeAliases create `14`, dependent `2`, skip `0`, blocked `0`, conflict `0`; apply blockers `0`; warnings `0`.
- First local safe apply: ProductCodes created `2`; ChargeAliases created `16`.
- Idempotent local rerun: ProductCodes created `0`; ChargeAliases created `0`; dry-run now reports ProductCodes reuse `2` and ChargeAliases skip `16`.
- Test DB idempotency coverage: first apply creates `2/16`, second apply creates `0/0`.

## Verification
- `python backend\manage.py air_freight_pilot_seed_plan --format json` passed.
- `python backend\manage.py air_freight_pilot_seed_plan --apply --format json` passed.
- `python backend\manage.py test quotes.tests.test_air_freight_pilot_seed_audit quotes.tests.test_air_freight_pilot_seed_plan` passed: 27 tests.
- `python backend\manage.py check` passed: System check identified no issues.
- `git diff --check` passed.
- `graphify update .` passed: rebuilt 10961 nodes, 26848 edges, 941 communities.

## Changed files
- `backend/quotes/management/commands/air_freight_pilot_seed_plan.py`
- `backend/quotes/services/air_freight_pilot_seed_plan.py`
- `backend/quotes/tests/test_air_freight_pilot_seed_plan.py`
- `docs/pilot/staging-seed-audit.md`

## PR base
This PR is now based on `main` after Phase 13.1G was merged.