### PR TITLE
fix(rbac): make customer register operating-entity visible

### DIFF
--- a/backend/accounts/management/commands/rbac_backend_enforcement_audit.py
+++ b/backend/accounts/management/commands/rbac_backend_enforcement_audit.py
@@ -197,6 +197,7 @@ class Command(BaseCommand):
                 source = inspect.getsource(view_class)
             return any(token in source for token in (
                 'scoped_queryset_for_user',
+                'customer_register_queryset_for_user',
                 'get_quotes_for_user',
                 'get_spes_for_user',
             ))

--- a/backend/accounts/scope.py
+++ b/backend/accounts/scope.py
@@ -201,11 +201,14 @@ def customer_register_queryset_for_user(queryset, user, *, prefix: str = ""):
     field_prefix = f"{prefix}__" if prefix else ""
     filters = {
         f"{field_prefix}organization_id": membership.organization_id,
-        f"{field_prefix}branch_id": membership.branch_id,
     }
     operating_entity_id = membership_operating_entity_id(membership)
-    if operating_entity_id and _model_has_field(queryset.model, f"{field_prefix}operating_entity"):
-        filters[f"{field_prefix}operating_entity_id"] = operating_entity_id
+    if operating_entity_id and _model_has_field(queryset.model, f"{field_prefix}branch__operating_entity"):
+        filters[f"{field_prefix}branch__operating_entity_id"] = operating_entity_id
+    else:
+        # Company has no direct operating_entity field yet; fall back to branch
+        # until every customer branch is linked to an operating entity.
+        filters[f"{field_prefix}branch_id"] = membership.branch_id
     return queryset.filter(**filters)
 
 

--- a/backend/accounts/scope.py
+++ b/backend/accounts/scope.py
@@ -188,6 +188,27 @@ def scoped_queryset_for_user(queryset, user, *, prefix: str = ""):
     return queryset.filter(**filters)
 
 
+def customer_register_queryset_for_user(queryset, user, *, prefix: str = ""):
+    if user_has_cross_scope_access(user):
+        return queryset
+
+    membership = get_single_complete_membership(user)
+    if membership is None:
+        if getattr(settings, "RBAC_ALLOW_LEGACY_SCOPE_FALLBACK_FOR_TESTS", False):
+            return queryset
+        return queryset.none()
+
+    field_prefix = f"{prefix}__" if prefix else ""
+    filters = {
+        f"{field_prefix}organization_id": membership.organization_id,
+        f"{field_prefix}branch_id": membership.branch_id,
+    }
+    operating_entity_id = membership_operating_entity_id(membership)
+    if operating_entity_id and _model_has_field(queryset.model, f"{field_prefix}operating_entity"):
+        filters[f"{field_prefix}operating_entity_id"] = operating_entity_id
+    return queryset.filter(**filters)
+
+
 def scoped_q_for_user(user, *, prefix: str = "") -> Q:
     if user_has_cross_scope_access(user):
         return Q()

--- a/backend/parties/tests.py
+++ b/backend/parties/tests.py
@@ -3853,7 +3853,26 @@ class BackendScopedAccessAPITests(APITestCase):
         self.role_sales = Role.objects.create(code="phase9d-sales", name="Sales", is_system=True)
 
         self.org_a = Organization.objects.create(name="Phase 9D Org A", slug="phase-9d-org-a")
-        self.branch_a = Branch.objects.create(organization=self.org_a, code="P9A", name="Phase 9D A")
+        self.operating_entity_a = OperatingEntity.objects.create(
+            organization=self.org_a,
+            code="P9PNG",
+            name="Phase 9D PNG",
+            slug="phase-9d-png",
+            country_code="PG",
+        )
+        self.operating_entity_b = OperatingEntity.objects.create(
+            organization=self.org_a,
+            code="P9AU",
+            name="Phase 9D Australia",
+            slug="phase-9d-australia",
+            country_code="AU",
+        )
+        self.branch_a = Branch.objects.create(
+            organization=self.org_a,
+            operating_entity=self.operating_entity_a,
+            code="P9A",
+            name="Phase 9D A",
+        )
         self.department_a = Department.objects.create(
             organization=self.org_a,
             branch=self.branch_a,
@@ -3866,12 +3885,29 @@ class BackendScopedAccessAPITests(APITestCase):
             code="SEA",
             name="Sea Freight",
         )
