### PR TITLE
Phase 16B: Define air freight requirements and gap assessment

### DIFF
--- a/docs/business-rules/phase-16a-air-freight-journey-productcode-rules.md
+++ b/docs/business-rules/phase-16a-air-freight-journey-productcode-rules.md
@@ -1,0 +1,554 @@
+# RateEngine Phase 16A - International Air Freight Journey, Domestic Leg and ProductCode Business Rules
+
+**Document ID:** RE-BR-16A-AIR-001  
+**Version:** 1.0  
+**Effective date:** 21 July 2026  
+**Status:** Authoritative working baseline  
+**Business owner:** Commercial Freight Manager  
+**Applies to:** RateEngine international air-freight quoting, ProductCode assignment, domestic pre-carriage, domestic on-forwarding, design, development, automated tests and UAT  
+**Canonical repository location:** `docs/business-rules/phase-16a-air-freight-journey-productcode-rules.md`
+
+---
+
+## 1. Authority and change control
+
+This document is the source of truth for Phase 16 design and implementation. Code, ProductCode rules, rate configuration, tests, UAT scripts and user guidance must conform to it.
+
+Where existing application behaviour conflicts with this document, the conflict must be treated as a defect or an explicitly approved change request. The application must not silently preserve contradictory legacy behaviour.
+
+Changes to these rules require:
+
+1. a documented business decision;
+2. a version update to this document;
+3. impact review for ProductCodes, rates, calculations, UI, audit, regression tests and UAT;
+4. implementation only after the revised rule is accepted.
+
+This document supersedes informal notes and chat decisions concerning the Phase 16 air-freight journey model.
+
+---
+
+## 2. Purpose and target outcome
+
+RateEngine must automatically:
+
+1. determine whether a shipment is an import or export from trusted route data;
+2. construct the correct ordered shipment journey;
+3. identify the leg and commercial context of every charge;
+4. select the correct active ProductCode when one exact valid match exists;
+5. source domestic rates from approved sources;
+6. expose missing, conflicting or ambiguous information for manual review;
+7. preserve the underlying leg, charge, rate and evidence detail while producing one coherent customer quote.
+
+The user must not be asked to choose or type an internal ProductCode ID. The system must ask only the business question needed to resolve missing context.
+
+---
+
+## 3. Non-negotiable commercial principles
+
+| Rule ID | Business rule |
+|---|---|
+| `BR-GOV-001` | POM is the only PNG international gateway for international air-freight shipments in the Phase 16 model. |
+| `BR-GOV-002` | Every charge included in a quote must be attached to one identifiable shipment leg and commercial position. |
+| `BR-GOV-003` | ProductCode assignment must be deterministic, context-compatible and auditable. |
+| `BR-GOV-004` | AI or document intake may suggest the meaning of supplier text, but it must not invent, bypass or force a ProductCode. |
+| `BR-GOV-005` | Users must never enter or select raw internal ProductCode database IDs. |
+| `BR-GOV-006` | Ambiguous, unsupported or incomplete context must fail visibly into manual review. It must not be guessed. |
+| `BR-GOV-007` | Missing BUY rates or required charge components must remain visible for manual sourcing. A local SELL rate must never be substituted as a hidden cost or completeness fallback. |
+| `BR-GOV-008` | Quote totals are sacred. Customer totals must be derived from the actual reviewed charge lines and legs included in totals. |
+| `BR-GOV-009` | Automatic and user-assisted decisions must retain source evidence, rule version, outcome, operator and timestamp. |
+| `BR-GOV-010` | No commercially relevant charge may be silently invented, discarded or moved to another leg. |
+| `BR-GOV-011` | Wrong-domain ProductCodes, unsupported gateway routes and unresolved required legs are hard failures, not warnings. |
+| `BR-GOV-012` | The initial release must be feature-flagged by supported route group so that unsafe route groups can be disabled independently. |
+
+---
+
+## 4. Definitions
+
+### 4.1 Gateway
+
+The PNG airport through which the international air-freight leg enters or leaves Papua New Guinea. For this release, the gateway is always Port Moresby (`POM`).
+
+### 4.2 International leg
+
+The air-freight movement between POM and an overseas airport.
+
+### 4.3 Domestic pre-carriage
+
+A domestic movement from a PNG regional origin to POM before an export international leg.
+
+Examples:
+
+- Lae (`LAE`) to POM before POM to Brisbane;
+- Mount Hagen (`HGU`) to POM before POM to Singapore.
+
+Domestic pre-carriage is not the international origin leg. It is a separate domestic leg feeding the POM gateway.
+
+### 4.4 Domestic on-forwarding
+
+A domestic movement from POM to a PNG regional destination after an import international leg.
+
+Examples:
+
+- POM to LAE after Singapore to POM;
+- POM to HGU after Brisbane to POM.
+
+Domestic on-forwarding is not part of the international freight leg. It is a separate domestic leg beginning after arrival at the POM gateway.
+
+### 4.5 Final local delivery
+
+A local pickup or delivery movement between an airport, branch, warehouse or terminal and the customer's specified address. It is separate from domestic pre-carriage and on-forwarding.
+
+Examples:
+
+- POM airport to a customer address in Port Moresby;
+- LAE airport to a customer address in Lae.
+
+A regional destination does not automatically mean final local delivery is included. The service scope must state it explicitly.
+
+### 4.6 Charge context
+
+The complete set of business dimensions needed to understand what a charge applies to and which ProductCode may be used.
+
+### 4.7 ProductCode domain
+
+The trusted import or export domain derived from the shipment's origin and destination countries. It is never taken from user-entered JSON, supplier wording or an editable frontend field.
+
+### 4.8 Manual review
+
+A visible unresolved state requiring a user or authorised reviewer to provide missing business context, source a rate, select an approved business option or request a ProductCode. Manual review is not permission to guess.
+
+---
+
+## 5. Direction and gateway rules
+
+### 5.1 Direction derivation
+
+| Rule ID | Route condition | Direction result |
+|---|---|---|
+| `BR-DIR-001` | Origin country is outside PNG and destination country is PNG | `IMPORT` |
+| `BR-DIR-002` | Origin country is PNG and destination country is outside PNG | `EXPORT` |
+| `BR-DIR-003` | Origin and destination countries are both PNG | `DOMESTIC_ONLY` and outside the Phase 16 international-air automation scope |
+| `BR-DIR-004` | Neither origin nor destination country is PNG | `THIRD_COUNTRY` and unsupported |
+| `BR-DIR-005` | Country data is missing, invalid or contradictory | Direction unresolved; block ProductCode assignment and journey finalisation |
+
+### 5.2 POM-only gateway enforcement
+
+| Rule ID | Business rule |
+|---|---|
+| `BR-GW-001` | Every supported international import air journey must contain an international leg ending at POM. |
+| `BR-GW-002` | Every supported international export air journey must contain an international leg starting at POM. |
+| `BR-GW-003` | LAE, HGU and all other PNG locations are domestic origins or destinations only in an international air journey. |
+| `BR-GW-004` | The system must not treat LAE, HGU or another PNG location as an international air gateway. |
+| `BR-GW-005` | A user-entered direct international route to or from a regional PNG location must be reconstructed through POM when the route is otherwise supported. If reconstruction is not possible, the route must be blocked. |
+| `BR-GW-006` | A supplier document or parsed route must not override the POM gateway rule. |
+
+---
+
+## 6. Supported journey patterns
+
+### 6.1 Import patterns
+
+| Pattern ID | Customer route | Required ordered journey | Launch status |
+|---|---|---|---|
+| `IMP-POM` | Overseas airport to POM | 1. International air: Overseas -> POM | Supported |
+| `IMP-LAE` | Overseas airport to LAE | 1. International air: Overseas -> POM; 2. Domestic on-forwarding: POM -> LAE | Supported |
+| `IMP-HGU` | Overseas airport to HGU | 1. International air: Overseas -> POM; 2. Domestic on-forwarding: POM -> HGU | Supported |
+
+Rules:
+
+- `BR-JNY-IMP-001`: An import ending at POM has no regional domestic on-forwarding leg unless another domestic destination is explicitly selected.
+- `BR-JNY-IMP-002`: An import ending at LAE must include POM-to-LAE domestic on-forwarding.
+- `BR-JNY-IMP-003`: An import ending at HGU must include POM-to-HGU domestic on-forwarding.
+- `BR-JNY-IMP-004`: POM import arrival, customs, breakdown and international destination handling charges remain attached to the international import destination context.
+- `BR-JNY-IMP-005`: Charges specifically incurred to transfer, book, handle or carry cargo from POM to a regional destination belong to the domestic on-forwarding leg.
+- `BR-JNY-IMP-006`: Final delivery from the regional airport is an optional separate leg and must not be inferred merely because the final PNG city is LAE or HGU.
+
+### 6.2 Export patterns
+
+| Pattern ID | Customer route | Required ordered journey | Launch status |
+|---|---|---|---|
+| `EXP-POM` | POM to overseas airport | 1. International air: POM -> Overseas | Supported |
+| `EXP-LAE` | LAE to overseas airport | 1. Domestic pre-carriage: LAE -> POM; 2. International air: POM -> Overseas | Supported |
+| `EXP-HGU` | HGU to overseas airport | 1. Domestic pre-carriage: HGU -> POM; 2. International air: POM -> Overseas | Supported |
+
+Rules:
+
+- `BR-JNY-EXP-001`: An export beginning at POM has no regional domestic pre-carriage leg unless another PNG origin is explicitly selected.
+- `BR-JNY-EXP-002`: An export beginning at LAE must include LAE-to-POM domestic pre-carriage.
+- `BR-JNY-EXP-003`: An export beginning at HGU must include HGU-to-POM domestic pre-carriage.
+- `BR-JNY-EXP-004`: Regional pickup, regional terminal handling and domestic freight to POM belong to the domestic pre-carriage leg.
+- `BR-JNY-EXP-005`: Export documentation, security, AWB, terminal and airline-origin charges at POM belong to the international export origin context.
+- `BR-JNY-EXP-006`: Overseas destination charges, when quoted, belong to the export destination context and are not confused with PNG domestic legs.
+
+### 6.3 Invalid or unsupported patterns
+
+| Rule ID | Route or condition | Required behaviour |
+|---|---|---|
+| `BR-JNY-INV-001` | Overseas -> LAE shown as a direct international leg | Reconstruct as Overseas -> POM -> LAE or block if the domestic leg is unsupported/missing |
+| `BR-JNY-INV-002` | LAE -> Overseas shown as a direct international leg | Reconstruct as LAE -> POM -> Overseas or block if the domestic leg is unsupported/missing |
+| `BR-JNY-INV-003` | International air route uses any PNG gateway other than POM | Hard block |
+| `BR-JNY-INV-004` | Domestic-only PNG route | Route to existing/manual domestic workflow; do not apply Phase 16 international rules |
+| `BR-JNY-INV-005` | Third-country route with no PNG origin or destination | Unsupported |
+| `BR-JNY-INV-006` | More than one regional domestic stop | Unsupported at launch; manual SPOT review |
+
+---
+
+## 7. Journey and leg construction rules
+
+Each journey must be an ordered list of explicit legs. A leg must contain at least:
+
+- sequence number;
+- leg type;
+- transport mode;
+- origin and destination location;
+- operating entity and responsible branch where applicable;
+- supplier/carrier or manual-source status;
+- rate source and validity;
+- chargeable weight or applicable rating quantity;
+- charges and ProductCodes;
+- currency, tax treatment and totals inclusion;
+- source evidence;
+- review status.
+
+| Rule ID | Business rule |
+|---|---|
+| `BR-LEG-001` | A charge cannot be included in totals without a leg assignment. |
+| `BR-LEG-002` | Leg sequence must reflect the physical journey order. |
+| `BR-LEG-003` | The international and domestic legs must retain separate calculations even when presented as one customer quote. |
+| `BR-LEG-004` | The system must not merge international freight, POM gateway handling and domestic linehaul into one hidden undifferentiated cost. |
+| `BR-LEG-005` | Optional local pickup or delivery must be explicitly selected or evidenced. |
+| `BR-LEG-006` | Removing or changing a journey location must trigger leg regeneration and charge-context revalidation. |
+| `BR-LEG-007` | Recalculation must not retain charges that are incompatible with the regenerated journey. Those charges must be reclassified or returned to review. |
+
+---
+
+## 8. Charge-context model
+
+### 8.1 Required dimensions
+
+| Dimension | Allowed or typical values | Use |
+|---|---|---|
+| Service domain | Air Freight | Mandatory selection and validation |
+| Shipment direction | Import, Export | Mandatory; derived from trusted countries |
+| Journey pattern | IMP-POM, IMP-LAE, IMP-HGU, EXP-POM, EXP-LAE, EXP-HGU | Mandatory |
+| Leg type | International, Domestic pre-carriage, Domestic on-forwarding, Final local pickup/delivery | Mandatory |
+| Leg sequence | 1, 2, 3... | Mandatory |
+| Commercial position | Origin, Freight, Destination | Mandatory where ProductCode catalogue distinguishes it |
+| Operational location | POM, LAE, HGU, overseas origin/destination | Mandatory where location-sensitive |
+| Transport mode | International air, Domestic air, Local road/cartage | Mandatory |
+| Charge family | Freight, Fuel, Handling, Documentation, AWB, Security, Storage, Customs, Screening, Cartage, Delivery, Other governed family | Mandatory |
+| Calculation basis | Flat, per kg, minimum-or-per-kg, percentage, per shipment, per AWB/document, per piece, per day | Mandatory when relevant |
+| Rate source | Contract, tariff, approved rate card, supplier spot, manual source | Rating and audit |
+| Currency | Source currency | Rating and validation, not a substitute for context |
+| Tax treatment | Existing company GST/tax policy | Calculation and validation |
+| Effective date | Quote/rate validity date | Rate and ProductCode validity |
+| Evidence | Source text, table row, rate reference, user decision | Audit and review |
+| Include in totals | Yes/No with reason | Quote integrity |
+
+### 8.2 Commercial-position rules
+
+| Direction and leg | Commercial position examples |
+|---|---|
+| Import international leg at overseas departure | Import origin |
+| Import international air linehaul | Import freight |
+| Import arrival/customs/handling at POM | Import destination |
+| Import POM-to-LAE/HGU domestic linehaul | Import domestic on-forwarding freight |
+| Import transfer handling at POM specifically for onward domestic movement | Import domestic on-forwarding origin |
+| Import handling/delivery at LAE/HGU after domestic arrival | Import domestic on-forwarding destination or final delivery, depending on purpose |
+| Export regional-to-POM domestic linehaul | Export domestic pre-carriage freight |
+| Export regional handling specifically for movement to POM | Export domestic pre-carriage origin |
+| Export processing at POM before international departure | Export origin |
+| Export international air linehaul | Export freight |
+| Export charges at overseas arrival | Export destination |
+
+### 8.3 Ambiguous labels
+
+A label alone is not sufficient when it can apply to multiple contexts.
+
+Examples requiring context resolution include:
+
+- `FSC`;
+- `Handling`;
+- `Terminal Fee`;
+- `Documentation`;
+- `Delivery`;
+- `Airport Charge`;
+- `Transfer Fee`.
+
+For `FSC`, the system must distinguish, at minimum:
+
+- international airline fuel surcharge;
+- domestic air fuel surcharge;
+- pickup/cartage fuel surcharge;
+- domestic on-forwarding fuel surcharge;
+- final delivery fuel surcharge.
+
+The system must ask a business clarification such as "What movement does this fuel surcharge apply to?" It must not ask the user to choose a ProductCode ID.
+
+---
+
+## 9. ProductCode assignment hierarchy
+
+### 9.1 Resolver sequence
+
+ProductCode selection must follow this sequence. Later steps may narrow a candidate set but must not contradict earlier trusted context.
+
+1. **Validate route countries and derive direction.**
+2. **Enforce the POM gateway and construct the journey.**
+3. **Attach the charge to a specific leg.**
+4. **Determine commercial position within that leg.**
+5. **Normalise the charge family from governed aliases and evidence.**
+6. **Apply transport mode and operational location.**
+7. **Apply calculation basis or document type where the ProductCode catalogue distinguishes it.**
+8. **Filter to active, effective and scope-compatible ProductCodes.**
+9. **Assign only when one exact valid ProductCode remains.**
+
+### 9.2 Precedence and trust
+
+| Rule ID | Business rule |
+|---|---|
+| `BR-PC-001` | Trusted origin and destination countries outrank parsed or user-supplied direction labels. |
+| `BR-PC-002` | Route-derived import/export domain cannot be overridden by frontend JSON, supplier terminology or a previous mapping. |
+| `BR-PC-003` | Journey leg and commercial position outrank generic charge aliases. |
+| `BR-PC-004` | An accepted alias or prior mapping may be reused only when its stored context remains compatible with the current route, leg, mode and position. |
+| `BR-PC-005` | Inactive, expired, wrong-domain or wrong-scope ProductCodes are not candidates. |
+| `BR-PC-006` | A generic ProductCode must not be used merely because a specific code is missing. |
+| `BR-PC-007` | The ProductCode ID is an implementation detail. The user sees the business classification and human-readable ProductCode code/name. |
+| `BR-PC-008` | Any override must preserve the original system classification, the replacement, reason, user and timestamp. |
+
+### 9.3 Resolver outcomes
+
+| Outcome | Required behaviour |
+|---|---|
+| One exact valid match | Assign automatically and record the rule version and context |
+| More than one valid match | Ask the minimum business clarification needed; re-run the resolver after the answer |
+| No valid match | Keep unresolved; offer the governed ProductCode request workflow |
+| Incomplete shipment context | Block assignment and identify the missing route/leg information |
+| Candidate conflicts with route domain or leg | Reject candidate; return to manual review |
+| Pending ProductCode request | Keep charge visible and unresolved under the existing finalisation policy |
+
+---
+
+## 10. Domestic rate sources and precedence
+
+### 10.1 Approved source types
+
+Domestic pre-carriage and on-forwarding rates may come only from:
+
+1. an active customer-specific contracted rate approved for the exact route and service;
+2. an active carrier or supplier contract/tariff;
+3. an approved EFM domestic route rate card;
+4. a current supplier spot quotation attached to the quote evidence;
+5. manual sourcing recorded against the quote when no approved configured rate exists.
+
+### 10.2 Selection hierarchy
+
+The most specific valid rate wins, subject to all of the following matching:
+
+- operating entity;
+- origin and destination;
+- direction/leg type;
+- transport mode and service level;
+- commodity or special-handling constraints;
+- weight/quantity band and minimum;
+- customer scope where applicable;
+- effective date and validity;
+- currency and tax treatment.
+
+If two equally specific active rates conflict, the system must not choose the cheapest, latest or highest-margin rate automatically. It must send the conflict to manual review.
+
+### 10.3 Rating safeguards
+
+| Rule ID | Business rule |
+|---|---|
+| `BR-RATE-001` | A domestic leg cannot be treated as complete without an applicable BUY cost or a recorded manual-source requirement. |
+| `BR-RATE-002` | An existing local SELL rate must never be used as a hidden substitute for a missing BUY cost. |
+| `BR-RATE-003` | Sell pricing must be calculated from the approved cost and existing margin/pricing rules, unless a governed customer sell tariff explicitly applies. |
+| `BR-RATE-004` | Expired rates are invalid unless an authorised override policy explicitly permits use and records the reason. No such automatic override is included at launch. |
+| `BR-RATE-005` | Minimum charges, chargeable weight, fuel, handling and other domestic components must remain individually reviewable. |
+| `BR-RATE-006` | The source currency must be preserved. FX conversion must follow the existing RateEngine/company policy. |
+| `BR-RATE-007` | GST and tax treatment must follow existing company policy and remain visible at charge level. |
+| `BR-RATE-008` | A spot rate must retain supplier, date, validity and source evidence. |
+
+---
+
+## 11. Manual-review conditions
+
+### 11.1 Hard blockers
+
+The following conditions block automatic completion and finalisation:
+
+| Rule ID | Condition | Required action |
+|---|---|---|
+| `BR-MR-001` | Missing or invalid origin/destination country | Correct shipment context |
+| `BR-MR-002` | International air route does not pass through POM | Reconstruct through POM or reject as unsupported |
+| `BR-MR-003` | Required domestic pre-carriage/on-forwarding leg is missing | Add/regenerate the leg |
+| `BR-MR-004` | Charge has no leg assignment | Classify the charge to a leg |
+| `BR-MR-005` | ProductCode candidate conflicts with direction, leg, mode or location | Select a compatible business context or request a ProductCode |
+| `BR-MR-006` | Multiple exact ProductCode candidates remain | Answer business clarification |
+| `BR-MR-007` | No ProductCode exists for a required charge | Use ProductCode request workflow |
+| `BR-MR-008` | Required domestic BUY rate is missing | Source and record an approved rate |
+| `BR-MR-009` | Two active domestic rates conflict at equal precedence | Authorised user chooses and records reason |
+| `BR-MR-010` | Rate is expired or outside route/service/weight scope | Obtain a valid rate |
+| `BR-MR-011` | Calculation basis, minimum or percentage base is ambiguous | Resolve commercial basis |
+| `BR-MR-012` | Required FX rate/currency handling is missing or contradictory | Resolve currency treatment |
+| `BR-MR-013` | GST/tax treatment cannot be determined under existing policy | Authorised review |
+| `BR-MR-014` | Reviewed totals do not reconcile with leg and charge-line totals | Correct calculation before finalisation |
+| `BR-MR-015` | Customer output differs from reviewed totals or omits a required leg/charge | Block publication and correct output |
+| `BR-MR-016` | Route/location/mode is outside launch scope | Use manual SPOT workflow or wait for later scope |
+
+### 11.2 Review without silent completion
+
+The following may allow the quote draft to remain open but must stay visibly unresolved:
+
+- optional final local delivery not yet priced;
+- supplier spot validity awaiting confirmation;
+- special cargo handling awaiting supplier response;
+- pending ProductCode creation request;
+- non-mandatory commercial term requiring user acknowledgement;
+- evidence quality warning where the commercial value has not been silently assumed.
+
+Whether a draft can be finalised with any of these items is governed by the existing finalisation policy. Phase 16 does not weaken that policy.
+
+### 11.3 Override policy
+
+At launch:
+
+- there is no override for a non-POM international gateway;
+- there is no override for a missing required leg;
+- there is no override for a totals mismatch;
+- there is no override that permits a wrong-domain ProductCode;
+- there is no override that silently supplies a missing BUY cost.
+
+Any future manager override must be separately designed, permissioned and audited.
+
+---
+
+## 12. Initial launch scope
+
+### 12.1 Included
+
+| Scope item | Launch baseline |
+|---|---|
+| Service domain | International Air Freight |
+| International gateway | POM only |
+| PNG locations | POM, LAE and HGU |
+| Import patterns | IMP-POM, IMP-LAE, IMP-HGU |
+| Export patterns | EXP-POM, EXP-LAE, EXP-HGU |
+| Domestic regional mode | Domestic air pre-carriage/on-forwarding between POM and LAE/HGU |
+| ProductCode behaviour | Automatic assignment only for one exact valid context-compatible match |
+| Rate behaviour | Approved configured rate, valid supplier spot rate or visible manual sourcing |
+| Quote output | One customer quote with preserved leg-level calculation and evidence |
+| Rollout | Route-group feature flags and controlled UAT |
+
+### 12.2 Explicit exclusions at launch
+
+The following are outside automated Phase 16 launch scope and must remain manual, SPOT or separately governed:
+
+1. international air gateways in PNG other than POM;
+2. PNG regional origins or destinations other than POM, LAE and HGU;
+3. domestic-only shipments;
+4. sea freight, coastal shipping and inter-island sea legs;
+5. intercity road linehaul as a substitute for the defined domestic air leg;
+6. multi-stop domestic journeys or more than one regional transfer;
+7. third-country movements with no PNG origin or destination;
+8. automated local pickup/final-delivery pricing where no approved existing rate source is configured;
+9. automatic pricing of dangerous goods, live animals, perishables, oversized or other special cargo surcharges when an exact governed rate is unavailable;
+10. automatic customs-only, brokerage-only or clearance-only journey construction;
+11. automatic use of inferred supplier rates, stale quotes, emails without validity, or historical SELL values;
+12. autonomous ProductCode creation or approval;
+13. autonomous overrides of tax, FX, margin, gateway, totals or missing-rate controls.
+
+Excluded shipments may still be quoted through the existing controlled manual/SPOT process. Exclusion means "not automatically completed," not "commercial evidence may be discarded."
+
+---
+
+## 13. Customer quote and totals rules
+
+| Rule ID | Business rule |
+|---|---|
+| `BR-TOT-001` | The customer may receive one quote, but the system must retain every underlying journey leg and reviewed charge line. |
+| `BR-TOT-002` | International cost, POM gateway charges, domestic pre-carriage/on-forwarding, optional delivery, tax and margin must roll up from included charge lines only. |
+| `BR-TOT-003` | Informational, ignored or excluded lines must not enter totals and must retain an explicit reason. |
+| `BR-TOT-004` | Compatible customer-facing lines may be grouped by ProductCode only at output boundaries; internal source lines and audit evidence remain intact. |
+| `BR-TOT-005` | Lines with different ProductCodes, currencies, tax codes or incompatible commercial components must not be grouped. |
+| `BR-TOT-006` | Missing domestic components remain visible and must not be concealed by a complete-looking customer total. |
+| `BR-TOT-007` | Reopening or recalculating a quote must regenerate affected legs and totals without losing recorded evidence or decisions. |
+
+---
+
+## 14. Audit and evidence requirements
+
+Every automatic ProductCode or rate decision must retain:
+
+- shipment and leg identifiers;
+- resolved direction and journey pattern;
+- charge-context dimensions;
+- source label/text and document location where available;
+- candidate ProductCodes considered;
+- selected ProductCode and human-readable code/name;
+- resolver/rule version;
+- rate source, validity and supplier;
+- automatic/manual outcome;
+- clarification or override reason;
+- operator and timestamp;
+- before/after values when a decision changes;
+- totals inclusion decision.
+
+Ignored means deliberately excluded with evidence. It never means disappeared.
+
+---
+
+## 15. Canonical UAT scenarios
+
+These scenarios are mandatory and must be traceable to automated tests and UAT evidence.
+
+| Scenario ID | Input | Expected result |
+|---|---|---|
+| `UAT-16A-001` | BNE -> POM | Import; one international leg; import origin/freight/destination contexts |
+| `UAT-16A-002` | SIN -> LAE | Reconstructed as SIN -> POM -> LAE; international plus domestic on-forwarding |
+| `UAT-16A-003` | BNE -> HGU | Reconstructed as BNE -> POM -> HGU; international plus domestic on-forwarding |
+| `UAT-16A-004` | POM -> BNE | Export; one international leg; export origin/freight/destination contexts |
+| `UAT-16A-005` | LAE -> SIN | Reconstructed as LAE -> POM -> SIN; domestic pre-carriage plus international |
+| `UAT-16A-006` | HGU -> BNE | Reconstructed as HGU -> POM -> BNE; domestic pre-carriage plus international |
+| `UAT-16A-007` | Supplier text says direct SIN -> LAE international | POM inserted; direct LAE international gateway rejected |
+| `UAT-16A-008` | Required POM -> LAE rate missing | Visible manual-sourcing blocker; no SELL substitution |
+| `UAT-16A-009` | `FSC` without leg context | Business clarification requested; no ProductCode guessed |
+| `UAT-16A-010` | One exact compatible ProductCode | Automatically assigned and audited |
+| `UAT-16A-011` | Two compatible ProductCodes | Manual business clarification required |
+| `UAT-16A-012` | No ProductCode | Unresolved charge and ProductCode request option |
+| `UAT-16A-013` | Import route offered export-domain ProductCode | Candidate rejected |
+| `UAT-16A-014` | Equal-precedence conflicting domestic rates | Manual rate decision required |
+| `UAT-16A-015` | Mixed currencies with valid FX | Correct source-currency preservation, conversion and disclosure |
+| `UAT-16A-016` | Mixed currencies without valid FX | Finalisation blocked |
+| `UAT-16A-017` | Charge not attached to a leg | Finalisation blocked |
+| `UAT-16A-018` | Customer output total differs from reviewed charge total | Publication blocked |
+| `UAT-16A-019` | Reopen LAE import and change destination to HGU | POM-to-LAE leg/charges removed or returned to review; POM-to-HGU regenerated |
+| `UAT-16A-020` | Special cargo with no exact governed domestic surcharge | Route built, surcharge remains manual SPOT review |
+
+---
+
+## 16. Phase 16A exit criteria
+
+Phase 16A is complete when:
+
+1. this document is accepted as the governing baseline;
+2. the ProductCode catalogue can be assessed against the context dimensions in this document;
+3. domestic rate owners can identify the source and validity of POM-LAE and POM-HGU rates in both directions;
+4. every Phase 16B requirement can reference one or more rule IDs from this document;
+5. every Phase 16 test and UAT case can trace back to a rule ID;
+6. no implementation team is required to invent a gateway, journey, leg, ProductCode or missing-rate rule.
+
+---
+
+## 17. Implementation interpretation rule
+
+When a case is not explicitly covered:
+
+1. do not infer a new commercial rule from code, labels or historical data;
+2. preserve the evidence;
+3. mark the item unsupported or unresolved;
+4. obtain a business decision;
+5. update this document before automating the new case.
+
+That is deliberate. RateEngine should be fast, but it must not become confidently wrong.

