### PR TITLE
Draft: Phase 14F ProductCode selector domain safety

### DIFF
--- a/backend/quotes/services/draft_quote_adapter.py
+++ b/backend/quotes/services/draft_quote_adapter.py
@@ -31,22 +31,20 @@ def build_draft_quote_payload(spe_db: SpotPricingEnvelopeDB) -> Dict[str, Any]:
             supplier_name = first_batch.label
     supplier_name = supplier_name or "Unknown Carrier"
 
-    # Classify shipment direction (IMPORT vs EXPORT vs DOMESTIC)
-    direction = _normalize_shipment_direction(shipment_ctx.get('direction'))
+    # Classify shipment direction (IMPORT vs EXPORT vs DOMESTIC).
+    # Origin/destination countries are authoritative when present; raw JSON
+    # direction is used only when the country pair is unavailable.
     origin_country = shipment_ctx.get('origin_country', '')
     destination_country = shipment_ctx.get('destination_country', '')
-    try:
-        from quotes.spot_services import classify_png_shipment
-        if not direction:
+    direction = None
+    if origin_country and destination_country:
+        try:
+            from quotes.spot_services import classify_png_shipment
             direction = _normalize_shipment_direction(classify_png_shipment(origin_country, destination_country))
-    except Exception:
-        # Fallback only when source countries conclusively identify a supported PNG direction.
-        if str(origin_country).upper() == "PG" and str(destination_country).upper() != "PG" and destination_country:
-            direction = "EXPORT"
-        elif str(origin_country).upper() != "PG" and origin_country and str(destination_country).upper() == "PG":
-            direction = "IMPORT"
-        elif str(origin_country).upper() == "PG" and str(destination_country).upper() == "PG":
-            direction = "DOMESTIC"
+        except Exception:
+            direction = None
+    else:
+        direction = _normalize_shipment_direction(shipment_ctx.get('direction'))
 
     quote_summary = f"Draft Quote Suggestion for {mode} Freight {direction or 'UNKNOWN'} - {origin} to {destination} via {supplier_name}"
 

--- a/backend/quotes/services/draft_quote_adapter.py
+++ b/backend/quotes/services/draft_quote_adapter.py
@@ -5,6 +5,14 @@ from typing import Any, Dict, List, Optional
 from quotes.spot_models import SpotPricingEnvelopeDB, SPEChargeLineDB
 from quotes.contracts.draft_quote_contract import DraftQuoteSchema
 
+VALID_PRODUCT_CODE_DOMAINS = {"IMPORT", "EXPORT", "DOMESTIC"}
+
+
+def _normalize_shipment_direction(value: Any) -> Optional[str]:
+    direction = str(value or "").strip().upper()
+    return direction if direction in VALID_PRODUCT_CODE_DOMAINS else None
+
+
 def build_draft_quote_payload(spe_db: SpotPricingEnvelopeDB) -> Dict[str, Any]:
     shipment_ctx = spe_db.shipment_context_json or {}
     
@@ -24,22 +32,23 @@ def build_draft_quote_payload(spe_db: SpotPricingEnvelopeDB) -> Dict[str, Any]:
     supplier_name = supplier_name or "Unknown Carrier"
 
     # Classify shipment direction (IMPORT vs EXPORT vs DOMESTIC)
-    direction = "Import"
+    direction = _normalize_shipment_direction(shipment_ctx.get('direction'))
     origin_country = shipment_ctx.get('origin_country', '')
     destination_country = shipment_ctx.get('destination_country', '')
     try:
         from quotes.spot_services import classify_png_shipment
-        direction = classify_png_shipment(origin_country, destination_country)
+        if not direction:
+            direction = _normalize_shipment_direction(classify_png_shipment(origin_country, destination_country))
     except Exception:
-        # Fallback
-        if str(origin_country).upper() == "PG" and str(destination_country).upper() != "PG":
+        # Fallback only when source countries conclusively identify a supported PNG direction.
+        if str(origin_country).upper() == "PG" and str(destination_country).upper() != "PG" and destination_country:
             direction = "EXPORT"
-        elif str(origin_country).upper() != "PG" and str(destination_country).upper() == "PG":
+        elif str(origin_country).upper() != "PG" and origin_country and str(destination_country).upper() == "PG":
             direction = "IMPORT"
         elif str(origin_country).upper() == "PG" and str(destination_country).upper() == "PG":
             direction = "DOMESTIC"
 
-    quote_summary = f"Draft Quote Suggestion for {mode} Freight {direction} - {origin} to {destination} via {supplier_name}"
+    quote_summary = f"Draft Quote Suggestion for {mode} Freight {direction or 'UNKNOWN'} - {origin} to {destination} via {supplier_name}"
 
     # 2. Shipment Context
     shipment_context = {
@@ -52,6 +61,8 @@ def build_draft_quote_payload(spe_db: SpotPricingEnvelopeDB) -> Dict[str, Any]:
         "chargeable_weight_kg": float(shipment_ctx.get('chargeable_weight_kg') or shipment_ctx.get('chargeable_weight') or 0.0),
         "commodity": shipment_ctx.get('commodity') or 'GCR'
     }