-        self.branch_a_other = Branch.objects.create(organization=self.org_a, code="P9A2", name="Phase 9D A2")
+        self.branch_a_other = Branch.objects.create(
+            organization=self.org_a,
+            operating_entity=self.operating_entity_a,
+            code="P9A2",
+            name="Phase 9D A2",
+        )
         self.department_a_other_branch = Department.objects.create(
             organization=self.org_a,
             branch=self.branch_a_other,
             code="CUS",
             name="Customs",
+        )
+        self.branch_a_other_operating_entity = Branch.objects.create(
+            organization=self.org_a,
+            operating_entity=self.operating_entity_b,
+            code="P9AU",
+            name="Phase 9D AU",
+        )
+        self.department_a_other_operating_entity = Department.objects.create(
+            organization=self.org_a,
+            branch=self.branch_a_other_operating_entity,
+            code="TRN",
+            name="Transport",
         )
         self.org_b = Organization.objects.create(name="Phase 9D Org B", slug="phase-9d-org-b")
         self.branch_b = Branch.objects.create(organization=self.org_b, code="P9B", name="Phase 9D B")
@@ -3899,6 +3935,12 @@ class BackendScopedAccessAPITests(APITestCase):
             self.branch_a_other,
             self.department_a_other_branch,
         )
+        self.company_a_other_operating_entity = self._company(
+            "Phase 9D Customer A Other Operating Entity",
+            self.org_a,
+            self.branch_a_other_operating_entity,
+            self.department_a_other_operating_entity,
+        )
         self.company_b = self._company("Phase 9D Customer B", self.org_b, self.branch_b, self.department_b)
         self.company_unscoped = Company.objects.create(
             name="Phase 9D Manual Review Customer",
@@ -3908,6 +3950,10 @@ class BackendScopedAccessAPITests(APITestCase):
         self.contact_a = self._contact(self.company_a, "a")
         self.contact_a_other_department = self._contact(self.company_a_other_department, "a-other-department")
         self.contact_a_other_branch = self._contact(self.company_a_other_branch, "a-other-branch")
+        self.contact_a_other_operating_entity = self._contact(
+            self.company_a_other_operating_entity,
+            "a-other-operating-entity",
+        )
         self.contact_b = self._contact(self.company_b, "b")
         self.company_a_other = self._company("Phase 9D Customer A Other", self.org_a, self.branch_a, self.department_a)
         self.contact_a_other = self._contact(self.company_a_other, "a-other")
@@ -3920,6 +3966,13 @@ class BackendScopedAccessAPITests(APITestCase):
             self.branch_a,
             self.department_a_other,
         )
+        self.opportunity_a_other_branch = self._opportunity(
+            "Phase 9D Opportunity A Other Branch",
+            self.company_a_other_branch,
+            self.org_a,
+            self.branch_a_other,
+            self.department_a_other_branch,
+        )
         self.opportunity_b = self._opportunity("Phase 9D Opportunity B", self.company_b, self.org_b, self.branch_b, self.department_b)
         self.interaction_a = self._interaction(self.company_a, self.org_a, self.branch_a, self.department_a)
         self.interaction_a_other_department = self._interaction(
@@ -3927,6 +3980,12 @@ class BackendScopedAccessAPITests(APITestCase):
             self.org_a,
             self.branch_a,
             self.department_a_other,
+        )
+        self.interaction_a_other_branch = self._interaction(
+            self.company_a_other_branch,
+            self.org_a,
+            self.branch_a_other,
+            self.department_a_other_branch,
         )
         self.interaction_b = self._interaction(self.company_b, self.org_b, self.branch_b, self.department_b)
         self.task_a = self._task("Phase 9D Task A", self.company_a, self.org_a, self.branch_a, self.department_a)
