### PR TITLE
Phase 14H — Manager/Admin Reopen UI

### DIFF
--- a/frontend/scripts/spot-workspace-orchestration.test.mjs
+++ b/frontend/scripts/spot-workspace-orchestration.test.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 const frontendRoot = path.resolve(process.cwd());
 const workspacePath = path.join(frontendRoot, "src", "components", "spot", "ExceptionWorkspace.tsx");
 const hookPath = path.join(frontendRoot, "src", "components", "spot", "workspace", "useSpotResolutionWorkflow.ts");
+const apiPath = path.join(frontendRoot, "src", "lib", "api.ts");
 const panelNames = [
     "NeedsAttentionPanel",
     "ReviewDecisionsPanel",
@@ -17,6 +18,7 @@ console.log("Starting Spot Workspace Orchestration Contract Assertions...");
 
 const workspaceSrc = await readFile(workspacePath, "utf8");
 const hookSrc = await readFile(hookPath, "utf8");
+const apiSrc = await readFile(apiPath, "utf8");
 const panelSources = new Map(
     await Promise.all(
         panelNames.map(async panelName => [
@@ -114,6 +116,20 @@ assert.ok(hookSrc.includes('import("../../../lib/api")'), "useSpotResolutionWork
 assert.ok(hookSrc.includes("resolveDraftQuoteDecisions"), "useSpotResolutionWorkflow must call resolveDraftQuoteDecisions");
 assert.ok(hookSrc.includes("getDraftQuote"), "useSpotResolutionWorkflow must reload the Draft Quote after live unknown-item decisions");
 assert.ok(hookSrc.includes("finalizeDraftQuoteReview"), "useSpotResolutionWorkflow must call finalizeDraftQuoteReview");
+assert.ok(hookSrc.includes("reopenDraftQuoteReview"), "useSpotResolutionWorkflow must call reopenDraftQuoteReview for authorized live reopen");
+assert.ok(apiSrc.includes("export async function reopenDraftQuoteReview"), "API client must expose reopenDraftQuoteReview");
+assert.ok(apiSrc.includes("/draft-quote/reopen/"), "Reopen API client must target the existing reopen endpoint");
+assert.ok(hookSrc.includes("useConfirmDialog"), "Reopen must require a confirmation dialog");
+assert.ok(hookSrc.includes("REOPEN_ROLES") && hookSrc.includes("manager") && hookSrc.includes("admin"), "Reopen UI must be role-gated to manager/admin");
+assert.ok(hookSrc.includes("state.reviewSession.status === \"finalized\""), "Reopen must only be available for finalized reviews");
+assert.ok(hookSrc.includes("state.reviewSession.available_actions.includes(\"reopen\") || isReopenAuthorized"), "Reopen visibility must honor backend available_actions or authorized manager/admin role");
+assert.ok(hookSrc.includes("Boolean(isLive && envelopeId)"), "Reopen must only be available in live workspaces");
+assert.ok(hookSrc.includes("isReopeningReview || !canReopenReviewNow()"), "Duplicate reopen submissions must be blocked");
+assert.ok(hookSrc.includes("await refreshLiveDraftQuote()"), "Successful reopen must reload the Draft Quote from the backend");
+assert.ok(hookSrc.includes("API error reopening review"), "Failed reopen must display backend errors");
+assert.ok(hookSrc.includes("setIsReopeningReview(true)") && hookSrc.includes("setIsReopeningReview(false)"), "Reopen must track in-flight submission state");
+assert.ok(hookSrc.includes('dispatch({ type: "SET_ACTION_MESSAGE", payload: "Draft Quote review reopened. Workspace is editable again." })'), "Successful reopen must show a clear success message");
+assert.ok(hookSrc.indexOf("const { reopenDraftQuoteReview }") > hookSrc.indexOf("if (isReopeningReview || !canReopenReviewNow())"), "Demo/unauthorized reopen must return before importing the live API client");
 assert.ok(hookSrc.includes('type: "classify_unclassified"'), "Unknown-item live actions must submit classify_unclassified decisions");
 assert.ok(!hookSrc.includes('type: "map_to_product_code",\n            target_id: itemId'), "Unknown-item mapping must not submit map_to_product_code with an unclassified item ID");
 assert.ok(!hookSrc.includes('newChargeId = `chg-new-${Date.now()}`;\n            try'), "Live unknown charge creation must not create synthetic IDs");
@@ -149,7 +165,8 @@ const parentBoundCallbacks = [
     "onSelectIssue={actions.selectIssue}",
     "onUndoDecision={actions.undoDecision}",
     "onTogglePrototypeOverride={actions.togglePrototypeOverride}",
-    "onFinalizeReview={actions.finalizeReview}"
+    "onFinalizeReview={actions.finalizeReview}",
+    "onReopenReview={actions.reopenReview}"
 ];
 for (const callbackBinding of parentBoundCallbacks) {
     assert.ok(workspaceSrc.includes(callbackBinding), `ExceptionWorkspace must keep callback binding ${callbackBinding}`);

--- a/frontend/src/components/spot/ExceptionWorkspace.tsx
+++ b/frontend/src/components/spot/ExceptionWorkspace.tsx
@@ -40,7 +40,8 @@ export function ExceptionWorkspace({ initialData, isLive = false, envelopeId }: 
         prototypeOverride,
         productCodes,
         isLoadingProductCodes,
-        productCodeLoadError
+        productCodeLoadError,
+        isReopeningReview
     } = state;
 
     const {
@@ -54,6 +55,7 @@ export function ExceptionWorkspace({ initialData, isLive = false, envelopeId }: 
         canFinishReview,
         isReviewLocked,
         canUsePrototypeOverride,
+        canReopenReview,
         nextStepGuidance
     } = derived;
 
@@ -545,9 +547,12 @@ export function ExceptionWorkspace({ initialData, isLive = false, envelopeId }: 
                     canUsePrototypeOverride={canUsePrototypeOverride}
                     isLive={isLive}
                     isReviewLocked={isReviewLocked}
+                    canReopenReview={canReopenReview}
+                    isReopeningReview={isReopeningReview}
                     prototypeOverride={prototypeOverride}
                     onTogglePrototypeOverride={actions.togglePrototypeOverride}
                     onFinalizeReview={actions.finalizeReview}
+                    onReopenReview={actions.reopenReview}
                 />
 
             </div>

--- a/frontend/src/components/spot/workspace/FinalReviewPanel.tsx
+++ b/frontend/src/components/spot/workspace/FinalReviewPanel.tsx
@@ -7,9 +7,12 @@ interface FinalReviewPanelProps {
   canUsePrototypeOverride: boolean;
   isLive: boolean;
   isReviewLocked: boolean;
+  canReopenReview: boolean;
+  isReopeningReview: boolean;
   prototypeOverride: boolean;
   onTogglePrototypeOverride: () => void;
   onFinalizeReview: () => void;
+  onReopenReview: () => void;
 }
 
 export function FinalReviewPanel({
@@ -21,9 +24,12 @@ export function FinalReviewPanel({
   canUsePrototypeOverride,
   isLive,
   isReviewLocked,
+  canReopenReview,
+  isReopeningReview,
   prototypeOverride,
   onTogglePrototypeOverride,
   onFinalizeReview,
+  onReopenReview,
 }: FinalReviewPanelProps) {
   return (
     <div className="mt-4 flex flex-col items-center gap-4 border-t border-slate-800 pt-6">
@@ -130,15 +136,27 @@ export function FinalReviewPanel({
           </div>
         )}
         {isLive && <div />} {/* spacer to maintain justify-between layout alignment when checkbox is hidden */}
-        <button
-          disabled={
-            isReviewLocked || (!canFinishReview && !canUsePrototypeOverride)
-          }
-          onClick={onFinalizeReview}
-          className="px-8 py-3 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 disabled:hover:bg-indigo-600 text-white rounded-xl font-bold text-sm shadow-xl shadow-indigo-900/40 w-full sm:w-auto text-center transition"
-        >
-          {isReviewLocked ? "Review Finalized" : "Finalize Review"}
-        </button>
+        <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
+          {canReopenReview && (
+            <button
+              type="button"
+              disabled={isReopeningReview}
+              onClick={onReopenReview}
+              className="px-8 py-3 bg-amber-600 hover:bg-amber-500 disabled:opacity-40 disabled:hover:bg-amber-600 text-white rounded-xl font-bold text-sm shadow-xl shadow-amber-900/30 w-full sm:w-auto text-center transition"
+            >
+              {isReopeningReview ? "Reopening..." : "Reopen Review"}
+            </button>
+          )}
+          <button
+            disabled={
+              isReviewLocked || (!canFinishReview && !canUsePrototypeOverride)
+            }
+            onClick={onFinalizeReview}
+            className="px-8 py-3 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 disabled:hover:bg-indigo-600 text-white rounded-xl font-bold text-sm shadow-xl shadow-indigo-900/40 w-full sm:w-auto text-center transition"
+          >
+            {isReviewLocked ? "Review Finalized" : "Finalize Review"}
+          </button>
+        </div>
       </div>
 
       {!isLive && (

--- a/frontend/src/components/spot/workspace/useSpotResolutionWorkflow.ts
+++ b/frontend/src/components/spot/workspace/useSpotResolutionWorkflow.ts
@@ -1,4 +1,6 @@
 import { useEffect, useReducer, useState } from "react";
+import { useAuth } from "../../../context/auth-context";
+import { useConfirmDialog } from "../../../context/confirm-dialog-context";
 import { DecisionResult, DraftCharge, DraftQuote, DraftQuoteResolveResponse } from "../../../lib/draft-quote-types";
 import {
     createSpotResolutionState,
@@ -25,6 +27,7 @@ interface ProductCodeSelectorOption {
 }
 
 const PRODUCT_CODE_DOMAINS = new Set(["IMPORT", "EXPORT", "DOMESTIC"]);
+const REOPEN_ROLES = new Set(["manager", "admin"]);
 const GENERIC_UNKNOWN_LABEL = "Unknown Charge Block";
 
 interface UseSpotResolutionWorkflowProps {
@@ -61,9 +64,14 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
     const [isLoadingProductCodes, setIsLoadingProductCodes] = useState(false);
     const [productCodeLoadError, setProductCodeLoadError] = useState<string | null>(null);
     const [productCodeRetryNonce, setProductCodeRetryNonce] = useState(0);
+    const [isReopeningReview, setIsReopeningReview] = useState(false);
+    const { user } = useAuth();
+    const { confirm } = useConfirmDialog();
 
     const shipmentDirection = String(initialData.shipment_context.direction || "").toUpperCase();
     const productCodeDomain = PRODUCT_CODE_DOMAINS.has(shipmentDirection) ? shipmentDirection : null;
+    const role = String(user?.role || "").toLowerCase();
+    const isReopenAuthorized = REOPEN_ROLES.has(role);
 
     useEffect(() => {
         let cancelled = false;
@@ -607,6 +615,43 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
         }
     };
 
+    const canReopenReviewNow = () => (
+        Boolean(isLive && envelopeId) &&
+        state.reviewSession.status === "finalized" &&
+        isReopenAuthorized &&
+        (state.reviewSession.available_actions.includes("reopen") || isReopenAuthorized)
+    );
+
+    const reopenReview = async () => {
+        if (isReopeningReview || !canReopenReviewNow()) {
+            return;
+        }
+
+        const confirmed = await confirm({
+            title: "Reopen Draft Quote review?",
+            description: "This will unlock the live SPOT Draft Quote review for further operator edits. Existing source evidence and audit history will be preserved.",
+            confirmLabel: "Reopen Review",
+            cancelLabel: "Keep Finalized",
+            variant: "destructive"
+        });
+        if (!confirmed || isReopeningReview || !canReopenReviewNow()) {
+            return;
+        }
+
+        setIsReopeningReview(true);
+        try {
+            const { reopenDraftQuoteReview } = await import("../../../lib/api");
+            await reopenDraftQuoteReview(envelopeId!);
+            await refreshLiveDraftQuote();
+            dispatch({ type: "SET_ACTION_MESSAGE", payload: "Draft Quote review reopened. Workspace is editable again." });
+        } catch (err) {
+            const errMsg = err instanceof Error ? err.message : String(err);
+            dispatch({ type: "SET_ACTION_MESSAGE", payload: `API error reopening review: ${errMsg}` });
+        } finally {
+            setIsReopeningReview(false);
+        }
+    };
+
     const dismissActionMessage = () => {
         dispatch({ type: "DISMISS_ACTION_MESSAGE" });
     };
@@ -631,6 +676,7 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
     const canFinishReview = selectCanFinishReview(state);
     const isReviewLocked = selectIsReviewLocked(state);
     const canUsePrototypeOverride = selectCanUsePrototypeOverride(state, isLive);
+    const canReopenReview = canReopenReviewNow();
     const nextStepGuidance = selectNextStepGuidance(state);
 
     return {
@@ -651,7 +697,8 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
             showHelpText: state.showHelpText,
             productCodes,
             isLoadingProductCodes,
-            productCodeLoadError
+            productCodeLoadError,
+            isReopeningReview
         },
         derived: {
             combinedUnresolved,
@@ -665,6 +712,7 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
             canFinishReview,
             isReviewLocked,
             canUsePrototypeOverride,
+            canReopenReview,
             nextStepGuidance
         },
         actions: {
@@ -692,6 +740,7 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
             toggleIncludeInTotals,
             undoDecision,
             finalizeReview,
+            reopenReview,
             dismissActionMessage,
             togglePrototypeOverride,
             toggleHelpText

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4,7 +4,7 @@ import { API_BASE_URL } from './config';
 import { getJson, sendJson } from './api/shared';
 import { mapQuoteDetailToComputeResult } from './quote-detail-mapping';
 import { ReplyAnalysisResult, SPEChargeLine, SPEConditions, SPECommodity } from './spot-types';
-import { DraftQuote, DraftQuoteFinalizeResponse, DraftQuoteResolvePayload, DraftQuoteResolveResponse } from './draft-quote-types';
+import { DraftQuote, DraftQuoteFinalizeResponse, DraftQuoteReopenResponse, DraftQuoteResolvePayload, DraftQuoteResolveResponse } from './draft-quote-types';
 import {
   LoginData,
   User,
@@ -852,6 +852,26 @@ export async function finalizeDraftQuoteReview(
     throw new Error(data?.message || data?.error || 'Failed to finalize draft quote review.');
   }
   return data as DraftQuoteFinalizeResponse;
+}
+
+export async function reopenDraftQuoteReview(
+  envelopeId: string
+): Promise<DraftQuoteReopenResponse> {
+  const url = API_BASE_URL + `/api/v3/spot/envelopes/${envelopeId}/draft-quote/reopen/`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Token ${resolveAuthToken()}`,
+    },
+    body: JSON.stringify({ audit_metadata: { timestamp: new Date().toISOString() } }),
+  });
+
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data?.message || data?.error || 'Failed to reopen draft quote review.');
+  }
+  return data as DraftQuoteReopenResponse;
 }
 
 

--- a/frontend/src/lib/draft-quote-types.ts
+++ b/frontend/src/lib/draft-quote-types.ts
@@ -182,3 +182,10 @@ export interface DraftQuoteFinalizeResponse {
     finalized_at?: string | null;
     message: string;
 }
+
+export interface DraftQuoteReopenResponse {
+    envelope_id: string;
+    status: 'accepted' | 'rejected';
+    review_status: 'draft' | 'in_review' | 'finalized';
+    message: string;
+}


### PR DESCRIPTION
Adds the live manager/admin Reopen Review control for finalized SPOT Draft Quotes. Includes role gating, confirmation, duplicate-submit protection, server reload on success, failure-safe locking, and regression coverage. No pricing, totals, tax, FX, backend RBAC, migrations, or quote-output changes.