+    if direction:
+        shipment_context["direction"] = direction
 
     # 3. Supplier Context
     supplier_context = {

--- a/backend/quotes/services/draft_quote_adapter.py
+++ b/backend/quotes/services/draft_quote_adapter.py
@@ -32,8 +32,7 @@ def build_draft_quote_payload(spe_db: SpotPricingEnvelopeDB) -> Dict[str, Any]:
     supplier_name = supplier_name or "Unknown Carrier"
 
     # Classify shipment direction (IMPORT vs EXPORT vs DOMESTIC).
-    # Origin/destination countries are authoritative when present; raw JSON
-    # direction is used only when the country pair is unavailable.
+    # Origin/destination countries are the only trusted direction source.
     origin_country = shipment_ctx.get('origin_country', '')
     destination_country = shipment_ctx.get('destination_country', '')
     direction = None
@@ -43,8 +42,6 @@ def build_draft_quote_payload(spe_db: SpotPricingEnvelopeDB) -> Dict[str, Any]:
             direction = _normalize_shipment_direction(classify_png_shipment(origin_country, destination_country))
         except Exception:
             direction = None
-    else:
-        direction = _normalize_shipment_direction(shipment_ctx.get('direction'))
 
     quote_summary = f"Draft Quote Suggestion for {mode} Freight {direction or 'UNKNOWN'} - {origin} to {destination} via {supplier_name}"
 

--- a/backend/quotes/services/draft_quote_resolve_service.py
+++ b/backend/quotes/services/draft_quote_resolve_service.py
@@ -50,25 +50,17 @@ def _normalize_product_code_domain(value):
 
 def _expected_product_code_domain(envelope):
     shipment_context = envelope.shipment_context_json if isinstance(envelope.shipment_context_json, dict) else {}
-    explicit_direction = _normalize_product_code_domain(shipment_context.get("direction"))
-    if explicit_direction:
-        return explicit_direction
-
     origin_country = shipment_context.get("origin_country", "")
     destination_country = shipment_context.get("destination_country", "")
-    try:
-        from quotes.spot_services import classify_png_shipment
-        return _normalize_product_code_domain(classify_png_shipment(origin_country, destination_country))
-    except Exception:
-        origin_country = str(origin_country).upper()
-        destination_country = str(destination_country).upper()
-        if origin_country == "PG" and destination_country != "PG":
-            return ProductCode.DOMAIN_EXPORT
-        if origin_country != "PG" and destination_country == "PG":
-            return ProductCode.DOMAIN_IMPORT
-        if origin_country == "PG" and destination_country == "PG":
-            return ProductCode.DOMAIN_DOMESTIC
-    return None
+
+    if origin_country and destination_country:
+        try:
+            from quotes.spot_services import classify_png_shipment
+            return _normalize_product_code_domain(classify_png_shipment(origin_country, destination_country))
+        except Exception:
+            return None
+
+    return _normalize_product_code_domain(shipment_context.get("direction"))
 
 
 def _valid_choice_values(choices):
@@ -336,7 +328,11 @@ def apply_draft_quote_decisions(
                     error_code_val = "PRODUCT_CODE_NOT_FOUND"
                 else:
                     expected_domain = _expected_product_code_domain(envelope)
-                    if expected_domain and product_code.domain != expected_domain:
+                    if not expected_domain:
+                        status_val = "rejected"
+                        message_val = "Shipment direction could not be determined from trusted route evidence. ProductCode mapping was not applied."
+                        error_code_val = "PRODUCT_CODE_DIRECTION_UNAVAILABLE"
+                    elif product_code.domain != expected_domain:
                         status_val = "rejected"
                         message_val = f"ProductCode domain {product_code.domain} does not match shipment direction {expected_domain}."
                         error_code_val = "PRODUCT_CODE_DOMAIN_MISMATCH"

--- a/backend/quotes/services/draft_quote_resolve_service.py
+++ b/backend/quotes/services/draft_quote_resolve_service.py
@@ -53,14 +53,14 @@ def _expected_product_code_domain(envelope):
     origin_country = shipment_context.get("origin_country", "")
     destination_country = shipment_context.get("destination_country", "")
 
-    if origin_country and destination_country:
-        try:
-            from quotes.spot_services import classify_png_shipment
-            return _normalize_product_code_domain(classify_png_shipment(origin_country, destination_country))
-        except Exception:
-            return None
+    if not origin_country or not destination_country:
+        return None
 
-    return _normalize_product_code_domain(shipment_context.get("direction"))
+    try:
+        from quotes.spot_services import classify_png_shipment
+        return _normalize_product_code_domain(classify_png_shipment(origin_country, destination_country))
+    except Exception:
+        return None
 
 
 def _valid_choice_values(choices):

--- a/backend/quotes/services/draft_quote_resolve_service.py
+++ b/backend/quotes/services/draft_quote_resolve_service.py
@@ -36,6 +36,39 @@ EDITABLE_CHARGE_FIELDS = {
     "notes": "note",
 }
 NUMERIC_CHARGE_FIELDS = {"amount", "rate", "minimum_charge"}
+PRODUCT_CODE_DOMAINS = {
+    ProductCode.DOMAIN_IMPORT,
+    ProductCode.DOMAIN_EXPORT,
+    ProductCode.DOMAIN_DOMESTIC,
+}
+
+
+def _normalize_product_code_domain(value):
+    domain = str(value or "").strip().upper()
+    return domain if domain in PRODUCT_CODE_DOMAINS else None
+
+
+def _expected_product_code_domain(envelope):
+    shipment_context = envelope.shipment_context_json if isinstance(envelope.shipment_context_json, dict) else {}
+    explicit_direction = _normalize_product_code_domain(shipment_context.get("direction"))
+    if explicit_direction:
+        return explicit_direction
+
+    origin_country = shipment_context.get("origin_country", "")
+    destination_country = shipment_context.get("destination_country", "")
+    try:
+        from quotes.spot_services import classify_png_shipment
+        return _normalize_product_code_domain(classify_png_shipment(origin_country, destination_country))
+    except Exception:
+        origin_country = str(origin_country).upper()
+        destination_country = str(destination_country).upper()
+        if origin_country == "PG" and destination_country != "PG":
+            return ProductCode.DOMAIN_EXPORT
+        if origin_country != "PG" and destination_country == "PG":
+            return ProductCode.DOMAIN_IMPORT
+        if origin_country == "PG" and destination_country == "PG":
+            return ProductCode.DOMAIN_DOMESTIC
+    return None
 
 
 def _valid_choice_values(choices):
@@ -302,8 +335,14 @@ def apply_draft_quote_decisions(
                     message_val = "ProductCode was not found."
                     error_code_val = "PRODUCT_CODE_NOT_FOUND"
                 else:
-                    _apply_product_code(charge_line, product_code, user, dec_item, payload)
-                    message_val = "ProductCode mapping applied successfully."
+                    expected_domain = _expected_product_code_domain(envelope)
+                    if expected_domain and product_code.domain != expected_domain:
+                        status_val = "rejected"
+                        message_val = f"ProductCode domain {product_code.domain} does not match shipment direction {expected_domain}."
+                        error_code_val = "PRODUCT_CODE_DOMAIN_MISMATCH"
+                    else:
+                        _apply_product_code(charge_line, product_code, user, dec_item, payload)
+                        message_val = "ProductCode mapping applied successfully."
             elif decision_type == "edit_charge":
                 status_val, message_val, error_code_val = _apply_edit_charge(charge_line, dec_item, payload, user)
             elif decision_type == "classify_unclassified":

--- a/backend/quotes/tests/fixtures/draft_quote_contract/hard_case_air_import.json
+++ b/backend/quotes/tests/fixtures/draft_quote_contract/hard_case_air_import.json
@@ -9,7 +9,8 @@
     "actual_weight_kg": 150.0,
     "volumetric_weight_kg": 200.0,
     "chargeable_weight_kg": 200.0,
-    "commodity": "GCR"
+    "commodity": "GCR",
+    "direction": "IMPORT"
   },
   "supplier_context": {
     "supplier_name": "Qantas Air Cargo",

--- a/backend/quotes/tests/test_draft_quote_contract.py
+++ b/backend/quotes/tests/test_draft_quote_contract.py
@@ -37,6 +37,7 @@ class DraftQuoteContractTests(SimpleTestCase):
         self.assertEqual(len(schema.commercial_terms), 4)
         self.assertEqual(len(schema.unclassified_items), 1)
         self.assertEqual(len(schema.ignored_items), 1)
+        self.assertEqual(schema.shipment_context["direction"], "IMPORT")
 
     def test_every_suggested_charge_has_evidence_with_source_text(self):
         """Verify that every charge in suggested status has evidence and source_text."""

--- a/backend/quotes/tests/test_draft_quote_resolve.py
+++ b/backend/quotes/tests/test_draft_quote_resolve.py
@@ -178,6 +178,44 @@ class DraftQuoteResolveHighValueTests(TestCase):
         self.charge.refresh_from_db()
         self.assertIsNone(self.charge.manual_resolved_product_code_id)
 
+    def test_map_to_product_code_rejects_product_code_from_wrong_domain(self):
+        export_product_code = ProductCode.objects.create(
+            id=1001,
+            code="EXP-DOC-FEE",
+            description="Export documentation fee",
+            domain=ProductCode.DOMAIN_EXPORT,
+            category=ProductCode.CATEGORY_DOCUMENTATION,
+            is_gst_applicable=False,
+            gl_revenue_code="4000",
+            gl_cost_code="5000",
+            default_unit=ProductCode.UNIT_SHIPMENT,
+        )
+        res = self._post([self._decision("map_to_product_code", details={"product_code": export_product_code.code})])
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data["rejected_decisions"][0]["error_code"], "PRODUCT_CODE_DOMAIN_MISMATCH")
+        self.charge.refresh_from_db()
+        self.assertIsNone(self.charge.manual_resolved_product_code_id)
+
+    def test_map_to_product_code_uses_trusted_shipment_context_direction(self):
+        self.envelope.shipment_context_json = {"direction": "EXPORT", "origin_country": "SG", "destination_country": "PG", "mode": "AIR"}
+        self.envelope.save(update_fields=["shipment_context_json"])
+        export_product_code = ProductCode.objects.create(
+            id=1001,
+            code="EXP-DOC-FEE",
+            description="Export documentation fee",
+            domain=ProductCode.DOMAIN_EXPORT,
+            category=ProductCode.CATEGORY_DOCUMENTATION,
+            is_gst_applicable=False,
+            gl_revenue_code="4000",
+            gl_cost_code="5000",
+            default_unit=ProductCode.UNIT_SHIPMENT,
+        )
+        res = self._post([self._decision("map_to_product_code", details={"product_code": export_product_code.code})])
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data["applied_decisions"][0]["status"], "applied")
+        self.charge.refresh_from_db()
+        self.assertEqual(self.charge.manual_resolved_product_code_id, export_product_code.id)
+
     def test_map_to_product_code_replay_is_idempotent(self):
         key = uuid.uuid4()
         decision = self._decision("map_to_product_code", details={"product_code": self.product_code.code})

--- a/backend/quotes/tests/test_draft_quote_resolve.py
+++ b/backend/quotes/tests/test_draft_quote_resolve.py
@@ -196,7 +196,7 @@ class DraftQuoteResolveHighValueTests(TestCase):
         self.charge.refresh_from_db()
         self.assertIsNone(self.charge.manual_resolved_product_code_id)
 
-    def test_map_to_product_code_uses_trusted_shipment_context_direction(self):
+    def test_map_to_product_code_route_countries_override_explicit_json_direction(self):
         self.envelope.shipment_context_json = {"direction": "EXPORT", "origin_country": "SG", "destination_country": "PG", "mode": "AIR"}
         self.envelope.save(update_fields=["shipment_context_json"])
         export_product_code = ProductCode.objects.create(
@@ -212,9 +212,43 @@ class DraftQuoteResolveHighValueTests(TestCase):
         )
         res = self._post([self._decision("map_to_product_code", details={"product_code": export_product_code.code})])
         self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data["rejected_decisions"][0]["error_code"], "PRODUCT_CODE_DOMAIN_MISMATCH")
