### PR TITLE
Phase 13.1I: Apply Air Freight seed and verify readiness

### DIFF
--- a/backend/quotes/services/air_freight_pilot_seed_audit.py
+++ b/backend/quotes/services/air_freight_pilot_seed_audit.py
@@ -33,7 +33,7 @@ PRODUCT_COVERAGE = [
     {"key": "security_surcharge", "label": "Security surcharge", "terms": ["security"]},
     {"key": "screening", "label": "Screening", "terms": ["screening"]},
     {"key": "awb_docs", "label": "AWB / documentation", "terms": ["awb", "documentation", "docs"]},
-    {"key": "import_handling", "label": "Import handling", "terms": ["import handling"]},
+    {"key": "import_handling", "label": "Import handling", "terms": ["import handling", "import destination handling"]},
     {"key": "export_handling", "label": "Export handling", "terms": ["export handling"]},
     {"key": "origin_handling", "label": "Origin handling", "terms": ["origin handling"]},
     {"key": "destination_handling", "label": "Destination handling", "terms": ["destination handling"]},

--- a/backend/quotes/tests/test_air_freight_pilot_seed_audit.py
+++ b/backend/quotes/tests/test_air_freight_pilot_seed_audit.py
@@ -51,6 +51,23 @@ class AirFreightPilotSeedAuditCommandTests(TestCase):
         self.assertIn({"section": "product_codes", "item": "fuel_surcharge"}, payload["missing"])
         self.assertGreater(payload["product_codes"]["missing_count"], 0)
 
+    def test_import_destination_handling_covers_import_handling(self):
+        ProductCode.objects.create(
+            id=2042,
+            code="IMP-HANDLE-DEST",
+            description="Import Destination Handling",
+            domain=ProductCode.DOMAIN_IMPORT,
+            category=ProductCode.CATEGORY_HANDLING,
+            is_gst_applicable=True,
+            gst_rate="0.1000",
+            gst_treatment=ProductCode.GST_TREATMENT_STANDARD,
+            gl_revenue_code="4400",
+            gl_cost_code="5400",
+            default_unit=ProductCode.UNIT_SHIPMENT,
+        )
+        payload = self.payload()
+        self.assertTrue(payload["product_codes"]["coverage"]["import_handling"]["exists"])
+
     def test_missing_aliases_are_reported(self):
         payload = self.payload()
         self.assertIn({"section": "charge_aliases", "item": "fsc"}, payload["missing"])

--- a/docs/pilot/staging-seed-audit.md
+++ b/docs/pilot/staging-seed-audit.md
@@ -602,3 +602,80 @@ Expected Phase 13.1H apply scope:
 | ProductCodes | `IMP-HANDLE-DEST`, `IMP-STORAGE-DEST` |
 | ChargeAliases | Approved scoped aliases only, including dependent `import handling` and `storage` after ProductCode creation |
 | Excluded | Customer data, supplier data, miscellaneous recoveries, broad `fsc`, generic `handling`, migrations, frontend changes |
+
+## 17. Phase 13.1I apply and readiness verification
+
+Phase 13.1I was run from latest `main` after Phase 13.1H merged. No migrations, frontend changes, customer data, or supplier data were touched. The safe environment already contained the Phase 13.1H applied ProductCodes and ChargeAliases from prior guarded verification, so the Phase 13.1I apply run was idempotent.
+
+Pre-apply dry-run result:
+
+| Field | Count |
+| --- | ---: |
+| Status | `ready_for_apply` |
+| Apply blockers | 0 |
+| ProductCode create | 0 |
+| ProductCode reuse | 2 |
+| ProductCode conflict | 0 |
+| ChargeAlias create | 0 |
+| ChargeAlias create after ProductCode | 0 |
+| ChargeAlias skip existing | 16 |
+| ChargeAlias blocked | 0 |
+| ChargeAlias conflict | 0 |
+| Warnings | 0 |
+
+First Phase 13.1I apply result:
+
+| Field | Count |
+| --- | ---: |
+| Status | `applied` |
+| ProductCodes created | 0 |
+| ChargeAliases created | 0 |
+| Apply blockers | 0 |
+
+Post-apply dry-run result:
+
+| Field | Count |
+| --- | ---: |
+| Status | `ready_for_apply` |
+| ProductCode create | 0 |
+| ProductCode reuse | 2 |
+| ChargeAlias create | 0 |
+| ChargeAlias skip existing | 16 |
+| Apply blockers | 0 |
+
+Post-apply audit result:
+
+| Field | Count |
+| --- | ---: |
+| Status | `not_ready` |
+| Missing | 2 |
+| Conflicts | 14 |
+| Warnings | 0 |
+| ProductCode missing coverage | 1 |
+| ChargeAlias missing coverage | 1 |
+| Hierarchy missing coverage | 0 |
+| Currency missing coverage | 0 |
+| Location missing coverage | 0 |
+
+Idempotency result:
+
+| Field | Count |
+| --- | ---: |
+| Status | `applied` |
+| ProductCodes created | 0 |
+| ChargeAliases created | 0 |
+| ProductCode reuse | 2 |
+| ChargeAlias skip existing | 16 |
+
+Remaining blockers:
+
+| Section | Item | Notes |
+| --- | --- | --- |
+| ProductCodes | `misc_recoveries` | Intentionally deferred by Phase 13.1G; do not seed until specific recovery categories and accounting treatment are approved. |
+| ChargeAlias | `handling` | Intentionally deferred by Phase 13.1G; generic handling remains ambiguous and should stay manual-review-only. |
+| ProductCode conflicts | 6 multi-match coverage groups | Air Freight, Fuel surcharge, Security surcharge, AWB/documentation, Destination handling, and Customs pass-through each have multiple possible ProductCodes and still require scoped interpretation. |
+| ChargeAlias conflicts | 8 multi-map aliases | `air freight`, `freight`, `fuel surcharge`, `security surcharge`, `screening`, `awb`, `documentation fee`, and `terminal fee` map to multiple ProductCodes by scope. |
+
+Audit correctness note:
+
+Phase 13.1I also corrected the audit coverage terms so `IMP-HANDLE-DEST` / `Import Destination Handling` satisfies the `import_handling` coverage check. After that correction, import handling is no longer reported missing.


### PR DESCRIPTION
## Summary
- Ran Phase 13.1I from latest `main` after Phase 13.1H merged.
- Ran guarded dry-run, apply, post-apply dry-run, post-apply audit, and idempotency apply.
- Updated `docs/pilot/staging-seed-audit.md` with exact Phase 13.1I results and remaining blockers.
- Corrected the audit coverage term so `IMP-HANDLE-DEST` / `Import Destination Handling` satisfies `import_handling` coverage, with a regression test.

## Seed plan counts
Pre-apply dry-run:
- Status: `ready_for_apply`
- Apply blockers: `0`
- ProductCode create/reuse/conflict: `0/2/0`
- ChargeAlias create/dependent/skip/blocked/conflict: `0/0/16/0/0`
- Warnings: `0`

First Phase 13.1I apply:
- Status: `applied`
- ProductCodes created: `0`
- ChargeAliases created: `0`
- Apply blockers: `0`

Post-apply dry-run:
- Status: `ready_for_apply`
- ProductCode create/reuse: `0/2`
- ChargeAlias create/skip: `0/16`
- Apply blockers: `0`

Idempotency apply:
- Status: `applied`
- ProductCodes created: `0`
- ChargeAliases created: `0`

## Post-apply audit
- Status: `not_ready`
- Missing: `2`
- Conflicts: `14`
- Warnings: `0`

Remaining blockers:
- Missing `product_codes.misc_recoveries` remains intentionally deferred.
- Missing generic `charge_aliases.handling` remains intentionally deferred.
- 6 ProductCode multi-match coverage conflicts remain.
- 8 ChargeAlias multi-map conflicts remain.

## Verification
- `python backend\manage.py air_freight_pilot_seed_plan --format json` passed.
- `python backend\manage.py air_freight_pilot_seed_plan --apply --format json` passed.
- `python backend\manage.py air_freight_pilot_seed_audit --format json` passed.
- `python backend\manage.py test quotes.tests.test_air_freight_pilot_seed_audit quotes.tests.test_air_freight_pilot_seed_plan` passed: 28 tests.
- `python backend\manage.py check` passed.
- `git diff --check` passed.
- `graphify update .` passed: rebuilt 10963 nodes, 26851 edges, 931 communities.

## Changed files
- `backend/quotes/services/air_freight_pilot_seed_audit.py`
- `backend/quotes/tests/test_air_freight_pilot_seed_audit.py`
- `docs/pilot/staging-seed-audit.md`

## Scope notes
- No migrations.
- No frontend changes.
- No customer/supplier data.
- `.qwen/` and `tmp/` were not touched.