--- a/docs/business-rules/phase-16a-air-freight-journey-productcode-rules.md
+++ b/docs/business-rules/phase-16a-air-freight-journey-productcode-rules.md
@@ -1,554 +1,303 @@
-# RateEngine Phase 16A - International Air Freight Journey, Domestic Leg and ProductCode Business Rules
+# RateEngine Phase 16A — International Air Freight Journey, Domestic Leg and ProductCode Business Rules
 
 **Document ID:** RE-BR-16A-AIR-001  
-**Version:** 1.0  
+**Version:** 1.1  
 **Effective date:** 21 July 2026  
-**Status:** Authoritative working baseline  
+**Status:** Authoritative business-rules baseline  
 **Business owner:** Commercial Freight Manager  
-**Applies to:** RateEngine international air-freight quoting, ProductCode assignment, domestic pre-carriage, domestic on-forwarding, design, development, automated tests and UAT  
-**Canonical repository location:** `docs/business-rules/phase-16a-air-freight-journey-productcode-rules.md`
+**Canonical location:** `docs/business-rules/phase-16a-air-freight-journey-productcode-rules.md`
 
----
+## 1. Authority
 
-## 1. Authority and change control
+This document is the source of truth for Phase 16 architecture, implementation, ProductCode rules, domestic rates, tests and UAT. Conflicting legacy behaviour is a defect unless a later approved version explicitly changes the rule.
 