+        self.charge.refresh_from_db()
+        self.assertIsNone(self.charge.manual_resolved_product_code_id)
+
+    def test_map_to_product_code_rejects_when_direction_unavailable(self):
+        self.envelope.shipment_context_json = {"origin_country": "SG", "destination_country": "AU", "mode": "AIR"}
+        self.envelope.save(update_fields=["shipment_context_json"])
+        res = self._post([self._decision("map_to_product_code", details={"product_code": self.product_code.code})])
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data["rejected_decisions"][0]["error_code"], "PRODUCT_CODE_DIRECTION_UNAVAILABLE")
+        self.charge.refresh_from_db()
+        self.assertIsNone(self.charge.manual_resolved_product_code_id)
+
+    def test_draft_quote_payload_direction_uses_route_countries_over_json_direction(self):
+        from quotes.services.draft_quote_adapter import build_draft_quote_payload
+
+        self.envelope.shipment_context_json = {"direction": "EXPORT", "origin_country": "SG", "destination_country": "PG", "mode": "AIR"}
+        self.envelope.save(update_fields=["shipment_context_json"])
+        payload = build_draft_quote_payload(self.envelope)
+        self.assertEqual(payload["shipment_context"]["direction"], "IMPORT")
+
+    def test_draft_quote_payload_omits_direction_when_route_countries_are_unsupported(self):
+        from quotes.services.draft_quote_adapter import build_draft_quote_payload
+
+        self.envelope.shipment_context_json = {"direction": "IMPORT", "origin_country": "SG", "destination_country": "AU", "mode": "AIR"}
+        self.envelope.save(update_fields=["shipment_context_json"])
+        payload = build_draft_quote_payload(self.envelope)
+        self.assertNotIn("direction", payload["shipment_context"])
+
+    def test_map_to_product_code_uses_explicit_direction_when_route_countries_missing(self):
+        self.envelope.shipment_context_json = {"direction": "IMPORT", "mode": "AIR"}
+        self.envelope.save(update_fields=["shipment_context_json"])
+        res = self._post([self._decision("map_to_product_code", details={"product_code": self.product_code.code})])
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertEqual(res.data["applied_decisions"][0]["status"], "applied")
         self.charge.refresh_from_db()
