### PR TITLE
Hotfix SPOT Draft Quote numeric and domain contract

### DIFF
--- a/backend/quotes/services/draft_quote_adapter.py
+++ b/backend/quotes/services/draft_quote_adapter.py
@@ -33,8 +33,10 @@ def build_draft_quote_payload(spe_db: SpotPricingEnvelopeDB) -> Dict[str, Any]:
 
     # Classify shipment direction (IMPORT vs EXPORT vs DOMESTIC).
     # Origin/destination countries are the only trusted direction source.
-    origin_country = shipment_ctx.get('origin_country', '')
-    destination_country = shipment_ctx.get('destination_country', '')
+    origin_country = str(shipment_ctx.get('origin_country') or '').strip().upper()
+    destination_country = str(shipment_ctx.get('destination_country') or '').strip().upper()
+    origin_code = str(shipment_ctx.get('origin_code') or '').strip().upper()
+    destination_code = str(shipment_ctx.get('destination_code') or '').strip().upper()
     direction = None
     if origin_country and destination_country:
         try:
@@ -47,8 +49,12 @@ def build_draft_quote_payload(spe_db: SpotPricingEnvelopeDB) -> Dict[str, Any]:
 
     # 2. Shipment Context
     shipment_context = {
-        "origin": shipment_ctx.get('origin_code') or shipment_ctx.get('origin') or '',
-        "destination": shipment_ctx.get('destination_code') or shipment_ctx.get('destination') or '',
+        "origin": origin_code or shipment_ctx.get('origin') or '',
+        "destination": destination_code or shipment_ctx.get('destination') or '',
+        "origin_country": origin_country,
+        "destination_country": destination_country,
+        "origin_code": origin_code,
+        "destination_code": destination_code,
         "mode": mode,
         "pieces": int(shipment_ctx.get('pieces') or 1),
         "actual_weight_kg": float(shipment_ctx.get('actual_weight_kg') or shipment_ctx.get('weight') or 0.0),

--- a/backend/quotes/tests/test_draft_quote_contract.py
+++ b/backend/quotes/tests/test_draft_quote_contract.py
@@ -169,6 +169,16 @@ class DraftQuoteContractTests(SimpleTestCase):
         self.assertIn("edit_charge", decisions_by_type)
         self.assertIn("classify_unclassified", decisions_by_type)
 
+    def test_request_product_code_domain_is_supported_in_details_not_decision_level(self):
+        """Decision-level domain is not part of the public resolve contract; domain metadata belongs in details."""
+        payload = json.loads(json.dumps(self.resolve_raw_data))
+        request_decision = next(d for d in payload["decisions"] if d["type"] == "request_product_code")
+        request_decision["details"]["domain"] = "IMPORT"
+        schema = DraftQuoteResolveSchema(**payload)
+        parsed_request = next(d for d in schema.decisions if d.type == "request_product_code")
+        self.assertEqual(parsed_request.details["domain"], "IMPORT")
+        self.assertFalse(hasattr(parsed_request, "domain"))
+
     def test_resolve_validation_rules_reject_invalid_payloads(self):
         """Verify resolve validation schema rejects invalid decision type or details."""
         # 1. Invalid decision type

--- a/backend/quotes/tests/test_draft_quote_resolve.py
+++ b/backend/quotes/tests/test_draft_quote_resolve.py
@@ -228,9 +228,51 @@ class DraftQuoteResolveHighValueTests(TestCase):
     def test_draft_quote_payload_direction_uses_route_countries_over_json_direction(self):
         from quotes.services.draft_quote_adapter import build_draft_quote_payload
 
-        self.envelope.shipment_context_json = {"direction": "EXPORT", "origin_country": "SG", "destination_country": "PG", "mode": "AIR"}
+        self.envelope.shipment_context_json = {
+            "direction": "EXPORT",
+            "origin_country": "SG",
+            "destination_country": "PG",
+            "origin_code": "SIN",
+            "destination_code": "POM",
+            "mode": "AIR",
+        }
         self.envelope.save(update_fields=["shipment_context_json"])
         payload = build_draft_quote_payload(self.envelope)
+        self.assertEqual(payload["shipment_context"]["direction"], "IMPORT")
+        self.assertEqual(payload["shipment_context"]["origin"], "SIN")
+        self.assertEqual(payload["shipment_context"]["destination"], "POM")
+        self.assertEqual(payload["shipment_context"]["origin_country"], "SG")
+        self.assertEqual(payload["shipment_context"]["destination_country"], "PG")
+        self.assertEqual(payload["shipment_context"]["origin_code"], "SIN")
+        self.assertEqual(payload["shipment_context"]["destination_code"], "POM")
+
+    def test_draft_quote_payload_derives_export_and_domestic_from_trusted_countries(self):
+        from quotes.services.draft_quote_adapter import build_draft_quote_payload
+
+        self.envelope.shipment_context_json = {"origin_country": "PG", "destination_country": "AU", "origin_code": "POM", "destination_code": "BNE", "mode": "AIR"}
+        self.envelope.save(update_fields=["shipment_context_json"])
+        export_payload = build_draft_quote_payload(self.envelope)
+        self.assertEqual(export_payload["shipment_context"]["direction"], "EXPORT")
+        self.assertEqual(export_payload["shipment_context"]["origin_country"], "PG")
+        self.assertEqual(export_payload["shipment_context"]["destination_country"], "AU")
+
+        self.envelope.shipment_context_json = {"origin_country": "PG", "destination_country": "PG", "origin_code": "POM", "destination_code": "LAE", "mode": "AIR"}
+        self.envelope.save(update_fields=["shipment_context_json"])
+        domestic_payload = build_draft_quote_payload(self.envelope)
+        self.assertEqual(domestic_payload["shipment_context"]["direction"], "DOMESTIC")
+        self.assertEqual(domestic_payload["shipment_context"]["origin_code"], "POM")
+        self.assertEqual(domestic_payload["shipment_context"]["destination_code"], "LAE")
+
+    def test_draft_quote_payload_preserves_stale_origin_destination_compatibility(self):
+        from quotes.services.draft_quote_adapter import build_draft_quote_payload
+
+        self.envelope.shipment_context_json = {"origin": "Singapore", "destination": "Port Moresby", "origin_country": "SG", "destination_country": "PG", "mode": "AIR"}
+        self.envelope.save(update_fields=["shipment_context_json"])
+        payload = build_draft_quote_payload(self.envelope)
+        self.assertEqual(payload["shipment_context"]["origin"], "Singapore")
+        self.assertEqual(payload["shipment_context"]["destination"], "Port Moresby")
+        self.assertEqual(payload["shipment_context"]["origin_code"], "")
+        self.assertEqual(payload["shipment_context"]["destination_code"], "")
         self.assertEqual(payload["shipment_context"]["direction"], "IMPORT")
 
     def test_draft_quote_payload_omits_direction_when_route_countries_are_unsupported(self):

--- a/frontend/scripts/draft-quote-domain.test.mjs
+++ b/frontend/scripts/draft-quote-domain.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import ts from "typescript";
+
+const frontendRoot = path.resolve(process.cwd());
+const domainSourcePath = path.join(frontendRoot, "src", "lib", "draft-quote-domain.ts");
+const workflowSourcePath = path.join(frontendRoot, "src", "components", "spot", "workspace", "useSpotResolutionWorkflow.ts");
+
+function transpile(source, fileName) {
+  return ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName,
+  }).outputText;
+}
+
+async function loadDomainModule() {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "draft-quote-domain-test-"));
+  const libDir = path.join(tempDir, "lib");
+  try {
+    await mkdir(libDir, { recursive: true });
+    const source = await readFile(domainSourcePath, "utf8");
+    await writeFile(path.join(libDir, "draft-quote-domain.mjs"), transpile(source, domainSourcePath), "utf8");
+    return await import(`file://${path.join(libDir, "draft-quote-domain.mjs")}`);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+const { inferProductCodeDomainFromDraftQuote } = await loadDomainModule();
+
+assert.equal(inferProductCodeDomainFromDraftQuote({ direction: "IMPORT", origin_country: "SG", destination_country: "PG" }), "IMPORT");
+assert.equal(inferProductCodeDomainFromDraftQuote({ direction: "EXPORT", origin_country: "PG", destination_country: "AU" }), "EXPORT");
+assert.equal(inferProductCodeDomainFromDraftQuote({ direction: "DOMESTIC", origin_country: "PG", destination_country: "PG" }), "DOMESTIC");
+assert.equal(inferProductCodeDomainFromDraftQuote({ origin_country: "SG", destination_country: "PG" }), "IMPORT");
+assert.equal(inferProductCodeDomainFromDraftQuote({ origin_country: "PG", destination_country: "AU" }), "EXPORT");
+assert.equal(inferProductCodeDomainFromDraftQuote({ origin_country: "PG", destination_country: "PG" }), "DOMESTIC");
+assert.equal(inferProductCodeDomainFromDraftQuote({ direction: "EXPORT", origin_country: "SG", destination_country: "PG" }), null);
+assert.equal(inferProductCodeDomainFromDraftQuote({ origin_country: "", destination_country: "PG" }), null);
+assert.equal(inferProductCodeDomainFromDraftQuote({ origin_country: "AU", destination_country: "SG" }), null);
+
+const workflowSource = await readFile(workflowSourcePath, "utf8");
+assert.ok(workflowSource.includes("inferProductCodeDomainFromDraftQuote(initialData.shipment_context)"));
+assert.ok(workflowSource.includes("domain: productCodeDomain"));
+assert.ok(!workflowSource.includes('domain: "IMPORT"'));
+assert.ok(!workflowSource.includes("POM") && !workflowSource.includes("LAE") && !workflowSource.includes("HGU"));
+
+console.log("draft quote domain checks passed");

--- a/frontend/scripts/draft-quote-normalization.test.mjs
+++ b/frontend/scripts/draft-quote-normalization.test.mjs
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import ts from "typescript";
+
+const frontendRoot = path.resolve(process.cwd());
+const normalizerSourcePath = path.join(frontendRoot, "src", "lib", "draft-quote-normalization.ts");
+const workspaceSourcePath = path.join(frontendRoot, "src", "components", "spot", "ExceptionWorkspace.tsx");
+const apiSourcePath = path.join(frontendRoot, "src", "lib", "api.ts");
+
+function transpile(source, fileName) {
+  return ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName,
+  }).outputText;
+}
+
+async function loadNormalizer() {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "draft-quote-normalization-test-"));
+  const libDir = path.join(tempDir, "lib");
+
+  try {
+    await mkdir(libDir, { recursive: true });
+    const source = await readFile(normalizerSourcePath, "utf8");
+    await writeFile(path.join(libDir, "draft-quote-normalization.mjs"), transpile(source, normalizerSourcePath), "utf8");
+    return await import(`file://${path.join(libDir, "draft-quote-normalization.mjs")}`);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+function baseDraftQuote(overrides = {}) {
+  return {
+    contract_version: "1",
+    quote_summary: "Test draft quote",
+    shipment_context: {},
+    supplier_context: {},
+    freight: {},
+    suggested_charges: [
+      {
+        id: "charge-1",
+        status: "suggested",
+        display_label: "Fuel",
+        raw_label: "Fuel",
+        suggested_product_code: "IMP-FUEL",
+        product_code_conflict: false,
+        bucket: "freight",
+        currency: "USD",
+        amount: "12.50",
+        rate: "1.25",
+        unit: "kg",
+        calculation_basis: null,
+        minimum_charge: "230.00",
+        percentage_base: null,
+        quantity: "10.5",
+        include_in_totals: true,
+        conditions: [],
+        warnings: [],
+        review_reason: null,
+        evidence: null,
+        similarity_group_id: null,
+        correction_actions: [],
+      },
+    ],
+    commercial_terms: [],
+    warnings: [],
+    unclassified_items: [],
+    ignored_items: [],
+    totals_validation: {
+      math_balances: true,
+      currency_consistent: true,
+      extracted_total: "12.50",
+      calculated_total: "12.50",
+      difference: "0.00",
+      tolerance: "0.01",
+      warnings: [],
+    },
+    review_queue: [],
+    correction_actions: [],
+    metadata: {},
+    ...overrides,
+  };
+}
+
+const { normalizeDraftQuotePayload } = await loadNormalizer();
+
+// Numeric strings from Decimal JSON are normalized at the Draft Quote API boundary.
+{
+  const normalized = normalizeDraftQuotePayload(baseDraftQuote());
+  assert.equal(normalized.suggested_charges[0].amount, 12.5);
+  assert.equal(normalized.suggested_charges[0].rate, 1.25);
+  assert.equal(normalized.suggested_charges[0].minimum_charge, 230);
+  assert.equal(normalized.suggested_charges[0].quantity, 10.5);
+  assert.equal(normalized.totals_validation.extracted_total, 12.5);
+  assert.equal(normalized.totals_validation.calculated_total, 12.5);
+  assert.equal(normalized.totals_validation.difference, 0);
+  assert.equal(normalized.totals_validation.tolerance, 0.01);
+}
+
+// JSON numbers remain numbers and optional null values remain null.
+{
+  const payload = baseDraftQuote({
+    suggested_charges: [
+      {
+        ...baseDraftQuote().suggested_charges[0],
+        amount: 0,
+        rate: null,
+        minimum_charge: null,
+        quantity: null,
+      },
+    ],
+    totals_validation: {
+      ...baseDraftQuote().totals_validation,
+      extracted_total: null,
+      calculated_total: null,
+      difference: null,
+      tolerance: 0,
+    },
+  });
+  const normalized = normalizeDraftQuotePayload(payload);
+  assert.equal(normalized.suggested_charges[0].amount, 0);
+  assert.equal(normalized.suggested_charges[0].rate, null);
+  assert.equal(normalized.suggested_charges[0].minimum_charge, null);
+  assert.equal(normalized.suggested_charges[0].quantity, null);
+  assert.equal(normalized.totals_validation.extracted_total, null);
+  assert.equal(normalized.totals_validation.calculated_total, null);
+  assert.equal(normalized.totals_validation.difference, null);
+  assert.equal(normalized.totals_validation.tolerance, 0);
+}
+
+// Required commercial amounts must fail visibly; they must not be coerced to zero.
+{
+  const payload = baseDraftQuote({
+    suggested_charges: [
+      {
+        ...baseDraftQuote().suggested_charges[0],
+        amount: "not-a-number",
+      },
+    ],
+  });
+  assert.throws(
+    () => normalizeDraftQuotePayload(payload),
+    /Invalid numeric value for suggested_charges\[0\]\.amount/
+  );
+}
+
+// The Draft Quote API boundary must normalize before returning to callers.
+{
+  const apiSource = await readFile(apiSourcePath, "utf8");
+  assert.ok(
+    apiSource.includes("import { normalizeDraftQuotePayload } from './draft-quote-normalization';"),
+    "getDraftQuote must import the Draft Quote numeric normalizer."
+  );
+  assert.ok(
+    apiSource.includes("return normalizeDraftQuotePayload(payload as DraftQuote);"),
+    "getDraftQuote must return the normalized Draft Quote payload."
+  );
+}
+
+// Exception Workspace should render rate text for zero/normalized values rather than using a truthy guard.
+{
+  const workspaceSource = await readFile(workspaceSourcePath, "utf8");
+  assert.ok(
+    workspaceSource.includes("charge.rate !== null && charge.rate !== undefined"),
+    "ExceptionWorkspace must render zero rates and avoid truthy rate checks."
+  );
+  assert.ok(
+    !workspaceSource.includes("{charge.rate && ` | ${humanizeRate"),
+    "ExceptionWorkspace must not use the legacy truthy rate render guard."
+  );
+}
+
+console.log("draft quote normalization checks passed");

--- a/frontend/scripts/spot-workspace-helpers.test.mjs
+++ b/frontend/scripts/spot-workspace-helpers.test.mjs
@@ -166,9 +166,13 @@ const {
 // 10. humanizeRate
 {
   assert.equal(humanizeRate(230, "kg", "...Min..."), "Minimum USD 230.00 or USD 230.00 per kg");
-  assert.equal(humanizeRate(0, "kg", "Fuel"), "Flat fee");
+  assert.equal(humanizeRate(0, "kg", "Fuel"), "USD 0.00 per kg");
   assert.equal(humanizeRate(null, null, "..."), "Flat fee");
+  assert.equal(humanizeRate(undefined, null, "..."), "Flat fee");
+  assert.equal(humanizeRate("", null, "..."), "Flat fee");
+  assert.equal(humanizeRate("not-a-number", "kg", "Fuel"), "Rate unavailable");
   assert.equal(humanizeRate(1.23, "set", "Handling"), "SGD 1.23 per set");
+  assert.equal(humanizeRate("1.23", "set", "Handling"), "SGD 1.23 per set");
   assert.equal(humanizeRate(1.5, "kg", "Fuel"), "USD 1.50 per kg");
   assert.equal(humanizeRate(0.85, "kg", "Security"), "USD 0.85 per kg");
   assert.equal(humanizeRate(5.00, "unit", "Freight"), "5.00 per unit");

--- a/frontend/scripts/spot-workspace-orchestration.test.mjs
+++ b/frontend/scripts/spot-workspace-orchestration.test.mjs
@@ -134,6 +134,9 @@ assert.ok(hookSrc.includes('type: "classify_unclassified"'), "Unknown-item live 
 assert.ok(!hookSrc.includes('type: "map_to_product_code",\n            target_id: itemId'), "Unknown-item mapping must not submit map_to_product_code with an unclassified item ID");
 assert.ok(!hookSrc.includes('newChargeId = `chg-new-${Date.now()}`;\n            try'), "Live unknown charge creation must not create synthetic IDs");
 assert.ok(!hookSrc.includes('domain: "IMPORT"'), "ProductCode requests must not hardcode IMPORT domain");
+assert.ok(hookSrc.includes("inferProductCodeDomainFromDraftQuote(initialData.shipment_context)"), "ProductCode request domain must come from Draft Quote route evidence");
+assert.ok(hookSrc.includes("domain: productCodeDomain"), "ProductCode requests must include derived domain in details");
+assert.ok(hookSrc.includes("Trusted route evidence is incomplete or contradictory"), "ProductCode requests must fail visibly when trusted route evidence is incomplete");
 assert.ok(!hookSrc.includes('currency: "SGD"'), "Unknown ProductCode requests must not hardcode SGD currency");
 assert.ok(workspaceSrc.includes("actions.openUnknownMapExisting"), "Unknown Map Existing must open a detail-collection workflow instead of submitting from ProductCode-only selection");
 assert.ok(workspaceSrc.includes('collectChargeDetails={currentIssue.type === "unknown_charge"}'), "Unknown Map Existing must collect full charge details");

--- a/frontend/src/components/spot/ExceptionWorkspace.tsx
+++ b/frontend/src/components/spot/ExceptionWorkspace.tsx
@@ -516,7 +516,7 @@ export function ExceptionWorkspace({ initialData, isLive = false, envelopeId, en
                                                 <span className="font-semibold block text-slate-100">{charge.display_label}</span>
                                                 <span className="text-xs text-slate-400 block mt-0.5">
                                                     Billing Code: <strong className="font-mono text-indigo-300">{charge.suggested_product_code || "Unmapped"}</strong>
-                                                    {charge.rate && ` | ${humanizeRate(charge.rate, charge.unit, charge.display_label)}`}
+                                                    {charge.rate !== null && charge.rate !== undefined && ` | ${humanizeRate(charge.rate, charge.unit, charge.display_label)}`}
                                                 </span>
                                             </div>
                                         </div>

--- a/frontend/src/components/spot/workspace/useSpotResolutionWorkflow.ts
+++ b/frontend/src/components/spot/workspace/useSpotResolutionWorkflow.ts
@@ -1,6 +1,7 @@
 import { useEffect, useReducer, useState } from "react";
 import { useAuth } from "../../../context/auth-context";
 import { useConfirmDialog } from "../../../context/confirm-dialog-context";
+import { inferProductCodeDomainFromDraftQuote } from "../../../lib/draft-quote-domain";
 import { DecisionResult, DraftCharge, DraftQuote, DraftQuoteResolveResponse } from "../../../lib/draft-quote-types";
 import {
     createSpotResolutionState,
@@ -26,7 +27,6 @@ interface ProductCodeSelectorOption {
     domain: string;
 }
 
-const PRODUCT_CODE_DOMAINS = new Set(["IMPORT", "EXPORT", "DOMESTIC"]);
 const REOPEN_ROLES = new Set(["manager", "admin"]);
 const GENERIC_UNKNOWN_LABEL = "Unknown Charge Block";
 
@@ -68,8 +68,7 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
     const { user } = useAuth();
     const { confirm } = useConfirmDialog();
 
-    const shipmentDirection = String(initialData.shipment_context.direction || "").toUpperCase();
-    const productCodeDomain = PRODUCT_CODE_DOMAINS.has(shipmentDirection) ? shipmentDirection : null;
+    const productCodeDomain = inferProductCodeDomainFromDraftQuote(initialData.shipment_context);
     const role = String(user?.role || "").toLowerCase();
     const isReopenAuthorized = REOPEN_ROLES.has(role);
 
@@ -312,6 +311,11 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
     };
 
     const submitProductCodeRequest = async (chargeId: string) => {
+        if (!productCodeDomain) {
+            dispatch({ type: "SET_ACTION_MESSAGE", payload: "Trusted route evidence is incomplete or contradictory; ProductCode request cannot be submitted." });
+            return;
+        }
+
         const decisionId = `dec-${Date.now()}`;
         const newDecisionItem = {
             decision_id: decisionId,
@@ -323,6 +327,7 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
                 display_label: state.requestForm.label,
                 bucket: state.requestForm.bucket,
                 category: state.requestForm.bucket,
+                domain: productCodeDomain,
                 currency: state.requestForm.currency,
                 amount: state.requestForm.amount,
                 unit: state.requestForm.unit,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5,6 +5,7 @@ import { getJson, sendJson } from './api/shared';
 import { mapQuoteDetailToComputeResult } from './quote-detail-mapping';
 import { ReplyAnalysisResult, SPEChargeLine, SPEConditions, SPECommodity } from './spot-types';
 import { DraftQuote, DraftQuoteFinalizeResponse, DraftQuoteReopenResponse, DraftQuoteResolvePayload, DraftQuoteResolveResponse } from './draft-quote-types';
+import { normalizeDraftQuotePayload } from './draft-quote-normalization';
 import {
   LoginData,
   User,
@@ -801,7 +802,8 @@ export async function getDraftQuote(id: string): Promise<DraftQuote> {
     throw new Error(`Failed to fetch draft quote: ${detail}`);
   }
 
-  return response.json();
+  const payload = await response.json();
+  return normalizeDraftQuotePayload(payload as DraftQuote);
 }
 
 

--- a/frontend/src/lib/draft-quote-domain.ts
+++ b/frontend/src/lib/draft-quote-domain.ts
@@ -1,0 +1,37 @@
+import type { DraftQuote } from "./draft-quote-types";
+
+const PRODUCT_CODE_DOMAINS = new Set(["IMPORT", "EXPORT", "DOMESTIC"]);
+const PNG_COUNTRY_VALUES = new Set(["PG", "PNG", "PAPUA NEW GUINEA"]);
+
+function normalizeDomain(value: unknown): string | null {
+    const normalized = String(value || "").trim().toUpperCase();
+    return PRODUCT_CODE_DOMAINS.has(normalized) ? normalized : null;
+}
+
+function isPngCountry(value: unknown): boolean {
+    return PNG_COUNTRY_VALUES.has(String(value || "").trim().toUpperCase());
+}
+
+function inferDomainFromTrustedCountries(shipmentContext: DraftQuote["shipment_context"]): string | null {
+    const originCountry = String(shipmentContext.origin_country || "").trim();
+    const destinationCountry = String(shipmentContext.destination_country || "").trim();
+    if (!originCountry || !destinationCountry) return null;
+
+    const originIsPng = isPngCountry(originCountry);
+    const destinationIsPng = isPngCountry(destinationCountry);
+    if (originIsPng && destinationIsPng) return "DOMESTIC";
+    if (originIsPng && !destinationIsPng) return "EXPORT";
+    if (!originIsPng && destinationIsPng) return "IMPORT";
+    return null;
+}
+
+export function inferProductCodeDomainFromDraftQuote(shipmentContext: DraftQuote["shipment_context"]): string | null {
+    const serverDirection = normalizeDomain(shipmentContext.direction);
+    const routeDomain = inferDomainFromTrustedCountries(shipmentContext);
+
+    if (serverDirection && routeDomain && serverDirection !== routeDomain) {
+        return null;
+    }
+
+    return serverDirection || routeDomain;
+}

--- a/frontend/src/lib/draft-quote-normalization.ts
+++ b/frontend/src/lib/draft-quote-normalization.ts
@@ -1,0 +1,61 @@
+import type { DraftCharge, DraftQuote, TotalsValidation } from "./draft-quote-types";
+
+class DraftQuoteNumericNormalizationError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "DraftQuoteNumericNormalizationError";
+    }
+}
+
+function isEmptyOptionalValue(value: unknown): boolean {
+    return value === null || value === undefined || (typeof value === "string" && value.trim() === "");
+}
+
+function parseFiniteNumber(value: unknown, fieldPath: string): number {
+    const numericValue = typeof value === "number" ? value : Number(String(value).trim());
+    if (!Number.isFinite(numericValue)) {
+        throw new DraftQuoteNumericNormalizationError(`Invalid numeric value for ${fieldPath}.`);
+    }
+    return numericValue;
+}
+
+function normalizeOptionalFiniteNumber(value: unknown, fieldPath: string): number | null {
+    if (isEmptyOptionalValue(value)) return null;
+    return parseFiniteNumber(value, fieldPath);
+}
+
+function normalizeRequiredFiniteNumber(value: unknown, fieldPath: string): number {
+    if (isEmptyOptionalValue(value)) {
+        throw new DraftQuoteNumericNormalizationError(`Missing required numeric value for ${fieldPath}.`);
+    }
+    return parseFiniteNumber(value, fieldPath);
+}
+
+function normalizeDraftCharge(charge: DraftCharge, index: number): DraftCharge {
+    const fieldPrefix = `suggested_charges[${index}]`;
+    return {
+        ...charge,
+        amount: normalizeRequiredFiniteNumber(charge.amount, `${fieldPrefix}.amount`),
+        rate: normalizeOptionalFiniteNumber(charge.rate, `${fieldPrefix}.rate`),
+        minimum_charge: normalizeOptionalFiniteNumber(charge.minimum_charge, `${fieldPrefix}.minimum_charge`),
+        quantity: normalizeOptionalFiniteNumber(charge.quantity, `${fieldPrefix}.quantity`),
+    };
+}
+
+function normalizeTotalsValidation(totalsValidation: TotalsValidation): TotalsValidation {
+    return {
+        ...totalsValidation,
+        extracted_total: normalizeOptionalFiniteNumber(totalsValidation.extracted_total, "totals_validation.extracted_total"),
+        calculated_total: normalizeOptionalFiniteNumber(totalsValidation.calculated_total, "totals_validation.calculated_total"),
+        difference: normalizeOptionalFiniteNumber(totalsValidation.difference, "totals_validation.difference"),
+        tolerance: normalizeRequiredFiniteNumber(totalsValidation.tolerance, "totals_validation.tolerance"),
+    };
+}
+
+export function normalizeDraftQuotePayload(payload: DraftQuote): DraftQuote {
+    return {
+        ...payload,
+        suggested_charges: (payload.suggested_charges || []).map(normalizeDraftCharge),
+        totals_validation: normalizeTotalsValidation(payload.totals_validation),
+    };
+}

--- a/frontend/src/lib/draft-quote-types.ts
+++ b/frontend/src/lib/draft-quote-types.ts
@@ -86,6 +86,10 @@ export interface DraftQuote {
     shipment_context: {
         origin: string;
         destination: string;
+        origin_country?: string;
+        destination_country?: string;
+        origin_code?: string;
+        destination_code?: string;
         mode: string;
         pieces: number;
         actual_weight_kg: number;

--- a/frontend/src/lib/spot-workspace-helpers.ts
+++ b/frontend/src/lib/spot-workspace-helpers.ts
@@ -249,23 +249,29 @@ export const formatListWithAnd = (items: string[]): string => {
 };
 
 // Helper to convert rate specs into human-friendly text
-export function humanizeRate(rate: number | null, unit: string | null, label: string): string {
-    if (label.includes("Min") && rate) {
-        return `Minimum USD 230.00 or USD ${rate.toFixed(2)} per ${unit || "kg"}`;
+export function humanizeRate(rate: number | string | null | undefined, unit: string | null, label: string): string {
+    if (rate === null || rate === undefined || (typeof rate === "string" && rate.trim() === "")) {
+        return "Flat fee";
     }
-    if (label.includes("Fuel") && rate) {
-        return `USD ${rate.toFixed(2)} per ${unit || "kg"}`;
+
+    const numericRate = typeof rate === "number" ? rate : Number(rate.trim());
+    if (!Number.isFinite(numericRate)) {
+        return "Rate unavailable";
     }
-    if (label.includes("Security") && rate) {
-        return `USD ${rate.toFixed(2)} per ${unit || "kg"}`;
+
+    if (label.includes("Min")) {
+        return `Minimum USD 230.00 or USD ${numericRate.toFixed(2)} per ${unit || "kg"}`;
     }
-    if (label.includes("Handling") && rate) {
-        return `SGD ${rate.toFixed(2)} per set`;
+    if (label.includes("Fuel")) {
+        return `USD ${numericRate.toFixed(2)} per ${unit || "kg"}`;
     }
-    if (rate) {
-        return `${rate.toFixed(2)} per ${unit || "unit"}`;
+    if (label.includes("Security")) {
+        return `USD ${numericRate.toFixed(2)} per ${unit || "kg"}`;
     }
-    return "Flat fee";
+    if (label.includes("Handling")) {
+        return `SGD ${numericRate.toFixed(2)} per set`;
+    }
+    return `${numericRate.toFixed(2)} per ${unit || "unit"}`;
 }
 
 export function friendlyStatus(status: string): string {


### PR DESCRIPTION
## Scope

Corrected SPOT Draft Quote numeric normalization and ProductCode request domain handling on a fresh branch from current `origin/main`.

This PR includes only the intended numeric-normalization hotfix and corrected ProductCode domain contract changes. It does not continue or reopen the merged/diverged `codex/spot-exception-workspace-cutover` branch.

## Changed Files

- `frontend/src/lib/draft-quote-normalization.ts`: normalizes Decimal-compatible Draft Quote numeric fields at the API boundary and fails visibly for invalid required amounts.
- `frontend/src/lib/api.ts`: applies Draft Quote normalization inside `getDraftQuote()`.
- `frontend/src/lib/spot-workspace-helpers.ts`: hardens `humanizeRate()` for number/string/null/undefined/invalid values before `toFixed()`.
- `frontend/src/components/spot/ExceptionWorkspace.tsx`: removes truthy rate guard so zero rates render.
- `frontend/src/lib/draft-quote-domain.ts`: derives ProductCode domain from server direction and explicit trusted route-country evidence, failing closed on incomplete/contradictory evidence.
- `frontend/src/lib/draft-quote-types.ts`: documents explicit trusted route fields in Draft Quote shipment context.
- `frontend/src/components/spot/workspace/useSpotResolutionWorkflow.ts`: submits ProductCode request domain in `details` only, derived from Draft Quote evidence.
- `backend/quotes/services/draft_quote_adapter.py`: publishes trusted `origin_country`, `destination_country`, `origin_code`, and `destination_code` while retaining existing `origin`/`destination`; direction remains server-derived from trusted countries.
- `backend/quotes/tests/test_draft_quote_resolve.py`: covers import/export/domestic derivation, explicit route fields, stale origin/destination compatibility, and fail-closed route evidence.
- `backend/quotes/tests/test_draft_quote_contract.py`: confirms request ProductCode domain is supported in `details`, not as a decision-level contract field.
- `frontend/scripts/draft-quote-normalization.test.mjs`: numeric normalization regressions.
- `frontend/scripts/draft-quote-domain.test.mjs`: import/export/domestic/missing/contradictory domain regressions.
- `frontend/scripts/spot-workspace-helpers.test.mjs`: rate formatting regressions.
- `frontend/scripts/spot-workspace-orchestration.test.mjs`: workflow contract assertions for non-hardcoded domain submission.

## What Was Intentionally Not Changed

- No backend pricing changes.
- No database or migration changes.
- No quote totals, GST, FX, margin, grouping, inclusion, public output, or persisted SPE mutation.
- No ProductCode approval bypass, seed data, or speculative mappings.
- No decision-level `domain` field was added; backend contract supports `details.domain` and server still derives authoritative domain from trusted route countries.

## Verification

Automated:
- `node scripts/spot-workspace-helpers.test.mjs` — passed.
- `node scripts/draft-quote-normalization.test.mjs` — passed.
- `node scripts/draft-quote-domain.test.mjs` — passed.
- `node scripts/exception-workspace-routing.test.mjs` — passed.
- `node scripts/spot-workspace-orchestration.test.mjs` — passed.
- `npm run typecheck` — passed.
- `npm run build` — passed with existing lint warnings.
- `python -m pytest quotes/tests/test_draft_quote_resolve.py quotes/tests/test_draft_quote_contract.py -q` — passed, 58 tests.
- `python -m pytest quotes/tests/test_draft_quote_api.py -q` — passed, 3 tests.
- `git diff --check` — passed.
- `graphify update .` — completed.

Manual:
- Confirmed frontend does not hardcode IMPORT or a small airport set for ProductCode request domain.
- Confirmed Draft Quote payload retains existing `origin`/`destination` fields while adding explicit trusted route fields.
- Confirmed invalid required numeric amounts surface as load errors instead of becoming zero.

## Risk

Low-to-medium SPOT workflow risk because this touches Draft Quote API boundary and ProductCode request payload shape. Risk is mitigated by fail-closed route evidence handling and targeted backend/frontend regressions.

## Rollback

Revert this PR. It has no migrations or data writes.

## Commercial Impact

No quote totals, GST, FX, margins, pricing, grouping, inclusion, public output, or operator approval lifecycle semantics changed. ProductCode requests remain pending admin review.

## Data Impact

No persisted data mutation, migration, backfill, seed data, SPE mutation, or rate mutation.

## Audit Impact

No audit records are changed. ProductCode request source context continues to be created server-side with server-derived trusted domain.
