### PR TITLE
fix(rbac): allow quote compute for OE-scoped customers

### DIFF
--- a/backend/quotes/tests/test_quote_stabilisation_regression.py
+++ b/backend/quotes/tests/test_quote_stabilisation_regression.py
@@ -7,9 +7,10 @@ from django.test import override_settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from accounts.models import Role, UserMembership
 from core.models import Country, Currency
 from core.tests.helpers import create_location
-from parties.models import Company, Contact
+from parties.models import Branch, Company, Contact, Department, OperatingEntity, Organization
 from pricing_v4.models import (
     Agent,
     Carrier,
@@ -37,6 +38,11 @@ class CoreQuoteStabilisationRegressionTests(APITestCase):
             password="testpass123",
             role="manager",
         )
+        self.sales_user = User.objects.create_user(
+            username="quote-rbac-sales",
+            password="testpass123",
+            role="sales",
+        )
         self.client.force_authenticate(self.user)
 
         # 1. Currencies & Countries
@@ -57,7 +63,57 @@ class CoreQuoteStabilisationRegressionTests(APITestCase):
         self.sin = create_location(code="SIN", name="Singapore", country=self.sg, is_active=True)
 
         # 3. Parties
-        self.customer = Company.objects.create(name="Regression Customer", company_type="CUSTOMER", is_customer=True)
+        self.organization = Organization.objects.create(name="Express Freight Management", slug="efm")
+        self.operating_entity = OperatingEntity.objects.create(
+            organization=self.organization,
+            code="PNG",
+            name="EFM PNG",
+            slug="efm-png",
+            country_code="PG",
+        )
+        self.other_operating_entity = OperatingEntity.objects.create(
+            organization=self.organization,
+            code="AU",
+            name="EFM Australia",
+            slug="efm-australia",
+            country_code="AU",
+        )
+        self.branch = Branch.objects.create(
+            organization=self.organization,
+            operating_entity=self.operating_entity,
+            code="POM",
+            name="Port Moresby",
+        )
+        self.department = Department.objects.create(
+            organization=self.organization,
+            branch=self.branch,
+            code="AIR",
+            name="Air Freight",
+        )
+        self.sales_role = Role.objects.create(code="quote-rbac-sales", name="Sales")
+        UserMembership.objects.create(
+            user=self.sales_user,
+            organization=self.organization,
+            operating_entity=self.operating_entity,
+            branch=self.branch,
+            department=self.department,
+            role=self.sales_role,
+        )
+        UserMembership.objects.create(
+            user=self.user,
+            organization=self.organization,
+            operating_entity=self.operating_entity,
+            branch=self.branch,
+            department=self.department,
+            role=self.sales_role,
+        )
+        self.customer = Company.objects.create(
+            name="Regression Customer",
+            company_type="CUSTOMER",
+            is_customer=True,
+            organization=self.organization,
+            operating_entity=self.operating_entity,
+        )
         self.contact = Contact.objects.create(
             company=self.customer,
             first_name="Reg",
@@ -183,6 +239,38 @@ class CoreQuoteStabilisationRegressionTests(APITestCase):
         self.valid_from = date.today() - timedelta(days=1)
         self.valid_until = date.today() + timedelta(days=30)
 
+    def _seed_import_collect_complete_rates(self):
+        ImportCOGS.objects.create(
+            product_code=self.imp_freight_pc, origin_airport="BNE", destination_airport="POM",
+            agent=self.agent_bne, currency="AUD", rate_per_kg=Decimal("4.50"),
+            valid_from=self.valid_from, valid_until=self.valid_until
+        )
+        ImportSellRate.objects.create(
+            product_code=self.imp_freight_pc, origin_airport="BNE", destination_airport="POM",
+            currency="PGK", rate_per_kg=Decimal("12.00"),
+            valid_from=self.valid_from, valid_until=self.valid_until
+        )
+        LocalCOGSRate.objects.create(
+            product_code=self.imp_origin_pc, location="BNE", direction="IMPORT",
+            agent=self.agent_bne, currency="AUD", rate_type="FIXED", amount=Decimal("50.00"),
+            valid_from=self.valid_from, valid_until=self.valid_until
+        )
+        LocalSellRate.objects.create(
+            product_code=self.imp_origin_pc, location="BNE", direction="IMPORT",
+            payment_term="COLLECT", currency="PGK", rate_type="FIXED", amount=Decimal("150.00"),
+            valid_from=self.valid_from, valid_until=self.valid_until
+        )
+        LocalCOGSRate.objects.create(
+            product_code=self.imp_dest_pc, location="POM", direction="IMPORT",
+            agent=self.agent_pom, currency="PGK", rate_type="FIXED", amount=Decimal("70.00"),
+            valid_from=self.valid_from, valid_until=self.valid_until
+        )
+        LocalSellRate.objects.create(
+            product_code=self.imp_dest_pc, location="POM", direction="IMPORT",
+            payment_term="COLLECT", currency="PGK", rate_type="FIXED", amount=Decimal("200.00"),
+            valid_from=self.valid_from, valid_until=self.valid_until
+        )
+
     def _payload(self, origin, destination, scope, payment_term, incoterm, **overrides):
         payload = {
             "customer_id": str(self.customer.id),
@@ -207,6 +295,135 @@ class CoreQuoteStabilisationRegressionTests(APITestCase):
         }
         payload.update(overrides)
         return payload
+
+    def test_sales_user_can_quote_operating_entity_customer_without_customer_branch_scope(self):
+        self.client.force_authenticate(self.sales_user)
+        self._seed_import_collect_complete_rates()
+
+        payload = self._payload(self.bne, self.pom, "D2D", "COLLECT", "EXW", agent_id=self.agent_bne.id, buy_currency="AUD")
+        response = self.client.post("/api/v3/quotes/compute/", payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        quote = Quote.objects.get(id=response.data["id"])
+        self.assertEqual(quote.customer, self.customer)
+        self.assertIsNone(self.customer.branch_id)
+        self.assertIsNone(self.customer.department_id)
+        self.assertEqual(quote.organization, self.organization)
+        self.assertEqual(quote.branch, self.branch)
+        self.assertEqual(quote.department, self.department)
+        self.assertEqual(quote.owner, self.sales_user)
+
+    def test_sales_user_cannot_quote_customer_from_other_operating_entity(self):
+        self.client.force_authenticate(self.sales_user)
+        other_customer = Company.objects.create(
+            name="Other OE Customer",
+            company_type="CUSTOMER",
+            is_customer=True,
+            organization=self.organization,
+            operating_entity=self.other_operating_entity,
+        )
+        other_contact = Contact.objects.create(
+            company=other_customer,
+            first_name="Other",
+            last_name="Contact",
+            email="other-oe@example.com",
+        )
+
+        payload = self._payload(
+            self.bne,
+            self.pom,
+            "D2D",
+            "COLLECT",
+            "EXW",
+            customer_id=str(other_customer.id),
+            contact_id=str(other_contact.id),
+        )
+        response = self.client.post("/api/v3/quotes/compute/", payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data["detail"], "Customer is not visible to your operating entity or does not exist.")
+
+    def test_quote_compute_rejects_contact_from_different_customer(self):
+        self.client.force_authenticate(self.sales_user)
+        other_customer = Company.objects.create(
+            name="Same OE Other Customer",
+            company_type="CUSTOMER",
+            is_customer=True,
+            organization=self.organization,
+            operating_entity=self.operating_entity,
+        )
+        other_contact = Contact.objects.create(
+            company=other_customer,
+            first_name="Wrong",
+            last_name="Contact",
+            email="wrong-contact@example.com",
+        )
+
+        payload = self._payload(
+            self.bne,
+            self.pom,
+            "D2D",
+            "COLLECT",
+            "EXW",
+            contact_id=str(other_contact.id),
+        )
+        response = self.client.post("/api/v3/quotes/compute/", payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data["detail"], "Selected contact is not available for this customer/user.")
+
+    def test_quote_recalculation_keeps_strict_quote_id_scope(self):
+        self.client.force_authenticate(self.sales_user)
+        User = get_user_model()
+        other_sales_user = User.objects.create_user(
+            username="quote-rbac-other-sales",
+            password="testpass123",
+            role="sales",
+        )
+        other_branch = Branch.objects.create(
+            organization=self.organization,
+            operating_entity=self.operating_entity,
+            code="LAE",
+            name="Lae",
+        )
+        other_department = Department.objects.create(
+            organization=self.organization,
+            branch=other_branch,
+            code="SEA",
+            name="Sea Freight",
+        )
+        UserMembership.objects.create(
+            user=other_sales_user,
+            organization=self.organization,
+            operating_entity=self.operating_entity,
+            branch=other_branch,
+            department=other_department,
+            role=self.sales_role,
+        )
+        other_quote = Quote.objects.create(
+            customer=self.customer,
+            contact=self.contact,
+            organization=self.organization,
+            branch=other_branch,
+            department=other_department,
+            owner=other_sales_user,
+            created_by=other_sales_user,
+            mode="AIR",
+        )
+
+        payload = self._payload(
+            self.bne,
+            self.pom,
+            "D2D",
+            "COLLECT",
+            "EXW",
+            quote_id=str(other_quote.id),
+            agent_id=self.agent_bne.id,
+            buy_currency="AUD",
+        )
+        response = self.client.post("/api/v3/quotes/compute/", payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     # =========================================================================
     # Scenario 1: Import COLLECT BNE → POM D2D with complete rates

--- a/backend/quotes/views/calculation.py
+++ b/backend/quotes/views/calculation.py
@@ -13,7 +13,7 @@ from quotes.models import Quote, QuoteVersion, QuoteLine, QuoteTotal
 from quotes.serializers import QuoteComputeRequestSerializer, QuoteModelSerializerV3
 from quotes.schemas import QuoteComputeRequest
 from accounts.permissions import QuoteAccessPermission
-from accounts.scope import scoped_queryset_for_user
+from accounts.scope import customer_register_queryset_for_user, resolve_create_scope_for_user
 from quotes.selectors import get_quote_for_user
 from quotes.state_machine import (
     QuoteImmutableError,
@@ -58,6 +58,9 @@ from core.dataclasses import (
 logger = logging.getLogger(__name__)
 
 from core.business_rules import classify_png_shipment
+
+CUSTOMER_NOT_VISIBLE_MESSAGE = "Customer is not visible to your operating entity or does not exist."
+CONTACT_NOT_VISIBLE_MESSAGE = "Selected contact is not available for this customer/user."
 
 def _classify_shipment_type(mode: str, origin_location: Location, destination_location: Location) -> str:
     if not origin_location or not destination_location:
@@ -150,9 +153,11 @@ class QuoteComputeV3APIView(generics.CreateAPIView):
         except ValueError as exc:
             return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 
-        customer_queryset = scoped_queryset_for_user(Company.objects.all(), request.user)
-        customer = get_object_or_404(customer_queryset, id=payload.customer_id)
-        get_object_or_404(Contact.objects.filter(company=customer), id=payload.contact_id)
+        customer = self._get_visible_customer(request.user, payload.customer_id)
+        if customer is None:
+            return Response({"detail": CUSTOMER_NOT_VISIBLE_MESSAGE}, status=status.HTTP_404_NOT_FOUND)
+        if not Contact.objects.filter(company=customer, id=payload.contact_id).exists():
+            return Response({"detail": CONTACT_NOT_VISIBLE_MESSAGE}, status=status.HTTP_404_NOT_FOUND)
 
         derived_output_currency = self._derive_output_currency(
             shipment_type,
@@ -368,6 +373,9 @@ class QuoteComputeV3APIView(generics.CreateAPIView):
             spot_rates=data.spot_rates or {}
         )
 
+    def _get_visible_customer(self, user, customer_id):
+        return customer_register_queryset_for_user(Company.objects.all(), user).filter(id=customer_id).first()
+
     def _location_to_ref(self, location: Location):
         country_code = location.country.code if location.country else None
         currency_code = None
@@ -482,11 +490,12 @@ class QuoteComputeV3APIView(generics.CreateAPIView):
         Helper to save the quote, version, lines, and totals to the database.
         When an existing quote is provided, we append a new version instead of creating a duplicate quote.
         """
-        customer = get_object_or_404(
-            scoped_queryset_for_user(Company.objects.all(), request.user),
-            id=validated_data.customer_id,
-        )
-        contact = get_object_or_404(Contact.objects.filter(company=customer), id=validated_data.contact_id)
+        customer = self._get_visible_customer(request.user, validated_data.customer_id)
+        if customer is None:
+            raise Http404(CUSTOMER_NOT_VISIBLE_MESSAGE)
+        contact = Contact.objects.filter(company=customer, id=validated_data.contact_id).first()
+        if contact is None:
+            raise Http404(CONTACT_NOT_VISIBLE_MESSAGE)
 
         request_payload = validated_data.model_dump(mode='json')
         if resolved_dimensions is not None:
@@ -522,6 +531,7 @@ class QuoteComputeV3APIView(generics.CreateAPIView):
             )
 
         if is_new_quote:
+            create_scope = resolve_create_scope_for_user(request.user)
             # --- Create the Quote object ---
             quote = Quote.objects.create(
                 customer=customer,
@@ -542,7 +552,10 @@ class QuoteComputeV3APIView(generics.CreateAPIView):
                 status=initial_status,
                 request_details_json=request_payload,
                 created_by=request.user,
-                organization=getattr(request.user, 'organization', None),
+                owner=create_scope.owner,
+                organization=create_scope.organization,
+                branch=create_scope.branch,
+                department=create_scope.department,
             )
             version_number = 1
         else:
@@ -564,8 +577,15 @@ class QuoteComputeV3APIView(generics.CreateAPIView):
             quote.is_dangerous_goods = validated_data.is_dangerous_goods
             quote.status = initial_status
             quote.request_details_json = request_payload
-            if quote.organization_id is None and getattr(request.user, 'organization_id', None):
-                quote.organization = request.user.organization
+            create_scope = resolve_create_scope_for_user(request.user)
+            if quote.organization_id is None and create_scope.organization is not None:
+                quote.organization = create_scope.organization
+            if quote.branch_id is None and create_scope.branch is not None:
+                quote.branch = create_scope.branch
+            if quote.department_id is None and create_scope.department is not None:
+                quote.department = create_scope.department
+            if quote.owner_id is None and create_scope.owner is not None:
+                quote.owner = create_scope.owner
             quote.save(update_fields=[
                 'customer',
                 'contact',
@@ -585,6 +605,9 @@ class QuoteComputeV3APIView(generics.CreateAPIView):
                 'status',
                 'request_details_json',
                 'organization',
+                'branch',
+                'department',
+                'owner',
             ])
 
             latest_version = quote.versions.order_by('-version_number').first()


### PR DESCRIPTION
## Summary
- Use `customer_register_queryset_for_user()` for quote compute customer lookup so customer master scope follows organization + operating entity.
- Keep contact validation tied to the selected customer.
- Stamp newly created quotes with the creator membership's organization, branch, department, and owner instead of deriving operational scope from the customer.
- Preserve `get_quote_for_user()` for existing quote recalculation and fill missing quote scope only when absent.

## Not changed
- `scoped_queryset_for_user()` strict behavior.
- CRM, quote object-level, SPOT, pricing, ProductCode, frontend, migrations, and customer master scope model.

## Verification
- `npx fallow --format json` (baseline: existing frontend findings)
- `npx fallow dead-code --format json` (baseline: existing frontend findings)
- `npx fallow dupes --format json` (baseline: existing frontend duplicate groups)
- `npx fallow health --format json` (baseline: existing frontend health hotspots)
- `python backend\manage.py test quotes.tests` - 489 tests passed
- `python backend\manage.py test parties.tests` - 217 tests passed
- `python backend\manage.py test accounts.tests.RBACBackendEnforcementAuditCommandTests` - 1 test passed
- `python backend\manage.py check` - no issues
- `git diff --check` - passed with Git line-ending warnings only
- `graphify update .` - updated graph report