### PR TITLE
Phase 13.1N: Wire live SPOT Exception Workspace

### DIFF
--- a/docs/pilot/air-freight-pilot-uat.md
+++ b/docs/pilot/air-freight-pilot-uat.md
@@ -44,6 +44,21 @@ Non-negotiable UAT rule: unscoped ambiguous labels must not be auto-priced witho
 7. Classify defects as blocker, fix-before-pilot, manual-review acceptable, or future enhancement.
 8. Decide proceed, fix, or rollback at the post-UAT decision gate.
 
+### Live Exception Workspace path
+
+Use the live workspace route for pilot evidence. The mock demo route remains available for development checks only and is not valid UAT evidence.
+
+1. Create or open the real Air Freight SPOT envelope from the quote workflow.
+2. On the SPOT quote page, select **Review in Exception Workspace**.
+3. Confirm the browser route is `/quotes/spot/<envelope_id>/exception-workspace`.
+4. Record the SPOT envelope ID from the route and, if a quote already exists, the related quote ID from the source quote page.
+5. Confirm the workspace displays live draft data and decision persistence messaging, not the demo-only prototype state.
+6. Perform the scenario action: accept a suggestion, ignore a non-commercial line, map an existing ProductCode, request a ProductCode, or consume an approved ProductCode.
+7. Refresh the workspace and confirm the decision remains visible in the Draft Quote payload.
+8. Capture evidence before and after finalization attempts, including any blocker message and final review status.
+
+Evidence must include the route, envelope ID, tested supplier label, action taken, resulting ProductCode or manual-review status, and whether refresh/reload preserved the decision.
+
 ## 4. Required UAT scenarios
 
 | ID | Scenario | Test data shape | Expected pass outcome | Fail outcome |

--- a/docs/spot-workspace-integration-plan.md
+++ b/docs/spot-workspace-integration-plan.md
@@ -250,5 +250,22 @@ To preserve accountability and feed the learning model for AI parsing:
 
 ---
 
+## Current Implementation Status
+
+Phase 13.1N confirms the live path is implemented as:
+
+- Real SPOT envelope page: `/quotes/spot/<envelope_id>`
+- Live Exception Workspace route: `/quotes/spot/<envelope_id>/exception-workspace`
+- Demo-only workspace route: `/quotes/spot/exception-workspace-demo`
+- Live read API: `GET /api/v3/spot/envelopes/<uuid:envelope_id>/draft-quote/`
+- Live decision API: `POST /api/v3/spot/envelopes/<uuid:envelope_id>/draft-quote/resolve/`
+- Live finalization API: `POST /api/v3/spot/envelopes/<uuid:envelope_id>/draft-quote/finalize/`
+
+The SPOT envelope page now exposes a **Review in Exception Workspace** action for existing envelopes. The live route passes the envelope ID to the workspace, loads the backend Draft Quote payload, and keeps the mock/demo route separate for non-UAT testing.
+
+Decision persistence currently routes accept suggestion, ignore, map ProductCode, request ProductCode, and use approved ProductCode actions through the Draft Quote resolve API in live mode. Refresh/reload evidence should be captured during Air Freight UAT by reopening the live route and confirming persisted decision state remains in the payload.
+
+---
+
 ## TODO Checklist
 - [ ] Review RateEngine/EFM brand style guide and align Exception Workspace styling with the rest of the app later.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "test:domestic-service-scope": "node scripts/domestic-service-scope.test.mjs",
     "test:spot-finalization": "node scripts/spot-finalization.test.mjs",
     "test:spot-workspace-helpers": "node scripts/spot-workspace-helpers.test.mjs",
+    "test:exception-workspace-routing": "node scripts/exception-workspace-routing.test.mjs",
     "test:draft-quote-contract": "node --experimental-strip-types scripts/draft-quote-contract.test.mjs",
     "test:quote-financial-helpers": "node scripts/quote-financial-helpers.test.mjs",
     "test:e2e": "playwright test",

