### PR TITLE
Hotfix SPOT ProductCode domain precedence

### DIFF
--- a/frontend/scripts/draft-quote-domain.test.mjs
+++ b/frontend/scripts/draft-quote-domain.test.mjs
@@ -31,21 +31,37 @@ async function loadDomainModule() {
   }
 }
 
-const { inferProductCodeDomainFromDraftQuote } = await loadDomainModule();
+const { inferProductCodeDomainFromDraftQuote, resolveProductCodeDomainFromDraftQuote } = await loadDomainModule();
 
-assert.equal(inferProductCodeDomainFromDraftQuote({ direction: "IMPORT", origin_country: "SG", destination_country: "PG" }), "IMPORT");
+// Server-derived Draft Quote direction is authoritative for frontend filtering/request metadata.
+assert.equal(inferProductCodeDomainFromDraftQuote({ direction: "IMPORT", origin_country: "CN", destination_country: "PG", origin_code: "CAN", destination_code: "POM" }), "IMPORT");
 assert.equal(inferProductCodeDomainFromDraftQuote({ direction: "EXPORT", origin_country: "PG", destination_country: "AU" }), "EXPORT");
 assert.equal(inferProductCodeDomainFromDraftQuote({ direction: "DOMESTIC", origin_country: "PG", destination_country: "PG" }), "DOMESTIC");
+assert.equal(inferProductCodeDomainFromDraftQuote({ direction: "IMPORT", origin_country: "PG", destination_country: "AU" }), "IMPORT");
+assert.equal(inferProductCodeDomainFromDraftQuote({ direction: "EXPORT", origin_country: "SG", destination_country: "PG" }), "EXPORT");
+assert.equal(inferProductCodeDomainFromDraftQuote({ direction: "DOMESTIC", origin_country: "AU", destination_country: "SG" }), "DOMESTIC");
+
+// Country inference is fallback only when the server direction is absent.
 assert.equal(inferProductCodeDomainFromDraftQuote({ origin_country: "SG", destination_country: "PG" }), "IMPORT");
 assert.equal(inferProductCodeDomainFromDraftQuote({ origin_country: "PG", destination_country: "AU" }), "EXPORT");
 assert.equal(inferProductCodeDomainFromDraftQuote({ origin_country: "PG", destination_country: "PG" }), "DOMESTIC");
-assert.equal(inferProductCodeDomainFromDraftQuote({ direction: "EXPORT", origin_country: "SG", destination_country: "PG" }), null);
-assert.equal(inferProductCodeDomainFromDraftQuote({ origin_country: "", destination_country: "PG" }), null);
-assert.equal(inferProductCodeDomainFromDraftQuote({ origin_country: "AU", destination_country: "SG" }), null);
+
+// Missing and unsupported trusted route evidence fail closed with distinct visible diagnostics.
+assert.deepEqual(resolveProductCodeDomainFromDraftQuote({ origin_country: "", destination_country: "PG" }), {
+  domain: null,
+  issueCode: "MISSING_ROUTE_EVIDENCE",
+  issueMessage: "Draft Quote is missing server direction and trusted route countries; ProductCode request cannot be submitted.",
+});
+assert.deepEqual(resolveProductCodeDomainFromDraftQuote({ origin_country: "AU", destination_country: "SG" }), {
+  domain: null,
+  issueCode: "UNSUPPORTED_ROUTE",
+  issueMessage: "Draft Quote route is outside supported PNG import/export/domestic scope; ProductCode request cannot be submitted.",
+});
 
 const workflowSource = await readFile(workflowSourcePath, "utf8");
-assert.ok(workflowSource.includes("inferProductCodeDomainFromDraftQuote(initialData.shipment_context)"));
+assert.ok(workflowSource.includes("resolveProductCodeDomainFromDraftQuote(initialData.shipment_context)"));
 assert.ok(workflowSource.includes("domain: productCodeDomain"));
+assert.ok(workflowSource.includes("Backend rejected ProductCode request"));
 assert.ok(!workflowSource.includes('domain: "IMPORT"'));
 assert.ok(!workflowSource.includes("POM") && !workflowSource.includes("LAE") && !workflowSource.includes("HGU"));
 