-This document is the source of truth for Phase 16 design and implementation. Code, ProductCode rules, rate configuration, tests, UAT scripts and user guidance must conform to it.
+Changes require a documented business decision, version update, impact assessment and corresponding test/UAT changes.
 
-Where existing application behaviour conflicts with this document, the conflict must be treated as a defect or an explicitly approved change request. The application must not silently preserve contradictory legacy behaviour.
+## 2. Non-negotiable principles
 
-Changes to these rules require:
-
-1. a documented business decision;
-2. a version update to this document;
-3. impact review for ProductCodes, rates, calculations, UI, audit, regression tests and UAT;
-4. implementation only after the revised rule is accepted.
-
-This document supersedes informal notes and chat decisions concerning the Phase 16 air-freight journey model.
-
----
-
-## 2. Purpose and target outcome
-
-RateEngine must automatically:
-
-1. determine whether a shipment is an import or export from trusted route data;
-2. construct the correct ordered shipment journey;
-3. identify the leg and commercial context of every charge;
-4. select the correct active ProductCode when one exact valid match exists;
-5. source domestic rates from approved sources;
-6. expose missing, conflicting or ambiguous information for manual review;
-7. preserve the underlying leg, charge, rate and evidence detail while producing one coherent customer quote.
-
-The user must not be asked to choose or type an internal ProductCode ID. The system must ask only the business question needed to resolve missing context.
-
----
-
-## 3. Non-negotiable commercial principles
-
-| Rule ID | Business rule |
+| Rule ID | Rule |
 |---|---|
-| `BR-GOV-001` | POM is the only PNG international gateway for international air-freight shipments in the Phase 16 model. |
-| `BR-GOV-002` | Every charge included in a quote must be attached to one identifiable shipment leg and commercial position. |
-| `BR-GOV-003` | ProductCode assignment must be deterministic, context-compatible and auditable. |
-| `BR-GOV-004` | AI or document intake may suggest the meaning of supplier text, but it must not invent, bypass or force a ProductCode. |
-| `BR-GOV-005` | Users must never enter or select raw internal ProductCode database IDs. |
-| `BR-GOV-006` | Ambiguous, unsupported or incomplete context must fail visibly into manual review. It must not be guessed. |
-| `BR-GOV-007` | Missing BUY rates or required charge components must remain visible for manual sourcing. A local SELL rate must never be substituted as a hidden cost or completeness fallback. |
-| `BR-GOV-008` | Quote totals are sacred. Customer totals must be derived from the actual reviewed charge lines and legs included in totals. |
-| `BR-GOV-009` | Automatic and user-assisted decisions must retain source evidence, rule version, outcome, operator and timestamp. |
-| `BR-GOV-010` | No commercially relevant charge may be silently invented, discarded or moved to another leg. |
-| `BR-GOV-011` | Wrong-domain ProductCodes, unsupported gateway routes and unresolved required legs are hard failures, not warnings. |
-| `BR-GOV-012` | The initial release must be feature-flagged by supported route group so that unsafe route groups can be disabled independently. |
+| `BR-GOV-001` | POM is the only PNG international air gateway. |
+| `BR-GOV-002` | Every included charge must be assigned to one explicit journey leg and commercial position. |
+| `BR-GOV-003` | ProductCode assignment is deterministic, context-compatible and auditable. |
+| `BR-GOV-004` | AI may interpret evidence but must not invent, approve or force ProductCodes. |
+| `BR-GOV-005` | Users never type or select raw ProductCode database IDs. |
+| `BR-GOV-006` | Ambiguous, unsupported or incomplete context fails visibly into review. |
+| `BR-GOV-007` | Missing BUY costs remain visible. SELL must never be substituted as hidden cost or completeness evidence. |
+| `BR-GOV-008` | Quote totals are derived only from reviewed, included leg charge lines. |
+| `BR-GOV-009` | Automatic and assisted decisions retain evidence, rule version, result, user and timestamp. |
+| `BR-GOV-010` | Commercial data is never silently invented, discarded or moved between legs. |
+| `BR-GOV-011` | Wrong-domain ProductCodes, non-POM gateways and unresolved required legs are hard failures. |
+| `BR-GOV-012` | Automation is controlled by route-group feature flags. |
 
----
+## 3. Definitions
 
-## 4. Definitions
+- **Gateway:** POM, the only PNG airport used by an international air leg.
+- **International leg:** Overseas airport to POM for imports, or POM to overseas airport for exports.
+- **Domestic pre-carriage:** Regional PNG airport to POM before export.
+- **Domestic on-forwarding:** POM to regional PNG airport after import.
+- **Final local pickup/delivery:** Separate local cartage between airport/terminal and an address. It is never inferred merely from the city.
+- **Journey direction:** Overall `IMPORT` or `EXPORT`, derived from trusted countries.
+- **ProductCode domain:** Derived from the assigned leg, not once for the whole journey:
+  - international import and POM import-gateway charges → `IMPORT`;
+  - international export and POM export-gateway charges → `EXPORT`;
+  - domestic pre-carriage/on-forwarding charges → `DOMESTIC`;
+  - existing import/export local ProductCodes may remain applicable where pickup/delivery is part of the international service rather than a separately modelled domestic transport leg.
+- **Manual review:** A visible unresolved state. It is not permission to guess.
 
-### 4.1 Gateway
+## 4. Direction and gateway
 
-The PNG airport through which the international air-freight leg enters or leaves Papua New Guinea. For this release, the gateway is always Port Moresby (`POM`).
-
-### 4.2 International leg
-
-The air-freight movement between POM and an overseas airport.
-
-### 4.3 Domestic pre-carriage
-
-A domestic movement from a PNG regional origin to POM before an export international leg.
-
-Examples:
-
-- Lae (`LAE`) to POM before POM to Brisbane;
-- Mount Hagen (`HGU`) to POM before POM to Singapore.
-
-Domestic pre-carriage is not the international origin leg. It is a separate domestic leg feeding the POM gateway.
-
-### 4.4 Domestic on-forwarding
-
-A domestic movement from POM to a PNG regional destination after an import international leg.
-
-Examples:
-
-- POM to LAE after Singapore to POM;
-- POM to HGU after Brisbane to POM.
-
-Domestic on-forwarding is not part of the international freight leg. It is a separate domestic leg beginning after arrival at the POM gateway.
-
-### 4.5 Final local delivery
-
-A local pickup or delivery movement between an airport, branch, warehouse or terminal and the customer's specified address. It is separate from domestic pre-carriage and on-forwarding.
-
-Examples:
-
-- POM airport to a customer address in Port Moresby;
-- LAE airport to a customer address in Lae.
-
-A regional destination does not automatically mean final local delivery is included. The service scope must state it explicitly.
-
-### 4.6 Charge context
-
-The complete set of business dimensions needed to understand what a charge applies to and which ProductCode may be used.
-
-### 4.7 ProductCode domain
-
-The trusted import or export domain derived from the shipment's origin and destination countries. It is never taken from user-entered JSON, supplier wording or an editable frontend field.
-
-### 4.8 Manual review
-
-A visible unresolved state requiring a user or authorised reviewer to provide missing business context, source a rate, select an approved business option or request a ProductCode. Manual review is not permission to guess.
-
----
-
-## 5. Direction and gateway rules
-
-### 5.1 Direction derivation
-
-| Rule ID | Route condition | Direction result |
+| Rule ID | Condition | Result |
 |---|---|---|
-| `BR-DIR-001` | Origin country is outside PNG and destination country is PNG | `IMPORT` |
-| `BR-DIR-002` | Origin country is PNG and destination country is outside PNG | `EXPORT` |
-| `BR-DIR-003` | Origin and destination countries are both PNG | `DOMESTIC_ONLY` and outside the Phase 16 international-air automation scope |
-| `BR-DIR-004` | Neither origin nor destination country is PNG | `THIRD_COUNTRY` and unsupported |
-| `BR-DIR-005` | Country data is missing, invalid or contradictory | Direction unresolved; block ProductCode assignment and journey finalisation |
+| `BR-DIR-001` | Non-PNG origin, PNG destination | `IMPORT` |
+| `BR-DIR-002` | PNG origin, non-PNG destination | `EXPORT` |
+| `BR-DIR-003` | PNG origin and destination | `DOMESTIC_ONLY`; outside Phase 16 international automation |
+| `BR-DIR-004` | Neither endpoint is PNG | `THIRD_COUNTRY`; unsupported |
+| `BR-DIR-005` | Missing, invalid or contradictory countries | Block journey and ProductCode resolution |
 
-### 5.2 POM-only gateway enforcement
-
-| Rule ID | Business rule |
+| Rule ID | Gateway rule |
 |---|---|
-| `BR-GW-001` | Every supported international import air journey must contain an international leg ending at POM. |
-| `BR-GW-002` | Every supported international export air journey must contain an international leg starting at POM. |
-| `BR-GW-003` | LAE, HGU and all other PNG locations are domestic origins or destinations only in an international air journey. |
-| `BR-GW-004` | The system must not treat LAE, HGU or another PNG location as an international air gateway. |
-| `BR-GW-005` | A user-entered direct international route to or from a regional PNG location must be reconstructed through POM when the route is otherwise supported. If reconstruction is not possible, the route must be blocked. |
-| `BR-GW-006` | A supplier document or parsed route must not override the POM gateway rule. |
+| `BR-GW-001` | Every import international leg ends at POM. |
+| `BR-GW-002` | Every export international leg starts at POM. |
+| `BR-GW-003` | LAE, HGU and other PNG locations are domestic endpoints within an international journey. |
+| `BR-GW-004` | No regional PNG location may be treated as an international gateway. |
+| `BR-GW-005` | A direct international regional route is reconstructed through POM when supported; otherwise blocked. |
+| `BR-GW-006` | Supplier text, parsed routes and editable fields cannot override the gateway rule. |
 
----
+## 5. Journey patterns
 
-## 6. Supported journey patterns
+### Imports
 
-### 6.1 Import patterns
-
-| Pattern ID | Customer route | Required ordered journey | Launch status |
+| Pattern | Customer route | Ordered legs | Launch status |
 |---|---|---|---|
-| `IMP-POM` | Overseas airport to POM | 1. International air: Overseas -> POM | Supported |
-| `IMP-LAE` | Overseas airport to LAE | 1. International air: Overseas -> POM; 2. Domestic on-forwarding: POM -> LAE | Supported |
-| `IMP-HGU` | Overseas airport to HGU | 1. International air: Overseas -> POM; 2. Domestic on-forwarding: POM -> HGU | Supported |
+| `IMP-POM` | Overseas → POM | International: Overseas → POM | Enabled after implementation/UAT |
+| `IMP-LAE` | Overseas → LAE | International: Overseas → POM; On-forwarding: POM → LAE | Enabled after implementation/UAT |
+| `IMP-HGU` | Overseas → HGU | International: Overseas → POM; On-forwarding: POM → HGU | Enabled after implementation/UAT |
 
-Rules:
+- `BR-JNY-IMP-001`: POM imports contain no regional onward leg unless explicitly selected.
+- `BR-JNY-IMP-002`: LAE imports include POM → LAE.
+- `BR-JNY-IMP-003`: HGU imports include POM → HGU.
+- `BR-JNY-IMP-004`: POM import arrival, customs, breakdown and gateway handling remain in the international import destination context.
+- `BR-JNY-IMP-005`: Charges incurred specifically for onward transfer/book/handling/carriage belong to the domestic onward leg.
+- `BR-JNY-IMP-006`: Regional final delivery is optional and separate.
 