-        self.assertEqual(self.charge.manual_resolved_product_code_id, export_product_code.id)
+        self.assertEqual(self.charge.manual_resolved_product_code_id, self.product_code.id)
 
     def test_map_to_product_code_replay_is_idempotent(self):
         key = uuid.uuid4()

--- a/backend/quotes/tests/test_draft_quote_resolve.py
+++ b/backend/quotes/tests/test_draft_quote_resolve.py
@@ -241,14 +241,22 @@ class DraftQuoteResolveHighValueTests(TestCase):
         payload = build_draft_quote_payload(self.envelope)
         self.assertNotIn("direction", payload["shipment_context"])
 
-    def test_map_to_product_code_uses_explicit_direction_when_route_countries_missing(self):
+    def test_draft_quote_payload_omits_raw_json_direction_without_route_countries(self):
+        from quotes.services.draft_quote_adapter import build_draft_quote_payload
+
+        self.envelope.shipment_context_json = {"direction": "IMPORT", "mode": "AIR"}
+        self.envelope.save(update_fields=["shipment_context_json"])
+        payload = build_draft_quote_payload(self.envelope)
+        self.assertNotIn("direction", payload["shipment_context"])
+
+    def test_map_to_product_code_rejects_raw_json_direction_without_route_countries(self):
         self.envelope.shipment_context_json = {"direction": "IMPORT", "mode": "AIR"}
         self.envelope.save(update_fields=["shipment_context_json"])
         res = self._post([self._decision("map_to_product_code", details={"product_code": self.product_code.code})])
         self.assertEqual(res.status_code, status.HTTP_200_OK)
-        self.assertEqual(res.data["applied_decisions"][0]["status"], "applied")
+        self.assertEqual(res.data["rejected_decisions"][0]["error_code"], "PRODUCT_CODE_DIRECTION_UNAVAILABLE")
         self.charge.refresh_from_db()
-        self.assertEqual(self.charge.manual_resolved_product_code_id, self.product_code.id)
+        self.assertIsNone(self.charge.manual_resolved_product_code_id)
 
     def test_map_to_product_code_replay_is_idempotent(self):
         key = uuid.uuid4()

--- a/docs/audits/spot-exception-workspace-simplification-audit.md
+++ b/docs/audits/spot-exception-workspace-simplification-audit.md
@@ -343,9 +343,9 @@ The fix was verified by:
 Phase 14F replaces the Exception Workspace's hardcoded Map Existing ProductCode list with a direction-scoped selector. The child form remains presentation-only and API-free; ProductCode loading is owned by the workspace orchestration hook.
 
 Implemented safeguards:
-- Draft Quote payloads now include normalized `shipment_context.direction` (`IMPORT`, `EXPORT`, or `DOMESTIC`) only when trusted route evidence supports a direction.
-- Origin/destination country pairs are authoritative; a raw JSON `direction` value cannot override the route-derived direction.
-- `useSpotResolutionWorkflow` loads ProductCodes with `getProductCodes({ domain })` using the trusted draft quote direction and exposes a retry action for failed loads.
+- Draft Quote payloads now include normalized `shipment_context.direction` (`IMPORT`, `EXPORT`, or `DOMESTIC`) only when `origin_country` and `destination_country` can be classified by `classify_png_shipment()`.
+- Origin/destination country pairs are authoritative; a raw JSON `direction` value is not trusted, cannot override route-derived direction, and is not accepted as a fallback when countries are missing or unsupported.
+- `useSpotResolutionWorkflow` loads ProductCodes with `getProductCodes({ domain })` using the backend-emitted route-derived draft quote direction and exposes a retry action for failed loads.
 - `MapExistingForm` renders parent-supplied options through the shared `Combobox` instead of a fixed HTML select, with visible loading/error states and an explicit Retry action.
 - Backend `map_to_product_code` decisions fail closed when direction is unavailable and reject ProductCodes whose domain does not match the trusted shipment direction.
 

--- a/docs/audits/spot-exception-workspace-simplification-audit.md
+++ b/docs/audits/spot-exception-workspace-simplification-audit.md
@@ -343,10 +343,11 @@ The fix was verified by:
 Phase 14F replaces the Exception Workspace's hardcoded Map Existing ProductCode list with a direction-scoped selector. The child form remains presentation-only and API-free; ProductCode loading is owned by the workspace orchestration hook.
 
 Implemented safeguards:
-- Draft Quote payloads now include normalized `shipment_context.direction` (`IMPORT`, `EXPORT`, or `DOMESTIC`).
-- `useSpotResolutionWorkflow` loads ProductCodes with `getProductCodes({ domain })` using the trusted draft quote direction.
-- `MapExistingForm` renders parent-supplied options through the shared `Combobox` instead of a fixed HTML select.
-- Backend `map_to_product_code` decisions reject ProductCodes whose domain does not match the trusted shipment direction.
+- Draft Quote payloads now include normalized `shipment_context.direction` (`IMPORT`, `EXPORT`, or `DOMESTIC`) only when trusted route evidence supports a direction.
+- Origin/destination country pairs are authoritative; a raw JSON `direction` value cannot override the route-derived direction.
+- `useSpotResolutionWorkflow` loads ProductCodes with `getProductCodes({ domain })` using the trusted draft quote direction and exposes a retry action for failed loads.
+- `MapExistingForm` renders parent-supplied options through the shared `Combobox` instead of a fixed HTML select, with visible loading/error states and an explicit Retry action.
+- Backend `map_to_product_code` decisions fail closed when direction is unavailable and reject ProductCodes whose domain does not match the trusted shipment direction.
 
 Intentional non-changes:
 - No pricing, quote total, GST, finalization, ProductCode approval, or RBAC behavior changed.