--- a/frontend/scripts/exception-workspace-routing.test.mjs
+++ b/frontend/scripts/exception-workspace-routing.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const frontendRoot = path.resolve(process.cwd());
+const spotPagePath = path.join(frontendRoot, "src", "app", "quotes", "spot", "[speId]", "page.tsx");
+const livePagePath = path.join(frontendRoot, "src", "app", "quotes", "spot", "[speId]", "exception-workspace", "page.tsx");
+const demoPagePath = path.join(frontendRoot, "src", "app", "quotes", "spot", "exception-workspace-demo", "page.tsx");
+const workspacePath = path.join(frontendRoot, "src", "components", "spot", "ExceptionWorkspace.tsx");
+
+const [spotPage, livePage, demoPage, workspace] = await Promise.all([
+  readFile(spotPagePath, "utf8"),
+  readFile(livePagePath, "utf8"),
+  readFile(demoPagePath, "utf8"),
+  readFile(workspacePath, "utf8"),
+]);
+
+assert.match(
+  spotPage,
+  /Review in Exception Workspace/,
+  "real SPOT envelope page must expose a live Exception Workspace action",
+);
+
+assert.match(
+  spotPage,
+  /router\.push\(`\/quotes\/spot\/\$\{speId\}\/exception-workspace`\)/,
+  "real SPOT envelope action must pass the current envelope ID into the live workspace route",
+);
+
+assert.match(
+  livePage,
+  /const speId = params\?\.speId as string;/,
+  "live workspace route must require the dynamic envelope ID",
+);
+
+assert.match(
+  livePage,
+  /getDraftQuote\(speId\)/,
+  "live workspace route must load the backend Draft Quote payload for the envelope",
+);
+
+assert.match(
+  livePage,
+  /<ExceptionWorkspace initialData=\{data\} isLive=\{true\} envelopeId=\{speId\} \/>/,
+  "live workspace must pass real payload and envelope ID into the workspace component",
+);
+
+assert.match(
+  demoPage,
+  /<ExceptionWorkspace \/>/,
+  "demo route must remain mock-only and not pass live mode props",
+);
+
+assert.match(
+  workspace,
+  /type: "accept_suggestion"/,
+  "live accept-suggestion actions must persist through the Draft Quote resolve API",
+);
+
+assert.match(
+  workspace,
+  /const canUsePrototypeOverride = !isLive && prototypeOverride;/,
+  "prototype finalization override must be disabled in live workspace mode",
+);
+
+console.log("exception workspace routing checks passed");

--- a/frontend/src/app/quotes/spot/[speId]/page.tsx
+++ b/frontend/src/app/quotes/spot/[speId]/page.tsx
@@ -1001,13 +1001,26 @@ export default function SpotRateEntryPage() {
                             </p>
                         )}
                     </div>
-                    <PageCancelButton
-                        href="/quotes"
-                        isDirty={hasPendingUnsavedWork}
-                        confirmMessage="Discard quote changes?"
-                        label="Cancel Quote"
-                        className="shrink-0"
-                    />
+                    <div className="flex shrink-0 flex-col gap-2 sm:flex-row">
+                        {!isNew && speId ? (
+                            <Button
+                                type="button"
+                                variant="outline"
+                                onClick={() => {
+                                    if (!confirmLeave()) return;
+                                    router.push(`/quotes/spot/${speId}/exception-workspace`);
+                                }}
+                            >
+                                Review in Exception Workspace
+                            </Button>
+                        ) : null}
+                        <PageCancelButton
+                            href="/quotes"
+                            isDirty={hasPendingUnsavedWork}
+                            confirmMessage="Discard quote changes?"
+                            label="Cancel Quote"
+                        />
+                    </div>
                 </div>
             </div>
 