-- `BR-JNY-IMP-001`: An import ending at POM has no regional domestic on-forwarding leg unless another domestic destination is explicitly selected.
-- `BR-JNY-IMP-002`: An import ending at LAE must include POM-to-LAE domestic on-forwarding.
-- `BR-JNY-IMP-003`: An import ending at HGU must include POM-to-HGU domestic on-forwarding.
-- `BR-JNY-IMP-004`: POM import arrival, customs, breakdown and international destination handling charges remain attached to the international import destination context.
-- `BR-JNY-IMP-005`: Charges specifically incurred to transfer, book, handle or carry cargo from POM to a regional destination belong to the domestic on-forwarding leg.
-- `BR-JNY-IMP-006`: Final delivery from the regional airport is an optional separate leg and must not be inferred merely because the final PNG city is LAE or HGU.
+### Exports
 
-### 6.2 Export patterns
-
-| Pattern ID | Customer route | Required ordered journey | Launch status |
+| Pattern | Customer route | Ordered legs | Launch status |
 |---|---|---|---|
-| `EXP-POM` | POM to overseas airport | 1. International air: POM -> Overseas | Supported |
-| `EXP-LAE` | LAE to overseas airport | 1. Domestic pre-carriage: LAE -> POM; 2. International air: POM -> Overseas | Supported |
-| `EXP-HGU` | HGU to overseas airport | 1. Domestic pre-carriage: HGU -> POM; 2. International air: POM -> Overseas | Supported |
+| `EXP-POM` | POM → Overseas | International: POM → Overseas | Enabled after implementation/UAT |
+| `EXP-LAE` | LAE → Overseas | Pre-carriage: LAE → POM; International: POM → Overseas | Enabled after implementation/UAT |
+| `EXP-HGU` | HGU → Overseas | Pre-carriage: HGU → POM; International: POM → Overseas | **Disabled until approved HGU → POM BUY and SELL coverage is configured and verified** |
 
-Rules:
-
-- `BR-JNY-EXP-001`: An export beginning at POM has no regional domestic pre-carriage leg unless another PNG origin is explicitly selected.
-- `BR-JNY-EXP-002`: An export beginning at LAE must include LAE-to-POM domestic pre-carriage.
-- `BR-JNY-EXP-003`: An export beginning at HGU must include HGU-to-POM domestic pre-carriage.
-- `BR-JNY-EXP-004`: Regional pickup, regional terminal handling and domestic freight to POM belong to the domestic pre-carriage leg.
+- `BR-JNY-EXP-001`: POM exports contain no regional pre-carriage unless explicitly selected.
+- `BR-JNY-EXP-002`: LAE exports include LAE → POM.
+- `BR-JNY-EXP-003`: HGU exports require HGU → POM but remain launch-gated while rates are missing.
+- `BR-JNY-EXP-004`: Regional pickup, regional handling and regional-to-POM freight belong to pre-carriage.
 - `BR-JNY-EXP-005`: Export documentation, security, AWB, terminal and airline-origin charges at POM belong to the international export origin context.
-- `BR-JNY-EXP-006`: Overseas destination charges, when quoted, belong to the export destination context and are not confused with PNG domestic legs.
+- `BR-JNY-EXP-006`: Overseas destination charges remain export destination charges.
 
-### 6.3 Invalid or unsupported patterns
+### Invalid or unsupported
 
-| Rule ID | Route or condition | Required behaviour |
+| Rule ID | Condition | Behaviour |
 |---|---|---|
-| `BR-JNY-INV-001` | Overseas -> LAE shown as a direct international leg | Reconstruct as Overseas -> POM -> LAE or block if the domestic leg is unsupported/missing |
-| `BR-JNY-INV-002` | LAE -> Overseas shown as a direct international leg | Reconstruct as LAE -> POM -> Overseas or block if the domestic leg is unsupported/missing |
-| `BR-JNY-INV-003` | International air route uses any PNG gateway other than POM | Hard block |
-| `BR-JNY-INV-004` | Domestic-only PNG route | Route to existing/manual domestic workflow; do not apply Phase 16 international rules |
-| `BR-JNY-INV-005` | Third-country route with no PNG origin or destination | Unsupported |
-| `BR-JNY-INV-006` | More than one regional domestic stop | Unsupported at launch; manual SPOT review |
+| `BR-JNY-INV-001` | Overseas → regional PNG shown as direct international | Insert POM or block |
+| `BR-JNY-INV-002` | Regional PNG → overseas shown as direct international | Insert POM or block |
+| `BR-JNY-INV-003` | International air uses a PNG gateway other than POM | Hard block |
+| `BR-JNY-INV-004` | Domestic-only route | Existing/manual domestic workflow |
+| `BR-JNY-INV-005` | Third-country route | Unsupported |
+| `BR-JNY-INV-006` | More than one regional domestic stop | Manual SPOT at launch |
 
----
+## 6. Journey and leg contract
 
-## 7. Journey and leg construction rules
+Every journey is an ordered list of explicit legs. Each leg records sequence, role, mode, origin, destination, responsible branch, supplier/carrier or manual-source status, chargeable quantity, rate provenance, charges, currencies, tax, totals status, evidence and review status.
 
-Each journey must be an ordered list of explicit legs. A leg must contain at least:
-
-- sequence number;
-- leg type;
-- transport mode;
-- origin and destination location;
-- operating entity and responsible branch where applicable;
-- supplier/carrier or manual-source status;
-- rate source and validity;
-- chargeable weight or applicable rating quantity;
-- charges and ProductCodes;
-- currency, tax treatment and totals inclusion;
-- source evidence;
-- review status.
-
-| Rule ID | Business rule |
+| Rule ID | Rule |
 |---|---|
-| `BR-LEG-001` | A charge cannot be included in totals without a leg assignment. |
-| `BR-LEG-002` | Leg sequence must reflect the physical journey order. |
-| `BR-LEG-003` | The international and domestic legs must retain separate calculations even when presented as one customer quote. |
-| `BR-LEG-004` | The system must not merge international freight, POM gateway handling and domestic linehaul into one hidden undifferentiated cost. |
-| `BR-LEG-005` | Optional local pickup or delivery must be explicitly selected or evidenced. |
-| `BR-LEG-006` | Removing or changing a journey location must trigger leg regeneration and charge-context revalidation. |
-| `BR-LEG-007` | Recalculation must not retain charges that are incompatible with the regenerated journey. Those charges must be reclassified or returned to review. |
+| `BR-LEG-001` | A charge without a valid leg cannot enter totals. |
+| `BR-LEG-002` | Leg sequence follows physical movement order. |
+| `BR-LEG-003` | International and domestic calculations stay separate beneath the combined quote. |
+| `BR-LEG-004` | International freight, POM gateway charges and domestic linehaul are never hidden as one undifferentiated cost. |
+| `BR-LEG-005` | Local pickup/delivery requires explicit selection or evidence. |
+| `BR-LEG-006` | Route/location changes regenerate affected legs and revalidate charge context. |
+| `BR-LEG-007` | Incompatible old charges are removed from totals and returned to classification/review. |
 
----
+## 7. Charge context
 
-## 8. Charge-context model
+Mandatory dimensions:
 
-### 8.1 Required dimensions
+`service_domain`, `journey_direction`, `journey_pattern`, `leg_id`, `leg_role`, `leg_sequence`, `product_code_domain`, `commercial_position`, `operational_location`, `transport_mode`, `charge_family`, `calculation_basis`, `rate_source`, `currency`, `tax_treatment`, `effective_date`, `evidence`, `include_in_totals`.
 
-| Dimension | Allowed or typical values | Use |
+Commercial-position examples:
+
+- overseas departure on import → import origin;
+- international import linehaul → import freight;
+- POM arrival/customs/gateway handling → import destination;
+- POM → LAE/HGU linehaul → domestic on-forwarding freight;
+- regional → POM export movement → domestic pre-carriage freight;
+- POM export processing → export origin;
+- POM → overseas linehaul → export freight;
+- overseas arrival → export destination.
+
+Ambiguous labels such as `FSC`, `Handling`, `Terminal Fee`, `Documentation`, `Delivery`, `Airport Charge` and `Transfer Fee` require the minimum business clarification. The user is asked what movement/service the charge applies to, not which ProductCode ID to use.
+
+## 8. ProductCode assignment
+
+Resolver order:
+
+1. validate trusted countries and direction;
+2. enforce POM and generate the journey;
+3. assign the charge to a leg;
+4. derive ProductCode domain from that leg;
+5. determine commercial position;
+6. normalise the governed charge family;
+7. apply mode, location, basis and effective date;
+8. filter to approved context-compatible candidates;
+9. auto-assign only one exact match.
+
+| Rule ID | Rule |
+|---|---|
+| `BR-PC-001` | Trusted countries outrank parsed/user direction labels. |
+| `BR-PC-002` | Overall direction cannot be overridden; ProductCode domain is then derived per leg as `IMPORT`, `EXPORT` or `DOMESTIC`. |
+| `BR-PC-003` | Leg and commercial position outrank generic aliases. |
+| `BR-PC-004` | Prior mappings/aliases are reusable only when full context remains compatible. |
+| `BR-PC-005` | Inactive, expired, wrong-domain or wrong-scope candidates are excluded. |
+| `BR-PC-006` | A generic code is not used merely because a specific code is missing. |
+| `BR-PC-007` | IDs remain implementation details; users see business meaning and code/name. |
+| `BR-PC-008` | Overrides preserve original classification, replacement, reason, user and time. |
+
+Outcomes:
+
+- one exact valid candidate → assign and audit;
+- multiple candidates → ask the minimum clarification and rerun;
+- no candidate → unresolved with ProductCode request option;
+- incomplete route/leg context → block and identify missing data;
+- incompatible candidate → reject;
+- pending request → remain visible under existing finalisation policy.
+
+## 9. Domestic rates
+
+Approved precedence, highest first:
+
+1. active customer-specific contracted BUY rate;
+2. active route/service contract;
+3. approved carrier/transport tariff;
+4. approved standard internal rate card;
+5. valid supplier SPOT quote;
+6. manual sourcing.
+
+At equal precedence, the most specific valid route/service/weight/currency/customer match wins. Equal conflicting matches block.
+
+| Rule ID | Rule |
+|---|---|
+| `BR-RATE-001` | Every required domestic leg needs an approved BUY cost or visible manual-sourcing blocker. |
+| `BR-RATE-002` | SELL never substitutes for missing BUY. |
+| `BR-RATE-003` | BUY and SELL remain separate and traceable. |
+| `BR-RATE-004` | Selection uses route, mode, service, weight/basis, currency, customer and date where applicable. |
+| `BR-RATE-005` | Minimums, fuel, handling, security, AWB/documentation and terminal charges are evaluated separately where configured. |
+| `BR-RATE-006` | Expired, inactive, unapproved or unsupported rates are excluded. |
+| `BR-RATE-007` | Selected rates retain source, supplier, owner, validity and evidence. |
+| `BR-RATE-008` | Missing required components remain visible and prevent a complete-looking quote. |
+
+Initial configured domestic freight evidence:
+
+- POM → LAE: present;
+- LAE → POM: present;
+- POM → HGU: present;
+- HGU → POM: absent and launch-blocking for `EXP-HGU`.
+
+## 10. Manual-review conditions
+
+| Rule ID | Trigger | Required action |
 |---|---|---|
-| Service domain | Air Freight | Mandatory selection and validation |
-| Shipment direction | Import, Export | Mandatory; derived from trusted countries |
-| Journey pattern | IMP-POM, IMP-LAE, IMP-HGU, EXP-POM, EXP-LAE, EXP-HGU | Mandatory |
-| Leg type | International, Domestic pre-carriage, Domestic on-forwarding, Final local pickup/delivery | Mandatory |
-| Leg sequence | 1, 2, 3... | Mandatory |
-| Commercial position | Origin, Freight, Destination | Mandatory where ProductCode catalogue distinguishes it |
-| Operational location | POM, LAE, HGU, overseas origin/destination | Mandatory where location-sensitive |
-| Transport mode | International air, Domestic air, Local road/cartage | Mandatory |
-| Charge family | Freight, Fuel, Handling, Documentation, AWB, Security, Storage, Customs, Screening, Cartage, Delivery, Other governed family | Mandatory |
-| Calculation basis | Flat, per kg, minimum-or-per-kg, percentage, per shipment, per AWB/document, per piece, per day | Mandatory when relevant |
-| Rate source | Contract, tariff, approved rate card, supplier spot, manual source | Rating and audit |
-| Currency | Source currency | Rating and validation, not a substitute for context |
-| Tax treatment | Existing company GST/tax policy | Calculation and validation |
-| Effective date | Quote/rate validity date | Rate and ProductCode validity |
-| Evidence | Source text, table row, rate reference, user decision | Audit and review |
-| Include in totals | Yes/No with reason | Quote integrity |
+| `BR-MR-001` | Missing/invalid countries | Correct route data |
+| `BR-MR-002` | Unsupported gateway | Block/reconstruct through POM |
+| `BR-MR-003` | Unsupported journey/location/mode | Manual SPOT |
+| `BR-MR-004` | Required leg missing | Generate or source it |
+| `BR-MR-005` | Charge has no leg | Assign context before totals |
+| `BR-MR-006` | Ambiguous charge context | Ask business clarification |
+| `BR-MR-007` | No ProductCode | Governed request workflow |
+| `BR-MR-008` | Required domestic BUY missing | Source approved rate |
+| `BR-MR-009` | Equal-precedence conflicting rates | Authorised decision with reason |
+| `BR-MR-010` | Expired/out-of-scope rate | Obtain valid rate |
+| `BR-MR-011` | Ambiguous basis/minimum/percentage base | Resolve basis |
+| `BR-MR-012` | Missing/contradictory FX | Resolve currency treatment |
+| `BR-MR-013` | Tax treatment unresolved | Authorised review |
+| `BR-MR-014` | Leg and line totals do not reconcile | Correct before finalisation |
+| `BR-MR-015` | Customer output differs/omits required content | Block publication |
+| `BR-MR-016` | Outside launch scope | Manual SPOT or later phase |
 