@@ -3936,6 +3995,13 @@ class BackendScopedAccessAPITests(APITestCase):
             self.org_a,
             self.branch_a,
             self.department_a_other,
+        )
+        self.task_a_other_branch = self._task(
+            "Phase 9D Task A Other Branch",
+            self.company_a_other_branch,
+            self.org_a,
+            self.branch_a_other,
+            self.department_a_other_branch,
         )
         self.task_b = self._task("Phase 9D Task B", self.company_b, self.org_b, self.branch_b, self.department_b)
 
@@ -4029,18 +4095,21 @@ class BackendScopedAccessAPITests(APITestCase):
         self.assertIn(str(self.company_a.id), returned_ids)
         self.assertIn(str(self.company_a_other_department.id), returned_ids)
         self.assertIn(str(self.company_a_other_branch.id), returned_ids)
+        self.assertIn(str(self.company_a_other_operating_entity.id), returned_ids)
         self.assertIn(str(self.company_b.id), returned_ids)
         self.assertIn(str(self.company_unscoped.id), returned_ids)
 
     def test_scoped_manager_can_access_in_scope_customer(self):
         self.client.force_authenticate(user=self.manager)
 
-        response = self.client.get(f"/api/v3/customers/{self.company_a.id}/")
+        response = self.client.get(f"/api/v3/customers/{self.company_a_other_branch.id}/")
+        other_operating_entity = self.client.get(f"/api/v3/customers/{self.company_a_other_operating_entity.id}/")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["id"], str(self.company_a.id))
+        self.assertEqual(response.data["id"], str(self.company_a_other_branch.id))
+        self.assertEqual(other_operating_entity.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_scoped_user_list_excludes_out_of_scope_and_unscoped_customers(self):
+    def test_scoped_user_list_includes_same_operating_entity_and_excludes_out_of_scope_customers(self):
         self.client.force_authenticate(user=self.sales)
 
         response = self.client.get("/api/v3/customers/")
@@ -4049,7 +4118,8 @@ class BackendScopedAccessAPITests(APITestCase):
         returned_ids = self._ids(response)
         self.assertIn(str(self.company_a.id), returned_ids)
         self.assertIn(str(self.company_a_other_department.id), returned_ids)
-        self.assertNotIn(str(self.company_a_other_branch.id), returned_ids)
+        self.assertIn(str(self.company_a_other_branch.id), returned_ids)
+        self.assertNotIn(str(self.company_a_other_operating_entity.id), returned_ids)
         self.assertNotIn(str(self.company_b.id), returned_ids)
         self.assertNotIn(str(self.company_unscoped.id), returned_ids)
 
@@ -4060,23 +4130,25 @@ class BackendScopedAccessAPITests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_scoped_user_can_retrieve_same_branch_customer_from_other_department(self):
+    def test_scoped_user_can_retrieve_same_operating_entity_customer_from_other_branch(self):
         self.client.force_authenticate(user=self.sales)
 
-        response = self.client.get(f"/api/v3/customers/{self.company_a_other_department.id}/")
+        response = self.client.get(f"/api/v3/customers/{self.company_a_other_branch.id}/")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["id"], str(self.company_a_other_department.id))
+        self.assertEqual(response.data["id"], str(self.company_a_other_branch.id))
 
-    def test_customer_detail_uses_branch_visible_customer_scope(self):
+    def test_customer_detail_uses_operating_entity_visible_customer_scope(self):
         self.client.force_authenticate(user=self.sales)
 