--- a/docs/audits/spot-exception-workspace-simplification-audit.md
+++ b/docs/audits/spot-exception-workspace-simplification-audit.md
@@ -335,3 +335,19 @@ The fix was verified by:
 - Adding targeted regression assertions to `spot-resolution-state.test.mjs`: six Step-1 transitions preserve `classification`, five review-item actions preserve the full wizard state, and reopening Add Charge updates only `name` and `amount`.
 - The corrected test suite now passes locally.
 - `tmp/test_spot_productcode_remediation_plan.csv` was removed from Git tracking (generated file committed inadvertently in the initial Phase 14D commit).
+
+---
+
+## 16. Phase 14F ProductCode Selector Safety Update
+
+Phase 14F replaces the Exception Workspace's hardcoded Map Existing ProductCode list with a direction-scoped selector. The child form remains presentation-only and API-free; ProductCode loading is owned by the workspace orchestration hook.
+
+Implemented safeguards:
+- Draft Quote payloads now include normalized `shipment_context.direction` (`IMPORT`, `EXPORT`, or `DOMESTIC`).
+- `useSpotResolutionWorkflow` loads ProductCodes with `getProductCodes({ domain })` using the trusted draft quote direction.
+- `MapExistingForm` renders parent-supplied options through the shared `Combobox` instead of a fixed HTML select.
+- Backend `map_to_product_code` decisions reject ProductCodes whose domain does not match the trusted shipment direction.
+
+Intentional non-changes:
+- No pricing, quote total, GST, finalization, ProductCode approval, or RBAC behavior changed.
+- ProductCode creation requests remain under the existing admin-review lifecycle.

