### PR TITLE
Draft: Phase 14G Persist unknown item resolutions

### DIFF
--- a/backend/quotes/contracts/draft_quote_contract.py
+++ b/backend/quotes/contracts/draft_quote_contract.py
@@ -159,11 +159,13 @@ class MapToProductCodeDetails(BaseModel):
 
 
 class RequestProductCodeDetails(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
     proposed_code: str = Field(..., description="Proposed code string")
     description: str = Field(..., description="Proposed code description")
-    category: str = Field(..., description="Target category (freight, etc.)")
-    domain: str = Field(..., description="Target domain (IMPORT, EXPORT, DOMESTIC)")
     reason: str = Field(..., description="Operator justification for request")
+    category: Optional[str] = Field(None, description="Target category/bucket when already known")
+    domain: Optional[str] = Field(None, description="Deprecated client hint; server derives domain from route countries")
 
 
 class UseApprovedProductCodeDetails(BaseModel):
@@ -203,7 +205,7 @@ class EditChargeDetails(BaseModel):
 
 
 class ClassifyUnclassifiedDetails(BaseModel):
-    classification: str = Field("charge", description="charge or ignored")
+    classification: str = Field("charge", description="charge or note")
     bucket: str = Field(..., description="Target bucket for classification")
     display_label: str = Field(..., description="Display label for the new charge line")
     product_code: str = Field(..., description="Target product code for classification")
@@ -212,6 +214,11 @@ class ClassifyUnclassifiedDetails(BaseModel):
     rate: Optional[Decimal] = Field(None, description="Parsed rate")
     unit: Optional[str] = Field(None, description="Parsed unit")
     minimum_charge: Optional[Decimal] = Field(None, description="Parsed minimum limit")
+    reason: Optional[str] = Field(None, description="Operator reason")
+
+
+class NoteUnclassifiedDetails(BaseModel):
+    classification: str = Field(..., description="note classification")
     reason: Optional[str] = Field(None, description="Operator reason")
 
 
@@ -257,6 +264,8 @@ class DecisionItemSchema(BaseModel):
             classification = str(self.details.get("classification") or "charge").lower()
             if classification in {"ignored", "ignore", "non_commercial", "non-commercial"}:
                 IgnoreUnclassifiedDetails(**self.details)
+            elif classification == "note":
+                NoteUnclassifiedDetails(**self.details)
             else:
                 ClassifyUnclassifiedDetails(**self.details)
         

--- a/backend/quotes/services/draft_quote_adapter.py
+++ b/backend/quotes/services/draft_quote_adapter.py
@@ -280,17 +280,31 @@ def build_draft_quote_payload(spe_db: SpotPricingEnvelopeDB) -> Dict[str, Any]:
     commercial_terms = []
     if isinstance(spe_db.conditions_json, dict):
         for key, val in spe_db.conditions_json.items():
-            if key != 'user_audit_log':
-                text = str(val.get('text') if isinstance(val, dict) else val)
-                normalized_value = val.get('normalized_value') if isinstance(val, dict) else None
-                commercial_terms.append({
-                    "type": str(key),
-                    "text": text,
-                    "normalized_value": normalized_value,
-                    "status": "suggested",
-                    "evidence": None,
-                    "review_reason": None
-                })
+            if key == 'user_audit_log':
+                continue
+            if key == 'commercial_terms' and isinstance(val, list):
+                for term in val:
+                    if isinstance(term, dict):
+                        commercial_terms.append({
+                            "type": str(term.get("type") or "note"),
+                            "text": str(term.get("text") or ""),
+                            "normalized_value": term.get("normalized_value"),
+                            "status": str(term.get("status") or "suggested"),
+                            "evidence": term.get("evidence"),
+                            "review_reason": term.get("review_reason"),
+                        })
+                continue
+            text = str(val.get('text') if isinstance(val, dict) else val)
+            normalized_value = val.get('normalized_value') if isinstance(val, dict) else None
+            evidence = val.get('evidence') if isinstance(val, dict) else None
+            commercial_terms.append({
+                "type": str(key),
+                "text": text,
+                "normalized_value": normalized_value,
+                "status": "suggested",
+                "evidence": evidence,
+                "review_reason": None
+            })
 
     # 7. Unclassified & Ignored Items
     unclassified_items = []

--- a/backend/quotes/services/draft_quote_resolve_service.py
+++ b/backend/quotes/services/draft_quote_resolve_service.py
@@ -214,6 +214,15 @@ def _unclassified_item(envelope, target_id):
     return None, None
 
 
+def _remove_unclassified(batch: SPESourceBatchDB, item: dict):
+    summary = dict(batch.analysis_summary_json or {})
+    summary["unclassified_items"] = [
+        i for i in summary.get("unclassified_items") or [] if str(i.get("id")) != str(item.get("id"))
+    ]
+    batch.analysis_summary_json = summary
+    batch.save(update_fields=["analysis_summary_json", "updated_at"])
+
+
 def _ignore_unclassified(batch: SPESourceBatchDB, item: dict, reason: str):
     summary = dict(batch.analysis_summary_json or {})
     unclassified = [i for i in summary.get("unclassified_items") or [] if str(i.get("id")) != str(item.get("id"))]
@@ -232,29 +241,128 @@ def _ignore_unclassified(batch: SPESourceBatchDB, item: dict, reason: str):
     batch.save(update_fields=["analysis_summary_json", "updated_at"])
 
 
-def _create_classified_charge(envelope, batch, item, product_code, decision, payload, user):
-    details = decision.details
+def _persist_unclassified_note(envelope, batch: SPESourceBatchDB, item: dict, reason: str | None = None):
+    conditions = dict(envelope.conditions_json or {}) if isinstance(envelope.conditions_json, dict) else {}
+    terms = list(conditions.get("commercial_terms") or [])
+    terms.append(
+        {
+            "type": "note",
+            "text": item.get("raw_text") or item.get("text") or "",
+            "normalized_value": None,
+            "status": "suggested",
+            "evidence": item.get("evidence"),
+            "review_reason": reason or "Operator classified unclassified item as commercial note.",
+        }
+    )
+    conditions["commercial_terms"] = terms
+    envelope.conditions_json = conditions
+    envelope.save(update_fields=["conditions_json"])
+    _remove_unclassified(batch, item)
+
+
+def _validate_charge_details(details):
+    required = ["display_label", "bucket", "currency", "amount", "unit", "product_code"]
+    missing = [field for field in required if details.get(field) in {None, ""}]
+    if missing:
+        return None, f"Classifying this item as a charge requires: {', '.join(missing)}.", "MISSING_CHARGE_FIELD"
+    if details["bucket"] not in _valid_choice_values(SPEChargeLineDB.Bucket.choices):
+        return None, "Bucket is not supported for SPOT charge lines.", "INVALID_BUCKET"
+    if details["unit"] not in _valid_choice_values(SPEChargeLineDB.Unit.choices):
+        return None, "Unit is not supported for SPOT charge lines.", "INVALID_UNIT"
+    currency = str(details.get("currency") or "").strip().upper()
+    if len(currency) != 3 or not currency.isalpha():
+        return None, "Currency must be a 3-letter ISO code.", "INVALID_CURRENCY"
+    try:
+        amount = Decimal(str(details.get("amount")))
+    except (InvalidOperation, TypeError, ValueError):
+        return None, "amount must be numeric.", "INVALID_NUMERIC_VALUE"
+    if amount < 0:
+        return None, "amount cannot be negative.", "NEGATIVE_NUMERIC_VALUE"
+    normalized = dict(details)
+    normalized["currency"] = currency
+    normalized["amount"] = amount
+    return normalized, "", None
+
+
+def _validate_product_code_domain(envelope, product_code):
+    expected_domain = _expected_product_code_domain(envelope)
+    if not expected_domain:
+        return "rejected", "Shipment direction could not be determined from trusted route evidence. ProductCode mapping was not applied.", "PRODUCT_CODE_DIRECTION_UNAVAILABLE"
+    if product_code.domain != expected_domain:
+        return "rejected", f"ProductCode domain {product_code.domain} does not match shipment direction {expected_domain}.", "PRODUCT_CODE_DOMAIN_MISMATCH"
+    return None, None, None
+
+
+def _build_unclassified_charge(envelope, batch, item, details, user, product_code=None):
     now = timezone.now()
-    charge_line = SPEChargeLineDB(
+    source_text = item.get("raw_text") or item.get("text") or ""
+    return SPEChargeLineDB(
         envelope=envelope,
         source_batch=batch,
-        code=product_code.code,
+        code=product_code.code if product_code else "UNCLASSIFIED-PROVISIONAL",
         description=details["display_label"],
         amount=details["amount"],
         currency=details["currency"],
-        unit=details.get("unit") or SPEChargeLineDB.Unit.FLAT,
+        unit=details["unit"],
         bucket=details["bucket"],
         rate=details.get("rate"),
         min_charge=details.get("minimum_charge"),
-        source_label=item.get("raw_text") or item.get("text") or details["display_label"],
-        source_excerpt=item.get("raw_text") or item.get("text") or "",
+        normalization_status=SPEChargeLineDB.NormalizationStatus.UNMAPPED if not product_code else SPEChargeLineDB.NormalizationStatus.MATCHED,
+        source_label=source_text or details["display_label"],
+        source_excerpt=source_text,
         source_reference=batch.file_name or batch.label or "draft quote unclassified item",
+        rule_meta={"unclassified_item_evidence": item.get("evidence"), "unclassified_item_id": item.get("id")},
         entered_by=user,
         entered_at=now,
     )
+
+
+def _create_classified_charge(envelope, batch, item, product_code, decision, payload, user):
+    details, message, error_code = _validate_charge_details(decision.details)
+    if error_code:
+        return "rejected", message, error_code
+    status, message, error_code = _validate_product_code_domain(envelope, product_code)
+    if error_code:
+        return status, message, error_code
+    charge_line = _build_unclassified_charge(envelope, batch, item, details, user, product_code=product_code)
     _stamp_manual_resolution(charge_line, product_code, user, decision, payload)
     charge_line.save()
-    _ignore_unclassified(batch, item, details.get("reason") or "Classified as charge")
+    _remove_unclassified(batch, item)
+    return "accepted", "Unclassified item classified as charge.", None
+
+
+def _create_product_code_request_for_unclassified(envelope, decision, user):
+    batch, item = _unclassified_item(envelope, decision.target_id)
+    if not item:
+        return "rejected", "Target unclassified item was not found in this envelope.", "TARGET_NOT_FOUND", None
+
+    details, message, error_code = _validate_charge_details({**decision.details, "product_code": "PENDING"})
+    if error_code and error_code != "PRODUCT_CODE_REQUIRED":
+        return "rejected", message, error_code, None
+
+    expected_domain = _expected_product_code_domain(envelope)
+    if not expected_domain:
+        return "rejected", "Shipment direction could not be determined from trusted route evidence. ProductCode request was not created.", "PRODUCT_CODE_DIRECTION_UNAVAILABLE", None
+
+    charge_line = _build_unclassified_charge(envelope, batch, item, details, user)
+    charge_line.save()
+    _remove_unclassified(batch, item)
+    pc_request = ProductCodeCreationRequest.objects.create(
+        source_label=item.get("raw_text") or item.get("text") or details["display_label"],
+        suggested_name=decision.details.get("proposed_code") or details["display_label"],
+        suggested_bucket=details["bucket"],
+        suggested_basis=details["unit"],
+        suggested_reason=decision.details.get("reason") or "Operator requested ProductCode for unclassified item.",
+        source_envelope=envelope,
+        source_charge_line=charge_line,
+        source_quote=envelope.quote if hasattr(envelope, "quote") else None,
+        source_context_json={**decision.details, "domain": expected_domain, "evidence": item.get("evidence")},
+        created_by=user,
+        status=ProductCodeCreationRequest.STATUS_PENDING,
+    )
+    decision.target_id = str(charge_line.id)
+    decision.details["product_code_request_id"] = pc_request.id
+    return "skipped", "ProductCode request created and pending admin review.", None, charge_line
 
 
 def _apply_classify_unclassified(envelope, decision, payload, user):
@@ -264,18 +372,24 @@ def _apply_classify_unclassified(envelope, decision, payload, user):
 
     classification = str(decision.details.get("classification") or "charge").lower()
     if classification in {"ignored", "ignore", "non_commercial", "non-commercial"}:
-        _ignore_unclassified(batch, item, decision.details.get("reason") or "Classified as non-commercial")
+        reason = str(decision.details.get("reason") or "").strip()
+        if not reason:
+            return "rejected", "Ignoring an unclassified item requires a reason.", "REASON_REQUIRED"
+        _ignore_unclassified(batch, item, reason)
         return "accepted", "Unclassified item classified as ignored.", None
+
+    if classification == "note":
+        _persist_unclassified_note(envelope, batch, item, decision.details.get("reason"))
+        return "accepted", "Unclassified item classified as note.", None
 
     if classification != "charge":
         return "rejected", "Unsupported unclassified classification.", "UNSUPPORTED_CLASSIFICATION"
 
     product_code = _product_code(decision.details.get("product_code"))
     if not product_code:
-        return "skipped", "Classifying this item as a charge requires an existing ProductCode.", "PRODUCT_CODE_REQUIRED"
+        return "rejected", "Classifying this item as a charge requires an existing ProductCode.", "PRODUCT_CODE_REQUIRED"
 
-    _create_classified_charge(envelope, batch, item, product_code, decision, payload, user)
-    return "accepted", "Unclassified item classified as charge.", None
+    return _create_classified_charge(envelope, batch, item, product_code, decision, payload, user)
 
 
 def apply_draft_quote_decisions(
@@ -344,22 +458,31 @@ def apply_draft_quote_decisions(
             elif decision_type == "classify_unclassified":
                 status_val, message_val, error_code_val = _apply_classify_unclassified(envelope, dec_item, payload, user)
             elif decision_type == "request_product_code":
-                pc_request = ProductCodeCreationRequest.objects.create(
-                    source_label=(charge_line.source_label or charge_line.description) if charge_line else dec_item.details.get("description", ""),
-                    suggested_name=dec_item.details.get("proposed_code", ""),
-                    suggested_bucket=dec_item.details.get("category", ""),
-                    suggested_basis="FLAT",
-                    suggested_reason=dec_item.details.get("reason", ""),
-                    source_envelope=envelope,
-                    source_charge_line=charge_line,
-                    source_quote=envelope.quote if hasattr(envelope, "quote") else None,
-                    source_context_json=dec_item.details,
-                    created_by=user,
-                    status=ProductCodeCreationRequest.STATUS_PENDING,
-                )
-                dec_item.details["product_code_request_id"] = pc_request.id
-                status_val = "skipped"
-                message_val = "ProductCode request created and pending admin review."
+                if not charge_line:
+                    status_val, message_val, error_code_val, charge_line = _create_product_code_request_for_unclassified(envelope, dec_item, user)
+                else:
+                    expected_domain = _expected_product_code_domain(envelope)
+                    if not expected_domain:
+                        status_val = "rejected"
+                        message_val = "Shipment direction could not be determined from trusted route evidence. ProductCode request was not created."
+                        error_code_val = "PRODUCT_CODE_DIRECTION_UNAVAILABLE"
+                    else:
+                        pc_request = ProductCodeCreationRequest.objects.create(
+                            source_label=(charge_line.source_label or charge_line.description) if charge_line else dec_item.details.get("description", ""),
+                            suggested_name=dec_item.details.get("proposed_code", ""),
+                            suggested_bucket=dec_item.details.get("category", ""),
+                            suggested_basis=dec_item.details.get("unit") or "FLAT",
+                            suggested_reason=dec_item.details.get("reason", ""),
+                            source_envelope=envelope,
+                            source_charge_line=charge_line,
+                            source_quote=envelope.quote if hasattr(envelope, "quote") else None,
+                            source_context_json={**dec_item.details, "domain": expected_domain},
+                            created_by=user,
+                            status=ProductCodeCreationRequest.STATUS_PENDING,
+                        )
+                        dec_item.details["product_code_request_id"] = pc_request.id
+                        status_val = "skipped"
+                        message_val = "ProductCode request created and pending admin review."
             elif decision_type == "use_approved_product_code":
                 req_id = dec_item.details.get("product_code_request_id")
                 pc_request = ProductCodeCreationRequest.objects.filter(id=req_id).first() if req_id else None

--- a/backend/quotes/services/draft_quote_resolve_service.py
+++ b/backend/quotes/services/draft_quote_resolve_service.py
@@ -467,16 +467,28 @@ def apply_draft_quote_decisions(
                         message_val = "Shipment direction could not be determined from trusted route evidence. ProductCode request was not created."
                         error_code_val = "PRODUCT_CODE_DIRECTION_UNAVAILABLE"
                     else:
+                        source_label = charge_line.source_label or charge_line.description or dec_item.details.get("description", "")
+                        suggested_bucket = charge_line.bucket or dec_item.details.get("bucket") or dec_item.details.get("category")
+                        suggested_basis = charge_line.unit or dec_item.details.get("unit") or "FLAT"
                         pc_request = ProductCodeCreationRequest.objects.create(
-                            source_label=(charge_line.source_label or charge_line.description) if charge_line else dec_item.details.get("description", ""),
+                            source_label=source_label,
                             suggested_name=dec_item.details.get("proposed_code", ""),
-                            suggested_bucket=dec_item.details.get("category", ""),
-                            suggested_basis=dec_item.details.get("unit") or "FLAT",
+                            suggested_bucket=suggested_bucket,
+                            suggested_basis=suggested_basis,
                             suggested_reason=dec_item.details.get("reason", ""),
                             source_envelope=envelope,
                             source_charge_line=charge_line,
                             source_quote=envelope.quote if hasattr(envelope, "quote") else None,
-                            source_context_json={**dec_item.details, "domain": expected_domain},
+                            source_context_json={
+                                **dec_item.details,
+                                "domain": expected_domain,
+                                "source_label": source_label,
+                                "source_charge_line_id": str(charge_line.id),
+                                "charge_bucket": charge_line.bucket,
+                                "charge_unit": charge_line.unit,
+                                "charge_currency": charge_line.currency,
+                                "charge_amount": str(charge_line.amount) if charge_line.amount is not None else None,
+                            },
                             created_by=user,
                             status=ProductCodeCreationRequest.STATUS_PENDING,
                         )

--- a/backend/quotes/services/draft_quote_review_service.py
+++ b/backend/quotes/services/draft_quote_review_service.py
@@ -29,13 +29,8 @@ def is_finalized(envelope: SpotPricingEnvelopeDB) -> bool:
 
 
 def unresolved_blockers(draft_quote: DraftQuoteSchema) -> list[dict[str, Any]]:
-    charges_by_id = {charge.id: charge for charge in draft_quote.suggested_charges}
     blockers: list[dict[str, Any]] = []
     for item in draft_quote.review_queue:
-        item_id = str(item.get("id") or "")
-        charge = charges_by_id.get(item_id)
-        if charge and "PENDING_ADMIN_REVIEW" in (charge.correction_actions or []):
-            continue
         blockers.append(item)
     return blockers
 

--- a/backend/quotes/tests/test_draft_quote_api.py
+++ b/backend/quotes/tests/test_draft_quote_api.py
@@ -202,7 +202,7 @@ def test_draft_quote_resolve_endpoint(transactional_db):
     user = _mk_user("test_sales_resolve", "sales")
     envelope = SpotPricingEnvelopeDB.objects.create(
         status=SpotPricingEnvelopeDB.Status.DRAFT,
-        shipment_context_json={},
+        shipment_context_json={"origin_country": "SG", "destination_country": "PG", "mode": "AIR"},
         shipment_context_hash="mock_hash_value",
         expires_at=timezone.now() + timezone.timedelta(days=7),
         created_by=user

--- a/backend/quotes/tests/test_draft_quote_resolve.py
+++ b/backend/quotes/tests/test_draft_quote_resolve.py
@@ -380,6 +380,60 @@ class DraftQuoteResolveHighValueTests(TestCase):
         charge.refresh_from_db()
         self.assertEqual(charge.manual_resolved_product_code_id, self.product_code.id)
 
+    def test_unknown_charge_creation_replay_creates_one_charge(self):
+        key = uuid.uuid4()
+        decision = self._decision(
+            "classify_unclassified",
+            target_id="unclass-1",
+            details={
+                "classification": "charge",
+                "display_label": "Documentation fee",
+                "bucket": SPEChargeLineDB.Bucket.DESTINATION_CHARGES,
+                "currency": "USD",
+                "amount": "25.00",
+                "unit": SPEChargeLineDB.Unit.FLAT,
+                "product_code": self.product_code.code,
+            },
+            decision_id="classify-replay",
+        )
+
+        first = self._post([decision], key=key)
+        second = self._post([decision], key=key)
+
+        self.assertEqual(first.status_code, status.HTTP_200_OK)
+        self.assertEqual(second.status_code, status.HTTP_200_OK)
+        self.assertEqual(SPEChargeLineDB.objects.filter(description="Documentation fee").count(), 1)
+        self.assertEqual(DraftQuoteDecisionDB.objects.filter(idempotency_key=key, decision_id="classify-replay").count(), 1)
+
+    def test_unknown_charge_reload_then_finalize(self):
+        res = self._post([
+            self._decision(
+                "classify_unclassified",
+                target_id="unclass-1",
+                details={
+                    "classification": "charge",
+                    "display_label": "Documentation fee",
+                    "bucket": SPEChargeLineDB.Bucket.DESTINATION_CHARGES,
+                    "currency": "USD",
+                    "amount": "25.00",
+                    "unit": SPEChargeLineDB.Unit.FLAT,
+                    "product_code": self.product_code.code,
+                },
+                decision_id="classify-reload-finalize",
+            ),
+            self._decision("classify_unclassified", target_id="unclass-2", details={"classification": "ignored", "reason": "Greeting"}, decision_id="ignore-note-finalize"),
+            self._decision("map_to_product_code", details={"product_code": self.product_code.code}, decision_id="map-existing-finalize"),
+        ])
+        self.assertEqual(res.data["rejected_decisions"], [])
+
+        self.client.force_authenticate(user=self.sales)
+        read_res = self.client.get(f"/api/v3/spot/envelopes/{self.envelope.id}/draft-quote/")
+        self.assertEqual(read_res.status_code, status.HTTP_200_OK)
+        self.assertEqual(read_res.data["review_session"]["remaining_blockers"], 0)
+        finalize = self._finalize()
+        self.assertEqual(finalize.status_code, status.HTTP_200_OK)
+        self.assertEqual(finalize.data["review_status"], "finalized")
+
     def test_edit_charge_updates_allowed_fields_and_preserves_evidence(self):
         res = self._post([
             self._decision(
@@ -535,6 +589,34 @@ class DraftQuoteResolveHighValueTests(TestCase):
         self.assertEqual(charge["correction_actions"], [])
         self.assertIsNone(charge["product_code_request_id"])
 
+    def test_ordinary_charge_request_retains_server_charge_bucket_unit_metadata(self):
+        res = self._post([
+            self._decision(
+                "request_product_code",
+                details={
+                    "proposed_code": "IMP-DOC-ORDINARY",
+                    "description": "Client-side edited description",
+                    "bucket": "",
+                    "category": "",
+                    "unit": "",
+                    "reason": "Supplier added new fee",
+                },
+                decision_id="request-ordinary-metadata",
+            )
+        ])
+
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data["applied_decisions"][0]["status"], "skipped")
+        request = ProductCodeCreationRequest.objects.get(suggested_name="IMP-DOC-ORDINARY")
+        self.assertEqual(request.source_label, "DOC FEE")
+        self.assertEqual(request.suggested_bucket, SPEChargeLineDB.Bucket.DESTINATION_CHARGES)
+        self.assertEqual(request.suggested_basis, SPEChargeLineDB.Unit.FLAT)
+        self.assertEqual(request.source_context_json["domain"], "IMPORT")
+        self.assertEqual(request.source_context_json["source_label"], "DOC FEE")
+        self.assertEqual(request.source_context_json["source_charge_line_id"], str(self.charge.id))
+        self.assertEqual(request.source_context_json["charge_bucket"], SPEChargeLineDB.Bucket.DESTINATION_CHARGES)
+        self.assertEqual(request.source_context_json["charge_unit"], SPEChargeLineDB.Unit.FLAT)
+
     def test_resubmitting_rejected_product_code_creates_new_pending_request(self):
         rejected_request = self._rejected_product_code_request()
         self._persist_request_decision(rejected_request)
@@ -645,6 +727,65 @@ class DraftQuoteResolveHighValueTests(TestCase):
         self.assertEqual(res.data["applied_decisions"][0]["status"], "applied")
         self.charge.refresh_from_db()
         self.assertEqual(self.charge.manual_resolved_product_code_id, self.product_code.id)
+
+    def test_pending_product_code_request_blocks_finalization(self):
+        res = self._post([
+            self._decision(
+                "request_product_code",
+                details={
+                    "proposed_code": "IMP-PENDING",
+                    "description": "Pending request",
+                    "category": "destination_charges",
+                    "reason": "Needs admin review",
+                },
+                decision_id="request-pending-finalize",
+            ),
+            self._decision("classify_unclassified", target_id="unclass-1", details={"classification": "ignored", "reason": "Not billable"}, decision_id="ignore-pending-u1"),
+            self._decision("classify_unclassified", target_id="unclass-2", details={"classification": "ignored", "reason": "Greeting"}, decision_id="ignore-pending-u2"),
+        ])
+        self.assertEqual(res.data["rejected_decisions"], [])
+
+        finalize = self._finalize()
+
+        self.assertEqual(finalize.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(finalize.data["status"], "rejected")
+        self.assertGreaterEqual(finalize.data["remaining_blockers"], 1)
+
+    def test_request_approve_apply_then_finalize(self):
+        res = self._post([
+            self._decision(
+                "request_product_code",
+                details={
+                    "proposed_code": "IMP-APPROVED-FLOW",
+                    "description": "Approved flow",
+                    "category": "destination_charges",
+                    "reason": "Needs admin review",
+                },
+                decision_id="request-approved-flow",
+            ),
+            self._decision("classify_unclassified", target_id="unclass-1", details={"classification": "ignored", "reason": "Not billable"}, decision_id="ignore-approved-u1"),
+            self._decision("classify_unclassified", target_id="unclass-2", details={"classification": "ignored", "reason": "Greeting"}, decision_id="ignore-approved-u2"),
+        ])
+        self.assertEqual(res.data["rejected_decisions"], [])
+        request = ProductCodeCreationRequest.objects.get(suggested_name="IMP-APPROVED-FLOW")
+        request.status = ProductCodeCreationRequest.STATUS_APPROVED
+        request.approved_product_code = self.product_code
+        request.approved_at = timezone.now()
+        request.approved_by = self.manager
+        request.save(update_fields=["status", "approved_product_code", "approved_at", "approved_by"])
+
+        apply_res = self._post([
+            self._decision(
+                "use_approved_product_code",
+                details={"product_code_request_id": request.id, "product_code_id": self.product_code.id},
+                decision_id="apply-approved-flow",
+            )
+        ])
+        self.assertEqual(apply_res.data["rejected_decisions"], [])
+
+        finalize = self._finalize()
+        self.assertEqual(finalize.status_code, status.HTTP_200_OK)
+        self.assertEqual(finalize.data["review_status"], "finalized")
 
     def test_finalize_succeeds_when_blockers_resolved_and_read_reflects_state(self):
         self._resolve_all_blockers()

--- a/backend/quotes/tests/test_draft_quote_resolve.py
+++ b/backend/quotes/tests/test_draft_quote_resolve.py
@@ -265,6 +265,121 @@ class DraftQuoteResolveHighValueTests(TestCase):
         self._post([decision], key=key)
         self.assertEqual(DraftQuoteDecisionDB.objects.filter(idempotency_key=key).count(), 1)
 
+    def test_classify_unclassified_charge_persists_line_and_preserves_evidence(self):
+        res = self._post([
+            self._decision(
+                "classify_unclassified",
+                target_id="unclass-1",
+                details={
+                    "classification": "charge",
+                    "display_label": "Documentation fee",
+                    "bucket": SPEChargeLineDB.Bucket.DESTINATION_CHARGES,
+                    "currency": "USD",
+                    "amount": "25.00",
+                    "unit": SPEChargeLineDB.Unit.FLAT,
+                    "product_code": self.product_code.code,
+                },
+                decision_id="classify-charge",
+            )
+        ])
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data["rejected_decisions"], [])
+        created = SPEChargeLineDB.objects.get(description="Documentation fee")
+        self.assertEqual(created.manual_resolved_product_code_id, self.product_code.id)
+        self.assertEqual(created.source_excerpt, "Documentation fee USD 25")
+        self.assertEqual(created.rule_meta["unclassified_item_evidence"]["source_text"], "Documentation fee USD 25")
+        self.batch.refresh_from_db()
+        summary = self.batch.analysis_summary_json
+        self.assertFalse(any(item.get("id") == "unclass-1" for item in summary["unclassified_items"]))
+        self.assertFalse(any(item.get("id") == "unclass-1" for item in summary.get("ignored_items", [])))
+
+    def test_classify_unclassified_charge_rejects_wrong_domain_and_invalid_fields(self):
+        export_product_code = ProductCode.objects.create(
+            id=1001,
+            code="EXP-DOC-FEE",
+            description="Export documentation fee",
+            domain=ProductCode.DOMAIN_EXPORT,
+            category=ProductCode.CATEGORY_DOCUMENTATION,
+            is_gst_applicable=False,
+            gl_revenue_code="4000",
+            gl_cost_code="5000",
+            default_unit=ProductCode.UNIT_SHIPMENT,
+        )
+        base_details = {
+            "classification": "charge",
+            "display_label": "Documentation fee",
+            "bucket": SPEChargeLineDB.Bucket.DESTINATION_CHARGES,
+            "currency": "USD",
+            "amount": "25.00",
+            "unit": SPEChargeLineDB.Unit.FLAT,
+            "product_code": export_product_code.code,
+        }
+        res = self._post([self._decision("classify_unclassified", target_id="unclass-1", details=base_details, decision_id="wrong-domain")])
+        self.assertEqual(res.data["rejected_decisions"][0]["error_code"], "PRODUCT_CODE_DOMAIN_MISMATCH")
+        self.assertFalse(SPEChargeLineDB.objects.filter(description="Documentation fee").exists())
+
+        invalid_cases = [
+            ({"bucket": "bad"}, "INVALID_BUCKET"),
+            ({"currency": "USDX"}, "INVALID_CURRENCY"),
+            ({"amount": "-1"}, "NEGATIVE_NUMERIC_VALUE"),
+            ({"unit": "bad"}, "INVALID_UNIT"),
+        ]
+        for idx, (override, error_code) in enumerate(invalid_cases):
+            details = {**base_details, "product_code": self.product_code.code, **override}
+            res = self._post([self._decision("classify_unclassified", target_id="unclass-1", details=details, decision_id=f"invalid-{idx}")])
+            self.assertEqual(res.data["rejected_decisions"][0]["error_code"], error_code)
+
+    def test_classify_unclassified_rejects_missing_direction(self):
+        self.envelope.shipment_context_json = {"origin_country": "SG", "destination_country": "AU", "mode": "AIR"}
+        self.envelope.save(update_fields=["shipment_context_json"])
+        res = self._post([
+            self._decision(
+                "classify_unclassified",
+                target_id="unclass-1",
+                details={"classification": "charge", "display_label": "Doc", "bucket": SPEChargeLineDB.Bucket.DESTINATION_CHARGES, "currency": "USD", "amount": "25", "unit": SPEChargeLineDB.Unit.FLAT, "product_code": self.product_code.code},
+                decision_id="missing-direction",
+            )
+        ])
+        self.assertEqual(res.data["rejected_decisions"][0]["error_code"], "PRODUCT_CODE_DIRECTION_UNAVAILABLE")
+
+    def test_classify_unclassified_ignored_and_note_persist_after_reload(self):
+        res = self._post([
+            self._decision("classify_unclassified", target_id="unclass-1", details={"classification": "ignored", "reason": "Not billable"}, decision_id="ignore-unknown"),
+            self._decision("classify_unclassified", target_id="unclass-2", details={"classification": "note", "reason": "Commercial note"}, decision_id="note-unknown"),
+        ])
+        self.assertEqual(res.data["rejected_decisions"], [])
+        payload = self.client.get(f"/api/v3/spot/envelopes/{self.envelope.id}/draft-quote/").data
+        self.assertFalse(any(item["id"] in {"unclass-1", "unclass-2"} for item in payload["unclassified_items"]))
+        self.assertTrue(any(item["id"] == "unclass-1" for item in payload["ignored_items"]))
+        self.assertTrue(any(term["type"] == "note" and "Have a nice day" in term["text"] for term in payload["commercial_terms"]))
+
+    def test_unknown_product_code_request_creates_provisional_charge_and_can_apply_approved_code(self):
+        res = self._post([
+            self._decision(
+                "request_product_code",
+                target_id="unclass-1",
+                details={"proposed_code": "IMP-DOC-NEW", "description": "Documentation fee", "display_label": "Documentation fee", "bucket": SPEChargeLineDB.Bucket.DESTINATION_CHARGES, "currency": "USD", "amount": "25", "unit": SPEChargeLineDB.Unit.FLAT, "reason": "Missing code"},
+                decision_id="request-unknown",
+            )
+        ])
+        self.assertEqual(res.data["rejected_decisions"], [])
+        request = ProductCodeCreationRequest.objects.get(suggested_name="IMP-DOC-NEW")
+        self.assertIsNotNone(request.source_charge_line_id)
+        charge = request.source_charge_line
+        self.assertEqual(charge.source_excerpt, "Documentation fee USD 25")
+        self.assertEqual(charge.normalization_status, SPEChargeLineDB.NormalizationStatus.UNMAPPED)
+        request.status = ProductCodeCreationRequest.STATUS_APPROVED
+        request.approved_product_code = self.product_code
+        request.approved_at = timezone.now()
+        request.approved_by = self.manager
+        request.save(update_fields=["status", "approved_product_code", "approved_at", "approved_by"])
+        res = self._post([
+            self._decision("use_approved_product_code", target_id=str(charge.id), details={"product_code_request_id": request.id, "product_code_id": self.product_code.id}, decision_id="use-approved-unknown")
+        ])
+        self.assertEqual(res.data["applied_decisions"][0]["status"], "applied")
+        charge.refresh_from_db()
+        self.assertEqual(charge.manual_resolved_product_code_id, self.product_code.id)
+
     def test_edit_charge_updates_allowed_fields_and_preserves_evidence(self):
         res = self._post([
             self._decision(
@@ -353,7 +468,7 @@ class DraftQuoteResolveHighValueTests(TestCase):
         self.assertEqual(created.source_excerpt, "Documentation fee USD 25")
         self.batch.refresh_from_db()
         self.assertEqual([i["id"] for i in self.batch.analysis_summary_json["unclassified_items"]], ["unclass-2"])
-        self.assertEqual(self.batch.analysis_summary_json["ignored_items"][0]["raw_text"], "Documentation fee USD 25")
+        self.assertFalse(any(i.get("id") == "unclass-1" for i in self.batch.analysis_summary_json.get("ignored_items", [])))
 
     def test_classify_unclassified_without_product_code_is_skipped(self):
         res = self._post([
@@ -367,12 +482,13 @@ class DraftQuoteResolveHighValueTests(TestCase):
                     "product_code": "MISSING",
                     "amount": "25.00",
                     "currency": "USD",
+                    "unit": SPEChargeLineDB.Unit.FLAT,
                 },
             )
         ])
         self.assertEqual(res.status_code, status.HTTP_200_OK)
-        self.assertEqual(res.data["applied_decisions"][0]["status"], "skipped")
-        self.assertEqual(res.data["applied_decisions"][0]["error_code"], "PRODUCT_CODE_REQUIRED")
+        self.assertEqual(res.data["rejected_decisions"][0]["status"], "rejected")
+        self.assertEqual(res.data["rejected_decisions"][0]["error_code"], "PRODUCT_CODE_REQUIRED")
 
     def test_classify_unclassified_as_ignored_preserves_text(self):
         res = self._post([self._decision("classify_unclassified", target_id="unclass-2", details={"classification": "ignored", "reason": "Greeting"})])

--- a/backend/quotes/tests/test_spot_exception_workspace_e2e.py
+++ b/backend/quotes/tests/test_spot_exception_workspace_e2e.py
@@ -485,6 +485,22 @@ class SpotExceptionWorkspaceE2ETests(TestCase):
         self.assertEqual(resubmit.status_code, status.HTTP_200_OK)
         self.assertEqual(resubmit.data["applied_decisions"][0]["status"], "skipped")
         self.assertEqual(ProductCodeCreationRequest.objects.filter(source_envelope=self.envelope, suggested_name="IMP-XRAY-CORRECTED").count(), 1)
+        corrected_req = ProductCodeCreationRequest.objects.get(source_envelope=self.envelope, suggested_name="IMP-XRAY-CORRECTED")
+        corrected_req.status = ProductCodeCreationRequest.STATUS_APPROVED
+        corrected_req.approved_product_code = self.handling_pc
+        corrected_req.approved_at = timezone.now()
+        corrected_req.approved_by = self.admin
+        corrected_req.save(update_fields=["status", "approved_product_code", "approved_at", "approved_by"])
+        apply_corrected = self._resolve([
+            self._decision(
+                "use_approved_product_code",
+                third_rejected.id,
+                {"product_code_request_id": corrected_req.id, "product_code_id": self.handling_pc.id},
+                "apply-xray-corrected",
+            )
+        ])
+        self.assertEqual(apply_corrected.status_code, status.HTTP_200_OK)
+        self.assertEqual(apply_corrected.data["applied_decisions"][0]["status"], "applied")
 
         final_read = self._read()
         self.assertEqual(final_read.status_code, status.HTTP_200_OK)

--- a/docs/audits/spot-exception-workspace-simplification-audit.md
+++ b/docs/audits/spot-exception-workspace-simplification-audit.md
@@ -352,3 +352,21 @@ Implemented safeguards:
 Intentional non-changes:
 - No pricing, quote total, GST, finalization, ProductCode approval, or RBAC behavior changed.
 - ProductCode creation requests remain under the existing admin-review lifecycle.
+
+---
+
+## 17. Phase 14G Unknown Item Resolution Persistence
+
+Phase 14G persists Unknown Charge Block decisions through the Draft Quote resolve API instead of relying on local-only frontend state.
+
+Implemented safeguards:
+- Live unknown-item actions submit `classify_unclassified` decisions rather than charge-line `map_to_product_code` decisions.
+- Unknown items classified as charges create persisted `SPEChargeLineDB` rows, preserve source text/evidence, validate required charge fields, and validate ProductCode domain from route-derived shipment direction.
+- Unknown items classified as ignored are removed from `unclassified_items` and copied to `ignored_items` with evidence and reason.
+- Unknown items classified as notes are removed from `unclassified_items` and persisted as commercial terms with evidence, outside quote totals.
+- Unknown-item ProductCode requests create a provisional unresolved charge line linked to a pending `ProductCodeCreationRequest`, preserving finalization blocking until the request is approved/resolved.
+- Live frontend unknown-item success paths reload the Draft Quote from the backend; failures surface an error and do not mutate local resolution state.
+
+Intentional non-changes:
+- No quote pricing, GST, FX, public quote rendering, RBAC, or finalization-rule changes.
+- Demo mode remains local/prototype-only and isolated from live persistence.

--- a/frontend/scripts/spot-workspace-orchestration.test.mjs
+++ b/frontend/scripts/spot-workspace-orchestration.test.mjs
@@ -25,6 +25,7 @@ const panelSources = new Map(
         ])
     )
 );
+const mapExistingFormSrc = await readFile(path.join(frontendRoot, "src", "components", "spot", "workspace", "MapExistingForm.tsx"), "utf8");
 
 // 1. Verify ExceptionWorkspace imports and consumes the hook
 assert.ok(
@@ -118,6 +119,16 @@ assert.ok(!hookSrc.includes('type: "map_to_product_code",\n            target_id
 assert.ok(!hookSrc.includes('newChargeId = `chg-new-${Date.now()}`;\n            try'), "Live unknown charge creation must not create synthetic IDs");
 assert.ok(!hookSrc.includes('domain: "IMPORT"'), "ProductCode requests must not hardcode IMPORT domain");
 assert.ok(!hookSrc.includes('currency: "SGD"'), "Unknown ProductCode requests must not hardcode SGD currency");
+assert.ok(workspaceSrc.includes("actions.openUnknownMapExisting"), "Unknown Map Existing must open a detail-collection workflow instead of submitting from ProductCode-only selection");
+assert.ok(workspaceSrc.includes('collectChargeDetails={currentIssue.type === "unknown_charge"}'), "Unknown Map Existing must collect full charge details");
+assert.ok(mapExistingFormSrc.includes("Confirm Mapping"), "MapExistingForm must require confirmation when collecting unknown charge details");
+assert.ok(mapExistingFormSrc.includes("collectChargeDetails"), "MapExistingForm must support the unknown charge detail collection mode");
+assert.ok(hookSrc.includes("return response;"), "submitLiveDecision must return the resolve response");
+assert.ok(hookSrc.includes("rejected_decisions.find"), "submitLiveDecision must inspect rejected_decisions for the submitted decision");
+assert.ok(hookSrc.includes("throw new Error(rejectedMessage)"), "submitLiveDecision must throw rejected decision messages without refreshing state");
+assert.ok(hookSrc.includes("chargeLabel === GENERIC_UNKNOWN_LABEL"), "Unknown Map Existing must never submit the generic Unknown Charge Block label");
+assert.ok(hookSrc.includes("Complete charge label, bucket, currency, amount, unit and ProductCode"), "Unknown Map Existing must require a complete charge payload");
+assert.ok(hookSrc.includes("category: state.requestForm.bucket"), "ProductCode requests must carry bucket metadata for compatibility");
 
 console.log("✓ Verified useSpotResolutionWorkflow owns resolve and finalization API calls.");
 

--- a/frontend/scripts/spot-workspace-orchestration.test.mjs
+++ b/frontend/scripts/spot-workspace-orchestration.test.mjs
@@ -111,7 +111,13 @@ console.log("✓ Verified ExceptionWorkspace does not locally declare resolution
 // 4. Verify hook owns the API calls
 assert.ok(hookSrc.includes('import("../../../lib/api")'), "useSpotResolutionWorkflow hook must import API functions");
 assert.ok(hookSrc.includes("resolveDraftQuoteDecisions"), "useSpotResolutionWorkflow must call resolveDraftQuoteDecisions");
+assert.ok(hookSrc.includes("getDraftQuote"), "useSpotResolutionWorkflow must reload the Draft Quote after live unknown-item decisions");
 assert.ok(hookSrc.includes("finalizeDraftQuoteReview"), "useSpotResolutionWorkflow must call finalizeDraftQuoteReview");
+assert.ok(hookSrc.includes('type: "classify_unclassified"'), "Unknown-item live actions must submit classify_unclassified decisions");
+assert.ok(!hookSrc.includes('type: "map_to_product_code",\n            target_id: itemId'), "Unknown-item mapping must not submit map_to_product_code with an unclassified item ID");
+assert.ok(!hookSrc.includes('newChargeId = `chg-new-${Date.now()}`;\n            try'), "Live unknown charge creation must not create synthetic IDs");
+assert.ok(!hookSrc.includes('domain: "IMPORT"'), "ProductCode requests must not hardcode IMPORT domain");
+assert.ok(!hookSrc.includes('currency: "SGD"'), "Unknown ProductCode requests must not hardcode SGD currency");
 
 console.log("✓ Verified useSpotResolutionWorkflow owns resolve and finalization API calls.");
 

--- a/frontend/src/components/spot/ExceptionWorkspace.tsx
+++ b/frontend/src/components/spot/ExceptionWorkspace.tsx
@@ -341,11 +341,17 @@ export function ExceptionWorkspace({ initialData, isLive = false, envelopeId }: 
                                 productCodeLoadError={productCodeLoadError}
                                 onRetry={actions.retryProductCodeLoad}
                                 onMap={(productCode) =>
-                                    actions.mapProductCode(
-                                        currentIssue.id,
-                                        productCode,
-                                        currentIssue.title
-                                    )
+                                    currentIssue.type === "unknown_charge"
+                                        ? actions.classifyUnknownAsExistingCharge(
+                                              currentIssue.id,
+                                              productCode,
+                                              currentIssue.title
+                                          )
+                                        : actions.mapProductCode(
+                                              currentIssue.id,
+                                              productCode,
+                                              currentIssue.title
+                                          )
                                 }
                                 onCancel={actions.cancelAction}
                             />
@@ -359,6 +365,10 @@ export function ExceptionWorkspace({ initialData, isLive = false, envelopeId }: 
                                 onReqCurrencyChange={(val) => actions.updateRequestForm({ currency: val })}
                                 reqAmount={state.requestForm.amount}
                                 onReqAmountChange={(val) => actions.updateRequestForm({ amount: val })}
+                                reqBucket={state.requestForm.bucket}
+                                onReqBucketChange={(val) => actions.updateRequestForm({ bucket: val })}
+                                reqUnit={state.requestForm.unit}
+                                onReqUnitChange={(val) => actions.updateRequestForm({ unit: val })}
                                 onSubmit={() =>
                                     actions.submitProductCodeRequest(currentIssue.id)
                                 }
@@ -378,6 +388,10 @@ export function ExceptionWorkspace({ initialData, isLive = false, envelopeId }: 
                                 onAddUnitChange={(val) => actions.updateAddChargeForm({ unit: val })}
                                 addProductCode={state.addChargeForm.productCode}
                                 onAddProductCodeChange={(val) => actions.updateAddChargeForm({ productCode: val })}
+                                productCodes={productCodes}
+                                isLoadingProductCodes={isLoadingProductCodes}
+                                productCodeLoadError={productCodeLoadError}
+                                onRetryProductCodes={actions.retryProductCodeLoad}
                                 onAdd={() =>
                                     actions.addUnknownAsCharge(currentIssue.id)
                                 }

--- a/frontend/src/components/spot/ExceptionWorkspace.tsx
+++ b/frontend/src/components/spot/ExceptionWorkspace.tsx
@@ -290,7 +290,7 @@ export function ExceptionWorkspace({ initialData, isLive = false, envelopeId }: 
                                                         <div className="text-xs font-semibold text-slate-300">Step 2: How should it be mapped?</div>
                                                         <div className="flex flex-col sm:flex-row gap-2">
                                                             <button
-                                                                onClick={actions.openMapExisting}
+                                                                onClick={() => actions.openUnknownMapExisting(currentIssue.itemDetails!.raw_text)}
                                                                 className="px-4 py-2 bg-slate-950 border border-slate-800 hover:border-slate-600 rounded-lg text-xs text-left grow text-slate-200"
                                                             >
                                                                 Map to an existing billing code
@@ -354,6 +354,19 @@ export function ExceptionWorkspace({ initialData, isLive = false, envelopeId }: 
                                           )
                                 }
                                 onCancel={actions.cancelAction}
+                                collectChargeDetails={currentIssue.type === "unknown_charge"}
+                                selectedProductCode={state.addChargeForm.productCode}
+                                onProductCodeChange={(val) => actions.updateAddChargeForm({ productCode: val })}
+                                chargeName={state.addChargeForm.name}
+                                onChargeNameChange={(val) => actions.updateAddChargeForm({ name: val })}
+                                chargeBucket={state.addChargeForm.bucket}
+                                onChargeBucketChange={(val) => actions.updateAddChargeForm({ bucket: val })}
+                                chargeCurrency={state.addChargeForm.currency}
+                                onChargeCurrencyChange={(val) => actions.updateAddChargeForm({ currency: val })}
+                                chargeAmount={state.addChargeForm.amount}
+                                onChargeAmountChange={(val) => actions.updateAddChargeForm({ amount: val })}
+                                chargeUnit={state.addChargeForm.unit}
+                                onChargeUnitChange={(val) => actions.updateAddChargeForm({ unit: val })}
                             />
                         ) : selectedActionType === "request_product_code" ? (
                             <RequestProductCodeForm

--- a/frontend/src/components/spot/workspace/AddChargeForm.tsx
+++ b/frontend/src/components/spot/workspace/AddChargeForm.tsx
@@ -1,6 +1,12 @@
 "use client";
 
 import React from "react";
+import { Combobox } from "@/components/ui/combobox";
+
+interface ProductCodeSelectorOption {
+    code: string;
+    description: string;
+}
 
 interface AddChargeFormProps {
     addName: string;
@@ -15,6 +21,10 @@ interface AddChargeFormProps {
     onAddUnitChange: (value: string) => void;
     addProductCode: string;
     onAddProductCodeChange: (value: string) => void;
+    productCodes: ProductCodeSelectorOption[];
+    isLoadingProductCodes: boolean;
+    productCodeLoadError: string | null;
+    onRetryProductCodes: () => void;
     onAdd: () => void;
     onCancel: () => void;
 }
@@ -32,9 +42,17 @@ export function AddChargeForm({
     onAddUnitChange,
     addProductCode,
     onAddProductCodeChange,
+    productCodes,
+    isLoadingProductCodes,
+    productCodeLoadError,
+    onRetryProductCodes,
     onAdd,
     onCancel,
 }: AddChargeFormProps) {
+    const productCodeOptions = productCodes.map(productCode => ({
+        value: productCode.code,
+        label: `${productCode.code} (${productCode.description})`
+    }));
     return (
         <div className="bg-slate-950 border border-slate-850 p-4 rounded-xl flex flex-col gap-3">
             <h3 className="text-xs uppercase font-bold text-indigo-400">Add manually as draft charge line</h3>
@@ -56,6 +74,7 @@ export function AddChargeForm({
                         onChange={e => onAddBucketChange(e.target.value)}
                         className="w-full bg-slate-900 border border-slate-800 rounded p-1.5"
                     >
+                        <option value="">Choose bucket...</option>
                         <option value="origin_charges">Origin Charges</option>
                         <option value="destination_charges">Destination Charges</option>
                         <option value="airfreight">Air Freight Linehaul</option>
@@ -89,14 +108,22 @@ export function AddChargeForm({
                     />
                 </div>
                 <div>
-                    <label className="text-slate-500 block mb-1">Mapping Code (Optional)</label>
-                    <input
-                        type="text"
+                    <label className="text-slate-500 block mb-1">Mapping Code (Required)</label>
+                    <Combobox
+                        options={productCodeOptions}
                         value={addProductCode}
-                        onChange={e => onAddProductCodeChange(e.target.value)}
-                        placeholder="Approved ProductCode"
-                        className="w-full bg-slate-900 border border-slate-800 rounded p-1.5"
+                        onChange={onAddProductCodeChange}
+                        placeholder="Search ProductCodes..."
+                        emptyMessage={productCodeLoadError || "No ProductCodes found for this shipment direction."}
+                        disabled={isLoadingProductCodes || Boolean(productCodeLoadError)}
+                        buttonClassName="text-xs bg-slate-900 border border-slate-800 rounded p-1.5 text-slate-200"
                     />
+                    {isLoadingProductCodes ? <p className="mt-1 text-[11px] text-slate-500">Loading ProductCodes...</p> : null}
+                    {productCodeLoadError ? (
+                        <button type="button" onClick={onRetryProductCodes} className="mt-1 text-[11px] font-semibold text-red-300 hover:underline">
+                            Retry ProductCode load
+                        </button>
+                    ) : null}
                 </div>
             </div>
             <div className="flex gap-2 justify-end mt-2">

--- a/frontend/src/components/spot/workspace/MapExistingForm.tsx
+++ b/frontend/src/components/spot/workspace/MapExistingForm.tsx
@@ -15,9 +15,42 @@ interface MapExistingFormProps {
     onRetry: () => void;
     onMap: (productCode: string) => void;
     onCancel: () => void;
+    collectChargeDetails?: boolean;
+    selectedProductCode?: string;
+    onProductCodeChange?: (value: string) => void;
+    chargeName?: string;
+    onChargeNameChange?: (value: string) => void;
+    chargeBucket?: string;
+    onChargeBucketChange?: (value: string) => void;
+    chargeCurrency?: string;
+    onChargeCurrencyChange?: (value: string) => void;
+    chargeAmount?: string;
+    onChargeAmountChange?: (value: string) => void;
+    chargeUnit?: string;
+    onChargeUnitChange?: (value: string) => void;
 }
 
-export function MapExistingForm({ productCodes, isLoadingProductCodes, productCodeLoadError, onRetry, onMap, onCancel }: MapExistingFormProps) {
+export function MapExistingForm({
+    productCodes,
+    isLoadingProductCodes,
+    productCodeLoadError,
+    onRetry,
+    onMap,
+    onCancel,
+    collectChargeDetails = false,
+    selectedProductCode = "",
+    onProductCodeChange,
+    chargeName = "",
+    onChargeNameChange,
+    chargeBucket = "",
+    onChargeBucketChange,
+    chargeCurrency = "",
+    onChargeCurrencyChange,
+    chargeAmount = "",
+    onChargeAmountChange,
+    chargeUnit = "flat",
+    onChargeUnitChange,
+}: MapExistingFormProps) {
     const options = productCodes.map(productCode => ({
         value: productCode.code,
         label: `${productCode.code} (${productCode.description})`
@@ -47,8 +80,11 @@ export function MapExistingForm({ productCodes, isLoadingProductCodes, productCo
                         options={options}
                         placeholder="Search ProductCodes..."
                         emptyMessage={productCodeLoadError || "No ProductCodes found for this shipment direction."}
+                        value={selectedProductCode}
                         onChange={value => {
-                            if (value) {
+                            if (collectChargeDetails) {
+                                onProductCodeChange?.(value);
+                            } else if (value) {
                                 onMap(value);
                             }
                         }}
@@ -56,13 +92,54 @@ export function MapExistingForm({ productCodes, isLoadingProductCodes, productCo
                         buttonClassName="text-xs bg-slate-900 border border-slate-800 rounded p-2 text-slate-200 grow"
                     />
                 </div>
-                <button
-                    onClick={onCancel}
-                    className="px-3 py-2 bg-slate-900 border border-slate-800 rounded text-xs text-slate-400"
-                >
-                    Cancel
-                </button>
+                {!collectChargeDetails ? (
+                    <button
+                        onClick={onCancel}
+                        className="px-3 py-2 bg-slate-900 border border-slate-800 rounded text-xs text-slate-400"
+                    >
+                        Cancel
+                    </button>
+                ) : null}
             </div>
+            {collectChargeDetails ? (
+                <>
+                    <div className="grid grid-cols-2 gap-3 text-xs">
+                        <div>
+                            <label className="text-slate-500 block mb-1">Charge description</label>
+                            <input type="text" value={chargeName} onChange={e => onChargeNameChange?.(e.target.value)} className="w-full bg-slate-900 border border-slate-800 rounded p-1.5" />
+                        </div>
+                        <div>
+                            <label className="text-slate-500 block mb-1">Section Bucket</label>
+                            <select value={chargeBucket} onChange={e => onChargeBucketChange?.(e.target.value)} className="w-full bg-slate-900 border border-slate-800 rounded p-1.5">
+                                <option value="">Choose bucket...</option>
+                                <option value="origin_charges">Origin Charges</option>
+                                <option value="destination_charges">Destination Charges</option>
+                                <option value="airfreight">Air Freight Linehaul</option>
+                            </select>
+                        </div>
+                        <div>
+                            <label className="text-slate-500 block mb-1">Currency</label>
+                            <input type="text" value={chargeCurrency} onChange={e => onChargeCurrencyChange?.(e.target.value)} className="w-full bg-slate-900 border border-slate-800 rounded p-1.5" />
+                        </div>
+                        <div>
+                            <label className="text-slate-500 block mb-1">Amount</label>
+                            <input type="text" value={chargeAmount} onChange={e => onChargeAmountChange?.(e.target.value)} className="w-full bg-slate-900 border border-slate-800 rounded p-1.5" />
+                        </div>
+                        <div>
+                            <label className="text-slate-500 block mb-1">Unit</label>
+                            <input type="text" value={chargeUnit} onChange={e => onChargeUnitChange?.(e.target.value)} className="w-full bg-slate-900 border border-slate-800 rounded p-1.5" />
+                        </div>
+                    </div>
+                    <div className="flex gap-2 justify-end mt-2">
+                        <button onClick={() => onMap(selectedProductCode)} className="px-4 py-2 bg-indigo-600 text-white rounded text-xs font-semibold">
+                            Confirm Mapping
+                        </button>
+                        <button onClick={onCancel} className="px-4 py-2 bg-slate-900 border border-slate-800 rounded text-xs text-slate-400">
+                            Cancel
+                        </button>
+                    </div>
+                </>
+            ) : null}
         </div>
     );
 }

--- a/frontend/src/components/spot/workspace/RequestProductCodeForm.tsx
+++ b/frontend/src/components/spot/workspace/RequestProductCodeForm.tsx
@@ -11,6 +11,10 @@ interface RequestProductCodeFormProps {
     onReqCurrencyChange: (value: string) => void;
     reqAmount: string;
     onReqAmountChange: (value: string) => void;
+    reqBucket: string;
+    onReqBucketChange: (value: string) => void;
+    reqUnit: string;
+    onReqUnitChange: (value: string) => void;
     onSubmit: () => void;
     onCancel: () => void;
 }
@@ -24,6 +28,10 @@ export function RequestProductCodeForm({
     onReqCurrencyChange,
     reqAmount,
     onReqAmountChange,
+    reqBucket,
+    onReqBucketChange,
+    reqUnit,
+    onReqUnitChange,
     onSubmit,
     onCancel,
 }: RequestProductCodeFormProps) {
@@ -67,6 +75,33 @@ export function RequestProductCodeForm({
                         onChange={e => onReqAmountChange(e.target.value)}
                         className="w-full bg-slate-900 border border-slate-800 rounded p-1.5"
                     />
+                </div>
+                <div>
+                    <label className="text-slate-500 block mb-1">Section Bucket</label>
+                    <select
+                        value={reqBucket}
+                        onChange={e => onReqBucketChange(e.target.value)}
+                        className="w-full bg-slate-900 border border-slate-800 rounded p-1.5"
+                    >
+                        <option value="">Choose bucket...</option>
+                        <option value="origin_charges">Origin Charges</option>
+                        <option value="destination_charges">Destination Charges</option>
+                        <option value="airfreight">Air Freight Linehaul</option>
+                    </select>
+                </div>
+                <div>
+                    <label className="text-slate-500 block mb-1">Unit</label>
+                    <select
+                        value={reqUnit}
+                        onChange={e => onReqUnitChange(e.target.value)}
+                        className="w-full bg-slate-900 border border-slate-800 rounded p-1.5"
+                    >
+                        <option value="flat">Flat</option>
+                        <option value="per_kg">Per KG</option>
+                        <option value="per_awb">Per AWB</option>
+                        <option value="per_shipment">Per Shipment</option>
+                        <option value="per_set">Per Set</option>
+                    </select>
                 </div>
             </div>
             <div className="flex gap-2 justify-end mt-2">

--- a/frontend/src/components/spot/workspace/spotResolutionState.ts
+++ b/frontend/src/components/spot/workspace/spotResolutionState.ts
@@ -51,6 +51,8 @@ export interface SpotResolutionState {
         source: string;
         currency: string;
         amount: string;
+        bucket: string;
+        unit: string;
     };
     unknownWizard: {
         step: number;
@@ -69,9 +71,10 @@ export interface SpotResolutionState {
 }
 
 export type SpotResolutionAction =
+    | { type: "RESET_FROM_SERVER"; payload: DraftQuote }
     | { type: "SELECT_ISSUE"; payload: { issueId: string | null } }
     | { type: "OPEN_MAP_EXISTING" }
-    | { type: "OPEN_REQUEST_PRODUCT_CODE"; payload: { label: string; source: string; currency: string; amount: string } }
+    | { type: "OPEN_REQUEST_PRODUCT_CODE"; payload: { label: string; source: string; currency: string; amount: string; bucket?: string; unit?: string } }
     | { type: "OPEN_ADD_UNKNOWN_CHARGE"; payload: { name: string; amount: string } }
     | { type: "CANCEL_ACTION" }
     | { type: "UPDATE_REQUEST_FORM"; payload: Partial<SpotResolutionState["requestForm"]> }
@@ -115,7 +118,9 @@ export function createSpotResolutionState(initialData: DraftQuote): SpotResoluti
             label: "",
             source: "",
             currency: "",
-            amount: ""
+            amount: "",
+            bucket: "",
+            unit: "flat"
         },
         unknownWizard: {
             step: 1,
@@ -123,10 +128,10 @@ export function createSpotResolutionState(initialData: DraftQuote): SpotResoluti
         },
         addChargeForm: {
             name: "New Charge",
-            bucket: "origin_charges",
-            currency: "SGD",
+            bucket: "",
+            currency: initialData.suggested_charges?.find(charge => charge.currency)?.currency || "",
             amount: "0",
-            unit: "set",
+            unit: "flat",
             productCode: ""
         },
         actionMessage: null,
@@ -150,6 +155,9 @@ function captureSnapshotHelper(state: SpotResolutionState, id: string, type: Dec
 
 export function spotResolutionReducer(state: SpotResolutionState, action: SpotResolutionAction): SpotResolutionState {
     switch (action.type) {
+        case "RESET_FROM_SERVER":
+            return createSpotResolutionState(action.payload);
+
         case "SELECT_ISSUE":
             return {
                 ...state,
@@ -171,7 +179,9 @@ export function spotResolutionReducer(state: SpotResolutionState, action: SpotRe
                     label: action.payload.label,
                     source: action.payload.source,
                     currency: action.payload.currency,
-                    amount: action.payload.amount
+                    amount: action.payload.amount,
+                    bucket: action.payload.bucket || state.requestForm.bucket,
+                    unit: action.payload.unit || state.requestForm.unit
                 },
                 selectedActionType: "request_product_code"
             };

--- a/frontend/src/components/spot/workspace/useSpotResolutionWorkflow.ts
+++ b/frontend/src/components/spot/workspace/useSpotResolutionWorkflow.ts
@@ -1,5 +1,5 @@
 import { useEffect, useReducer, useState } from "react";
-import { DraftCharge, DraftQuote } from "../../../lib/draft-quote-types";
+import { DecisionResult, DraftCharge, DraftQuote, DraftQuoteResolveResponse } from "../../../lib/draft-quote-types";
 import {
     createSpotResolutionState,
     spotResolutionReducer,
@@ -25,11 +25,34 @@ interface ProductCodeSelectorOption {
 }
 
 const PRODUCT_CODE_DOMAINS = new Set(["IMPORT", "EXPORT", "DOMESTIC"]);
+const GENERIC_UNKNOWN_LABEL = "Unknown Charge Block";
 
 interface UseSpotResolutionWorkflowProps {
     initialData: DraftQuote;
     isLive: boolean;
     envelopeId?: string;
+}
+
+function unknownChargeDefaults(rawText: string, fallbackCurrency: string) {
+    const currencyMatch = rawText.match(/\b([A-Z]{3})\b/);
+    const amountMatch = rawText.match(/(?:[A-Z]{3}\s*)?(\d+(?:\.\d{1,2})?)/);
+    const name = rawText
+        .replace(/\b[A-Z]{3}\b/g, "")
+        .replace(/\d+(?:\.\d{1,2})?/g, "")
+        .replace(/\s+/g, " ")
+        .trim();
+    return {
+        name: name || rawText.trim() || "Unknown charge item",
+        currency: currencyMatch?.[1] || fallbackCurrency,
+        amount: amountMatch?.[1] || "",
+        unit: "flat"
+    };
+}
+
+function rejectedDecisionMessage(decisionItem: { decision_id: string }, response: DraftQuoteResolveResponse): string | null {
+    const rejected = response.rejected_decisions.find((decision: DecisionResult) => decision.decision_id === decisionItem.decision_id);
+    if (!rejected) return null;
+    return `${rejected.error_code ? `${rejected.error_code}: ` : ""}${rejected.message}`;
 }
 
 export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: UseSpotResolutionWorkflowProps) {
@@ -98,12 +121,12 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
         target_id: string;
         details: Record<string, unknown>;
         audit_metadata: { user_id: number; timestamp: string };
-    }) => {
+    }): Promise<DraftQuoteResolveResponse | undefined> => {
         if (state.reviewSession.status === "finalized") {
             throw new Error("Draft Quote review is finalized and locked.");
         }
         if (!isLive || !envelopeId) {
-            return;
+            return undefined;
         }
         const { resolveDraftQuoteDecisions } = await import("../../../lib/api");
         const cryptoObj = typeof window !== "undefined" ? window.crypto : null;
@@ -111,10 +134,15 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
             ? cryptoObj.randomUUID() 
             : "3b128522-a89e-4055-bf51-199eecc5628b";
 
-        await resolveDraftQuoteDecisions(envelopeId, {
+        const response = await resolveDraftQuoteDecisions(envelopeId, {
             idempotency_key: idempotencyKey,
             decisions: [decisionItem]
         });
+        const rejectedMessage = rejectedDecisionMessage(decisionItem, response);
+        if (rejectedMessage) {
+            throw new Error(rejectedMessage);
+        }
+        return response;
     };
 
     // Actions
@@ -123,6 +151,21 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
     };
 
     const openMapExisting = () => {
+        dispatch({ type: "OPEN_MAP_EXISTING" });
+    };
+
+    const openUnknownMapExisting = (rawText: string) => {
+        const defaults = unknownChargeDefaults(rawText, state.addChargeForm.currency);
+        dispatch({
+            type: "UPDATE_ADD_CHARGE_FORM",
+            payload: {
+                name: defaults.name,
+                currency: defaults.currency,
+                amount: defaults.amount,
+                unit: defaults.unit,
+                productCode: ""
+            }
+        });
         dispatch({ type: "OPEN_MAP_EXISTING" });
     };
 
@@ -137,7 +180,9 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
                 label: charge.display_label,
                 source: charge.evidence?.source_text || charge.raw_label,
                 currency: charge.currency,
-                amount: String(charge.amount)
+                amount: String(charge.amount),
+                bucket: charge.bucket,
+                unit: charge.unit || "flat"
             }
         });
     };
@@ -204,6 +249,10 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
 
         try {
             await submitLiveDecision(newDecisionItem);
+            if (isLive) {
+                await refreshLiveDraftQuote();
+                return;
+            }
         } catch (err) {
             console.error("Failed to submit resolve decision:", err);
             const errMsg = err instanceof Error ? err.message : String(err);
@@ -219,6 +268,11 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
 
     const classifyUnknownAsExistingCharge = async (itemId: string, productCode: string, displayLabel: string) => {
         if (selectIsReviewLocked(state)) return;
+        const chargeLabel = (state.addChargeForm.name || displayLabel || "").trim();
+        if (!productCode || !chargeLabel || chargeLabel === GENERIC_UNKNOWN_LABEL || !state.addChargeForm.bucket || !state.addChargeForm.currency || !state.addChargeForm.amount || !state.addChargeForm.unit) {
+            dispatch({ type: "SET_ACTION_MESSAGE", payload: "Complete charge label, bucket, currency, amount, unit and ProductCode before mapping this unknown item." });
+            return;
+        }
         const decisionId = `dec-${Date.now()}`;
         const newDecisionItem = {
             decision_id: decisionId,
@@ -227,7 +281,7 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
             details: {
                 classification: "charge",
                 product_code: productCode,
-                display_label: displayLabel,
+                display_label: chargeLabel,
                 bucket: state.addChargeForm.bucket,
                 currency: state.addChargeForm.currency,
                 amount: state.addChargeForm.amount,
@@ -250,7 +304,6 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
     };
 
     const submitProductCodeRequest = async (chargeId: string) => {
-        const isUnknownItem = state.unclassifiedItems.some(item => item.id === chargeId);
         const decisionId = `dec-${Date.now()}`;
         const newDecisionItem = {
             decision_id: decisionId,
@@ -260,10 +313,11 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
                 proposed_code: state.requestForm.label,
                 description: state.requestForm.source || state.requestForm.label,
                 display_label: state.requestForm.label,
-                bucket: isUnknownItem ? state.requestForm.bucket : undefined,
-                currency: isUnknownItem ? state.requestForm.currency : undefined,
-                amount: isUnknownItem ? state.requestForm.amount : undefined,
-                unit: isUnknownItem ? state.requestForm.unit : undefined,
+                bucket: state.requestForm.bucket,
+                category: state.requestForm.bucket,
+                currency: state.requestForm.currency,
+                amount: state.requestForm.amount,
+                unit: state.requestForm.unit,
                 reason: "Operator requested ProductCode review"
             },
             audit_metadata: {
@@ -318,6 +372,10 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
 
         try {
             await submitLiveDecision(newDecisionItem);
+            if (isLive) {
+                await refreshLiveDraftQuote();
+                return;
+            }
         } catch (err) {
             console.error("Failed to submit resolve decision:", err);
             const errMsg = err instanceof Error ? err.message : String(err);
@@ -347,6 +405,10 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
 
         try {
             await submitLiveDecision(newDecisionItem);
+            if (isLive) {
+                await refreshLiveDraftQuote();
+                return;
+            }
         } catch (err) {
             console.error("Failed to submit accept suggestion decision:", err);
             const errMsg = err instanceof Error ? err.message : String(err);
@@ -375,6 +437,10 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
 
         try {
             await submitLiveDecision(newDecisionItem);
+            if (isLive) {
+                await refreshLiveDraftQuote();
+                return;
+            }
         } catch (err) {
             console.error("Failed to submit ignore decision:", err);
             const errMsg = err instanceof Error ? err.message : String(err);
@@ -604,6 +670,7 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
         actions: {
             selectIssue,
             openMapExisting,
+            openUnknownMapExisting,
             retryProductCodeLoad,
             openRequestProductCode,
             openUnknownProductCodeRequest,

--- a/frontend/src/components/spot/workspace/useSpotResolutionWorkflow.ts
+++ b/frontend/src/components/spot/workspace/useSpotResolutionWorkflow.ts
@@ -82,6 +82,15 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
         };
     }, [productCodeDomain, productCodeRetryNonce]);
 
+    const refreshLiveDraftQuote = async () => {
+        if (!isLive || !envelopeId) {
+            return;
+        }
+        const { getDraftQuote } = await import("../../../lib/api");
+        const refreshed = await getDraftQuote(envelopeId);
+        dispatch({ type: "RESET_FROM_SERVER", payload: refreshed });
+    };
+
     // API submission helper
     const submitLiveDecision = async (decisionItem: {
         decision_id: string;
@@ -139,8 +148,10 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
             payload: {
                 label: "Unknown Charge Item",
                 source: rawText,
-                currency: "SGD",
-                amount: "0"
+                currency: state.addChargeForm.currency,
+                amount: state.addChargeForm.amount,
+                bucket: state.addChargeForm.bucket,
+                unit: state.addChargeForm.unit
             }
         });
     };
@@ -206,18 +217,21 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
         });
     };
 
-    const submitProductCodeRequest = async (chargeId: string) => {
+    const classifyUnknownAsExistingCharge = async (itemId: string, productCode: string, displayLabel: string) => {
+        if (selectIsReviewLocked(state)) return;
         const decisionId = `dec-${Date.now()}`;
         const newDecisionItem = {
             decision_id: decisionId,
-            type: "request_product_code",
-            target_id: chargeId,
+            type: "classify_unclassified",
+            target_id: itemId,
             details: {
-                proposed_code: state.requestForm.label,
-                description: state.requestForm.source || state.requestForm.label,
-                category: "destination_charges",
-                domain: "IMPORT",
-                reason: "Operator edited and resubmitted ProductCode request"
+                classification: "charge",
+                product_code: productCode,
+                display_label: displayLabel,
+                bucket: state.addChargeForm.bucket,
+                currency: state.addChargeForm.currency,
+                amount: state.addChargeForm.amount,
+                unit: state.addChargeForm.unit
             },
             audit_metadata: {
                 user_id: 1,
@@ -227,6 +241,43 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
 
         try {
             await submitLiveDecision(newDecisionItem);
+            await refreshLiveDraftQuote();
+        } catch (err) {
+            console.error("Failed to submit unclassified charge mapping:", err);
+            const errMsg = err instanceof Error ? err.message : String(err);
+            dispatch({ type: "SET_ACTION_MESSAGE", payload: `API error classifying unknown item: ${errMsg}` });
+        }
+    };
+
+    const submitProductCodeRequest = async (chargeId: string) => {
+        const isUnknownItem = state.unclassifiedItems.some(item => item.id === chargeId);
+        const decisionId = `dec-${Date.now()}`;
+        const newDecisionItem = {
+            decision_id: decisionId,
+            type: "request_product_code",
+            target_id: chargeId,
+            details: {
+                proposed_code: state.requestForm.label,
+                description: state.requestForm.source || state.requestForm.label,
+                display_label: state.requestForm.label,
+                bucket: isUnknownItem ? state.requestForm.bucket : undefined,
+                currency: isUnknownItem ? state.requestForm.currency : undefined,
+                amount: isUnknownItem ? state.requestForm.amount : undefined,
+                unit: isUnknownItem ? state.requestForm.unit : undefined,
+                reason: "Operator requested ProductCode review"
+            },
+            audit_metadata: {
+                user_id: 1,
+                timestamp: new Date().toISOString()
+            }
+        };
+
+        try {
+            await submitLiveDecision(newDecisionItem);
+            if (isLive) {
+                await refreshLiveDraftQuote();
+                return;
+            }
         } catch (err) {
             console.error("Failed to submit ProductCode request:", err);
             const errMsg = err instanceof Error ? err.message : String(err);
@@ -337,27 +388,89 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
         });
     };
 
-    const ignoreUnknownCharge = (itemId: string, rawText: string) => {
+    const ignoreUnknownCharge = async (itemId: string, rawText: string) => {
         if (selectIsReviewLocked(state)) return;
         const evidence = state.unclassifiedItems.find(i => i.id === itemId)?.evidence || null;
+        if (isLive) {
+            const decisionId = `dec-${Date.now()}`;
+            try {
+                await submitLiveDecision({
+                    decision_id: decisionId,
+                    type: "classify_unclassified",
+                    target_id: itemId,
+                    details: { classification: "ignored", reason: "Operator ignored unknown item as non-commercial" },
+                    audit_metadata: { user_id: 1, timestamp: new Date().toISOString() }
+                });
+                await refreshLiveDraftQuote();
+            } catch (err) {
+                const errMsg = err instanceof Error ? err.message : String(err);
+                dispatch({ type: "SET_ACTION_MESSAGE", payload: `API error ignoring unknown item: ${errMsg}` });
+            }
+            return;
+        }
         dispatch({
             type: "IGNORE_UNKNOWN_CHARGE",
             payload: { itemId, rawText, evidence }
         });
     };
 
-    const approveUnknownNote = (itemId: string, rawText: string) => {
+    const approveUnknownNote = async (itemId: string, rawText: string) => {
+        if (isLive) {
+            const decisionId = `dec-${Date.now()}`;
+            try {
+                await submitLiveDecision({
+                    decision_id: decisionId,
+                    type: "classify_unclassified",
+                    target_id: itemId,
+                    details: { classification: "note", reason: "Operator approved unknown item as commercial note" },
+                    audit_metadata: { user_id: 1, timestamp: new Date().toISOString() }
+                });
+                await refreshLiveDraftQuote();
+            } catch (err) {
+                const errMsg = err instanceof Error ? err.message : String(err);
+                dispatch({ type: "SET_ACTION_MESSAGE", payload: `API error approving unknown note: ${errMsg}` });
+            }
+            return;
+        }
         dispatch({
             type: "APPROVE_UNKNOWN_NOTE",
             payload: { itemId, rawText }
         });
     };
 
-    const addUnknownAsCharge = (itemId: string) => {
+    const addUnknownAsCharge = async (itemId: string) => {
         if (selectIsReviewLocked(state)) return;
-        const newChargeId = `chg-new-${Date.now()}`;
         const evidence = state.unclassifiedItems.find(i => i.id === itemId)?.evidence || null;
-        
+        if (isLive) {
+            if (!state.addChargeForm.productCode) {
+                dispatch({ type: "SET_ACTION_MESSAGE", payload: "Choose an approved ProductCode before adding this unknown charge." });
+                return;
+            }
+            const decisionId = `dec-${Date.now()}`;
+            try {
+                await submitLiveDecision({
+                    decision_id: decisionId,
+                    type: "classify_unclassified",
+                    target_id: itemId,
+                    details: {
+                        classification: "charge",
+                        product_code: state.addChargeForm.productCode,
+                        display_label: state.addChargeForm.name,
+                        bucket: state.addChargeForm.bucket,
+                        currency: state.addChargeForm.currency,
+                        amount: state.addChargeForm.amount,
+                        unit: state.addChargeForm.unit
+                    },
+                    audit_metadata: { user_id: 1, timestamp: new Date().toISOString() }
+                });
+                await refreshLiveDraftQuote();
+            } catch (err) {
+                const errMsg = err instanceof Error ? err.message : String(err);
+                dispatch({ type: "SET_ACTION_MESSAGE", payload: `API error adding unknown charge: ${errMsg}` });
+            }
+            return;
+        }
+        const newChargeId = `chg-new-${Date.now()}`;
         dispatch({
             type: "ADD_UNKNOWN_AS_CHARGE",
             payload: {
@@ -501,6 +614,7 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
             classifyUnknown,
             returnToUnknownClassification,
             mapProductCode,
+            classifyUnknownAsExistingCharge,
             submitProductCodeRequest,
             useApprovedProductCode,
             acceptSuggestedMapping,


### PR DESCRIPTION
## Scope

Phase 14G persists Unknown Charge Block resolutions through the Draft Quote resolve API instead of local-only frontend state.

## Changed Files

- `backend/quotes/contracts/draft_quote_contract.py`: relaxes request ProductCode details for server-derived route domain and supports note classifications.
- `backend/quotes/services/draft_quote_resolve_service.py`: persists unknown item charge/ignore/note/request-new flows, validates fields/domain, preserves evidence, and keeps pending requests blocking finalization.
- `backend/quotes/services/draft_quote_adapter.py`: emits persisted commercial note terms with evidence.
- `backend/quotes/tests/test_draft_quote_resolve.py`: adds focused persistence/domain/evidence/request/idempotency-adjacent regression coverage and updates legacy unknown-item expectations.
- `frontend/src/components/spot/workspace/useSpotResolutionWorkflow.ts`: live unknown-item actions submit `classify_unclassified`, refresh from the server on success, and avoid local mutation on failure.
- `frontend/src/components/spot/ExceptionWorkspace.tsx`: routes unknown-item Map Existing through classify flow and wires ProductCode selector props to Add Charge.
- `frontend/src/components/spot/workspace/AddChargeForm.tsx`: uses the direction-scoped ProductCode `Combobox` and requires mapping code for live charge creation.
- `frontend/src/components/spot/workspace/RequestProductCodeForm.tsx`: captures bucket/unit instead of relying on hardcoded request assumptions.
- `frontend/src/components/spot/workspace/spotResolutionState.ts`: adds server reset action and removes SGD/destination-charge defaults.
- `frontend/scripts/spot-workspace-orchestration.test.mjs`: asserts live unknown-item decisions use `classify_unclassified`, reload, and avoid hardcoded IMPORT/SGD/synthetic live IDs.
- `docs/audits/spot-exception-workspace-simplification-audit.md`: documents Phase 14G behavior.

## What Was Intentionally Not Changed

- No quote totals, GST, FX, pricing engine, public quote rendering, RBAC permissions, or finalization lock behavior changed.
- Demo mode remains local/prototype-only.
- ProductCode approval workflow remains admin-controlled.
- Legacy SPOT CRUD was not revived.

## Verification

Automated:
- `npm run typecheck` — passed.
- `npm run lint` — passed with existing warnings.
- `npm run build` — passed with existing warnings.
- `npm run test:draft-quote-contract` — passed.
- `npm run test:exception-workspace-routing` — passed.
- `npm run test:spot-finalization` — passed.
- `npm run test:spot-workspace-helpers` — passed.
- `node.exe scripts/spot-workspace-orchestration.test.mjs` — passed.
- `node.exe scripts/spot-workspace-form-extraction.test.mjs` — passed.
- `node.exe scripts/spot-resolution-state.test.mjs` — passed.
- `python backend/manage.py check` — passed with local env vars.
- `python backend/manage.py test quotes.tests.test_draft_quote_resolve` — passed, 37 tests.
- `python backend/manage.py test quotes.tests.test_spot_exception_workspace_e2e` — passed, 1 test.
- `python backend/manage.py test quotes.tests` — passed, 501 tests.
- `git diff --check` — passed.

Audit/baseline:
- Fallow baselines were run; dead-code and health reports were written under `/tmp/phase14g-fallow*.json`. Fallow reported pre-existing findings and Windows/WSL cache/git-root warnings.
- `ruff check backend` and `vulture backend` could not run because those modules are unavailable in the installed Python environment.
- `graphify update .` could not run because `graphify` is not on PATH.

Manual:
- Confirmed live unknown-item code paths submit API decisions and call backend reload on success.
- Confirmed no synthetic live charge IDs are created in the live Add Charge path.

## Commercial Impact

No quote calculation, totals, GST, FX, pricing, or public quote output changes. The change preserves commercial truth by making unknown-item operator decisions persisted and auditable rather than local-only.

## Data Impact

Creates persisted `SPEChargeLineDB` rows for unknown charges and provisional ProductCode requests, writes ignored/note metadata to existing JSON fields, and records decisions in `DraftQuoteDecisionDB`. No migrations or backfills.

## Audit Impact

Preserves source text/evidence on created charges, ignored items, and notes. Decision persistence remains idempotent and auditable through existing decision records.

## Risk

Unknown charge creation now requires complete charge fields and route-derived ProductCode domain. Incomplete route direction or invalid charge fields fail visibly instead of guessing.

## Rollback

Revert this PR to restore prior local-only unknown-item behavior. No migrations need rollback.