--- a/frontend/src/components/spot/ExceptionWorkspace.tsx
+++ b/frontend/src/components/spot/ExceptionWorkspace.tsx
@@ -298,8 +298,25 @@ export function ExceptionWorkspace({ initialData = hardCaseAirImportData, isLive
         setSelectedActionType(null);
     };
 
-    const handleAcceptSuggestedMapping = (chargeId: string, displayLabel: string, suggestedCode: string) => {
+    const handleAcceptSuggestedMapping = async (chargeId: string, displayLabel: string, suggestedCode: string) => {
         if (isReviewLocked) return;
+        try {
+            await submitLiveDecision({
+                decision_id: `dec-${Date.now()}`,
+                type: "accept_suggestion",
+                target_id: chargeId,
+                details: {},
+                audit_metadata: {
+                    user_id: 1,
+                    timestamp: new Date().toISOString()
+                }
+            });
+        } catch (err) {
+            console.error("Failed to submit accept suggestion decision:", err);
+            const errMsg = err instanceof Error ? err.message : String(err);
+            setActionMessage(`API error accepting suggested mapping: ${errMsg}`);
+            return;
+        }
         captureSnapshot(chargeId, "accept", `Accepted code ${suggestedCode} for ${displayLabel}`);
         setSuggestedCharges(prev =>
             prev.map(c => (c.id === chargeId ? { ...c, status: "accepted_by_user" as DraftChargeStatus } : c))
@@ -462,6 +479,7 @@ export function ExceptionWorkspace({ initialData = hardCaseAirImportData, isLive
 
     const canFinishReview = checklistIssuesResolved && checklistNoUnknown && checklistProductCodesVerified;
     const isReviewLocked = reviewSession.status === "finalized";
+    const canUsePrototypeOverride = !isLive && prototypeOverride;
 
     // Direct Next-Step instructions guidance
     let nextStepGuidance = "Review the remaining commercial term before finishing.";
@@ -1162,7 +1180,7 @@ export function ExceptionWorkspace({ initialData = hardCaseAirImportData, isLive
                         </div>
                     </div>
 
-                    {!canFinishReview && !prototypeOverride && (
+                    {!canFinishReview && !canUsePrototypeOverride && (
                         <div className="w-full bg-red-950/20 border border-red-900/60 rounded-xl p-4 text-xs text-red-200">
                             <span className="font-bold block mb-1">Finish Review unavailable</span>
                             <span>Resolve all pending issues and verify ProductCode mappings to complete review.</span>
@@ -1184,7 +1202,7 @@ export function ExceptionWorkspace({ initialData = hardCaseAirImportData, isLive
                         </div>
 
                         <button
-                            disabled={isReviewLocked || (!canFinishReview && !prototypeOverride)}
+                            disabled={isReviewLocked || (!canFinishReview && !canUsePrototypeOverride)}
                             onClick={handleFinalizeReview}
                             className="px-8 py-3 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 disabled:hover:bg-indigo-600 text-white rounded-xl font-bold text-sm shadow-xl shadow-indigo-900/40 w-full sm:w-auto text-center transition"
                         >


### PR DESCRIPTION
## Scope

Wire real SPOT envelopes into the live Exception Workspace path for Air Freight UAT while preserving the mock demo route.

## Changed Files

- `frontend/src/app/quotes/spot/[speId]/page.tsx`: adds `Review in Exception Workspace` action for existing real SPOT envelopes.
- `frontend/src/components/spot/ExceptionWorkspace.tsx`: persists live accept-suggestion decisions through the Draft Quote resolve API and keeps prototype override disabled for live blocker checks.
- `frontend/scripts/exception-workspace-routing.test.mjs`: regression coverage for live route, real envelope ID requirement, mock/live separation, and live persistence wiring.
- `frontend/package.json`: adds the route regression test script.
- `docs/pilot/air-freight-pilot-uat.md`: documents the live UAT workflow and evidence fields.
- `docs/spot-workspace-integration-plan.md`: records current live route/API implementation status.

## What Was Intentionally Not Changed

- No parser logic changes.
- No seed data, ProductCode, ChargeAlias, or migration changes.
- No quote total, V4 pricing, public quote rendering, or ProductCode approval behavior changes.
- Demo route `/quotes/spot/exception-workspace-demo` remains available for mock/dev testing.
- `tmp/` was not touched.

## Verification

Automated:
- `npm run test:exception-workspace-routing` - passed.
- `python backend\manage.py check` - passed, system check identified no issues.
- `npm run lint` - passed with 44 existing warnings and 0 errors.
- `npm run build` - passed with existing browser/lockfile warnings.
- `python -m pytest backend\quotes\tests -q` - 683 passed, 21 warnings in 701.65s.
- `git diff --check` - passed with CRLF normalization warnings only.
- `graphify update .` - rebuilt graph.json and GRAPH_REPORT.md; graph.html skipped due node limit.

Manual:
- Confirmed existing live route `/quotes/spot/[speId]/exception-workspace` loads `getDraftQuote(speId)` and passes `initialData`, `isLive`, and `envelopeId` to `ExceptionWorkspace`.
- Confirmed demo route renders `<ExceptionWorkspace />` without live props.
- Confirmed real SPOT envelope page now navigates to `/quotes/spot/${speId}/exception-workspace` via `Review in Exception Workspace`.

## Commercial Impact

No quote total, ProductCode mapping rule, public quote output, or operator decision semantics are intentionally changed. This PR only exposes the existing live workspace path and persists the already-supported accept-suggestion decision through the existing resolve contract.

## Data Impact

No migrations, seed writes, ProductCode creation, ChargeAlias creation, or backfills. Live user actions continue to persist only through existing Draft Quote resolve/finalize APIs.

## Audit Impact

Decision persistence uses existing Draft Quote resolve audit/history flow. UAT docs now require envelope ID, route, decision action, and refresh/reload evidence capture.

## Risk

The live workspace UI remains a large existing component with known lint/fallow complexity debt. Manual browser UAT with a real staged envelope is still required to capture scenario evidence.

## Rollback

Revert this PR to remove the navigation action, frontend regression script, and docs status updates. Existing backend Draft Quote APIs and demo route are not introduced by this PR.