-### 8.2 Commercial-position rules
+No launch override is permitted for non-POM gateway, missing required leg, totals mismatch, wrong-domain ProductCode or silently missing BUY cost.
 
-| Direction and leg | Commercial position examples |
+## 11. Initial automated scope
+
+Included after implementation and UAT:
+
+- International Air Freight;
+- POM gateway only;
+- import patterns `IMP-POM`, `IMP-LAE`, `IMP-HGU`;
+- export patterns `EXP-POM`, `EXP-LAE`;
+- domestic air legs POM → LAE, LAE → POM and POM → HGU;
+- one exact context-compatible ProductCode;
+- configured approved rate, valid SPOT source or visible manual blocker;
+- one customer quote with preserved leg calculations and evidence;
+- route-group feature flags.
+
+Excluded or disabled:
+
+1. `EXP-HGU` / HGU → POM until approved BUY and SELL coverage exists;
+2. other PNG international gateways;
+3. regional locations other than POM, LAE and HGU;
+4. domestic-only journeys under this international workflow;
+5. sea/coastal/inter-island legs;
+6. intercity road linehaul as substitute for the defined domestic air leg;
+7. multi-stop domestic journeys;
+8. third-country movements;
+9. unconfigured automated local pickup/delivery;
+10. unsupported automatic special-cargo surcharges;
+11. customs-only/brokerage-only journey construction;
+12. inferred, stale or unverified rates;
+13. autonomous ProductCode approval/creation;
+14. autonomous tax, FX, margin, gateway, totals or missing-rate overrides.
+
+## 12. Totals and customer output
+
+| Rule ID | Rule |
 |---|---|
-| Import international leg at overseas departure | Import origin |
-| Import international air linehaul | Import freight |
-| Import arrival/customs/handling at POM | Import destination |
-| Import POM-to-LAE/HGU domestic linehaul | Import domestic on-forwarding freight |
-| Import transfer handling at POM specifically for onward domestic movement | Import domestic on-forwarding origin |
-| Import handling/delivery at LAE/HGU after domestic arrival | Import domestic on-forwarding destination or final delivery, depending on purpose |
-| Export regional-to-POM domestic linehaul | Export domestic pre-carriage freight |
-| Export regional handling specifically for movement to POM | Export domestic pre-carriage origin |
-| Export processing at POM before international departure | Export origin |
-| Export international air linehaul | Export freight |
-| Export charges at overseas arrival | Export destination |
+| `BR-TOT-001` | One customer quote retains all underlying legs and lines. |
+| `BR-TOT-002` | Totals roll up from included international, gateway, domestic, delivery, tax and margin lines only. |
+| `BR-TOT-003` | Ignored/informational lines remain evidenced and excluded. |
+| `BR-TOT-004` | Compatible lines may group by ProductCode only at output boundaries. |
+| `BR-TOT-005` | Different ProductCodes, currencies, tax codes or incompatible components do not group. |
+| `BR-TOT-006` | Missing domestic components remain visible and prevent a complete-looking total. |
+| `BR-TOT-007` | Reopen/recalculate regenerates affected legs without losing valid evidence/audit. |
 
-### 8.3 Ambiguous labels
+Every automatic ProductCode/rate decision retains journey/leg identifiers, direction/pattern, context, evidence, candidates, selected code, rule version, rate provenance, outcome, reason, user/time, before/after values and totals treatment.
 
-A label alone is not sufficient when it can apply to multiple contexts.
+## 13. Canonical UAT
 
-Examples requiring context resolution include:
-
-- `FSC`;
-- `Handling`;
-- `Terminal Fee`;
-- `Documentation`;
-- `Delivery`;
-- `Airport Charge`;
-- `Transfer Fee`.
-
-For `FSC`, the system must distinguish, at minimum:
-
-- international airline fuel surcharge;
-- domestic air fuel surcharge;
-- pickup/cartage fuel surcharge;
-- domestic on-forwarding fuel surcharge;
-- final delivery fuel surcharge.
-
-The system must ask a business clarification such as "What movement does this fuel surcharge apply to?" It must not ask the user to choose a ProductCode ID.
-
----
-
-## 9. ProductCode assignment hierarchy
-
-### 9.1 Resolver sequence
-
-ProductCode selection must follow this sequence. Later steps may narrow a candidate set but must not contradict earlier trusted context.
-
-1. **Validate route countries and derive direction.**
-2. **Enforce the POM gateway and construct the journey.**
-3. **Attach the charge to a specific leg.**
-4. **Determine commercial position within that leg.**
-5. **Normalise the charge family from governed aliases and evidence.**
-6. **Apply transport mode and operational location.**
-7. **Apply calculation basis or document type where the ProductCode catalogue distinguishes it.**
-8. **Filter to active, effective and scope-compatible ProductCodes.**
-9. **Assign only when one exact valid ProductCode remains.**
-
-### 9.2 Precedence and trust
-
-| Rule ID | Business rule |
-|---|---|
-| `BR-PC-001` | Trusted origin and destination countries outrank parsed or user-supplied direction labels. |
-| `BR-PC-002` | Route-derived import/export domain cannot be overridden by frontend JSON, supplier terminology or a previous mapping. |
-| `BR-PC-003` | Journey leg and commercial position outrank generic charge aliases. |
-| `BR-PC-004` | An accepted alias or prior mapping may be reused only when its stored context remains compatible with the current route, leg, mode and position. |
-| `BR-PC-005` | Inactive, expired, wrong-domain or wrong-scope ProductCodes are not candidates. |
-| `BR-PC-006` | A generic ProductCode must not be used merely because a specific code is missing. |
-| `BR-PC-007` | The ProductCode ID is an implementation detail. The user sees the business classification and human-readable ProductCode code/name. |
-| `BR-PC-008` | Any override must preserve the original system classification, the replacement, reason, user and timestamp. |
-
-### 9.3 Resolver outcomes
-
-| Outcome | Required behaviour |
-|---|---|
-| One exact valid match | Assign automatically and record the rule version and context |
-| More than one valid match | Ask the minimum business clarification needed; re-run the resolver after the answer |
-| No valid match | Keep unresolved; offer the governed ProductCode request workflow |
-| Incomplete shipment context | Block assignment and identify the missing route/leg information |
-| Candidate conflicts with route domain or leg | Reject candidate; return to manual review |
-| Pending ProductCode request | Keep charge visible and unresolved under the existing finalisation policy |
-
----
-
-## 10. Domestic rate sources and precedence
-
-### 10.1 Approved source types
-
-Domestic pre-carriage and on-forwarding rates may come only from:
-
-1. an active customer-specific contracted rate approved for the exact route and service;
-2. an active carrier or supplier contract/tariff;
-3. an approved EFM domestic route rate card;
-4. a current supplier spot quotation attached to the quote evidence;
-5. manual sourcing recorded against the quote when no approved configured rate exists.
-
-### 10.2 Selection hierarchy
-
-The most specific valid rate wins, subject to all of the following matching:
-
-- operating entity;
-- origin and destination;
-- direction/leg type;
-- transport mode and service level;
-- commodity or special-handling constraints;
-- weight/quantity band and minimum;
-- customer scope where applicable;
-- effective date and validity;
-- currency and tax treatment.
-
-If two equally specific active rates conflict, the system must not choose the cheapest, latest or highest-margin rate automatically. It must send the conflict to manual review.
-
-### 10.3 Rating safeguards
-
-| Rule ID | Business rule |
-|---|---|
-| `BR-RATE-001` | A domestic leg cannot be treated as complete without an applicable BUY cost or a recorded manual-source requirement. |
-| `BR-RATE-002` | An existing local SELL rate must never be used as a hidden substitute for a missing BUY cost. |
-| `BR-RATE-003` | Sell pricing must be calculated from the approved cost and existing margin/pricing rules, unless a governed customer sell tariff explicitly applies. |
-| `BR-RATE-004` | Expired rates are invalid unless an authorised override policy explicitly permits use and records the reason. No such automatic override is included at launch. |
-| `BR-RATE-005` | Minimum charges, chargeable weight, fuel, handling and other domestic components must remain individually reviewable. |
-| `BR-RATE-006` | The source currency must be preserved. FX conversion must follow the existing RateEngine/company policy. |
-| `BR-RATE-007` | GST and tax treatment must follow existing company policy and remain visible at charge level. |
-| `BR-RATE-008` | A spot rate must retain supplier, date, validity and source evidence. |
-
----
-
-## 11. Manual-review conditions
-
-### 11.1 Hard blockers
-
-The following conditions block automatic completion and finalisation:
-
-| Rule ID | Condition | Required action |
+| ID | Input | Expected |
 |---|---|---|
-| `BR-MR-001` | Missing or invalid origin/destination country | Correct shipment context |
-| `BR-MR-002` | International air route does not pass through POM | Reconstruct through POM or reject as unsupported |
-| `BR-MR-003` | Required domestic pre-carriage/on-forwarding leg is missing | Add/regenerate the leg |
-| `BR-MR-004` | Charge has no leg assignment | Classify the charge to a leg |
-| `BR-MR-005` | ProductCode candidate conflicts with direction, leg, mode or location | Select a compatible business context or request a ProductCode |
-| `BR-MR-006` | Multiple exact ProductCode candidates remain | Answer business clarification |
-| `BR-MR-007` | No ProductCode exists for a required charge | Use ProductCode request workflow |
-| `BR-MR-008` | Required domestic BUY rate is missing | Source and record an approved rate |
-| `BR-MR-009` | Two active domestic rates conflict at equal precedence | Authorised user chooses and records reason |
-| `BR-MR-010` | Rate is expired or outside route/service/weight scope | Obtain a valid rate |
-| `BR-MR-011` | Calculation basis, minimum or percentage base is ambiguous | Resolve commercial basis |
-| `BR-MR-012` | Required FX rate/currency handling is missing or contradictory | Resolve currency treatment |
-| `BR-MR-013` | GST/tax treatment cannot be determined under existing policy | Authorised review |
-| `BR-MR-014` | Reviewed totals do not reconcile with leg and charge-line totals | Correct calculation before finalisation |
-| `BR-MR-015` | Customer output differs from reviewed totals or omits a required leg/charge | Block publication and correct output |
-| `BR-MR-016` | Route/location/mode is outside launch scope | Use manual SPOT workflow or wait for later scope |
+| `UAT-16A-001` | BNE → POM | One import international leg |
+| `UAT-16A-002` | SIN → LAE | SIN → POM → LAE |
+| `UAT-16A-003` | BNE → HGU | BNE → POM → HGU |
+| `UAT-16A-004` | POM → BNE | One export international leg |
+| `UAT-16A-005` | LAE → SIN | LAE → POM → SIN |
+| `UAT-16A-006` | HGU → BNE | Pattern recognised but blocked/manual while HGU → POM rate gate is unmet; enabled only after verified coverage |
+| `UAT-16A-007` | Supplier says direct SIN → LAE | POM inserted |
+| `UAT-16A-008` | Required POM → LAE BUY missing | Visible blocker; no SELL substitution |
+| `UAT-16A-009` | FSC lacks leg context | Business clarification |
+| `UAT-16A-010` | One exact candidate | Auto-assigned and audited |
+| `UAT-16A-011` | Two candidates | Clarification required |
+| `UAT-16A-012` | No ProductCode | Request option; unresolved |
+| `UAT-16A-013` | Wrong-domain candidate | Rejected |
+| `UAT-16A-014` | Equal-precedence rates conflict | Manual decision |
+| `UAT-16A-015` | Mixed currencies, valid FX | Preserve, convert and disclose |
+| `UAT-16A-016` | Missing FX | Finalisation blocked |
+| `UAT-16A-017` | Charge has no leg | Finalisation blocked |
+| `UAT-16A-018` | Output total differs | Publication blocked |
+| `UAT-16A-019` | Change LAE import to HGU | LAE leg invalidated; HGU leg generated |
+| `UAT-16A-020` | Special cargo lacks governed surcharge | Manual SPOT |
 
-### 11.2 Review without silent completion
+## 14. Interpretation rule
 