--- a/frontend/scripts/draft-quote-contract.test.mjs
+++ b/frontend/scripts/draft-quote-contract.test.mjs
@@ -29,6 +29,7 @@ async function runTests() {
 
   // 1. Structure validation
   assert.equal(hardCaseAirImportData.contract_version, "1.0.0");
+  assert.equal(hardCaseAirImportData.shipment_context.direction, "IMPORT");
   assert.ok(Array.isArray(hardCaseAirImportData.suggested_charges));
 
   // 2. Undo & Reopen Transition Simulation

--- a/frontend/scripts/spot-workspace-form-extraction.test.mjs
+++ b/frontend/scripts/spot-workspace-form-extraction.test.mjs
@@ -42,6 +42,9 @@ assert.ok(mapFormSrc.includes('import { Combobox } from "@/components/ui/combobo
 assert.ok(mapFormSrc.includes("productCodes.map"), "MapExistingForm must render ProductCode options supplied by its parent");
 assert.ok(!mapFormSrc.includes("AF-FREIGHT"), "MapExistingForm must not hardcode ProductCode options");
 assert.ok(!mapFormSrc.includes("<select"), "MapExistingForm must not use the legacy hardcoded select");
+assert.ok(mapFormSrc.includes("Loading ProductCodes for this shipment direction"), "MapExistingForm must render a visible loading state");
+assert.ok(mapFormSrc.includes("productCodeLoadError"), "MapExistingForm must render a visible ProductCode load error state");
+assert.ok(mapFormSrc.includes("Retry"), "MapExistingForm must expose an explicit retry action");
 
 console.log("✓ Verified MapExistingForm renders parent-supplied Combobox options without hardcoded ProductCodes.");
 
@@ -81,6 +84,7 @@ const hookPath = path.join(frontendRoot, "src", "components", "spot", "workspace
 const hookSrc = await readFile(hookPath, "utf8");
 assert.ok(hookSrc.includes('import("../../../lib/api")'), "useSpotResolutionWorkflow hook must import API functions");
 assert.ok(hookSrc.includes("getProductCodes({ domain: productCodeDomain })"), "useSpotResolutionWorkflow must load ProductCodes by shipment direction domain");
+assert.ok(hookSrc.includes("retryProductCodeLoad"), "useSpotResolutionWorkflow must expose an explicit ProductCode reload action");
 assert.ok(hookSrc.includes("resolveDraftQuoteDecisions"), "useSpotResolutionWorkflow must call resolveDraftQuoteDecisions");
 assert.ok(hookSrc.includes("finalizeDraftQuoteReview"), "useSpotResolutionWorkflow must call finalizeDraftQuoteReview");
 

--- a/frontend/scripts/spot-workspace-form-extraction.test.mjs
+++ b/frontend/scripts/spot-workspace-form-extraction.test.mjs
@@ -37,24 +37,17 @@ assert.ok(workspaceSrc.includes('import { AddChargeForm } from "./workspace/AddC
 
 console.log("✓ Verified ExceptionWorkspace correctly imports the extracted components.");
 
-// 4. MapExistingForm option values and order checks
-const options = [];
-const selectRegex = /<option value="([^"]*)">/g;
-let match;
-while ((match = selectRegex.exec(mapFormSrc)) !== null) {
-  options.push(match[1]);
-}
-assert.deepEqual(
-  options,
-  ["", "AF-FREIGHT", "AF-FUEL", "AF-SEC", "AF-HC"],
-  "MapExistingForm select options and order must match exactly"
-);
+// 4. MapExistingForm must use API-provided ProductCode options via Combobox, not hardcoded select options
+assert.ok(mapFormSrc.includes('import { Combobox } from "@/components/ui/combobox";'), "MapExistingForm must use the shared Combobox");
+assert.ok(mapFormSrc.includes("productCodes.map"), "MapExistingForm must render ProductCode options supplied by its parent");
+assert.ok(!mapFormSrc.includes("AF-FREIGHT"), "MapExistingForm must not hardcode ProductCode options");
+assert.ok(!mapFormSrc.includes("<select"), "MapExistingForm must not use the legacy hardcoded select");
 
-console.log("✓ Verified MapExistingForm contains exact option values and sequence.");
+console.log("✓ Verified MapExistingForm renders parent-supplied Combobox options without hardcoded ProductCodes.");
 
 // 5. MapExistingForm checks for non-empty selected values before calling onMap
 assert.ok(
-  mapFormSrc.includes("if (e.target.value) {") || mapFormSrc.includes("if(e.target.value)"),
+  mapFormSrc.includes("if (value) {") || mapFormSrc.includes("if(value)"),
   "MapExistingForm must check for non-empty selection before invoking callback"
 );
 
@@ -87,6 +80,7 @@ assert.ok(!workspaceSrc.includes("const [suggestedCharges"), "ExceptionWorkspace
 const hookPath = path.join(frontendRoot, "src", "components", "spot", "workspace", "useSpotResolutionWorkflow.ts");
 const hookSrc = await readFile(hookPath, "utf8");
 assert.ok(hookSrc.includes('import("../../../lib/api")'), "useSpotResolutionWorkflow hook must import API functions");
+assert.ok(hookSrc.includes("getProductCodes({ domain: productCodeDomain })"), "useSpotResolutionWorkflow must load ProductCodes by shipment direction domain");
 assert.ok(hookSrc.includes("resolveDraftQuoteDecisions"), "useSpotResolutionWorkflow must call resolveDraftQuoteDecisions");
 assert.ok(hookSrc.includes("finalizeDraftQuoteReview"), "useSpotResolutionWorkflow must call finalizeDraftQuoteReview");
 

--- a/frontend/src/components/spot/ExceptionWorkspace.tsx
+++ b/frontend/src/components/spot/ExceptionWorkspace.tsx
@@ -37,7 +37,10 @@ export function ExceptionWorkspace({ initialData, isLive = false, envelopeId }: 
         reviewSession,
         selectedActionType,
         actionMessage,
-        prototypeOverride
+        prototypeOverride,
+        productCodes,
+        isLoadingProductCodes,
+        productCodeLoadError
     } = state;
 
     const {
@@ -333,6 +336,9 @@ export function ExceptionWorkspace({ initialData, isLive = false, envelopeId }: 
                             </div>
                         ) : selectedActionType === "map_existing" ? (
                             <MapExistingForm
+                                productCodes={productCodes}
+                                isLoadingProductCodes={isLoadingProductCodes}
+                                productCodeLoadError={productCodeLoadError}
                                 onMap={(productCode) =>
                                     actions.mapProductCode(
                                         currentIssue.id,

--- a/frontend/src/components/spot/ExceptionWorkspace.tsx
+++ b/frontend/src/components/spot/ExceptionWorkspace.tsx
@@ -339,6 +339,7 @@ export function ExceptionWorkspace({ initialData, isLive = false, envelopeId }: 
                                 productCodes={productCodes}
                                 isLoadingProductCodes={isLoadingProductCodes}
                                 productCodeLoadError={productCodeLoadError}
+                                onRetry={actions.retryProductCodeLoad}
                                 onMap={(productCode) =>
                                     actions.mapProductCode(
                                         currentIssue.id,

--- a/frontend/src/components/spot/workspace/MapExistingForm.tsx
+++ b/frontend/src/components/spot/workspace/MapExistingForm.tsx
@@ -1,32 +1,45 @@
 "use client";
 
 import React from "react";
+import { Combobox } from "@/components/ui/combobox";
+
+interface ProductCodeSelectorOption {
+    code: string;
+    description: string;
+}
 
 interface MapExistingFormProps {
+    productCodes: ProductCodeSelectorOption[];
+    isLoadingProductCodes: boolean;
+    productCodeLoadError: string | null;
     onMap: (productCode: string) => void;
     onCancel: () => void;
 }
 
-export function MapExistingForm({ onMap, onCancel }: MapExistingFormProps) {
+export function MapExistingForm({ productCodes, isLoadingProductCodes, productCodeLoadError, onMap, onCancel }: MapExistingFormProps) {
+    const options = productCodes.map(productCode => ({
+        value: productCode.code,
+        label: `${productCode.code} (${productCode.description})`
+    }));
     return (
         <div className="bg-slate-950 border border-slate-850 p-4 rounded-xl flex flex-col gap-3">
             <h3 className="text-xs uppercase font-bold text-indigo-400">Map to Existing ProductCode</h3>
             <p className="text-xs text-slate-400">Choose this if the billing code already exists in EFM RateEngine catalog.</p>
             <div className="flex gap-2">
-                <select
-                    onChange={e => {
-                        if (e.target.value) {
-                            onMap(e.target.value);
-                        }
-                    }}
-                    className="text-xs bg-slate-900 border border-slate-800 rounded p-2 text-slate-200 grow"
-                >
-                    <option value="">-- Choose Billing Code --</option>
-                    <option value="AF-FREIGHT">AF-FREIGHT (Air Freight Linehaul)</option>
-                    <option value="AF-FUEL">AF-FUEL (Fuel Surcharge)</option>
-                    <option value="AF-SEC">AF-SEC (Security Charge)</option>
-                    <option value="AF-HC">AF-HC (Handling Charge)</option>
-                </select>
+                <div className="grow">
+                    <Combobox
+                        options={options}
+                        placeholder="Search ProductCodes..."
+                        emptyMessage={productCodeLoadError || "No ProductCodes found for this shipment direction."}
+                        onChange={value => {
+                            if (value) {
+                                onMap(value);
+                            }
+                        }}
+                        disabled={isLoadingProductCodes || Boolean(productCodeLoadError)}
+                        buttonClassName="text-xs bg-slate-900 border border-slate-800 rounded p-2 text-slate-200 grow"
+                    />
+                </div>
                 <button
                     onClick={onCancel}
                     className="px-3 py-2 bg-slate-900 border border-slate-800 rounded text-xs text-slate-400"

--- a/frontend/src/components/spot/workspace/MapExistingForm.tsx
+++ b/frontend/src/components/spot/workspace/MapExistingForm.tsx
@@ -12,11 +12,12 @@ interface MapExistingFormProps {
     productCodes: ProductCodeSelectorOption[];
     isLoadingProductCodes: boolean;
     productCodeLoadError: string | null;
+    onRetry: () => void;
     onMap: (productCode: string) => void;
     onCancel: () => void;
 }
 
-export function MapExistingForm({ productCodes, isLoadingProductCodes, productCodeLoadError, onMap, onCancel }: MapExistingFormProps) {
+export function MapExistingForm({ productCodes, isLoadingProductCodes, productCodeLoadError, onRetry, onMap, onCancel }: MapExistingFormProps) {
     const options = productCodes.map(productCode => ({
         value: productCode.code,
         label: `${productCode.code} (${productCode.description})`
@@ -25,6 +26,21 @@ export function MapExistingForm({ productCodes, isLoadingProductCodes, productCo
         <div className="bg-slate-950 border border-slate-850 p-4 rounded-xl flex flex-col gap-3">
             <h3 className="text-xs uppercase font-bold text-indigo-400">Map to Existing ProductCode</h3>
             <p className="text-xs text-slate-400">Choose this if the billing code already exists in EFM RateEngine catalog.</p>
+            {isLoadingProductCodes ? (
+                <p className="text-xs text-slate-500">Loading ProductCodes for this shipment direction...</p>
+            ) : null}
+            {productCodeLoadError ? (
+                <div className="flex items-center justify-between gap-2 rounded-lg border border-red-900/60 bg-red-950/30 px-3 py-2 text-xs text-red-200">
+                    <span>{productCodeLoadError}</span>
+                    <button
+                        type="button"
+                        onClick={onRetry}
+                        className="rounded border border-red-800 px-2 py-1 font-semibold text-red-100 hover:border-red-600"
+                    >
+                        Retry
+                    </button>
+                </div>
+            ) : null}
             <div className="flex gap-2">
                 <div className="grow">
                     <Combobox

--- a/frontend/src/components/spot/workspace/useSpotResolutionWorkflow.ts
+++ b/frontend/src/components/spot/workspace/useSpotResolutionWorkflow.ts
@@ -37,6 +37,7 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
     const [productCodes, setProductCodes] = useState<ProductCodeSelectorOption[]>([]);
     const [isLoadingProductCodes, setIsLoadingProductCodes] = useState(false);
     const [productCodeLoadError, setProductCodeLoadError] = useState<string | null>(null);
+    const [productCodeRetryNonce, setProductCodeRetryNonce] = useState(0);
 
     const shipmentDirection = String(initialData.shipment_context.direction || "").toUpperCase();
     const productCodeDomain = PRODUCT_CODE_DOMAINS.has(shipmentDirection) ? shipmentDirection : null;
@@ -79,7 +80,7 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
         return () => {
             cancelled = true;
         };
-    }, [productCodeDomain]);
+    }, [productCodeDomain, productCodeRetryNonce]);
 
     // API submission helper
     const submitLiveDecision = async (decisionItem: {
@@ -114,6 +115,10 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
 
     const openMapExisting = () => {
         dispatch({ type: "OPEN_MAP_EXISTING" });
+    };
+
+    const retryProductCodeLoad = () => {
+        setProductCodeRetryNonce((value) => value + 1);
     };
 
     const openRequestProductCode = (charge: DraftCharge) => {
@@ -486,6 +491,7 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
         actions: {
             selectIssue,
             openMapExisting,
+            retryProductCodeLoad,
             openRequestProductCode,
             openUnknownProductCodeRequest,
             openAddUnknownCharge,

--- a/frontend/src/components/spot/workspace/useSpotResolutionWorkflow.ts
+++ b/frontend/src/components/spot/workspace/useSpotResolutionWorkflow.ts
@@ -1,4 +1,4 @@
-import { useReducer } from "react";
+import { useEffect, useReducer, useState } from "react";
 import { DraftCharge, DraftQuote } from "../../../lib/draft-quote-types";
 import {
     createSpotResolutionState,
@@ -18,6 +18,14 @@ import {
     SpotResolutionState
 } from "./spotResolutionState";
 
+interface ProductCodeSelectorOption {
+    code: string;
+    description: string;
+    domain: string;
+}
+
+const PRODUCT_CODE_DOMAINS = new Set(["IMPORT", "EXPORT", "DOMESTIC"]);
+
 interface UseSpotResolutionWorkflowProps {
     initialData: DraftQuote;
     isLive: boolean;
@@ -26,6 +34,52 @@ interface UseSpotResolutionWorkflowProps {
 
 export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: UseSpotResolutionWorkflowProps) {
     const [state, dispatch] = useReducer(spotResolutionReducer, initialData, createSpotResolutionState);
+    const [productCodes, setProductCodes] = useState<ProductCodeSelectorOption[]>([]);
+    const [isLoadingProductCodes, setIsLoadingProductCodes] = useState(false);
+    const [productCodeLoadError, setProductCodeLoadError] = useState<string | null>(null);
+
+    const shipmentDirection = String(initialData.shipment_context.direction || "").toUpperCase();
+    const productCodeDomain = PRODUCT_CODE_DOMAINS.has(shipmentDirection) ? shipmentDirection : null;
+
+    useEffect(() => {
+        let cancelled = false;
+
+        if (!productCodeDomain) {
+            setProductCodes([]);
+            setProductCodeLoadError("Draft Quote shipment direction is missing; ProductCode selection is disabled.");
+            setIsLoadingProductCodes(false);
+            return;
+        }
+
+        setIsLoadingProductCodes(true);
+        setProductCodeLoadError(null);
+
+        import("../../../lib/api")
+            .then(({ getProductCodes }) => getProductCodes({ domain: productCodeDomain }))
+            .then((codes) => {
+                if (cancelled) return;
+                setProductCodes(codes.map((code) => ({
+                    code: code.code,
+                    description: code.description,
+                    domain: code.domain
+                })));
+            })
+            .catch((error) => {
+                if (cancelled) return;
+                const message = error instanceof Error ? error.message : "Failed to fetch ProductCodes";
+                setProductCodes([]);
+                setProductCodeLoadError(message);
+            })
+            .finally(() => {
+                if (!cancelled) {
+                    setIsLoadingProductCodes(false);
+                }
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [productCodeDomain]);
 
     // API submission helper
     const submitLiveDecision = async (decisionItem: {
@@ -410,7 +464,10 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
             addChargeForm: state.addChargeForm,
             actionMessage: state.actionMessage,
             prototypeOverride: state.prototypeOverride,
-            showHelpText: state.showHelpText
+            showHelpText: state.showHelpText,
+            productCodes,
+            isLoadingProductCodes,
+            productCodeLoadError
         },
         derived: {
             combinedUnresolved,

--- a/frontend/src/data/hardCaseAirImport.ts
+++ b/frontend/src/data/hardCaseAirImport.ts
@@ -12,7 +12,8 @@ export const hardCaseAirImportData: DraftQuote = {
     "actual_weight_kg": 150.0,
     "volumetric_weight_kg": 200.0,
     "chargeable_weight_kg": 200.0,
-    "commodity": "GCR"
+    "commodity": "GCR",
+    "direction": "IMPORT"
   },
   "supplier_context": {
     "supplier_name": "Qantas Air Cargo",

--- a/frontend/src/lib/draft-quote-types.ts
+++ b/frontend/src/lib/draft-quote-types.ts
@@ -78,6 +78,8 @@ export interface TotalsValidation {
     warnings: string[];
 }
 
+export type ShipmentDirection = 'IMPORT' | 'EXPORT' | 'DOMESTIC';
+
 export interface DraftQuote {
     contract_version: string;
     quote_summary: string;
@@ -90,6 +92,7 @@ export interface DraftQuote {
         volumetric_weight_kg: number;
         chargeable_weight_kg: number;
         commodity: string;
+        direction?: ShipmentDirection;
         [key: string]: unknown;
     };
     supplier_context: {


### PR DESCRIPTION
## Scope

Phase 14F: replace the hardcoded Exception Workspace Map Existing ProductCode list with a direction-scoped API-backed selector, add route-derived Draft Quote shipment direction, and enforce backend domain validation for `map_to_product_code` decisions.

## Changed Files

- `frontend/src/components/spot/workspace/MapExistingForm.tsx`: replaced hardcoded `<select>` ProductCodes with a parent-supplied `Combobox` selector while keeping the form API-free/stateless; shows loading/error states and Retry.
- `frontend/src/components/spot/workspace/useSpotResolutionWorkflow.ts`: loads ProductCodes via `getProductCodes({ domain })` from backend-emitted Draft Quote `shipment_context.direction` and exposes selector retry state.
- `frontend/src/components/spot/ExceptionWorkspace.tsx`: passes ProductCode selector state into `MapExistingForm`.
- `frontend/src/lib/draft-quote-types.ts`: adds `ShipmentDirection` typing for Draft Quote shipment context.
- `frontend/src/data/hardCaseAirImport.ts`: updates frontend fixture with normalized `direction: "IMPORT"`.
- `frontend/scripts/draft-quote-contract.test.mjs`: asserts fixture direction is present.
- `frontend/scripts/spot-workspace-form-extraction.test.mjs`: updates structural assertions for Combobox/API-backed ProductCode options plus loading/error/retry UI.
- `backend/quotes/services/draft_quote_adapter.py`: emits normalized `shipment_context.direction` only when `origin_country` and `destination_country` are classified by `classify_png_shipment()`.
- `backend/quotes/services/draft_quote_resolve_service.py`: rejects `map_to_product_code` when route-derived direction is unavailable or the ProductCode domain mismatches it.
- `backend/quotes/tests/fixtures/draft_quote_contract/hard_case_air_import.json`: updates backend fixture with normalized direction.
- `backend/quotes/tests/test_draft_quote_contract.py`: asserts Draft Quote direction in the contract fixture.
- `backend/quotes/tests/test_draft_quote_resolve.py`: adds focused tests for domain mismatch, unavailable direction, raw JSON direction rejection, and adapter direction emission/omission.
- `docs/audits/spot-exception-workspace-simplification-audit.md`: documents Phase 14F selector/domain safety update.

## What Was Intentionally Not Changed

- No pricing, quote totals, GST, FX, finalization, RBAC, route calculation, or ProductCode approval behavior.
- No legacy SPOT CRUD revival.
- No autonomous ProductCode mapping or fallback ProductCode guessing.
- Raw `shipment_context_json.direction` is not trusted and is not used as a fallback.
- ProductCode creation request lifecycle remains unchanged.

## Verification

Automated:
- `python backend/manage.py check` — passed via Windows Python with local test env vars.
- `python backend/manage.py test quotes.tests.test_draft_quote_resolve` — passed, 32 tests.
- `python backend/manage.py test quotes.tests` — passed, 496 tests.
- `git diff --check` — passed.

Previously also run on this PR:
- `npm run typecheck` — passed.
- `node.exe scripts/spot-workspace-form-extraction.test.mjs` — passed.
- `npm run lint` — passed with existing warnings.
- `npm run test:draft-quote-contract` — passed.
- `npm run test:exception-workspace-routing` — passed.
- `node.exe scripts/spot-workspace-orchestration.test.mjs` — passed.
- `npm run build` — passed with existing warnings.

Audit/baseline:
- Fallow baseline files were written under `/tmp/phase14f-fallow*-final.json`; Fallow reported pre-existing issues and `note: hotspot analysis skipped: no git repository found at project root` in this Windows/WSL worktree.
- `ruff check backend` and `vulture backend` could not run because those modules are not installed in the available Python environment.
- `graphify update .` could not run because `graphify` is not available on PATH.

Manual:
- Confirmed `MapExistingForm` has no API imports/fetch calls and receives ProductCode options from the orchestration hook.
- Confirmed backend rejects mapping when countries are missing/unsupported even if raw JSON `direction` is present.
- Confirmed adapter does not emit raw JSON direction without route country evidence.

## Commercial Impact

Does not change quote totals, GST, FX, pricing, public quote output, or finalization. It prevents wrong-domain or unverifiable ProductCodes from being manually mapped through the Draft Quote resolve endpoint.

## Data Impact

No migrations or data backfills. Runtime reads ProductCodes by route-derived domain and may reject invalid map decisions; existing data is not modified except normal accepted operator decisions.

## Audit Impact

Decision persistence remains through existing `DraftQuoteDecisionDB`; rejected map decisions are recorded with `PRODUCT_CODE_DIRECTION_UNAVAILABLE` or `PRODUCT_CODE_DOMAIN_MISMATCH`.

## Risk

Selector availability depends on backend route-derived Draft Quote direction and `/api/v4/product-codes/?domain=...`. If route countries are unavailable or unsupported, selector/domain mapping fails closed instead of guessing.

## Rollback

Revert this PR to restore the previous hardcoded selector and remove backend domain validation.