-        response = self.client.get(f"/api/v3/customer-details/{self.company_a_other_department.id}/")
-        other_branch = self.client.get(f"/api/v3/customer-details/{self.company_a_other_branch.id}/")
+        response = self.client.get(f"/api/v3/customer-details/{self.company_a_other_branch.id}/")
+        other_operating_entity = self.client.get(
+            f"/api/v3/customer-details/{self.company_a_other_operating_entity.id}/"
+        )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["id"], str(self.company_a_other_department.id))
-        self.assertEqual(other_branch.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data["id"], str(self.company_a_other_branch.id))
+        self.assertEqual(other_operating_entity.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_company_selector_filters_out_of_scope_companies(self):
         self.client.force_authenticate(user=self.sales)
@@ -4087,7 +4159,8 @@ class BackendScopedAccessAPITests(APITestCase):
         returned_ids = self._ids(response)
         self.assertIn(str(self.company_a.id), returned_ids)
         self.assertIn(str(self.company_a_other_department.id), returned_ids)
-        self.assertNotIn(str(self.company_a_other_branch.id), returned_ids)
+        self.assertIn(str(self.company_a_other_branch.id), returned_ids)
+        self.assertNotIn(str(self.company_a_other_operating_entity.id), returned_ids)
         self.assertNotIn(str(self.company_b.id), returned_ids)
 
     def test_contact_by_company_endpoint_checks_parent_company_scope(self):
@@ -4097,14 +4170,21 @@ class BackendScopedAccessAPITests(APITestCase):
         same_branch_other_department = self.client.get(
             f"/api/v3/parties/companies/{self.company_a_other_department.id}/contacts/"
         )
-        other_branch = self.client.get(f"/api/v3/parties/companies/{self.company_a_other_branch.id}/contacts/")
+        same_operating_entity_other_branch = self.client.get(
+            f"/api/v3/parties/companies/{self.company_a_other_branch.id}/contacts/"
+        )
+        other_operating_entity = self.client.get(
+            f"/api/v3/parties/companies/{self.company_a_other_operating_entity.id}/contacts/"
+        )
         out_of_scope = self.client.get(f"/api/v3/parties/companies/{self.company_b.id}/contacts/")
 
         self.assertEqual(in_scope.status_code, status.HTTP_200_OK)
         self.assertEqual(self._ids(in_scope), {str(self.contact_a.id)})
         self.assertEqual(same_branch_other_department.status_code, status.HTTP_200_OK)
         self.assertEqual(self._ids(same_branch_other_department), {str(self.contact_a_other_department.id)})
-        self.assertEqual(other_branch.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(same_operating_entity_other_branch.status_code, status.HTTP_200_OK)
+        self.assertEqual(self._ids(same_operating_entity_other_branch), {str(self.contact_a_other_branch.id)})
+        self.assertEqual(other_operating_entity.status_code, status.HTTP_404_NOT_FOUND)
         self.assertEqual(out_of_scope.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_crm_viewsets_filter_and_deny_direct_out_of_scope_ids(self):
@@ -4119,12 +4199,15 @@ class BackendScopedAccessAPITests(APITestCase):
         self.assertEqual(task_list.status_code, status.HTTP_200_OK)
         self.assertIn(str(self.opportunity_a.id), self._ids(opportunity_list))
         self.assertNotIn(str(self.opportunity_a_other_department.id), self._ids(opportunity_list))
+        self.assertNotIn(str(self.opportunity_a_other_branch.id), self._ids(opportunity_list))
         self.assertNotIn(str(self.opportunity_b.id), self._ids(opportunity_list))
         self.assertIn(str(self.interaction_a.id), self._ids(interaction_list))
         self.assertNotIn(str(self.interaction_a_other_department.id), self._ids(interaction_list))
+        self.assertNotIn(str(self.interaction_a_other_branch.id), self._ids(interaction_list))
         self.assertNotIn(str(self.interaction_b.id), self._ids(interaction_list))
         self.assertIn(str(self.task_a.id), self._ids(task_list))
         self.assertNotIn(str(self.task_a_other_department.id), self._ids(task_list))
+        self.assertNotIn(str(self.task_a_other_branch.id), self._ids(task_list))
         self.assertNotIn(str(self.task_b.id), self._ids(task_list))
 
         self.assertEqual(
@@ -4132,11 +4215,23 @@ class BackendScopedAccessAPITests(APITestCase):
             status.HTTP_404_NOT_FOUND,
         )
         self.assertEqual(
+            self.client.get(f"/api/v3/crm/opportunities/{self.opportunity_a_other_branch.id}/").status_code,
+            status.HTTP_404_NOT_FOUND,
+        )
+        self.assertEqual(
             self.client.get(f"/api/v3/crm/interactions/{self.interaction_a_other_department.id}/").status_code,
             status.HTTP_404_NOT_FOUND,
         )
         self.assertEqual(
+            self.client.get(f"/api/v3/crm/interactions/{self.interaction_a_other_branch.id}/").status_code,
+            status.HTTP_404_NOT_FOUND,
+        )
+        self.assertEqual(
             self.client.get(f"/api/v3/crm/tasks/{self.task_a_other_department.id}/").status_code,
+            status.HTTP_404_NOT_FOUND,
+        )
+        self.assertEqual(
+            self.client.get(f"/api/v3/crm/tasks/{self.task_a_other_branch.id}/").status_code,
             status.HTTP_404_NOT_FOUND,
         )
         self.assertEqual(

--- a/backend/parties/tests.py
+++ b/backend/parties/tests.py
@@ -3860,6 +3860,19 @@ class BackendScopedAccessAPITests(APITestCase):
             code="AIR",
             name="Air Freight",
         )
+        self.department_a_other = Department.objects.create(
+            organization=self.org_a,
+            branch=self.branch_a,
+            code="SEA",
+            name="Sea Freight",
+        )
+        self.branch_a_other = Branch.objects.create(organization=self.org_a, code="P9A2", name="Phase 9D A2")
+        self.department_a_other_branch = Department.objects.create(
+            organization=self.org_a,
+            branch=self.branch_a_other,
+            code="CUS",
+            name="Customs",
+        )
         self.org_b = Organization.objects.create(name="Phase 9D Org B", slug="phase-9d-org-b")
         self.branch_b = Branch.objects.create(organization=self.org_b, code="P9B", name="Phase 9D B")
         self.department_b = Department.objects.create(
@@ -3874,6 +3887,18 @@ class BackendScopedAccessAPITests(APITestCase):
         self.sales = self._user("phase9d-sales-user", CustomUser.ROLE_SALES, self.org_a, self.branch_a, self.department_a, self.role_sales)
 
         self.company_a = self._company("Phase 9D Customer A", self.org_a, self.branch_a, self.department_a)
+        self.company_a_other_department = self._company(
+            "Phase 9D Customer A Same Branch Other Department",
+            self.org_a,
+            self.branch_a,
+            self.department_a_other,
+        )
+        self.company_a_other_branch = self._company(
+            "Phase 9D Customer A Other Branch",
+            self.org_a,
+            self.branch_a_other,
+            self.department_a_other_branch,
+        )
         self.company_b = self._company("Phase 9D Customer B", self.org_b, self.branch_b, self.department_b)
         self.company_unscoped = Company.objects.create(
             name="Phase 9D Manual Review Customer",
@@ -3881,15 +3906,37 @@ class BackendScopedAccessAPITests(APITestCase):
             company_type="CUSTOMER",
         )
         self.contact_a = self._contact(self.company_a, "a")
+        self.contact_a_other_department = self._contact(self.company_a_other_department, "a-other-department")
+        self.contact_a_other_branch = self._contact(self.company_a_other_branch, "a-other-branch")
         self.contact_b = self._contact(self.company_b, "b")
         self.company_a_other = self._company("Phase 9D Customer A Other", self.org_a, self.branch_a, self.department_a)
         self.contact_a_other = self._contact(self.company_a_other, "a-other")
 
         self.opportunity_a = self._opportunity("Phase 9D Opportunity A", self.company_a, self.org_a, self.branch_a, self.department_a)
+        self.opportunity_a_other_department = self._opportunity(
+            "Phase 9D Opportunity A Other Department",
+            self.company_a_other_department,
+            self.org_a,
+            self.branch_a,
+            self.department_a_other,
+        )
         self.opportunity_b = self._opportunity("Phase 9D Opportunity B", self.company_b, self.org_b, self.branch_b, self.department_b)
         self.interaction_a = self._interaction(self.company_a, self.org_a, self.branch_a, self.department_a)
+        self.interaction_a_other_department = self._interaction(
+            self.company_a_other_department,
+            self.org_a,
+            self.branch_a,
+            self.department_a_other,
+        )
         self.interaction_b = self._interaction(self.company_b, self.org_b, self.branch_b, self.department_b)
         self.task_a = self._task("Phase 9D Task A", self.company_a, self.org_a, self.branch_a, self.department_a)
+        self.task_a_other_department = self._task(
+            "Phase 9D Task A Other Department",
+            self.company_a_other_department,
+            self.org_a,
+            self.branch_a,
+            self.department_a_other,
+        )
         self.task_b = self._task("Phase 9D Task B", self.company_b, self.org_b, self.branch_b, self.department_b)
 
     def _user(self, username, role, organization, branch, department, membership_role):
@@ -3980,6 +4027,8 @@ class BackendScopedAccessAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         returned_ids = self._ids(response)
         self.assertIn(str(self.company_a.id), returned_ids)
+        self.assertIn(str(self.company_a_other_department.id), returned_ids)
+        self.assertIn(str(self.company_a_other_branch.id), returned_ids)
         self.assertIn(str(self.company_b.id), returned_ids)
         self.assertIn(str(self.company_unscoped.id), returned_ids)
 
@@ -3999,6 +4048,8 @@ class BackendScopedAccessAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         returned_ids = self._ids(response)
         self.assertIn(str(self.company_a.id), returned_ids)
+        self.assertIn(str(self.company_a_other_department.id), returned_ids)
+        self.assertNotIn(str(self.company_a_other_branch.id), returned_ids)
         self.assertNotIn(str(self.company_b.id), returned_ids)
         self.assertNotIn(str(self.company_unscoped.id), returned_ids)
 
@@ -4009,6 +4060,24 @@ class BackendScopedAccessAPITests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_scoped_user_can_retrieve_same_branch_customer_from_other_department(self):
+        self.client.force_authenticate(user=self.sales)
+
+        response = self.client.get(f"/api/v3/customers/{self.company_a_other_department.id}/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["id"], str(self.company_a_other_department.id))
+
+    def test_customer_detail_uses_branch_visible_customer_scope(self):
+        self.client.force_authenticate(user=self.sales)
+
+        response = self.client.get(f"/api/v3/customer-details/{self.company_a_other_department.id}/")
+        other_branch = self.client.get(f"/api/v3/customer-details/{self.company_a_other_branch.id}/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["id"], str(self.company_a_other_department.id))
+        self.assertEqual(other_branch.status_code, status.HTTP_404_NOT_FOUND)
+
     def test_company_selector_filters_out_of_scope_companies(self):
         self.client.force_authenticate(user=self.sales)
 
@@ -4017,16 +4086,25 @@ class BackendScopedAccessAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         returned_ids = self._ids(response)
         self.assertIn(str(self.company_a.id), returned_ids)
+        self.assertIn(str(self.company_a_other_department.id), returned_ids)
+        self.assertNotIn(str(self.company_a_other_branch.id), returned_ids)
         self.assertNotIn(str(self.company_b.id), returned_ids)
 
     def test_contact_by_company_endpoint_checks_parent_company_scope(self):
         self.client.force_authenticate(user=self.sales)
 
         in_scope = self.client.get(f"/api/v3/parties/companies/{self.company_a.id}/contacts/")
+        same_branch_other_department = self.client.get(
+            f"/api/v3/parties/companies/{self.company_a_other_department.id}/contacts/"
+        )
+        other_branch = self.client.get(f"/api/v3/parties/companies/{self.company_a_other_branch.id}/contacts/")
         out_of_scope = self.client.get(f"/api/v3/parties/companies/{self.company_b.id}/contacts/")
 
         self.assertEqual(in_scope.status_code, status.HTTP_200_OK)
         self.assertEqual(self._ids(in_scope), {str(self.contact_a.id)})
+        self.assertEqual(same_branch_other_department.status_code, status.HTTP_200_OK)
+        self.assertEqual(self._ids(same_branch_other_department), {str(self.contact_a_other_department.id)})
+        self.assertEqual(other_branch.status_code, status.HTTP_404_NOT_FOUND)
         self.assertEqual(out_of_scope.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_crm_viewsets_filter_and_deny_direct_out_of_scope_ids(self):
@@ -4040,12 +4118,27 @@ class BackendScopedAccessAPITests(APITestCase):
         self.assertEqual(interaction_list.status_code, status.HTTP_200_OK)
         self.assertEqual(task_list.status_code, status.HTTP_200_OK)
         self.assertIn(str(self.opportunity_a.id), self._ids(opportunity_list))
+        self.assertNotIn(str(self.opportunity_a_other_department.id), self._ids(opportunity_list))
         self.assertNotIn(str(self.opportunity_b.id), self._ids(opportunity_list))
         self.assertIn(str(self.interaction_a.id), self._ids(interaction_list))
+        self.assertNotIn(str(self.interaction_a_other_department.id), self._ids(interaction_list))
         self.assertNotIn(str(self.interaction_b.id), self._ids(interaction_list))
         self.assertIn(str(self.task_a.id), self._ids(task_list))
+        self.assertNotIn(str(self.task_a_other_department.id), self._ids(task_list))
         self.assertNotIn(str(self.task_b.id), self._ids(task_list))
 
+        self.assertEqual(
+            self.client.get(f"/api/v3/crm/opportunities/{self.opportunity_a_other_department.id}/").status_code,
+            status.HTTP_404_NOT_FOUND,
+        )
+        self.assertEqual(
+            self.client.get(f"/api/v3/crm/interactions/{self.interaction_a_other_department.id}/").status_code,
+            status.HTTP_404_NOT_FOUND,
+        )
+        self.assertEqual(
+            self.client.get(f"/api/v3/crm/tasks/{self.task_a_other_department.id}/").status_code,
+            status.HTTP_404_NOT_FOUND,
+        )
         self.assertEqual(
             self.client.get(f"/api/v3/crm/opportunities/{self.opportunity_b.id}/").status_code,
             status.HTTP_404_NOT_FOUND,

--- a/backend/parties/views.py
+++ b/backend/parties/views.py
@@ -12,7 +12,7 @@ from rest_framework.permissions import AllowAny, BasePermission
 from rest_framework.views import APIView
 from rest_framework.response import Response
 
-from accounts.scope import populate_missing_scope_values, scoped_queryset_for_user
+from accounts.scope import customer_register_queryset_for_user, populate_missing_scope_values
 from .models import Address, Company, Contact, Organization, OrganizationBranding
 from .serializers import (
     CompanySearchV3Serializer,
@@ -85,7 +85,7 @@ class CustomerV3ViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         customer_filter = Q(is_customer=True) | Q(company_type="CUSTOMER")
         queryset = Company.objects.filter(customer_filter, is_active=True)
-        queryset = scoped_queryset_for_user(queryset, self.request.user)
+        queryset = customer_register_queryset_for_user(queryset, self.request.user)
         return (
             queryset
             .order_by("name")
@@ -136,7 +136,7 @@ class CompanyV3SearchView(generics.ListAPIView):
             return Company.objects.none()
         queryset = Company.objects.filter(name__icontains=query, is_active=True)
         queryset = queryset.filter(Q(is_customer=True) | Q(company_type="CUSTOMER"))
-        queryset = scoped_queryset_for_user(queryset, self.request.user)
+        queryset = customer_register_queryset_for_user(queryset, self.request.user)
         return queryset.order_by("name")[:20]
 
 
@@ -150,7 +150,7 @@ class CompanyContactListV3View(generics.ListAPIView):
 
     def get_queryset(self):
         company_id = self.kwargs.get("company_id")
-        company_queryset = scoped_queryset_for_user(Company.objects.all(), self.request.user)
+        company_queryset = customer_register_queryset_for_user(Company.objects.all(), self.request.user)
         company = get_object_or_404(company_queryset, pk=company_id)
         return company.contacts.filter(is_active=True).order_by("last_name", "first_name")
 

--- a/backend/quotes/views/services.py
+++ b/backend/quotes/views/services.py
@@ -15,7 +15,7 @@ from rest_framework.parsers import MultiPartParser, FormParser
 from rest_framework.permissions import IsAuthenticated
 
 from parties.models import Address, Company, Contact, CustomerCommercialProfile
-from accounts.scope import scoped_queryset_for_user
+from accounts.scope import customer_register_queryset_for_user
 from core.models import Airport, City, Country, Currency
 from core.security import validate_csv_upload
 from ratecards.models import PartnerRateCard
@@ -137,7 +137,7 @@ class CustomerDetailAPIView(APIView):
     def _get_company(self, company_id):
         base_filter = Q(is_customer=True) | Q(company_type='CUSTOMER')
         queryset = Company.objects.filter(base_filter)
-        queryset = scoped_queryset_for_user(queryset, self.request.user)
+        queryset = customer_register_queryset_for_user(queryset, self.request.user)
         queryset = queryset.select_related(
             'commercial_profile__preferred_quote_currency'
         ).prefetch_related('contacts', 'addresses__city__country')


### PR DESCRIPTION
## Summary

Fixes RBAC customer visibility so sales and manager users can see customer master records across their operating entity, without requiring the customer record to match their exact branch or department.

This resolves the issue where `/customers`, company search, customer detail, and contact parent checks only returned customers in the user's exact organization + branch + department.

## Key Changes

- Added `customer_register_queryset_for_user()` in `backend/accounts/scope.py`.
- Customer register scope now uses `organization_id + branch__operating_entity_id` when the user's operating entity resolves.
- Falls back to branch-level filtering only if operating entity cannot be resolved.
- Updated customer master/read paths:
  - `CustomerV3ViewSet.get_queryset()`
  - `CompanyV3SearchView.get_queryset()`
  - `CompanyContactListV3View.get_queryset()`
  - `CustomerDetailAPIView._get_company()`
- Updated `rbac_backend_enforcement_audit.py` so the RBAC audit recognises `customer_register_queryset_for_user()` as valid queryset scoping evidence.
- Left strict RBAC unchanged for:
  - CRM opportunities/interactions/tasks
  - quote compute validation
  - SPOT customer/contact validation
  - existing `scoped_queryset_for_user()`

## Business Rule

Customer master records are operating-entity visible.

Operational records remain stricter and stay branch/department scoped where already enforced.

## Verification

- `python backend\manage.py test accounts.tests.RBACBackendEnforcementAuditCommandTests` passed: 1 test.
- `python backend\manage.py test parties.tests` passed: 215 tests.
- `python backend\manage.py test quotes.tests.test_rbac_backend_enforcement` passed: 14 tests.
- `python backend\manage.py check` passed.
- `git diff --check` passed with CRLF normalization warnings only.
- `graphify update .` completed.

## Scope Notes

- No frontend changes.
- No migrations.
- No customer data backfill.
- No weakening of CRM/quote/SPOT object-level RBAC.
- Existing `.qwen/` and `tmp/` folders left untouched.