-The following may allow the quote draft to remain open but must stay visibly unresolved:
-
-- optional final local delivery not yet priced;
-- supplier spot validity awaiting confirmation;
-- special cargo handling awaiting supplier response;
-- pending ProductCode creation request;
-- non-mandatory commercial term requiring user acknowledgement;
-- evidence quality warning where the commercial value has not been silently assumed.
-
-Whether a draft can be finalised with any of these items is governed by the existing finalisation policy. Phase 16 does not weaken that policy.
-
-### 11.3 Override policy
-
-At launch:
-
-- there is no override for a non-POM international gateway;
-- there is no override for a missing required leg;
-- there is no override for a totals mismatch;
-- there is no override that permits a wrong-domain ProductCode;
-- there is no override that silently supplies a missing BUY cost.
-
-Any future manager override must be separately designed, permissioned and audited.
-
----
-
-## 12. Initial launch scope
-
-### 12.1 Included
-
-| Scope item | Launch baseline |
-|---|---|
-| Service domain | International Air Freight |
-| International gateway | POM only |
-| PNG locations | POM, LAE and HGU |
-| Import patterns | IMP-POM, IMP-LAE, IMP-HGU |
-| Export patterns | EXP-POM, EXP-LAE, EXP-HGU |
-| Domestic regional mode | Domestic air pre-carriage/on-forwarding between POM and LAE/HGU |
-| ProductCode behaviour | Automatic assignment only for one exact valid context-compatible match |
-| Rate behaviour | Approved configured rate, valid supplier spot rate or visible manual sourcing |
-| Quote output | One customer quote with preserved leg-level calculation and evidence |
-| Rollout | Route-group feature flags and controlled UAT |
-
-### 12.2 Explicit exclusions at launch
-
-The following are outside automated Phase 16 launch scope and must remain manual, SPOT or separately governed:
-
-1. international air gateways in PNG other than POM;
-2. PNG regional origins or destinations other than POM, LAE and HGU;
-3. domestic-only shipments;
-4. sea freight, coastal shipping and inter-island sea legs;
-5. intercity road linehaul as a substitute for the defined domestic air leg;
-6. multi-stop domestic journeys or more than one regional transfer;
-7. third-country movements with no PNG origin or destination;
-8. automated local pickup/final-delivery pricing where no approved existing rate source is configured;
-9. automatic pricing of dangerous goods, live animals, perishables, oversized or other special cargo surcharges when an exact governed rate is unavailable;
-10. automatic customs-only, brokerage-only or clearance-only journey construction;
-11. automatic use of inferred supplier rates, stale quotes, emails without validity, or historical SELL values;
-12. autonomous ProductCode creation or approval;
-13. autonomous overrides of tax, FX, margin, gateway, totals or missing-rate controls.
-
-Excluded shipments may still be quoted through the existing controlled manual/SPOT process. Exclusion means "not automatically completed," not "commercial evidence may be discarded."
-
----
-
-## 13. Customer quote and totals rules
-
-| Rule ID | Business rule |
-|---|---|
-| `BR-TOT-001` | The customer may receive one quote, but the system must retain every underlying journey leg and reviewed charge line. |
-| `BR-TOT-002` | International cost, POM gateway charges, domestic pre-carriage/on-forwarding, optional delivery, tax and margin must roll up from included charge lines only. |
-| `BR-TOT-003` | Informational, ignored or excluded lines must not enter totals and must retain an explicit reason. |
-| `BR-TOT-004` | Compatible customer-facing lines may be grouped by ProductCode only at output boundaries; internal source lines and audit evidence remain intact. |
-| `BR-TOT-005` | Lines with different ProductCodes, currencies, tax codes or incompatible commercial components must not be grouped. |
-| `BR-TOT-006` | Missing domestic components remain visible and must not be concealed by a complete-looking customer total. |
-| `BR-TOT-007` | Reopening or recalculating a quote must regenerate affected legs and totals without losing recorded evidence or decisions. |
-
----
-
-## 14. Audit and evidence requirements
-
-Every automatic ProductCode or rate decision must retain:
-
-- shipment and leg identifiers;
-- resolved direction and journey pattern;
-- charge-context dimensions;
-- source label/text and document location where available;
-- candidate ProductCodes considered;
-- selected ProductCode and human-readable code/name;
-- resolver/rule version;
-- rate source, validity and supplier;
-- automatic/manual outcome;
-- clarification or override reason;
-- operator and timestamp;
-- before/after values when a decision changes;
-- totals inclusion decision.
-
-Ignored means deliberately excluded with evidence. It never means disappeared.
-
----
-
-## 15. Canonical UAT scenarios
-
-These scenarios are mandatory and must be traceable to automated tests and UAT evidence.
-
-| Scenario ID | Input | Expected result |
-|---|---|---|
-| `UAT-16A-001` | BNE -> POM | Import; one international leg; import origin/freight/destination contexts |
-| `UAT-16A-002` | SIN -> LAE | Reconstructed as SIN -> POM -> LAE; international plus domestic on-forwarding |
-| `UAT-16A-003` | BNE -> HGU | Reconstructed as BNE -> POM -> HGU; international plus domestic on-forwarding |
-| `UAT-16A-004` | POM -> BNE | Export; one international leg; export origin/freight/destination contexts |
-| `UAT-16A-005` | LAE -> SIN | Reconstructed as LAE -> POM -> SIN; domestic pre-carriage plus international |
-| `UAT-16A-006` | HGU -> BNE | Reconstructed as HGU -> POM -> BNE; domestic pre-carriage plus international |
-| `UAT-16A-007` | Supplier text says direct SIN -> LAE international | POM inserted; direct LAE international gateway rejected |
-| `UAT-16A-008` | Required POM -> LAE rate missing | Visible manual-sourcing blocker; no SELL substitution |
-| `UAT-16A-009` | `FSC` without leg context | Business clarification requested; no ProductCode guessed |
-| `UAT-16A-010` | One exact compatible ProductCode | Automatically assigned and audited |
-| `UAT-16A-011` | Two compatible ProductCodes | Manual business clarification required |
-| `UAT-16A-012` | No ProductCode | Unresolved charge and ProductCode request option |
-| `UAT-16A-013` | Import route offered export-domain ProductCode | Candidate rejected |
-| `UAT-16A-014` | Equal-precedence conflicting domestic rates | Manual rate decision required |
-| `UAT-16A-015` | Mixed currencies with valid FX | Correct source-currency preservation, conversion and disclosure |
-| `UAT-16A-016` | Mixed currencies without valid FX | Finalisation blocked |
-| `UAT-16A-017` | Charge not attached to a leg | Finalisation blocked |
-| `UAT-16A-018` | Customer output total differs from reviewed charge total | Publication blocked |
-| `UAT-16A-019` | Reopen LAE import and change destination to HGU | POM-to-LAE leg/charges removed or returned to review; POM-to-HGU regenerated |
-| `UAT-16A-020` | Special cargo with no exact governed domestic surcharge | Route built, surcharge remains manual SPOT review |
-
----
-
-## 16. Phase 16A exit criteria
-
-Phase 16A is complete when:
-
-1. this document is accepted as the governing baseline;
-2. the ProductCode catalogue can be assessed against the context dimensions in this document;
-3. domestic rate owners can identify the source and validity of POM-LAE and POM-HGU rates in both directions;
-4. every Phase 16B requirement can reference one or more rule IDs from this document;
-5. every Phase 16 test and UAT case can trace back to a rule ID;
-6. no implementation team is required to invent a gateway, journey, leg, ProductCode or missing-rate rule.
-
----
-
-## 17. Implementation interpretation rule
-
-When a case is not explicitly covered:
-
-1. do not infer a new commercial rule from code, labels or historical data;
-2. preserve the evidence;
-3. mark the item unsupported or unresolved;
-4. obtain a business decision;
-5. update this document before automating the new case.
-
-That is deliberate. RateEngine should be fast, but it must not become confidently wrong.
+For uncovered cases: preserve evidence, do not invent a rule, mark unsupported/unresolved, obtain a business decision, update this document, then automate.