--- a/frontend/scripts/spot-workspace-orchestration.test.mjs
+++ b/frontend/scripts/spot-workspace-orchestration.test.mjs
@@ -134,9 +134,10 @@ assert.ok(hookSrc.includes('type: "classify_unclassified"'), "Unknown-item live 
 assert.ok(!hookSrc.includes('type: "map_to_product_code",\n            target_id: itemId'), "Unknown-item mapping must not submit map_to_product_code with an unclassified item ID");
 assert.ok(!hookSrc.includes('newChargeId = `chg-new-${Date.now()}`;\n            try'), "Live unknown charge creation must not create synthetic IDs");
 assert.ok(!hookSrc.includes('domain: "IMPORT"'), "ProductCode requests must not hardcode IMPORT domain");
-assert.ok(hookSrc.includes("inferProductCodeDomainFromDraftQuote(initialData.shipment_context)"), "ProductCode request domain must come from Draft Quote route evidence");
+assert.ok(hookSrc.includes("resolveProductCodeDomainFromDraftQuote(initialData.shipment_context)"), "ProductCode request domain must come from Draft Quote route evidence");
 assert.ok(hookSrc.includes("domain: productCodeDomain"), "ProductCode requests must include derived domain in details");
-assert.ok(hookSrc.includes("Trusted route evidence is incomplete or contradictory"), "ProductCode requests must fail visibly when trusted route evidence is incomplete");
+assert.ok(hookSrc.includes("productCodeDomainResolution.issueMessage"), "ProductCode requests must fail visibly with specific route evidence diagnostics");
+assert.ok(hookSrc.includes("Backend rejected ProductCode request"), "Backend ProductCode request rejection must remain visible after submission");
 assert.ok(!hookSrc.includes('currency: "SGD"'), "Unknown ProductCode requests must not hardcode SGD currency");
 assert.ok(workspaceSrc.includes("actions.openUnknownMapExisting"), "Unknown Map Existing must open a detail-collection workflow instead of submitting from ProductCode-only selection");
 assert.ok(workspaceSrc.includes('collectChargeDetails={currentIssue.type === "unknown_charge"}'), "Unknown Map Existing must collect full charge details");

--- a/frontend/src/components/spot/workspace/useSpotResolutionWorkflow.ts
+++ b/frontend/src/components/spot/workspace/useSpotResolutionWorkflow.ts
@@ -1,7 +1,7 @@
 import { useEffect, useReducer, useState } from "react";
 import { useAuth } from "../../../context/auth-context";
 import { useConfirmDialog } from "../../../context/confirm-dialog-context";
-import { inferProductCodeDomainFromDraftQuote } from "../../../lib/draft-quote-domain";
+import { resolveProductCodeDomainFromDraftQuote } from "../../../lib/draft-quote-domain";
 import { DecisionResult, DraftCharge, DraftQuote, DraftQuoteResolveResponse } from "../../../lib/draft-quote-types";
 import {
     createSpotResolutionState,
@@ -68,7 +68,8 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
     const { user } = useAuth();
     const { confirm } = useConfirmDialog();
 
-    const productCodeDomain = inferProductCodeDomainFromDraftQuote(initialData.shipment_context);
+    const productCodeDomainResolution = resolveProductCodeDomainFromDraftQuote(initialData.shipment_context);
+    const productCodeDomain = productCodeDomainResolution.domain;
     const role = String(user?.role || "").toLowerCase();
     const isReopenAuthorized = REOPEN_ROLES.has(role);
 
@@ -77,7 +78,7 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
 
         if (!productCodeDomain) {
             setProductCodes([]);
-            setProductCodeLoadError("Draft Quote shipment direction is missing; ProductCode selection is disabled.");
+            setProductCodeLoadError(productCodeDomainResolution.issueMessage || "Draft Quote shipment direction is missing; ProductCode selection is disabled.");
             setIsLoadingProductCodes(false);
             return;
         }
@@ -110,7 +111,7 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
         return () => {
             cancelled = true;
         };
-    }, [productCodeDomain, productCodeRetryNonce]);
+    }, [productCodeDomain, productCodeDomainResolution.issueMessage, productCodeRetryNonce]);
 
     const refreshLiveDraftQuote = async () => {
         if (!isLive || !envelopeId) {
@@ -312,7 +313,7 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
 
     const submitProductCodeRequest = async (chargeId: string) => {
         if (!productCodeDomain) {
-            dispatch({ type: "SET_ACTION_MESSAGE", payload: "Trusted route evidence is incomplete or contradictory; ProductCode request cannot be submitted." });
+            dispatch({ type: "SET_ACTION_MESSAGE", payload: productCodeDomainResolution.issueMessage || "Draft Quote ProductCode domain is unavailable; ProductCode request cannot be submitted." });
             return;
         }
 
@@ -348,7 +349,7 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
         } catch (err) {
             console.error("Failed to submit ProductCode request:", err);
             const errMsg = err instanceof Error ? err.message : String(err);
-            dispatch({ type: "SET_ACTION_MESSAGE", payload: `API error submitting ProductCode request: ${errMsg}` });
+            dispatch({ type: "SET_ACTION_MESSAGE", payload: `Backend rejected ProductCode request: ${errMsg}` });
             return;
         }
 

--- a/frontend/src/lib/draft-quote-domain.ts
+++ b/frontend/src/lib/draft-quote-domain.ts
@@ -3,6 +3,14 @@ import type { DraftQuote } from "./draft-quote-types";
 const PRODUCT_CODE_DOMAINS = new Set(["IMPORT", "EXPORT", "DOMESTIC"]);
 const PNG_COUNTRY_VALUES = new Set(["PG", "PNG", "PAPUA NEW GUINEA"]);
 
+export type DraftQuoteDomainIssueCode = "MISSING_ROUTE_EVIDENCE" | "UNSUPPORTED_ROUTE";
+
+export interface DraftQuoteDomainResolution {
+    domain: string | null;
+    issueCode: DraftQuoteDomainIssueCode | null;
+    issueMessage: string | null;
+}
+
 function normalizeDomain(value: unknown): string | null {
     const normalized = String(value || "").trim().toUpperCase();
     return PRODUCT_CODE_DOMAINS.has(normalized) ? normalized : null;
@@ -25,13 +33,34 @@ function inferDomainFromTrustedCountries(shipmentContext: DraftQuote["shipment_c
     return null;
 }
 
-export function inferProductCodeDomainFromDraftQuote(shipmentContext: DraftQuote["shipment_context"]): string | null {
+export function resolveProductCodeDomainFromDraftQuote(shipmentContext: DraftQuote["shipment_context"]): DraftQuoteDomainResolution {
     const serverDirection = normalizeDomain(shipmentContext.direction);
-    const routeDomain = inferDomainFromTrustedCountries(shipmentContext);
-
-    if (serverDirection && routeDomain && serverDirection !== routeDomain) {
-        return null;
+    if (serverDirection) {
+        return { domain: serverDirection, issueCode: null, issueMessage: null };
     }
 
-    return serverDirection || routeDomain;
+    const originCountry = String(shipmentContext.origin_country || "").trim();
+    const destinationCountry = String(shipmentContext.destination_country || "").trim();
+    const routeDomain = inferDomainFromTrustedCountries(shipmentContext);
+    if (routeDomain) {
+        return { domain: routeDomain, issueCode: null, issueMessage: null };
+    }
+
+    if (!originCountry || !destinationCountry) {
+        return {
+            domain: null,
+            issueCode: "MISSING_ROUTE_EVIDENCE",
+            issueMessage: "Draft Quote is missing server direction and trusted route countries; ProductCode request cannot be submitted.",
+        };
+    }
+
+    return {
+        domain: null,
+        issueCode: "UNSUPPORTED_ROUTE",
+        issueMessage: "Draft Quote route is outside supported PNG import/export/domestic scope; ProductCode request cannot be submitted.",
+    };
+}
+
+export function inferProductCodeDomainFromDraftQuote(shipmentContext: DraftQuote["shipment_context"]): string | null {
+    return resolveProductCodeDomainFromDraftQuote(shipmentContext).domain;
 }


### PR DESCRIPTION
## Scope

Focused SPOT ProductCode domain precedence hotfix.

The frontend now treats the backend Draft Quote `shipment_context.direction` as authoritative when it is `IMPORT`, `EXPORT`, or `DOMESTIC`. Country-based inference is fallback-only when the server direction is absent.

## Changed Files

- `frontend/src/lib/draft-quote-domain.ts`: makes valid backend Draft Quote direction authoritative, adds fallback-only country inference, and returns distinct missing-route vs unsupported-route diagnostics.
- `frontend/src/components/spot/workspace/useSpotResolutionWorkflow.ts`: uses the richer domain resolution diagnostic and preserves backend rejection messages after submission.
- `frontend/scripts/draft-quote-domain.test.mjs`: covers CAN/CN→POM/PG import, export, domestic, stale/contradictory optional country fields with valid server direction, fallback country inference, and fail-closed diagnostics.
- `frontend/scripts/spot-workspace-orchestration.test.mjs`: updates workflow assertions for direction precedence and backend rejection visibility.

## What Was Intentionally Not Changed

- No backend route/domain validation was weakened.
- No backend pricing, database, migration, quote totals, GST, FX, margin, grouping, inclusion, public output, or persisted SPE behavior changed.
- No client URL parameter or user-entered direction is used as authoritative.
- No ProductCode approval lifecycle changes.

## Verification

Automated:
- `node scripts/draft-quote-domain.test.mjs` — passed.
- `node scripts/spot-workspace-orchestration.test.mjs` — passed.
- `node scripts/exception-workspace-routing.test.mjs` — passed.
- `npm run typecheck` — passed.
- `npm run build` — passed with existing lint warnings.
- `python -m pytest quotes/tests/test_draft_quote_resolve.py -q` — passed, 44 tests.
- `git diff --check` — passed.
- `graphify update .` — completed.

Manual:
- Confirmed valid server-derived direction returns immediately and is not marked contradictory when optional route-country compatibility fields differ.
- Confirmed unsupported/missing route evidence still fails closed when server direction is absent.

## Risk

Low. Frontend filtering/request metadata now follows backend direction precedence. Backend remains authoritative for ProductCode request validation and can still reject invalid route/domain cases.

## Rollback

Revert this PR. No migrations or data writes are included.

## Commercial Impact

No quote totals, GST, FX, margin, pricing, grouping, inclusion, public output, or operator approval semantics changed.

## Data Impact

No persisted data mutation, SPE mutation, migration, backfill, seed data, or rate mutation.

## Audit Impact

No audit records changed.
