### PR TITLE
Phase 14E: Extract SPOT workspace presentation panels

### DIFF
--- a/frontend/scripts/exception-workspace-routing.test.mjs
+++ b/frontend/scripts/exception-workspace-routing.test.mjs
@@ -7,15 +7,17 @@ const spotPagePath = path.join(frontendRoot, "src", "app", "quotes", "spot", "[s
 const livePagePath = path.join(frontendRoot, "src", "app", "quotes", "spot", "[speId]", "exception-workspace", "page.tsx");
 const demoPagePath = path.join(frontendRoot, "src", "app", "quotes", "spot", "exception-workspace-demo", "page.tsx");
 const workspacePath = path.join(frontendRoot, "src", "components", "spot", "ExceptionWorkspace.tsx");
+const finalReviewPanelPath = path.join(frontendRoot, "src", "components", "spot", "workspace", "FinalReviewPanel.tsx");
 
 const hookPath = path.join(frontendRoot, "src", "components", "spot", "workspace", "useSpotResolutionWorkflow.ts");
 const statePath = path.join(frontendRoot, "src", "components", "spot", "workspace", "spotResolutionState.ts");
 
-const [spotPage, livePage, demoPage, workspace, hook, stateFile] = await Promise.all([
+const [spotPage, livePage, demoPage, workspace, finalReviewPanel, hook, stateFile] = await Promise.all([
   readFile(spotPagePath, "utf8"),
   readFile(livePagePath, "utf8"),
   readFile(demoPagePath, "utf8"),
   readFile(workspacePath, "utf8"),
+  readFile(finalReviewPanelPath, "utf8"),
   readFile(hookPath, "utf8"),
   readFile(statePath, "utf8"),
 ]);
@@ -81,19 +83,25 @@ assert.match(
 
 assert.match(
   workspace,
+  /<FinalReviewPanel[\s\S]*isLive=\{isLive\}/,
+  "ExceptionWorkspace must pass isLive into the final review panel"
+);
+
+assert.match(
+  finalReviewPanel,
   /\{!isLive\s*&&\s*\(\s*<div className="flex items-center gap-2 text-xs">/,
   "prototype override checkbox must be wrapped in !isLive"
 );
 
 assert.match(
-  workspace,
+  finalReviewPanel,
   /\{!isLive\s*&&\s*\(\s*<div className="text-center text-xs text-slate-500 mt-2">/,
   "prototype warning footer must be wrapped in !isLive"
 );
 
 assert.match(
-  workspace,
-  /disabled=\{isReviewLocked\s*\|\|\s*\(!canFinishReview\s*&&\s*!canUsePrototypeOverride\)\}/,
+  finalReviewPanel,
+  /disabled=\{\s*isReviewLocked\s*\|\|\s*\(!canFinishReview\s*&&\s*!canUsePrototypeOverride\)\s*\}/,
   "demo override behaviour must remain integrated with finalization button state"
 );
 

--- a/frontend/scripts/spot-workspace-orchestration.test.mjs
+++ b/frontend/scripts/spot-workspace-orchestration.test.mjs
@@ -5,11 +5,26 @@ import path from "node:path";
 const frontendRoot = path.resolve(process.cwd());
 const workspacePath = path.join(frontendRoot, "src", "components", "spot", "ExceptionWorkspace.tsx");
 const hookPath = path.join(frontendRoot, "src", "components", "spot", "workspace", "useSpotResolutionWorkflow.ts");
+const panelNames = [
+    "NeedsAttentionPanel",
+    "ReviewDecisionsPanel",
+    "VerificationWarningsPanel",
+    "IgnoredItemsPanel",
+    "FinalReviewPanel"
+];
 
 console.log("Starting Spot Workspace Orchestration Contract Assertions...");
 
 const workspaceSrc = await readFile(workspacePath, "utf8");
 const hookSrc = await readFile(hookPath, "utf8");
+const panelSources = new Map(
+    await Promise.all(
+        panelNames.map(async panelName => [
+            panelName,
+            await readFile(path.join(frontendRoot, "src", "components", "spot", "workspace", `${panelName}.tsx`), "utf8")
+        ])
+    )
+);
 
 // 1. Verify ExceptionWorkspace imports and consumes the hook
 assert.ok(
@@ -23,6 +38,20 @@ assert.ok(
 );
 
 console.log("✓ Verified useSpotResolutionWorkflow is imported and consumed by ExceptionWorkspace.");
+
+// 1b. Verify presentation panels are imported and rendered by ExceptionWorkspace
+for (const panelName of panelNames) {
+    assert.ok(
+        workspaceSrc.includes(`import { ${panelName} } from "./workspace/${panelName}";`),
+        `ExceptionWorkspace must import ${panelName}`
+    );
+    assert.ok(
+        workspaceSrc.includes(`<${panelName}`),
+        `ExceptionWorkspace must render ${panelName}`
+    );
+}
+
+console.log("✓ Verified extracted presentation panels are imported and rendered by ExceptionWorkspace.");
 
 // 2. Verify state and handler functions are NOT declared inside ExceptionWorkspace anymore
 const forbiddenStates = [
@@ -85,5 +114,30 @@ assert.ok(hookSrc.includes("resolveDraftQuoteDecisions"), "useSpotResolutionWork
 assert.ok(hookSrc.includes("finalizeDraftQuoteReview"), "useSpotResolutionWorkflow must call finalizeDraftQuoteReview");
 
 console.log("✓ Verified useSpotResolutionWorkflow owns resolve and finalization API calls.");
+
+// 5. Verify extracted presentation panels are stateless and do not own workflow/API behavior
+for (const [panelName, panelSrc] of panelSources) {
+    assert.ok(!panelSrc.includes("useSpotResolutionWorkflow"), `${panelName} must not import or call workflow hook`);
+    assert.ok(!panelSrc.includes("useState("), `${panelName} must not own local React state`);
+    assert.ok(!/import.*from.*(api|lib\/api)/i.test(panelSrc), `${panelName} must not import API clients`);
+    assert.ok(!panelSrc.includes("fetch("), `${panelName} must not perform fetch operations`);
+    assert.ok(!panelSrc.includes("resolveDraftQuoteDecisions"), `${panelName} must not call resolve API`);
+    assert.ok(!panelSrc.includes("finalizeDraftQuoteReview"), `${panelName} must not call finalize API`);
+}
+
+console.log("✓ Verified extracted presentation panels are stateless and API-free.");
+
+// 6. Verify resolution callbacks remain parent-bound through the actions object
+const parentBoundCallbacks = [
+    "onSelectIssue={actions.selectIssue}",
+    "onUndoDecision={actions.undoDecision}",
+    "onTogglePrototypeOverride={actions.togglePrototypeOverride}",
+    "onFinalizeReview={actions.finalizeReview}"
+];
+for (const callbackBinding of parentBoundCallbacks) {
+    assert.ok(workspaceSrc.includes(callbackBinding), `ExceptionWorkspace must keep callback binding ${callbackBinding}`);
+}
+
+console.log("✓ Verified extracted panels receive parent-bound callbacks.");
 
 console.log("All Spot Workspace Orchestration contract assertions passed successfully!");

--- a/frontend/src/components/spot/ExceptionWorkspace.tsx
+++ b/frontend/src/components/spot/ExceptionWorkspace.tsx
@@ -1,13 +1,18 @@
 "use client";
 
 import React, { useState } from "react";
-import { AlertCircle, CheckCircle, ChevronDown, ChevronUp, Info, ShieldAlert, FileText, ArrowLeft } from "lucide-react";
+import { CheckCircle, ChevronDown, ChevronUp, Info, ShieldAlert, FileText, ArrowLeft } from "lucide-react";
 import { DraftQuote } from "../../lib/draft-quote-types";
 import { humanizeRate, friendlyStatus } from "@/lib/spot-workspace-helpers";
 import { MapExistingForm } from "./workspace/MapExistingForm";
 import { RequestProductCodeForm } from "./workspace/RequestProductCodeForm";
 import { AddChargeForm } from "./workspace/AddChargeForm";
 import { useSpotResolutionWorkflow } from "./workspace/useSpotResolutionWorkflow";
+import { NeedsAttentionPanel } from "./workspace/NeedsAttentionPanel";
+import { ReviewDecisionsPanel } from "./workspace/ReviewDecisionsPanel";
+import { VerificationWarningsPanel } from "./workspace/VerificationWarningsPanel";
+import { IgnoredItemsPanel } from "./workspace/IgnoredItemsPanel";
+import { FinalReviewPanel } from "./workspace/FinalReviewPanel";
 
 export function ExceptionWorkspace({ initialData, isLive = false, envelopeId }: { initialData: DraftQuote; isLive?: boolean; envelopeId?: string }) {
     const [draftQuote] = useState(initialData);
@@ -385,55 +390,16 @@ export function ExceptionWorkspace({ initialData, isLive = false, envelopeId }: 
                 )}
 
                 {/* "Still Needs Attention" block list matches checklist issues */}
-                {combinedUnresolved.length > 0 && (
-                    <div className="bg-slate-900 border border-slate-800 rounded-2xl p-5 shadow-sm">
-                        <h2 className="text-sm font-bold uppercase tracking-wider text-slate-400 mb-3">Still Needs Attention</h2>
-                        <div className="flex flex-col gap-2.5">
-                            {combinedUnresolved.map(item => (
-                                <div key={`${item.type}-${item.id}`} className="bg-slate-950 border border-slate-850 rounded-xl p-3 flex justify-between items-center text-xs">
-                                    <div>
-                                        <strong className="block text-slate-200">{item.title}</strong>
-                                        <span className="text-slate-400 mt-0.5 block">{item.problem}</span>
-                                    </div>
-                                    <button
-                                        onClick={() => actions.selectIssue(item.id)}
-                                        className="px-2.5 py-1.5 bg-indigo-600/30 hover:bg-indigo-600 border border-indigo-900 text-indigo-300 hover:text-white rounded font-semibold transition"
-                                    >
-                                        Resolve Now
-                                    </button>
-                                </div>
-                            ))}
-                        </div>
-                    </div>
-                )}
+                <NeedsAttentionPanel
+                    items={combinedUnresolved}
+                    onSelectIssue={actions.selectIssue}
+                />
 
                 {/* decisions Log / Review Decisions Panel */}
-                {decisions.length > 0 && (
-                    <div className="bg-slate-900 border border-slate-800 rounded-2xl p-5 shadow-sm">
-                        <h2 className="text-sm font-bold uppercase tracking-wider text-slate-400 mb-3">Review Decisions</h2>
-                        <div className="flex flex-col gap-2 text-xs">
-                            {decisions.map(d => (
-                                <div key={d.id} className="bg-slate-950 border border-slate-850 p-2.5 rounded-lg flex justify-between items-center">
-                                    <span className="text-slate-300">✓ {d.description}</span>
-                                    <div className="flex gap-2">
-                                        <button
-                                            onClick={() => actions.undoDecision(d.id)}
-                                            className="text-xs text-indigo-400 font-semibold hover:underline"
-                                        >
-                                            {d.type === "map" ? "Edit Mapping" : d.type === "request" ? "Edit Request" : "Reopen"}
-                                        </button>
-                                        <button
-                                            onClick={() => actions.undoDecision(d.id)}
-                                            className="text-xs text-slate-500 font-semibold hover:underline"
-                                        >
-                                            Undo
-                                        </button>
-                                    </div>
-                                </div>
-                            ))}
-                        </div>
-                    </div>
-                )}
+                <ReviewDecisionsPanel
+                    decisions={decisions}
+                    onUndoDecision={actions.undoDecision}
+                />
 
                 {/* Suggested Charges Accordion */}
                 <div className="bg-slate-900 border border-slate-800 rounded-2xl overflow-hidden shadow-sm">
@@ -519,177 +485,36 @@ export function ExceptionWorkspace({ initialData, isLive = false, envelopeId }: 
                 </div>
 
                 {/* Totals split display warnings */}
-                <div className="bg-slate-900 border border-slate-800 rounded-2xl overflow-hidden shadow-sm">
-                    <button
-                        onClick={() => setShowTotalsPanel(!showTotalsPanel)}
-                        className="w-full px-6 py-4 flex items-center justify-between text-left font-bold text-slate-50 bg-slate-900 hover:bg-slate-800/40 transition"
-                    >
-                        <div className="flex items-center gap-2">
-                            <ShieldAlert className="h-5 w-5 text-indigo-400" />
-                            <span>Verification Warnings & Totals</span>
-                        </div>
-                        {showTotalsPanel ? <ChevronUp className="h-5 w-5 text-slate-400" /> : <ChevronDown className="h-5 w-5 text-slate-400" />}
-                    </button>
-                    
-                    {showTotalsPanel && (
-                        <div className="border-t border-slate-800 p-5 bg-slate-900/40 flex flex-col gap-4">
-                            {uniqueCurrencies.length > 1 ? (
-                                <div className="bg-amber-955 border border-amber-900/60 rounded-xl p-4 flex flex-col gap-2">
-                                    <div className="flex items-center gap-2 text-amber-400 font-bold text-sm">
-                                        <AlertCircle className="h-4 w-4" />
-                                        <span>Totals Need Review</span>
-                                    </div>
-                                    <p className="text-xs text-slate-300">
-                                        Reason: This quote contains multiple currencies. A single calculations total is not safe to display.
-                                    </p>
-                                    
-                                    <div className="mt-2 divide-y divide-slate-800 text-xs">
-                                        {Object.entries(subtotals).map(([curr, sum]) => (
-                                            <div key={curr} className="py-1.5 flex justify-between font-mono">
-                                                <span className="text-slate-400">{curr} subtotal:</span>
-                                                <span className="text-slate-200">{sum.toFixed(2)}</span>
-                                            </div>
-                                        ))}
-                                        <div className="py-2 flex justify-between font-mono text-sm border-t border-slate-700">
-                                            <span className="text-indigo-300 font-semibold">Supplier extracted total:</span>
-                                            <span className="text-indigo-200 font-bold">USD {draftQuote.totals_validation.extracted_total?.toFixed(2)}</span>
-                                        </div>
-                                    </div>
-                                </div>
-                            ) : (
-                                <div className="flex flex-col gap-3">
-                                    <div className="flex justify-between items-center bg-slate-950 border border-slate-800 rounded-xl p-3 text-sm">
-                                        <span className="text-slate-400">Calculated sum difference:</span>
-                                        <div className="flex items-center gap-2">
-                                            <span className={`font-semibold ${draftQuote.totals_validation.difference ? "text-red-400" : "text-emerald-400"}`}>
-                                                USD {draftQuote.totals_validation.difference?.toFixed(2) || "0.00"}
-                                            </span>
-                                            <button 
-                                                onClick={() => setExplainTotals(!explainTotals)}
-                                                className="text-xs text-indigo-400 font-semibold hover:underline"
-                                            >
-                                                [Explain]
-                                            </button>
-                                        </div>
-                                    </div>
-
-                                    {explainTotals && (
-                                        <div className="bg-slate-950 border border-slate-800 rounded-xl p-4 flex flex-col gap-2 text-xs">
-                                            <div className="flex justify-between">
-                                                <span className="text-slate-400">Calculated Sum:</span>
-                                                <span>USD {draftQuote.totals_validation.calculated_total?.toFixed(2)}</span>
-                                            </div>
-                                            <div className="flex justify-between">
-                                                <span className="text-slate-400">Extracted Total from document:</span>
-                                                <span>USD {draftQuote.totals_validation.extracted_total?.toFixed(2)}</span>
-                                            </div>
-                                        </div>
-                                    )}
-                                </div>
-                            )}
-                        </div>
-                    )}
-                </div>
+                <VerificationWarningsPanel
+                    showTotalsPanel={showTotalsPanel}
+                    onToggleTotalsPanel={() => setShowTotalsPanel(!showTotalsPanel)}
+                    uniqueCurrencies={uniqueCurrencies}
+                    subtotals={subtotals}
+                    totalsValidation={draftQuote.totals_validation}
+                    explainTotals={explainTotals}
+                    onToggleExplainTotals={() => setExplainTotals(!explainTotals)}
+                />
 
                 {/* Muted Ignored Items */}
-                {ignoredItems.length > 0 && (
-                    <div className="bg-slate-900 border border-slate-800 rounded-2xl p-5 shadow-sm">
-                        <h2 className="text-sm font-bold uppercase tracking-wider text-slate-400 mb-3">Ignored Items</h2>
-                        <div className="flex flex-col gap-2.5">
-                            {ignoredItems.map(item => (
-                                <div key={item.id} className="bg-slate-950 border border-slate-855 rounded-xl p-3 text-xs flex justify-between items-center">
-                                    <div>
-                                        <span className="text-[10px] text-slate-500 font-bold block uppercase tracking-wider">Reason: {item.ignored_reason}</span>
-                                        <p className="text-slate-400 italic font-mono mt-1">&quot;{item.raw_text}&quot;</p>
-                                    </div>
-                                    <button
-                                        onClick={() => actions.undoDecision(item.id)}
-                                        className="text-xs text-indigo-400 font-semibold hover:underline"
-                                    >
-                                        Reopen
-                                    </button>
-                                </div>
-                            ))}
-                        </div>
-                    </div>
-                )}
+                <IgnoredItemsPanel
+                    ignoredItems={ignoredItems}
+                    onUndoDecision={actions.undoDecision}
+                />
 
                 {/* Final Checklist Review */}
-                <div className="mt-4 flex flex-col items-center gap-4 border-t border-slate-800 pt-6">
-                    
-                    <div className="w-full bg-slate-900 border border-slate-800 rounded-xl p-4 text-xs flex flex-col gap-2.5">
-                        <h3 className="font-bold text-slate-300 uppercase tracking-wider mb-1">Final Review Checklist</h3>
-                        
-                        <div className="flex items-center justify-between border-b border-slate-850 pb-2">
-                            <div>
-                                <span className="text-slate-200 block font-semibold">All review items resolved</span>
-                                <span className="text-slate-400 text-[10px]">{checklistIssuesResolved ? "Complete" : `${combinedUnresolved.length} charges still need action.`}</span>
-                            </div>
-                            <span className={checklistIssuesResolved ? "text-emerald-400 font-semibold" : "text-amber-400"}>
-                                {checklistIssuesResolved ? "Complete" : "Pending"}
-                            </span>
-                        </div>
-                        
-                        <div className="flex items-center justify-between border-b border-slate-850 pb-2">
-                            <div>
-                                <span className="text-slate-200 block font-semibold">No unknown commercial charges remain</span>
-                                <span className="text-slate-400 text-[10px]">{checklistNoUnknown ? "Complete" : "Unmapped extracted charge block exists."}</span>
-                            </div>
-                            <span className={checklistNoUnknown ? "text-emerald-400 font-semibold" : "text-amber-400"}>
-                                {checklistNoUnknown ? "Complete" : "Pending"}
-                            </span>
-                        </div>
-
-                        <div className="flex items-center justify-between pb-2">
-                            <div>
-                                <span className="text-slate-200 block font-semibold">No included charge is missing a ProductCode mapping</span>
-                                <span className="text-slate-400 text-[10px]">{checklistProductCodesVerified ? "Complete" : "Include charge has no mapped billing code."}</span>
-                            </div>
-                            <span className={checklistProductCodesVerified ? "text-emerald-400 font-semibold" : "text-amber-400"}>
-                                {checklistProductCodesVerified ? "Complete" : "Pending"}
-                            </span>
-                        </div>
-                    </div>
-
-                    {!canFinishReview && !canUsePrototypeOverride && (
-                        <div className="w-full bg-red-950/20 border border-red-900/60 rounded-xl p-4 text-xs text-red-200">
-                            <span className="font-bold block mb-1">Finish Review unavailable</span>
-                            <span>Resolve all pending issues and verify ProductCode mappings to complete review.</span>
-                        </div>
-                    )}
-
-                    <div className="w-full flex flex-col sm:flex-row justify-between items-center gap-4">
-                        {!isLive && (
-                            <div className="flex items-center gap-2 text-xs">
-                                <input
-                                    type="checkbox"
-                                    id="proto-override"
-                                    checked={prototypeOverride}
-                                    onChange={actions.togglePrototypeOverride}
-                                    className="rounded bg-slate-950 border-slate-800 text-indigo-600 focus:ring-indigo-500 w-4.5 h-4.5"
-                                />
-                                <label htmlFor="proto-override" className="text-slate-400 cursor-pointer font-medium select-none">
-                                    Prototype override only — not available for production.
-                                </label>
-                            </div>
-                        )}
-                        {isLive && <div />} {/* spacer to maintain justify-between layout alignment when checkbox is hidden */}
-
-                        <button
-                            disabled={isReviewLocked || (!canFinishReview && !canUsePrototypeOverride)}
-                            onClick={actions.finalizeReview}
-                            className="px-8 py-3 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 disabled:hover:bg-indigo-600 text-white rounded-xl font-bold text-sm shadow-xl shadow-indigo-900/40 w-full sm:w-auto text-center transition"
-                        >
-                            {isReviewLocked ? "Review Finalized" : "Finalize Review"}
-                        </button>
-                    </div>
-                    
-                    {!isLive && (
-                        <div className="text-center text-xs text-slate-500 mt-2">
-                            Prototype only — Changes made will not be permanently saved.
-                        </div>
-                    )}
-                </div>
+                <FinalReviewPanel
+                    checklistIssuesResolved={checklistIssuesResolved}
+                    checklistNoUnknown={checklistNoUnknown}
+                    checklistProductCodesVerified={checklistProductCodesVerified}
+                    unresolvedCount={combinedUnresolved.length}
+                    canFinishReview={canFinishReview}
+                    canUsePrototypeOverride={canUsePrototypeOverride}
+                    isLive={isLive}
+                    isReviewLocked={isReviewLocked}
+                    prototypeOverride={prototypeOverride}
+                    onTogglePrototypeOverride={actions.togglePrototypeOverride}
+                    onFinalizeReview={actions.finalizeReview}
+                />
 
             </div>
         </div>

--- a/frontend/src/components/spot/workspace/FinalReviewPanel.tsx
+++ b/frontend/src/components/spot/workspace/FinalReviewPanel.tsx
@@ -129,8 +129,7 @@ export function FinalReviewPanel({
             </label>
           </div>
         )}
-        {isLive && <div />}{" "}
-        {/* spacer to maintain justify-between layout alignment when checkbox is hidden */}
+        {isLive && <div />} {/* spacer to maintain justify-between layout alignment when checkbox is hidden */}
         <button
           disabled={
             isReviewLocked || (!canFinishReview && !canUsePrototypeOverride)

--- a/frontend/src/components/spot/workspace/FinalReviewPanel.tsx
+++ b/frontend/src/components/spot/workspace/FinalReviewPanel.tsx
@@ -1,0 +1,152 @@
+interface FinalReviewPanelProps {
+  checklistIssuesResolved: boolean;
+  checklistNoUnknown: boolean;
+  checklistProductCodesVerified: boolean;
+  unresolvedCount: number;
+  canFinishReview: boolean;
+  canUsePrototypeOverride: boolean;
+  isLive: boolean;
+  isReviewLocked: boolean;
+  prototypeOverride: boolean;
+  onTogglePrototypeOverride: () => void;
+  onFinalizeReview: () => void;
+}
+
+export function FinalReviewPanel({
+  checklistIssuesResolved,
+  checklistNoUnknown,
+  checklistProductCodesVerified,
+  unresolvedCount,
+  canFinishReview,
+  canUsePrototypeOverride,
+  isLive,
+  isReviewLocked,
+  prototypeOverride,
+  onTogglePrototypeOverride,
+  onFinalizeReview,
+}: FinalReviewPanelProps) {
+  return (
+    <div className="mt-4 flex flex-col items-center gap-4 border-t border-slate-800 pt-6">
+      <div className="w-full bg-slate-900 border border-slate-800 rounded-xl p-4 text-xs flex flex-col gap-2.5">
+        <h3 className="font-bold text-slate-300 uppercase tracking-wider mb-1">
+          Final Review Checklist
+        </h3>
+
+        <div className="flex items-center justify-between border-b border-slate-850 pb-2">
+          <div>
+            <span className="text-slate-200 block font-semibold">
+              All review items resolved
+            </span>
+            <span className="text-slate-400 text-[10px]">
+              {checklistIssuesResolved
+                ? "Complete"
+                : `${unresolvedCount} charges still need action.`}
+            </span>
+          </div>
+          <span
+            className={
+              checklistIssuesResolved
+                ? "text-emerald-400 font-semibold"
+                : "text-amber-400"
+            }
+          >
+            {checklistIssuesResolved ? "Complete" : "Pending"}
+          </span>
+        </div>
+
+        <div className="flex items-center justify-between border-b border-slate-850 pb-2">
+          <div>
+            <span className="text-slate-200 block font-semibold">
+              No unknown commercial charges remain
+            </span>
+            <span className="text-slate-400 text-[10px]">
+              {checklistNoUnknown
+                ? "Complete"
+                : "Unmapped extracted charge block exists."}
+            </span>
+          </div>
+          <span
+            className={
+              checklistNoUnknown
+                ? "text-emerald-400 font-semibold"
+                : "text-amber-400"
+            }
+          >
+            {checklistNoUnknown ? "Complete" : "Pending"}
+          </span>
+        </div>
+
+        <div className="flex items-center justify-between pb-2">
+          <div>
+            <span className="text-slate-200 block font-semibold">
+              No included charge is missing a ProductCode mapping
+            </span>
+            <span className="text-slate-400 text-[10px]">
+              {checklistProductCodesVerified
+                ? "Complete"
+                : "Include charge has no mapped billing code."}
+            </span>
+          </div>
+          <span
+            className={
+              checklistProductCodesVerified
+                ? "text-emerald-400 font-semibold"
+                : "text-amber-400"
+            }
+          >
+            {checklistProductCodesVerified ? "Complete" : "Pending"}
+          </span>
+        </div>
+      </div>
+
+      {!canFinishReview && !canUsePrototypeOverride && (
+        <div className="w-full bg-red-950/20 border border-red-900/60 rounded-xl p-4 text-xs text-red-200">
+          <span className="font-bold block mb-1">
+            Finish Review unavailable
+          </span>
+          <span>
+            Resolve all pending issues and verify ProductCode mappings to
+            complete review.
+          </span>
+        </div>
+      )}
+
+      <div className="w-full flex flex-col sm:flex-row justify-between items-center gap-4">
+        {!isLive && (
+          <div className="flex items-center gap-2 text-xs">
+            <input
+              type="checkbox"
+              id="proto-override"
+              checked={prototypeOverride}
+              onChange={onTogglePrototypeOverride}
+              className="rounded bg-slate-950 border-slate-800 text-indigo-600 focus:ring-indigo-500 w-4.5 h-4.5"
+            />
+            <label
+              htmlFor="proto-override"
+              className="text-slate-400 cursor-pointer font-medium select-none"
+            >
+              Prototype override only — not available for production.
+            </label>
+          </div>
+        )}
+        {isLive && <div />}{" "}
+        {/* spacer to maintain justify-between layout alignment when checkbox is hidden */}
+        <button
+          disabled={
+            isReviewLocked || (!canFinishReview && !canUsePrototypeOverride)
+          }
+          onClick={onFinalizeReview}
+          className="px-8 py-3 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 disabled:hover:bg-indigo-600 text-white rounded-xl font-bold text-sm shadow-xl shadow-indigo-900/40 w-full sm:w-auto text-center transition"
+        >
+          {isReviewLocked ? "Review Finalized" : "Finalize Review"}
+        </button>
+      </div>
+
+      {!isLive && (
+        <div className="text-center text-xs text-slate-500 mt-2">
+          Prototype only — Changes made will not be permanently saved.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/spot/workspace/IgnoredItemsPanel.tsx
+++ b/frontend/src/components/spot/workspace/IgnoredItemsPanel.tsx
@@ -1,0 +1,46 @@
+import { SpotResolutionState } from "./spotResolutionState";
+
+interface IgnoredItemsPanelProps {
+  ignoredItems: SpotResolutionState["ignoredItems"];
+  onUndoDecision: (decisionId: string) => void;
+}
+
+export function IgnoredItemsPanel({
+  ignoredItems,
+  onUndoDecision,
+}: IgnoredItemsPanelProps) {
+  if (ignoredItems.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="bg-slate-900 border border-slate-800 rounded-2xl p-5 shadow-sm">
+      <h2 className="text-sm font-bold uppercase tracking-wider text-slate-400 mb-3">
+        Ignored Items
+      </h2>
+      <div className="flex flex-col gap-2.5">
+        {ignoredItems.map((item) => (
+          <div
+            key={item.id}
+            className="bg-slate-950 border border-slate-855 rounded-xl p-3 text-xs flex justify-between items-center"
+          >
+            <div>
+              <span className="text-[10px] text-slate-500 font-bold block uppercase tracking-wider">
+                Reason: {item.ignored_reason}
+              </span>
+              <p className="text-slate-400 italic font-mono mt-1">
+                &quot;{item.raw_text}&quot;
+              </p>
+            </div>
+            <button
+              onClick={() => onUndoDecision(item.id)}
+              className="text-xs text-indigo-400 font-semibold hover:underline"
+            >
+              Reopen
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/spot/workspace/NeedsAttentionPanel.tsx
+++ b/frontend/src/components/spot/workspace/NeedsAttentionPanel.tsx
@@ -1,0 +1,44 @@
+import { SpotWorkspaceIssue } from "./spotResolutionState";
+
+interface NeedsAttentionPanelProps {
+  items: SpotWorkspaceIssue[];
+  onSelectIssue: (issueId: string) => void;
+}
+
+export function NeedsAttentionPanel({
+  items,
+  onSelectIssue,
+}: NeedsAttentionPanelProps) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="bg-slate-900 border border-slate-800 rounded-2xl p-5 shadow-sm">
+      <h2 className="text-sm font-bold uppercase tracking-wider text-slate-400 mb-3">
+        Still Needs Attention
+      </h2>
+      <div className="flex flex-col gap-2.5">
+        {items.map((item) => (
+          <div
+            key={`${item.type}-${item.id}`}
+            className="bg-slate-950 border border-slate-850 rounded-xl p-3 flex justify-between items-center text-xs"
+          >
+            <div>
+              <strong className="block text-slate-200">{item.title}</strong>
+              <span className="text-slate-400 mt-0.5 block">
+                {item.problem}
+              </span>
+            </div>
+            <button
+              onClick={() => onSelectIssue(item.id)}
+              className="px-2.5 py-1.5 bg-indigo-600/30 hover:bg-indigo-600 border border-indigo-900 text-indigo-300 hover:text-white rounded font-semibold transition"
+            >
+              Resolve Now
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/spot/workspace/ReviewDecisionsPanel.tsx
+++ b/frontend/src/components/spot/workspace/ReviewDecisionsPanel.tsx
@@ -1,0 +1,51 @@
+import { Decision } from "./spotResolutionState";
+
+interface ReviewDecisionsPanelProps {
+  decisions: Decision[];
+  onUndoDecision: (decisionId: string) => void;
+}
+
+export function ReviewDecisionsPanel({
+  decisions,
+  onUndoDecision,
+}: ReviewDecisionsPanelProps) {
+  if (decisions.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="bg-slate-900 border border-slate-800 rounded-2xl p-5 shadow-sm">
+      <h2 className="text-sm font-bold uppercase tracking-wider text-slate-400 mb-3">
+        Review Decisions
+      </h2>
+      <div className="flex flex-col gap-2 text-xs">
+        {decisions.map((d) => (
+          <div
+            key={d.id}
+            className="bg-slate-950 border border-slate-850 p-2.5 rounded-lg flex justify-between items-center"
+          >
+            <span className="text-slate-300">✓ {d.description}</span>
+            <div className="flex gap-2">
+              <button
+                onClick={() => onUndoDecision(d.id)}
+                className="text-xs text-indigo-400 font-semibold hover:underline"
+              >
+                {d.type === "map"
+                  ? "Edit Mapping"
+                  : d.type === "request"
+                    ? "Edit Request"
+                    : "Reopen"}
+              </button>
+              <button
+                onClick={() => onUndoDecision(d.id)}
+                className="text-xs text-slate-500 font-semibold hover:underline"
+              >
+                Undo
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/spot/workspace/VerificationWarningsPanel.tsx
+++ b/frontend/src/components/spot/workspace/VerificationWarningsPanel.tsx
@@ -1,0 +1,118 @@
+import { AlertCircle, ChevronDown, ChevronUp, ShieldAlert } from "lucide-react";
+import { DraftQuote } from "../../../lib/draft-quote-types";
+
+interface VerificationWarningsPanelProps {
+  showTotalsPanel: boolean;
+  onToggleTotalsPanel: () => void;
+  uniqueCurrencies: string[];
+  subtotals: Record<string, number>;
+  totalsValidation: DraftQuote["totals_validation"];
+  explainTotals: boolean;
+  onToggleExplainTotals: () => void;
+}
+
+export function VerificationWarningsPanel({
+  showTotalsPanel,
+  onToggleTotalsPanel,
+  uniqueCurrencies,
+  subtotals,
+  totalsValidation,
+  explainTotals,
+  onToggleExplainTotals,
+}: VerificationWarningsPanelProps) {
+  return (
+    <div className="bg-slate-900 border border-slate-800 rounded-2xl overflow-hidden shadow-sm">
+      <button
+        onClick={onToggleTotalsPanel}
+        className="w-full px-6 py-4 flex items-center justify-between text-left font-bold text-slate-50 bg-slate-900 hover:bg-slate-800/40 transition"
+      >
+        <div className="flex items-center gap-2">
+          <ShieldAlert className="h-5 w-5 text-indigo-400" />
+          <span>Verification Warnings & Totals</span>
+        </div>
+        {showTotalsPanel ? (
+          <ChevronUp className="h-5 w-5 text-slate-400" />
+        ) : (
+          <ChevronDown className="h-5 w-5 text-slate-400" />
+        )}
+      </button>
+
+      {showTotalsPanel && (
+        <div className="border-t border-slate-800 p-5 bg-slate-900/40 flex flex-col gap-4">
+          {uniqueCurrencies.length > 1 ? (
+            <div className="bg-amber-955 border border-amber-900/60 rounded-xl p-4 flex flex-col gap-2">
+              <div className="flex items-center gap-2 text-amber-400 font-bold text-sm">
+                <AlertCircle className="h-4 w-4" />
+                <span>Totals Need Review</span>
+              </div>
+              <p className="text-xs text-slate-300">
+                Reason: This quote contains multiple currencies. A single
+                calculations total is not safe to display.
+              </p>
+
+              <div className="mt-2 divide-y divide-slate-800 text-xs">
+                {Object.entries(subtotals).map(([curr, sum]) => (
+                  <div
+                    key={curr}
+                    className="py-1.5 flex justify-between font-mono"
+                  >
+                    <span className="text-slate-400">{curr} subtotal:</span>
+                    <span className="text-slate-200">{sum.toFixed(2)}</span>
+                  </div>
+                ))}
+                <div className="py-2 flex justify-between font-mono text-sm border-t border-slate-700">
+                  <span className="text-indigo-300 font-semibold">
+                    Supplier extracted total:
+                  </span>
+                  <span className="text-indigo-200 font-bold">
+                    USD {totalsValidation.extracted_total?.toFixed(2)}
+                  </span>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-3">
+              <div className="flex justify-between items-center bg-slate-950 border border-slate-800 rounded-xl p-3 text-sm">
+                <span className="text-slate-400">
+                  Calculated sum difference:
+                </span>
+                <div className="flex items-center gap-2">
+                  <span
+                    className={`font-semibold ${totalsValidation.difference ? "text-red-400" : "text-emerald-400"}`}
+                  >
+                    USD {totalsValidation.difference?.toFixed(2) || "0.00"}
+                  </span>
+                  <button
+                    onClick={onToggleExplainTotals}
+                    className="text-xs text-indigo-400 font-semibold hover:underline"
+                  >
+                    [Explain]
+                  </button>
+                </div>
+              </div>
+
+              {explainTotals && (
+                <div className="bg-slate-950 border border-slate-800 rounded-xl p-4 flex flex-col gap-2 text-xs">
+                  <div className="flex justify-between">
+                    <span className="text-slate-400">Calculated Sum:</span>
+                    <span>
+                      USD {totalsValidation.calculated_total?.toFixed(2)}
+                    </span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-slate-400">
+                      Extracted Total from document:
+                    </span>
+                    <span>
+                      USD {totalsValidation.extracted_total?.toFixed(2)}
+                    </span>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Scope

Phase 14E extracts presentation-only SPOT Exception Workspace panels into stateless components while preserving workflow ownership in `spotResolutionState.ts` and `useSpotResolutionWorkflow.ts`.

## Changed Files

- `frontend/src/components/spot/ExceptionWorkspace.tsx`: imports and renders extracted presentation panels; retains accordion visibility state and parent-bound callbacks.
- `frontend/src/components/spot/workspace/NeedsAttentionPanel.tsx`: extracted Still Needs Attention presentation list.
- `frontend/src/components/spot/workspace/ReviewDecisionsPanel.tsx`: extracted Review Decisions / undo presentation panel.
- `frontend/src/components/spot/workspace/VerificationWarningsPanel.tsx`: extracted verification warnings and totals accordion presentation panel.
- `frontend/src/components/spot/workspace/IgnoredItemsPanel.tsx`: extracted ignored items presentation panel.
- `frontend/src/components/spot/workspace/FinalReviewPanel.tsx`: extracted final checklist and finalize controls presentation panel.
- `frontend/scripts/exception-workspace-routing.test.mjs`: updated structural assertions for extracted final review panel while preserving demo/live behavior checks.
- `frontend/scripts/spot-workspace-orchestration.test.mjs`: added structural assertions for panel imports/rendering, stateless/API-free panels, and parent-bound callbacks.

## What Was Intentionally Not Changed

- No backend code.
- No API contracts or payloads.
- No ProductCode workflows.
- No pricing, totals, GST, currencies, margins, RBAC, routing, resolution, undo, finalize, lock, reopen, demo/live behavior, or visible UI wording/design.

## Verification

Automated:
- `cd frontend && npm run lint`: passed with existing warnings only.
- `npm run typecheck`: passed.
- `npm run build`: passed.
- `npm run test:spot-finalization`: passed.
- `npm run test:spot-workspace-helpers`: passed.
- `npm run test:exception-workspace-routing`: passed.
- `npm run test:draft-quote-contract`: passed.
- `npm run test:spot-resolution-state`: passed.
- `node scripts/spot-workspace-form-extraction.test.mjs`: passed via Windows `node`/`node.exe` in this worktree.
- `node scripts/spot-workspace-orchestration.test.mjs`: passed via Windows `node`/`node.exe` in this worktree.
- `npx fallow --format json`: passed.
- `python backend/manage.py check`: passed with local test env (`DJANGO_DEBUG=True`, `rate_engine.test_settings`).
- `python backend/manage.py test quotes.tests`: passed, 489 tests.
- `git diff --check`: passed.
- `graphify update .`: passed via local Python graphify module.

Manual:
- Structural parity reviewed by extraction boundaries: child panels are stateless and callback-driven; workflow state remains in the reducer/hook path.

## Metrics

LOC before → after:
- `ExceptionWorkspace.tsx`: 697 → 522
- `FinalReviewPanel.tsx`: 0 → 152
- `IgnoredItemsPanel.tsx`: 0 → 46
- `NeedsAttentionPanel.tsx`: 0 → 44
- `ReviewDecisionsPanel.tsx`: 0 → 51
- `VerificationWarningsPanel.tsx`: 0 → 118

Current Fallow fields:
- `ExceptionWorkspace.tsx`: LOC 522 | total_cognitive 85 | crap_max 1122.0
- `FinalReviewPanel.tsx`: LOC 152 | total_cognitive 23 | crap_max 342.0
- `IgnoredItemsPanel.tsx`: LOC 46 | total_cognitive 1 | crap_max 6.0
- `NeedsAttentionPanel.tsx`: LOC 44 | total_cognitive 1 | crap_max 6.0
- `ReviewDecisionsPanel.tsx`: LOC 51 | total_cognitive 4 | crap_max 12.0
- `VerificationWarningsPanel.tsx`: LOC 118 | total_cognitive 10 | crap_max 56.0

## Commercial Impact

No intended commercial impact. This is a presentation-only extraction and does not alter quote totals, ProductCode mapping, public quote output, or operator decision semantics.

## Data Impact

No data model, migration, seed, or persistence changes.

## Audit Impact

Existing decision/audit behavior is preserved; callbacks remain parent-bound to the existing workflow hook.

## Risk

Residual risk is limited to UI parity from component extraction. Focused structural tests verify panel boundaries and ownership; existing SPOT workspace contracts continue passing.

## Rollback

Revert this commit to inline the extracted presentation panels back into `ExceptionWorkspace.tsx`.