--- a/docs/business-rules/phase-16b-air-freight-requirements-gap-assessment.md
+++ b/docs/business-rules/phase-16b-air-freight-requirements-gap-assessment.md
@@ -1,0 +1,467 @@
+# RateEngine Phase 16B - International Air Freight Requirements and Current-System Gap Assessment
+
+**Document ID:** RE-REQ-16B-AIR-001  
+**Version:** 1.0  
+**Assessment date:** 21 July 2026  
+**Status:** Authoritative requirements baseline and read-only repository assessment  
+**Source business rules:** `docs/business-rules/phase-16a-air-freight-journey-productcode-rules.md`  
+**Repository assessed:** `nace-martin/Project-RateEngine`  
+**Assessed branch / commit:** `main` at `f14c3ba2f37af1897cef38f3570f74d10aa37f14`  
+**Applies to:** Phase 16C architecture, Phase 16D-16G implementation, automated tests, staging UAT and launch decisions
+
+---
+
+## 1. Purpose
+
+This document converts the Phase 16A business rules into testable requirements and records the current RateEngine implementation status against each requirement.
+
+It is intentionally read-only. It does not create ProductCodes, alter rates, change calculations, add migrations or modify application behaviour.
+
+Status values used in this assessment:
+
+- `SUPPORTED` - current code substantially satisfies the requirement;
+- `PARTIALLY_SUPPORTED` - a useful foundation exists, but the Phase 16 rule is not fully satisfied;
+- `MISSING` - no adequate implementation exists;
+- `CONFLICTING` - current behaviour would prevent or contradict the Phase 16 rule;
+- `OUT_OF_SCOPE` - the condition is intentionally excluded from automated launch scope.
+
+---
+
+## 2. Executive assessment
+
+### 2.1 Overall verdict
+
+**Phase 16B is ready to proceed to Phase 16C architecture design, but RateEngine is not ready for Phase 16 implementation.**
+
+The repository already provides several strong foundations:
+
+- trusted PNG import/export/domestic country classification;
+- separate import, export and domestic pricing engines;
+- deterministic rate-selection services with not-found and ambiguity errors;
+- domestic COGS and SELL tables;
+- domestic POM-to-LAE, LAE-to-POM and POM-to-HGU launch rates;
+- ProductCode domains and direction-scoped selection;
+- SPOT ProductCode exception handling, audit and finalisation controls;
+- customer-output grouping that preserves internal source lines.
+
+The primary missing capability is not another rate table. It is a **journey orchestration layer** that can construct and price an international shipment as ordered international and domestic legs.
+
+### 2.2 Principal launch blockers
+
+1. There is no POM-only international-gateway enforcement or route reconstruction.
+2. There is no persisted or contractual shipment-journey / shipment-leg model.
+3. Import and export engines cannot compose the domestic engine for regional PNG origins or destinations.
+4. SPOT charges have only `airfreight`, `origin_charges` and `destination_charges` buckets; they cannot identify domestic pre-carriage, domestic on-forwarding or final local delivery legs.
+5. ProductCode validation uses the overall shipment direction. It therefore rejects `DOMESTIC` ProductCodes inside an `IMPORT` or `EXPORT` international journey.
+6. The configured launch tariff contains no HGU-to-POM domestic COGS or SELL freight rate.
+7. Domestic-rate rows do not capture the full approved-source hierarchy, source evidence, rate owner, service level, customer specificity or approval status required by Phase 16A.
+8. There are no route-group feature flags limiting automation to POM, LAE and HGU.
+9. Existing international quote totals do not roll up explicit domestic legs while preserving leg-level reconciliation.
+
+### 2.3 Critical architecture conclusion
+
+ProductCode domain must be resolved **per charge leg**, not once for the whole shipment:
+
+- international import leg and POM import gateway charges use `IMPORT` ProductCodes;
+- international export leg and POM export gateway charges use `EXPORT` ProductCodes;
+- domestic air pre-carriage or on-forwarding freight and domestic-air surcharges use `DOMESTIC` ProductCodes;
+- the journey role still records whether that domestic leg is `EXPORT_PRE_CARRIAGE` or `IMPORT_ON_FORWARDING`.
+
+This retains one commercial truth for domestic air freight while preserving the international journey context. The current overall-direction ProductCode validator must be redesigned for leg-aware validation before Phase 16 can work.
+
+---
+
+## 3. Repository evidence reviewed
+
+| Area | Principal evidence |
+|---|---|
+| Country classification | `backend/core/business_rules.py` |
+| SPOT scope and triggers | `backend/quotes/spot_services.py` |
+| SPOT envelope and charge data | `backend/quotes/spot_models.py` |
+| Draft Quote route direction | `backend/quotes/services/draft_quote_adapter.py` |
+| ProductCode map validation | `backend/quotes/services/draft_quote_resolve_service.py` |
+| ProductCode and rate models | `backend/pricing_v4/models.py` |
+| Rate selection | `backend/pricing_v4/services/rate_selector.py` |
+| Domestic calculation | `backend/pricing_v4/engine/domestic_engine.py` |
+| International calculation | `backend/pricing_v4/engine/import_engine.py`, `backend/pricing_v4/engine/export_engine.py` |
+| Calculation/API orchestration | `backend/pricing_v4/views.py`, `backend/pricing_v4/adapter.py` |
+| ProductCode API | `backend/pricing_v4/views.py::ProductCodeListViewSet` |
+| Domestic tariff data | `backend/pricing_v4/management/commands/seed_launch_domestic_tariffs.py` |
+| Existing on-forwarding audit | `docs/audits/business-rule-next-phase-audit.md` |
+| Customer output grouping | `backend/quotes/quote_result_contract.py`, public quote serializers/views |
+| Existing UAT controls | `docs/pilot/air-freight-pilot-uat.md` and Phase 13-15 pilot documents |
+
+---
+
+## 4. Requirements traceability matrix
+
+| Requirement ID | Phase 16A rules | Testable requirement | Current status | Current evidence / gap | Acceptance criterion | Priority | Planned phase |
+|---|---|---|---|---|---|---|---|
+| `REQ-16B-001` | BR-DIR-001 to 005 | Derive IMPORT, EXPORT, DOMESTIC_ONLY or unsupported direction from trusted countries and fail when country data is missing. | `SUPPORTED` | `classify_png_shipment()` implements PG direction matrix and fails for missing/third-country routes. Current return value is `DOMESTIC`, not the document label `DOMESTIC_ONLY`. | Given trusted country pairs, the resolver returns the expected domain; missing or third-country data blocks automation. | Launch blocker | 16C regression only |
+| `REQ-16B-002` | BR-GW-001, BR-GW-002 | Every international air import ends its international leg at POM; every export starts its international leg at POM. | `MISSING` | Country classification does not enforce airport gateway. | SIN-LAE becomes SIN-POM plus POM-LAE; LAE-SIN becomes LAE-POM plus POM-SIN. | Launch blocker | 16C-16E |
+| `REQ-16B-003` | BR-GW-003 to 006 | Never treat LAE, HGU or another PNG airport as an international gateway, regardless of user or supplier text. | `MISSING` | Current route validation accepts any PNG airport as an import/export endpoint. | Direct international regional routes are reconstructed through POM or hard-blocked. | Launch blocker | 16C-16E |
+| `REQ-16B-004` | BR-JNY-IMP-001 to 006 | Construct `IMP-POM`, `IMP-LAE` and `IMP-HGU` as ordered journey patterns. | `MISSING` | Import engine calculates one lane only and cannot invoke the domestic engine. | All three import UAT patterns contain the exact required legs in order. | Launch blocker | 16C-16E |
+| `REQ-16B-005` | BR-JNY-EXP-001 to 006 | Construct `EXP-POM`, `EXP-LAE` and `EXP-HGU` as ordered journey patterns. | `MISSING` | Export engine calculates one lane only and cannot invoke the domestic engine. | All three export UAT patterns contain the exact required legs in order. | Launch blocker | 16C-16E |
+| `REQ-16B-006` | BR-JNY-INV-001 to 006 | Reconstruct supported direct regional routes and reject unsupported gateways, domestic-only, third-country and multi-stop patterns. | `PARTIALLY_SUPPORTED` | Domestic-only and third-country classification exist. Gateway reconstruction and multi-stop controls do not. | Every invalid pattern returns a deterministic route decision and no silently incomplete quote. | Launch blocker | 16C-16E |
+| `REQ-16B-007` | BR-LEG-001 to 005 | Represent a journey as ordered explicit legs and attach every included charge to one leg. | `MISSING` | No `ShipmentJourney` or `ShipmentLeg` model/contract exists. SPE charge buckets are not leg identifiers. | API and persistence expose leg ID, sequence, type, mode, origin and destination for each included line. | Launch blocker | 16C |
+| `REQ-16B-008` | BR-LEG-006, BR-LEG-007 | Regenerate legs and revalidate charges when route or location changes. | `MISSING` | No journey generator exists. | Changing LAE destination to HGU removes/reviews LAE leg lines and generates the HGU leg. | Launch blocker | 16C-16E |
+| `REQ-16B-009` | BR-GOV-002, BR-GOV-010 | Prevent totals inclusion for an unassigned or silently moved charge. | `PARTIALLY_SUPPORTED` | SPOT lines support totals exclusion and evidence, but no leg assignment is available. | A line without a valid leg remains visible and blocks finalisation. | Launch blocker | 16C-16G |
+| `REQ-16B-010` | Section 8.1 | Resolve the full charge context: domain, journey pattern, leg, position, location, mode, family, basis, rate source, currency, tax, date and evidence. | `PARTIALLY_SUPPORTED` | Current models cover domain, category, bucket, basis, route snapshots, currency and evidence. Journey pattern, leg type/sequence, operational role and governed rate-source hierarchy are absent. | A charge-context object validates all mandatory dimensions before ProductCode selection. | Launch blocker | 16C-16D |
+| `REQ-16B-011` | Section 8.2 | Distinguish international origin/freight/destination from domestic pre-carriage/on-forwarding origin/freight/destination and optional final delivery. | `MISSING` | Current charge buckets provide only origin, freight and destination at shipment level. | Every UAT charge is classified to the correct leg and commercial position. | Launch blocker | 16C-16D |
+| `REQ-16B-012` | Section 8.3, BR-GOV-006 | For ambiguous labels such as FSC or Handling, request the minimum business clarification rather than guessing. | `PARTIALLY_SUPPORTED` | SPOT supports ambiguous/unmapped review, but questions are not driven by leg-aware context. | An ambiguous FSC asks what movement it applies to, then re-runs context and ProductCode resolution. | Required | 16D-16G |
+| `REQ-16B-013` | BR-PC-001 to 003 | Derive ProductCode domain from trusted route and leg context. | `CONFLICTING` | Current Draft Quote resolver derives one expected domain from the whole shipment and rejects any other domain. A domestic leg inside an import/export journey therefore cannot use `DOMESTIC` ProductCodes. | International charges validate to IMPORT/EXPORT; domestic leg charges validate to DOMESTIC without losing journey role. | Launch blocker | 16C-16D |
+| `REQ-16B-014` | BR-PC-004 to 006 | Reuse aliases or prior mappings only when route, leg, mode and position remain compatible; do not fall back to a generic code. | `PARTIALLY_SUPPORTED` | ChargeAlias supports mode/domain and origin/main/destination scopes, but not journey leg, location or transport mode. | An alias match incompatible with the current leg is rejected or reviewed. | Launch blocker | 16C-16D |
+| `REQ-16B-015` | Section 9.1, 9.3 | Assign a ProductCode automatically only when exactly one active, effective and scope-compatible candidate remains. | `PARTIALLY_SUPPORTED` | Exact/ambiguous alias handling and manual mapping exist. ProductCode has no active/effective fields and candidate filtering lacks Phase 16 context. | One candidate auto-assigns; multiple or zero candidates remain unresolved. | Launch blocker | 16C-16D |
+| `REQ-16B-016` | BR-PC-005 | Exclude inactive, expired, wrong-domain and wrong-scope ProductCodes. | `PARTIALLY_SUPPORTED` | Wrong-domain rejection exists. ProductCode itself has no active or validity fields; aliases have active/review state. | Candidate query returns only effective ProductCodes and compatible approved aliases. | Required | 16C-16D |
+| `REQ-16B-017` | BR-PC-007, BR-GOV-005 | Never require raw ProductCode IDs from the user. | `SUPPORTED` | Frontend uses human-readable API-backed ProductCode options; IDs remain implementation details. | Operator chooses business meaning/code name, never types an internal ID. | Required | Regression only |
+| `REQ-16B-018` | BR-PC-008, BR-GOV-009 | Audit automatic assignment, clarification, override and later changes. | `PARTIALLY_SUPPORTED` | DraftQuoteDecisionDB and charge `rule_meta` audit manual decisions. Automatic resolver rule version and full context are not stored. | Decision record contains candidates, chosen code, rule version, context, evidence, user and timestamp. | Required | 16C-16D |
+| `REQ-16B-019` | Section 10.1, 10.2 | Select domestic rates using approved source precedence and exact route/service/customer/date context. | `PARTIALLY_SUPPORTED` | Deterministic date, route, ProductCode, currency and counterparty selection exists. Contract/customer-specific precedence and approval/source-type hierarchy do not. | Most specific valid approved source wins; equal precedence conflicts block. | Launch blocker | 16C-16F |
+| `REQ-16B-020` | BR-RATE-001, 002 | A required domestic leg must have a BUY cost or visible manual-source blocker; never substitute SELL for BUY. | `PARTIALLY_SUPPORTED` | Domestic engine has separate COGS/SELL and emits a missing placeholder only when both are absent. It can still produce a SELL line when BUY is missing. International journey finalisation does not know a domestic BUY is required. | Missing BUY always creates a blocking sourcing gap even when a SELL tariff exists. | Launch blocker | 16F |
+| `REQ-16B-021` | BR-RATE-003 to 008 | Preserve cost, sell, minimum, weight basis, surcharge, currency, GST, validity, supplier and evidence. | `PARTIALLY_SUPPORTED` | Rate tables cover cost/sell, basis, currency and validity. Rate rows lack source evidence, approval, owner and tax fields; domestic GST is derived from ProductCode. | Each selected domestic rate exposes provenance and all calculation dimensions in audit output. | Required | 16C-16F |
+| `REQ-16B-022` | BR-MR-008 to 010 | Missing, conflicting or expired domestic rates must enter manual review. | `PARTIALLY_SUPPORTED` | Rate selector raises not-found/ambiguity. No international-leg orchestrator converts these into Phase 16 journey blockers. | Draft remains open with route-specific sourcing action and cannot finalise. | Launch blocker | 16F-16G |
+| `REQ-16B-023` | BR-MR-001 to 007 | Missing route, gateway, leg or ProductCode context must block completion with a specific remediation. | `PARTIALLY_SUPPORTED` | Country and ProductCode errors exist. Gateway and leg errors do not. | Every blocker has a stable error code and business action. | Launch blocker | 16C-16G |
+| `REQ-16B-024` | BR-MR-011 to 015 | Ambiguous basis, FX, tax or totals mismatch must block finalisation/publication. | `PARTIALLY_SUPPORTED` | SPOT supports basis/currency review and unresolved-item finalisation blocks. Explicit leg reconciliation and publication comparison are not Phase 16 aware. | Finalise/publish fails until charge, leg and output totals reconcile. | Launch blocker | 16F-16H |
+| `REQ-16B-025` | Section 11.3 | No launch override for gateway, required leg, totals, wrong-domain code or missing BUY. | `MISSING` | These Phase 16 blocker types do not yet exist. | Permissions cannot bypass the five non-overridable controls. | Launch blocker | 16C-16G |
+| `REQ-16B-026` | Section 12.1 | Automate only international air via POM for POM, LAE and HGU route patterns. | `MISSING` | Current domestic tariff seed contains many PNG routes; no journey automation allowlist exists. | Route allowlist exposes only six approved journey patterns. | Launch blocker | 16C-16E |
+| `REQ-16B-027` | BR-GOV-012 | Feature-flag automation by route group. | `MISSING` | No route-group feature flag was found. | IMP-LAE, IMP-HGU, EXP-LAE and EXP-HGU can be independently disabled. | Launch blocker | 16C-16E |
+| `REQ-16B-028` | Section 12.2 | Excluded locations, modes, multi-stop, special cargo and unsupported services remain manual/SPOT. | `PARTIALLY_SUPPORTED` | SPOT/manual commodity controls exist. Route, mode and location exclusions are not governed by a Phase 16 allowlist. | Excluded case never appears automatically complete and preserves all evidence. | Required | 16C-16G |
+| `REQ-16B-029` | BR-TOT-001 to 003 | Produce one customer quote from included leg lines while retaining underlying calculations and explicit exclusions. | `PARTIALLY_SUPPORTED` | Quote line result and exclusion behaviour exist, but not multi-leg roll-up. | Quote total equals the sum of included lines across all journey legs. | Launch blocker | 16F |
+| `REQ-16B-030` | BR-TOT-004, 005 | Group compatible public lines only at output boundaries and preserve internal lines. | `SUPPORTED` | Existing ProductCode grouping protects currency/tax/component boundaries and retains internal lines. | Phase 16 domestic lines follow the same grouping guardrails. | Required | Regression only |
+| `REQ-16B-031` | BR-TOT-006 | Missing domestic components must remain visible and prevent a complete-looking total. | `MISSING` | International quotes have no required domestic leg/component awareness. | Missing POM-LAE or HGU-POM component appears as a visible blocker, not a zero-hidden line. | Launch blocker | 16F-16G |
+| `REQ-16B-032` | BR-TOT-007 | Reopen/recalculate without losing evidence and with affected leg regeneration. | `PARTIALLY_SUPPORTED` | SPOT reopen and decision persistence exist. Journey regeneration does not. | Reopened route change produces correct new legs and preserved decision history. | Required | 16E-16H |
+| `REQ-16B-033` | Section 14 | Retain full ProductCode, rate, leg, source and before/after audit evidence. | `PARTIALLY_SUPPORTED` | Strong SPOT evidence exists, but leg and automatic-rate provenance fields are incomplete. | Audit can reconstruct why each final charge and rate was used. | Required | 16C-16F |
+| `REQ-16B-034` | Section 15 | Implement all 20 canonical scenarios as traceable automated and UAT cases. | `MISSING` | Existing tests cover direction, domestic engine and SPOT independently, not the Phase 16 journeys. | Every UAT ID links to at least one automated test and recorded staging evidence. | Launch blocker | 16H-16I |
+
+---
+
+## 5. Current-system gap assessment by subsystem
+
+### 5.1 Direction and gateway
+
+`classify_png_shipment()` is suitable as the trusted top-level country classifier. It should remain small and deterministic.
+
+It must not be expanded into a full routing engine. Phase 16C should introduce a separate journey resolver that receives trusted countries and airport/location codes, applies the POM rule, and produces a journey decision.
+
+Current risk: `SIN -> LAE` is correctly classified as `IMPORT`, but nothing prevents the application from treating LAE as the direct international destination.
+
+### 5.2 Journey and leg representation
+
+No durable journey abstraction was found.
+
+Current structures are insufficient:
+
+- `SpotPricingEnvelopeDB.shipment_context_json` stores one overall origin/destination;
+- `SPEChargeLineDB.bucket` stores only airfreight/origin/destination;
+- `QuoteComponent` represents commercial grouping, not physical journey order;
+- import/export/domestic engines return independent `QuoteResult` objects;
+- no orchestration contract links those results as legs.
+
+Phase 16C must define the canonical journey and leg contract before migrations or engine integration are attempted.
+
+### 5.3 ProductCode assignment
+
+#### Existing strengths
+
+- ProductCode domains are explicit: EXPORT, IMPORT and DOMESTIC.
+- ID ranges are domain-protected.
+- aliases support approved/candidate/rejected states and origin/main/destination scope.
+- SPOT mapping fails closed when trusted direction is unavailable.
+- wrong-domain manual mappings are rejected.
+- unresolved codes have a governed ProductCode request lifecycle.
+
+#### Gaps
+
+ProductCode currently lacks the Phase 16 dimensions needed for exact context matching:
+
+- journey role;
+- leg type;
+- transport mode;
+- operational location;
+- service domain;
+- effective/active lifecycle on ProductCode itself;
+- contextual specificity ranking.
+
+#### Direct conflict to resolve
+
+`_expected_product_code_domain()` returns the shipment's overall IMPORT/EXPORT/DOMESTIC direction. `_validate_product_code_domain()` then requires every mapped line to match that single domain.
+
+That is safe for a single-leg quote but incompatible with Phase 16. An import to LAE needs IMPORT codes for the international/POM context and DOMESTIC codes for the POM-LAE air leg.
+
+#### Phase 16C recommended rule
+
+Add `product_code_domain` to the resolved charge context and derive it from the assigned leg:
+
+| Leg / charge context | ProductCode domain |
+|---|---|
+| International import and POM import gateway charges | IMPORT |
+| International export and POM export gateway charges | EXPORT |
+| Domestic air pre-carriage/on-forwarding freight and domestic-air surcharges | DOMESTIC |
+| International destination charges overseas | EXPORT |
+| Optional local PNG cartage directly tied to import/export service | Existing IMPORT/EXPORT local ProductCode rules unless explicitly modelled as a separate domestic transport service |
+
+This avoids creating duplicate domestic freight ProductCodes merely to label the wider journey direction.
+
+### 5.4 Domestic pricing and rate source
+
+The domestic engine is a useful reusable calculation unit. It already supports:
+
+- route-specific COGS and SELL freight;
+- separate cost and sell;
+- date validity;
+- currency and counterparty selection;
+- global domestic surcharges;
+- missing-rate placeholders;
+- ProductCode line output;
+- GST calculation.
+
+It is currently a standalone quote engine. The international engines do not dispatch to it.
+
+Important safety gap: `_calculate_freight()` emits a missing placeholder only when both COGS and SELL are missing. Phase 16 requires missing BUY to remain a blocker even when a SELL tariff exists.
+
+### 5.5 SPOT and manual review
+
+The Exception Workspace is a strong base for ProductCode and source-evidence exceptions. It already handles:
+
+- ambiguous/unmapped lines;
+- manual ProductCode selection;
+- ProductCode request, approval and rejection;
+- persisted user decisions;
+- ignored items with evidence;
+- finalisation lock and manager/admin reopen;
+- wrong overall-domain mapping rejection.
+
+It does not yet understand:
+
+- gateway failures;
+- missing journey legs;
+- domestic rate sourcing per leg;
+- leg-aware ProductCode candidates;
+- route reconstruction;
+- per-leg totals reconciliation.
+
+Phase 16G should extend the existing workspace rather than create a parallel exception UI.
+
+### 5.6 Quote totals and public output
+
+Existing output-boundary grouping should be retained. The missing work is upstream:
+
+1. calculate each leg separately;
+2. preserve each line's leg identity;
+3. consolidate included lines into one quote result;
+4. reconcile per-leg subtotal, quote total and public total;
+5. group only compatible public lines.
+
+The existing SPOT merge audit also identifies a separate risk: bucket-level replacement can remove valid standard lines when one SPOT line exists in the bucket. Phase 16 implementation must use line/ProductCode-level reconciliation, not broad bucket replacement.
+
+---
+
+## 6. ProductCode catalogue gap report
+
+### 6.1 Existing relevant catalogue structure
+
+| Capability | Current state |
+|---|---|
+| Overall domain | IMPORT / EXPORT / DOMESTIC |
+| Broad category | Freight, handling, clearance, documentation, regulatory, cartage, agency, screening, surcharge |
+| Default unit | Shipment, kg or percent |
+| Alias domain scope | Import, export, domestic or any |
+| Alias position scope | Origin, main, destination or any |
+| Domestic freight code | `DOM-FRT-AIR` |
+| Domestic surcharge examples | `DOM-DOC`, `DOM-TERMINAL`, `DOM-AWB`, `DOM-SECURITY`, `DOM-FSC`, `DOM-DG-HANDLING` |
+| Import destination examples | `IMP-HANDLE-DEST`, `IMP-STORAGE-DEST` |
+
+### 6.2 Catalogue gaps
+
+1. No ProductCode/alias dimension identifies domestic pre-carriage versus domestic on-forwarding.
+2. No dimension identifies the physical leg or sequence.
+3. No mode field distinguishes domestic air from local road/cartage within the same broad category.
+4. No operational-location scope distinguishes POM transfer handling from LAE/HGU arrival handling.
+5. Generic aliases such as FSC can match only broad domain/position scopes, not the exact movement.
+6. ProductCode records have no active/effective lifecycle fields.
+7. The API endpoint filters by one domain only and cannot request valid codes for a selected leg context.
+8. Current overall-direction validation rejects domestic codes inside international journeys.
+
+### 6.3 Do not create ProductCodes during Phase 16B
+
+Phase 16C must first decide which missing distinctions belong in:
+
+- the ProductCode's commercial identity;
+- the journey/charge context;
+- the rate row;
+- the alias scope.
+
+Strong recommendation: do not create separate `IMP-DOM-FRT-*` and `EXP-DOM-FRT-*` codes merely to encode journey role. Keep `DOM-FRT-AIR` as the domestic freight truth and store `IMPORT_ON_FORWARDING` / `EXPORT_PRE_CARRIAGE` on the leg and charge context.
+
+Create a new ProductCode only when the charge is commercially different, not merely because it appears in a different journey.
+
+---
+
+## 7. Domestic rate-source inventory
+
+The repository's launch tariff command states that COGS comes from the original buy-rate sheet and SELL comes from the corrected POM/LAE commercial sheet. The source sheets themselves, approval owner and validity evidence are not attached to the selected rate rows.
+
+### 7.1 Launch route inventory found in code
+
+| Required route | COGS freight | SELL freight | Currency | Repository status | Phase 16 assessment |
+|---|---:|---:|---|---|---|
+| POM -> LAE | K6.10/kg | K7.30/kg | PGK | Present in `seed_launch_domestic_tariffs.py` | Configured foundation; source approval/evidence still required |
+| LAE -> POM | K6.10/kg | K7.10/kg | PGK | Present | Configured foundation; source approval/evidence still required |
+| POM -> HGU | K8.85/kg | K10.30/kg | PGK | Present | Configured foundation; source approval/evidence still required |
+| HGU -> POM | Not found | Not found | - | Missing from launch tariff tuples | **Launch blocker for EXP-HGU** |
+
+### 7.2 Global domestic surcharge inventory found in code
+
+#### COGS
+
+| ProductCode | Basis | Rate | Minimum |
+|---|---|---:|---:|
+| `DOM-DOC` | Flat | K35.00 | - |
+| `DOM-TERMINAL` | Flat | K35.00 | - |
+| `DOM-SECURITY` | Per kg | K0.20 | K5.00 |
+| `DOM-FSC` | Per kg | K0.50 | - |
+
+#### SELL
+
+| ProductCode | Basis | Rate | Minimum |
+|---|---|---:|---:|
+| `DOM-AWB` | Flat | K70.00 | - |
+| `DOM-SECURITY` | Per kg | K0.20 | K5.00 |
+| `DOM-FSC` | Per kg | K0.70 | - |
+| `DOM-DG-HANDLING` | Flat | K195.00 | - |
+
+Special uplifts also exist for express, valuable cargo, live animals and oversize cargo. Phase 16A excludes automatic special-cargo surcharges where no exact governed rate applies; these rules must remain subject to commodity eligibility and SPOT controls.
+
+### 7.3 Rate-data gaps
+
+- HGU-to-POM freight is missing.
+- No source document/reference is persisted on DomesticCOGS or DomesticSellRate.
+- No approval state or approving user is persisted on rate rows.
+- No rate-source type expresses customer contract, carrier tariff, EFM rate card, supplier spot or manual source.
+- No customer-specific domestic COGS/SELL selection hierarchy exists in the domestic engine.
+- No service-level field distinguishes standard, express or other service on freight rate rows.
+- No explicit commodity/special-handling scope exists on the base rate row; separate commodity rules are used.
+- Domestic GST/tax is derived from ProductCode rather than rate source, which is acceptable if existing policy remains authoritative.
+- Existing tariffs include many locations beyond the Phase 16 launch scope; automation therefore requires a separate journey allowlist, not deletion of those rates.
+
+### 7.4 Required business evidence before Phase 16I UAT
+
+For each of the four launch directions, record:
+
+- supplier/carrier;
+- exact source sheet or quotation;
+- rate owner;
+- validity dates;
+- minimum charge;
+- chargeable-weight rule;
+- included and excluded surcharges;
+- GST treatment;
+- service level;
+- approval status;
+- whether the rate is COGS, SELL or both.
+
+---
+
+## 8. Manual-review and finalisation assessment
+
+| Phase 16 condition | Current support | Gap |
+|---|---|---|
+| Missing countries | Supported | Existing error must be carried into journey contract |
+| Wrong ProductCode overall domain | Supported | Must become per-leg domain validation |
+| Unmapped / ambiguous ProductCode | Supported | Needs leg-aware clarification questions |
+| Pending ProductCode request | Supported | Must remain blocking under current policy |
+| Missing domestic freight rate | Partial | Standalone domestic error exists; no international journey blocker |
+| Equal-precedence rate conflict | Partial | Rate selector raises ambiguity; source precedence is incomplete |
+| Missing domestic BUY with SELL present | Not supported safely | Must block; current domestic engine may still emit SELL |
+| Missing required leg | Missing | Requires journey model/generator |
+| Non-POM international gateway | Missing | Requires hard gateway rule |
+| Charge without leg | Missing | Requires leg assignment |
+| FX/tax ambiguity | Partial | Existing controls must be connected to leg roll-up |
+| Totals mismatch | Partial | No leg reconciliation |
+| Public output mismatch | Partial | Existing output safeguards, no multi-leg proof |
+| Unsupported launch route | Missing | Requires allowlist/feature flag |
+
+---
+
+## 9. Required Phase 16C architecture decisions
+
+Phase 16C must resolve the following before code implementation:
+
+1. **Journey contract:** exact fields, stable enums and persistence boundary for journey and legs.
+2. **Journey resolver:** pure deterministic service for direction, POM enforcement, pattern and leg generation.
+3. **Per-leg ProductCode domain:** replace overall shipment-domain validation with context-aware validation.
+4. **Charge-to-leg assignment:** how parser buckets, standard engine lines and manual lines receive leg identity.
+5. **Pricing orchestrator:** compose import/export and domestic engines without mutating their core commercial calculations unnecessarily.
+6. **Rate provenance:** extend or companion-model domestic rates with source type, evidence, approval and owner.
+7. **Missing BUY behaviour:** represent cost gaps independently from SELL availability.
+8. **Route feature flags:** independently enable IMP-LAE, IMP-HGU, EXP-LAE and EXP-HGU.
+9. **Totals contract:** per-leg subtotal, total cost, sell, margin, GST, FX and public-output reconciliation.
+10. **SPOT integration:** extend the existing Exception Workspace with journey/rate blockers rather than create a new workflow.
+11. **Recalculation:** route changes regenerate affected legs while preserving audit history.
+12. **Rollback:** disable route groups without reverting unrelated pricing features.
+
+---
+
+## 10. Recommended Phase 16C boundaries
+
+Phase 16C should remain architecture and contract work only.
+
+### Include
+
+- architecture decision record;
+- journey and charge-context schemas/enums;
+- ProductCode domain decision flow;
+- API request/response contracts;
+- data-model proposal and migration plan;
+- pricing-orchestrator design;
+- rate-provenance design;
+- feature-flag design;
+- totals/reconciliation contract;
+- implementation sequence and rollback plan.
+
+### Exclude
+
+- migrations;
+- ProductCode creation;
+- domestic-rate writes;
+- engine behaviour changes;
+- frontend implementation;
+- live data backfill;
+- route automation.
+
+---
+
+## 11. Phase 16B exit gate
+
+Phase 16B is complete when this document and the Phase 16A source rules are accepted in the repository.
+
+The phase concludes with the following decision:
+
+```text
+READY_FOR_PHASE_16C_DESIGN = YES
+READY_FOR_PHASE_16_IMPLEMENTATION = NO
+```
+
+Implementation must not begin until Phase 16C resolves the per-leg ProductCode domain, journey contract, orchestration and rate-provenance decisions.
+
+---
+
+## 12. Immediate next action
+
+Begin **Phase 16C - Journey, Charge Context and ProductCode Resolver Architecture**.
+
+The first design artifact must show, end to end, how this example is represented and priced:
+
+```text
+SIN -> POM -> LAE
+
+Leg 1: INTERNATIONAL_IMPORT
+ProductCode domain: IMPORT
+
+Leg 2: IMPORT_ON_FORWARDING / DOMESTIC_AIR
+ProductCode domain: DOMESTIC
+
+Customer output: one quote
+Internal truth: two legs, separately calculated and reconciled
+```
+
+If the architecture cannot represent that case without guessing, duplicating commercial truth or hiding a missing BUY rate, it is not ready.


