### PR TITLE
Hotfix SPOT cutover Draft Quote numeric normalization

### DIFF
--- a/frontend/scripts/draft-quote-normalization.test.mjs
+++ b/frontend/scripts/draft-quote-normalization.test.mjs
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import ts from "typescript";
+
+const frontendRoot = path.resolve(process.cwd());
+const normalizerSourcePath = path.join(frontendRoot, "src", "lib", "draft-quote-normalization.ts");
+const workspaceSourcePath = path.join(frontendRoot, "src", "components", "spot", "ExceptionWorkspace.tsx");
+const apiSourcePath = path.join(frontendRoot, "src", "lib", "api.ts");
+
+function transpile(source, fileName) {
+  return ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName,
+  }).outputText;
+}
+
+async function loadNormalizer() {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "draft-quote-normalization-test-"));
+  const libDir = path.join(tempDir, "lib");
+
+  try {
+    await mkdir(libDir, { recursive: true });
+    const source = await readFile(normalizerSourcePath, "utf8");
+    await writeFile(path.join(libDir, "draft-quote-normalization.mjs"), transpile(source, normalizerSourcePath), "utf8");
+    return await import(`file://${path.join(libDir, "draft-quote-normalization.mjs")}`);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+function baseDraftQuote(overrides = {}) {
+  return {
+    contract_version: "1",
+    quote_summary: "Test draft quote",
+    shipment_context: {},
+    supplier_context: {},
+    freight: {},
+    suggested_charges: [
+      {
+        id: "charge-1",
+        status: "suggested",
+        display_label: "Fuel",
+        raw_label: "Fuel",
+        suggested_product_code: "IMP-FUEL",
+        product_code_conflict: false,
+        bucket: "freight",
+        currency: "USD",
+        amount: "12.50",
+        rate: "1.25",
+        unit: "kg",
+        calculation_basis: null,
+        minimum_charge: "230.00",
+        percentage_base: null,
+        quantity: "10.5",
+        include_in_totals: true,
+        conditions: [],
+        warnings: [],
+        review_reason: null,
+        evidence: null,
+        similarity_group_id: null,
+        correction_actions: [],
+      },
+    ],
+    commercial_terms: [],
+    warnings: [],
+    unclassified_items: [],
+    ignored_items: [],
+    totals_validation: {
+      math_balances: true,
+      currency_consistent: true,
+      extracted_total: "12.50",
+      calculated_total: "12.50",
+      difference: "0.00",
+      tolerance: "0.01",
+      warnings: [],
+    },
+    review_queue: [],
+    correction_actions: [],
+    metadata: {},
+    ...overrides,
+  };
+}
+
+const { normalizeDraftQuotePayload } = await loadNormalizer();
+
+// Numeric strings from Decimal JSON are normalized at the Draft Quote API boundary.
+{
+  const normalized = normalizeDraftQuotePayload(baseDraftQuote());
+  assert.equal(normalized.suggested_charges[0].amount, 12.5);
+  assert.equal(normalized.suggested_charges[0].rate, 1.25);
+  assert.equal(normalized.suggested_charges[0].minimum_charge, 230);
+  assert.equal(normalized.suggested_charges[0].quantity, 10.5);
+  assert.equal(normalized.totals_validation.extracted_total, 12.5);
+  assert.equal(normalized.totals_validation.calculated_total, 12.5);
+  assert.equal(normalized.totals_validation.difference, 0);
+  assert.equal(normalized.totals_validation.tolerance, 0.01);
+}
+
+// JSON numbers remain numbers and optional null values remain null.
+{
+  const payload = baseDraftQuote({
+    suggested_charges: [
+      {
+        ...baseDraftQuote().suggested_charges[0],
+        amount: 0,
+        rate: null,
+        minimum_charge: null,
+        quantity: null,
+      },
+    ],
+    totals_validation: {
+      ...baseDraftQuote().totals_validation,
+      extracted_total: null,
+      calculated_total: null,
+      difference: null,
+      tolerance: 0,
+    },
+  });
+  const normalized = normalizeDraftQuotePayload(payload);
+  assert.equal(normalized.suggested_charges[0].amount, 0);
+  assert.equal(normalized.suggested_charges[0].rate, null);
+  assert.equal(normalized.suggested_charges[0].minimum_charge, null);
+  assert.equal(normalized.suggested_charges[0].quantity, null);
+  assert.equal(normalized.totals_validation.extracted_total, null);
+  assert.equal(normalized.totals_validation.calculated_total, null);
+  assert.equal(normalized.totals_validation.difference, null);
+  assert.equal(normalized.totals_validation.tolerance, 0);
+}
+
+// Required commercial amounts must fail visibly; they must not be coerced to zero.
+{
+  const payload = baseDraftQuote({
+    suggested_charges: [
+      {
+        ...baseDraftQuote().suggested_charges[0],
+        amount: "not-a-number",
+      },
+    ],
+  });
+  assert.throws(
+    () => normalizeDraftQuotePayload(payload),
+    /Invalid numeric value for suggested_charges\[0\]\.amount/
+  );
+}
+
+// The Draft Quote API boundary must normalize before returning to callers.
+{
+  const apiSource = await readFile(apiSourcePath, "utf8");
+  assert.ok(
+    apiSource.includes("import { normalizeDraftQuotePayload } from './draft-quote-normalization';"),
+    "getDraftQuote must import the Draft Quote numeric normalizer."
+  );
+  assert.ok(
+    apiSource.includes("return normalizeDraftQuotePayload(payload as DraftQuote);"),
+    "getDraftQuote must return the normalized Draft Quote payload."
+  );
+}
+
+// Exception Workspace should render rate text for zero/normalized values rather than using a truthy guard.
+{
+  const workspaceSource = await readFile(workspaceSourcePath, "utf8");
+  assert.ok(
+    workspaceSource.includes("charge.rate !== null && charge.rate !== undefined"),
+    "ExceptionWorkspace must render zero rates and avoid truthy rate checks."
+  );
+  assert.ok(
+    !workspaceSource.includes("{charge.rate && ` | ${humanizeRate"),
+    "ExceptionWorkspace must not use the legacy truthy rate render guard."
+  );
+}
+
+console.log("draft quote normalization checks passed");

--- a/frontend/scripts/spot-workspace-helpers.test.mjs
+++ b/frontend/scripts/spot-workspace-helpers.test.mjs
@@ -166,11 +166,13 @@ const {
 // 10. humanizeRate
 {
   assert.equal(humanizeRate(230, "kg", "...Min..."), "Minimum USD 230.00 or USD 230.00 per kg");
-  assert.equal(humanizeRate(0, "kg", "Fuel"), "Flat fee");
+  assert.equal(humanizeRate(0, "kg", "Fuel"), "USD 0.00 per kg");
   assert.equal(humanizeRate(null, null, "..."), "Flat fee");
+  assert.equal(humanizeRate(undefined, null, "..."), "Flat fee");
+  assert.equal(humanizeRate("", null, "..."), "Flat fee");
+  assert.equal(humanizeRate("not-a-number", "kg", "Fuel"), "Rate unavailable");
   assert.equal(humanizeRate(1.23, "set", "Handling"), "SGD 1.23 per set");
   assert.equal(humanizeRate("1.23", "set", "Handling"), "SGD 1.23 per set");
-  assert.equal(humanizeRate("not-a-number", "kg", "Fuel"), "Rate unavailable");
   assert.equal(humanizeRate(1.5, "kg", "Fuel"), "USD 1.50 per kg");
   assert.equal(humanizeRate(0.85, "kg", "Security"), "USD 0.85 per kg");
   assert.equal(humanizeRate(5.00, "unit", "Freight"), "5.00 per unit");

--- a/frontend/src/components/spot/ExceptionWorkspace.tsx
+++ b/frontend/src/components/spot/ExceptionWorkspace.tsx
@@ -516,7 +516,7 @@ export function ExceptionWorkspace({ initialData, isLive = false, envelopeId, en
                                                 <span className="font-semibold block text-slate-100">{charge.display_label}</span>
                                                 <span className="text-xs text-slate-400 block mt-0.5">
                                                     Billing Code: <strong className="font-mono text-indigo-300">{charge.suggested_product_code || "Unmapped"}</strong>
-                                                    {charge.rate && ` | ${humanizeRate(charge.rate, charge.unit, charge.display_label)}`}
+                                                    {charge.rate !== null && charge.rate !== undefined && ` | ${humanizeRate(charge.rate, charge.unit, charge.display_label)}`}
                                                 </span>
                                             </div>
                                         </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5,6 +5,7 @@ import { getJson, sendJson } from './api/shared';
 import { mapQuoteDetailToComputeResult } from './quote-detail-mapping';
 import { ReplyAnalysisResult, SPEChargeLine, SPEConditions, SPECommodity } from './spot-types';
 import { DraftQuote, DraftQuoteFinalizeResponse, DraftQuoteReopenResponse, DraftQuoteResolvePayload, DraftQuoteResolveResponse } from './draft-quote-types';
+import { normalizeDraftQuotePayload } from './draft-quote-normalization';
 import {
   LoginData,
   User,
@@ -801,7 +802,8 @@ export async function getDraftQuote(id: string): Promise<DraftQuote> {
     throw new Error(`Failed to fetch draft quote: ${detail}`);
   }
 
-  return response.json();
+  const payload = await response.json();
+  return normalizeDraftQuotePayload(payload as DraftQuote);
 }
 
 

--- a/frontend/src/lib/draft-quote-normalization.ts
+++ b/frontend/src/lib/draft-quote-normalization.ts
@@ -1,0 +1,61 @@
+import type { DraftCharge, DraftQuote, TotalsValidation } from "./draft-quote-types";
+
+class DraftQuoteNumericNormalizationError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "DraftQuoteNumericNormalizationError";
+    }
+}
+
+function isEmptyOptionalValue(value: unknown): boolean {
+    return value === null || value === undefined || (typeof value === "string" && value.trim() === "");
+}
+
+function parseFiniteNumber(value: unknown, fieldPath: string): number {
+    const numericValue = typeof value === "number" ? value : Number(String(value).trim());
+    if (!Number.isFinite(numericValue)) {
+        throw new DraftQuoteNumericNormalizationError(`Invalid numeric value for ${fieldPath}.`);
+    }
+    return numericValue;
+}
+
+function normalizeOptionalFiniteNumber(value: unknown, fieldPath: string): number | null {
+    if (isEmptyOptionalValue(value)) return null;
+    return parseFiniteNumber(value, fieldPath);
+}
+
+function normalizeRequiredFiniteNumber(value: unknown, fieldPath: string): number {
+    if (isEmptyOptionalValue(value)) {
+        throw new DraftQuoteNumericNormalizationError(`Missing required numeric value for ${fieldPath}.`);
+    }
+    return parseFiniteNumber(value, fieldPath);
+}
+
+function normalizeDraftCharge(charge: DraftCharge, index: number): DraftCharge {
+    const fieldPrefix = `suggested_charges[${index}]`;
+    return {
+        ...charge,
+        amount: normalizeRequiredFiniteNumber(charge.amount, `${fieldPrefix}.amount`),
+        rate: normalizeOptionalFiniteNumber(charge.rate, `${fieldPrefix}.rate`),
+        minimum_charge: normalizeOptionalFiniteNumber(charge.minimum_charge, `${fieldPrefix}.minimum_charge`),
+        quantity: normalizeOptionalFiniteNumber(charge.quantity, `${fieldPrefix}.quantity`),
+    };
+}
+
+function normalizeTotalsValidation(totalsValidation: TotalsValidation): TotalsValidation {
+    return {
+        ...totalsValidation,
+        extracted_total: normalizeOptionalFiniteNumber(totalsValidation.extracted_total, "totals_validation.extracted_total"),
+        calculated_total: normalizeOptionalFiniteNumber(totalsValidation.calculated_total, "totals_validation.calculated_total"),
+        difference: normalizeOptionalFiniteNumber(totalsValidation.difference, "totals_validation.difference"),
+        tolerance: normalizeRequiredFiniteNumber(totalsValidation.tolerance, "totals_validation.tolerance"),
+    };
+}
+
+export function normalizeDraftQuotePayload(payload: DraftQuote): DraftQuote {
+    return {
+        ...payload,
+        suggested_charges: (payload.suggested_charges || []).map(normalizeDraftCharge),
+        totals_validation: normalizeTotalsValidation(payload.totals_validation),
+    };
+}

--- a/frontend/src/lib/spot-workspace-helpers.ts
+++ b/frontend/src/lib/spot-workspace-helpers.ts
@@ -249,14 +249,16 @@ export const formatListWithAnd = (items: string[]): string => {
 };
 
 // Helper to convert rate specs into human-friendly text
-export function humanizeRate(rate: number | string | null, unit: string | null, label: string): string {
-    const numericRate = typeof rate === "number" ? rate : Number(String(rate ?? "").trim());
+export function humanizeRate(rate: number | string | null | undefined, unit: string | null, label: string): string {
+    if (rate === null || rate === undefined || (typeof rate === "string" && rate.trim() === "")) {
+        return "Flat fee";
+    }
+
+    const numericRate = typeof rate === "number" ? rate : Number(rate.trim());
     if (!Number.isFinite(numericRate)) {
         return "Rate unavailable";
     }
-    if (!numericRate) {
-        return "Flat fee";
-    }
+
     if (label.includes("Min")) {
         return `Minimum USD 230.00 or USD ${numericRate.toFixed(2)} per ${unit || "kg"}`;
     }


### PR DESCRIPTION
## Scope

Applies the SPOT Draft Quote numeric normalization hotfix on top of the SPOT Exception Workspace cutover branch.

This is needed because PR #300 fixes `origin/main`, while the live cutover branch has a newer Exception Workspace path and can still serve the legacy `humanizeRate()` implementation if the hotfix is not stacked into that branch.

## Changed Files

- `frontend/src/lib/draft-quote-normalization.ts`: normalizes Draft Quote Decimal-compatible values and fails visibly for invalid required amounts.
- `frontend/src/lib/api.ts`: normalizes `getDraftQuote()` responses before returning them to the workspace.
- `frontend/src/lib/spot-workspace-helpers.ts`: hardens `humanizeRate()` for numeric strings, zero, null/undefined/empty and invalid non-empty values.
- `frontend/src/components/spot/ExceptionWorkspace.tsx`: renders zero rates instead of using a truthy guard.
- `frontend/scripts/draft-quote-normalization.test.mjs`: regression tests for normalization and workspace/API wiring.
- `frontend/scripts/spot-workspace-helpers.test.mjs`: regression tests for rate formatting inputs.

## What Was Intentionally Not Changed

- No backend, database, migration, pricing, quote total, GST, FX, margin, grouping, inclusion, public output, or persisted SPE changes.
- No ProductCode mapping or seed data changes.

## Verification

Automated:
- `node scripts/spot-workspace-helpers.test.mjs` — passed.
- `node scripts/draft-quote-normalization.test.mjs` — passed.
- `node scripts/exception-workspace-routing.test.mjs` — passed.
- `node scripts/spot-workspace-orchestration.test.mjs` — passed.
- `npm run typecheck` — passed.
- `npm run build` — passed with existing lint warnings.
- `git diff --check` — passed.

Manual:
- Confirmed the cutover branch now contains the finite-number guarded `humanizeRate()` implementation and no longer has the legacy `rate.toFixed()` path before validation.

## Risk

Low; frontend API-boundary/display hotfix only. Invalid required commercial amounts now surface as load errors rather than silently becoming zero.

## Rollback

Revert this PR to restore the previous cutover branch display/API-boundary behavior.

## Commercial Impact

No quote totals, GST, FX, margins, pricing, public output, grouping, inclusion, or operator decision semantics changed.

## Data Impact

No persisted data mutation.

## Audit Impact

No audit records changed.