### PR DESCRIPTION
## Scope

Adds the authoritative Phase 16A international air-freight business rules and the Phase 16B requirements traceability/current-system gap assessment.

## Documents

- `docs/business-rules/phase-16a-air-freight-journey-productcode-rules.md`
- `docs/business-rules/phase-16b-air-freight-requirements-gap-assessment.md`

## Review correction

Phase 16A was revised to version 1.1 during final review to remove two contradictions:

- ProductCode domain is now explicitly derived per assigned leg, so one international journey may correctly contain IMPORT/EXPORT and DOMESTIC ProductCodes.
- `EXP-HGU` is now explicitly disabled until approved HGU→POM BUY and SELL rate coverage is configured and verified.

## Phase 16B findings

- Records 34 traceable requirements mapped to design, implementation, testing and UAT phases.
- Confirms trusted PNG import/export/domestic direction classification already exists.
- Confirms there is no POM-only gateway enforcement, journey/leg contract or multi-leg pricing orchestrator.
- Identifies a direct ProductCode conflict: current validation uses the overall shipment direction and therefore rejects DOMESTIC ProductCodes for domestic legs inside an IMPORT or EXPORT journey.
- Confirms domestic pricing/rate-selection foundations exist, but are standalone and are not composed into international quotes.
- Confirms POM→LAE, LAE→POM and POM→HGU domestic freight tariffs are configured.
- Records HGU→POM as missing and therefore a launch blocker for `EXP-HGU` automation.
- Identifies missing route-group feature flags, rate provenance and per-leg totals reconciliation.

## Architecture direction

ProductCode domain must be resolved per leg:

- international import/POM gateway charges → `IMPORT`
- international export/POM gateway charges → `EXPORT`
- domestic pre-carriage/on-forwarding charges → `DOMESTIC`

Journey role remains explicit as `IMPORT_ON_FORWARDING` or `EXPORT_PRE_CARRIAGE`, avoiding duplicate ProductCodes for the same domestic commercial service.

## Decision gate

```text
READY_FOR_PHASE_16C_DESIGN = YES
READY_FOR_PHASE_16_IMPLEMENTATION = NO
```

Implementation must wait until Phase 16C defines the journey contract, leg-aware ProductCode resolver, multi-leg pricing orchestration, domestic-rate provenance, feature flags and totals reconciliation.

## What was intentionally not changed

- No application code.
- No migrations.
- No ProductCodes or ChargeAliases.
- No domestic rate rows or seed behaviour.
- No quote calculations, totals, GST, FX, margins or public quote output.
- No SPOT workflow or RBAC behaviour.

## Verification

- Read-only repository assessment against `main` at `f14c3ba2f37af1897cef38f3570f74d10aa37f14`.
- Cross-checked current direction rules, ProductCode models/validation, SPOT contracts, domestic engine, deterministic rate selector, tariff seed data, existing on-forwarding audit and output grouping safeguards.
- Final review confirmed no unresolved review threads.
- Container Integrity and frontend checks passed on the corrected head; backend tests were rerun because the documentation commit changed the head.

## Risk

Documentation-only. The main risk is implementing Phase 16 before the Phase 16C architecture decisions are fixed, particularly per-leg ProductCode domains and missing-BUY handling.