### PR TITLE
fix(spot): unify source review with Exception Workspace safety

### DIFF
--- a/backend/quotes/contracts/draft_quote_contract.py
+++ b/backend/quotes/contracts/draft_quote_contract.py
@@ -177,6 +177,20 @@ class IgnoreDetails(BaseModel):
     reason: str = Field(..., description="Reason why item is ignored (must not be empty)")
 
 
+class ResolveSourceFindingDetails(BaseModel):
+    source_batch_id: str = Field(..., description="Source batch containing the finding")
+    source_finding_id: str = Field(..., description="Stable source finding ID")
+    action: str = Field(..., description="Resolution action")
+    review_note: str = Field(..., description="Required operator review note")
+    charge_line_id: Optional[str] = Field(None, description="Optional charge line linked to the finding")
+
+    @model_validator(mode="after")
+    def validate_review_note(self) -> ResolveSourceFindingDetails:
+        if not self.review_note or not self.review_note.strip():
+            raise ValueError("Source finding resolution requires a non-empty review_note.")
+        return self
+
+
 class ChargeValuesSchema(BaseModel):
     model_config = ConfigDict(extra="allow")
 
@@ -244,6 +258,7 @@ class DecisionItemSchema(BaseModel):
             "edit_charge",
             "classify_unclassified",
             "use_approved_product_code",
+            "resolve_source_finding",
         }
         if self.type not in valid_types:
             raise ValueError(f"Invalid decision type: {self.type}")
@@ -258,6 +273,8 @@ class DecisionItemSchema(BaseModel):
             IgnoreDetails(**self.details)
             if not self.details.get("reason") or not str(self.details["reason"]).strip():
                 raise ValueError("Ignored decisions must carry a non-empty reason.")
+        elif self.type == "resolve_source_finding":
+            ResolveSourceFindingDetails(**self.details)
         elif self.type == "edit_charge":
             EditChargeDetails(**self.details)
         elif self.type == "classify_unclassified":

--- a/backend/quotes/intake_safety.py
+++ b/backend/quotes/intake_safety.py
@@ -1,11 +1,22 @@
 from __future__ import annotations
 
 from typing import Any, Iterable
+import re
 
 
 REVIEW_STATUS_PENDING = "PENDING"
 REVIEW_STATUS_APPROVED = "APPROVED"
 REVIEW_STATUS_NOT_REQUIRED = "NOT_REQUIRED"
+SOURCE_FINDING_STATUS_OPEN = "open"
+SOURCE_FINDING_STATUS_RESOLVED = "resolved"
+SOURCE_FINDING_BLOCKING_TYPES = {
+    "missing_required_fields",
+    "critic_missed_charges",
+    "critic_hallucinations",
+    "unmapped_lines",
+    "no_imported_charges",
+    "multiple_currencies",
+}
 
 
 def _string_list(value: Any) -> list[str]:
@@ -26,12 +37,124 @@ def _int_value(value: Any) -> int:
         return 0
 
 
+def _slug(value: Any) -> str:
+    text = re.sub(r"[^a-z0-9]+", "-", str(value or "").strip().lower()).strip("-")
+    return text[:60] or "finding"
+
+
+def _existing_source_findings(raw: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    findings = raw.get("source_findings")
+    if not isinstance(findings, list):
+        return {}
+    return {str(item.get("id") or ""): dict(item) for item in findings if isinstance(item, dict) and item.get("id")}
+
+
+def _finding_payload(
+    raw: dict[str, Any],
+    *,
+    finding_id: str,
+    finding_type: str,
+    message: str,
+    evidence_text: str | None = None,
+    charge_line_id: str | None = None,
+    blocking: bool = True,
+) -> dict[str, Any]:
+    existing = _existing_source_findings(raw).get(finding_id, {})
+    status = existing.get("status") or SOURCE_FINDING_STATUS_OPEN
+    return {
+        "id": finding_id,
+        "type": finding_type,
+        "message": message,
+        "evidence": existing.get("evidence") or {"source_text": evidence_text or message},
+        "charge_line_id": existing.get("charge_line_id") or charge_line_id,
+        "status": status,
+        "blocking": bool(blocking),
+        "resolution_action": existing.get("resolution_action"),
+        "review_note": existing.get("review_note"),
+        "resolved_by_user_id": existing.get("resolved_by_user_id"),
+        "resolved_at": existing.get("resolved_at"),
+    }
+
+
+def _derive_source_findings(raw: dict[str, Any], summary: dict[str, Any]) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    if summary["ai_used"] and not summary["can_proceed"]:
+        findings.append(_finding_payload(
+            raw,
+            finding_id="source-missing-required-fields",
+            finding_type="missing_required_fields",
+            message="Imported lines are missing required rate or currency fields.",
+        ))
+    for idx, text in enumerate(summary["critic_missed_charges"]):
+        findings.append(_finding_payload(
+            raw,
+            finding_id=f"critic-missed-charges-{idx}-{_slug(text)}",
+            finding_type="critic_missed_charges",
+            message=f"Possible missed charge: {text}",
+            evidence_text=text,
+        ))
+    for idx, text in enumerate(summary["critic_hallucinations"]):
+        findings.append(_finding_payload(
+            raw,
+            finding_id=f"critic-hallucinations-{idx}-{_slug(text)}",
+            finding_type="critic_hallucinations",
+            message=f"Questionable extracted mapping or charge: {text}",
+            evidence_text=text,
+        ))
+    if summary["unmapped_line_count"] > 0:
+        findings.append(_finding_payload(
+            raw,
+            finding_id="source-unmapped-lines",
+            finding_type="unmapped_lines",
+            message=f"{summary['unmapped_line_count']} extracted charge(s) could not be mapped cleanly.",
+        ))
+    if summary["imported_charge_count"] == 0 and summary["ai_used"]:
+        findings.append(_finding_payload(
+            raw,
+            finding_id="source-no-imported-charges",
+            finding_type="no_imported_charges",
+            message="No charge lines were imported for review.",
+        ))
+    if len(summary["detected_currencies"]) > 1:
+        findings.append(_finding_payload(
+            raw,
+            finding_id="source-multiple-currencies",
+            finding_type="multiple_currencies",
+            message="Multiple currencies were detected in a single source: " + ", ".join(summary["detected_currencies"]),
+        ))
+    if summary["low_confidence_line_count"] > 0:
+        findings.append(_finding_payload(
+            raw,
+            finding_id="source-low-confidence-lines",
+            finding_type="low_confidence_lines",
+            message=f"{summary['low_confidence_line_count']} extracted charge line(s) were low-confidence.",
+            blocking=False,
+        ))
+    if summary["pdf_fallback_used"]:
+        findings.append(_finding_payload(
+            raw,
+            finding_id="source-pdf-fallback-used",
+            finding_type="pdf_fallback_used",
+            message="Scanned-PDF fallback extraction was used; verify the imported lines carefully.",
+            blocking=False,
+        ))
+    return findings
+
+
+def unresolved_source_findings(value: Any) -> list[dict[str, Any]]:
+    summary = normalize_source_analysis_summary(value)
+    return [
+        item for item in summary.get("source_findings", [])
+        if item.get("blocking") and item.get("status") != SOURCE_FINDING_STATUS_RESOLVED
+    ]
+
+
 def _derive_blocking_reasons(summary: dict[str, Any]) -> tuple[list[str], list[str], str, bool]:
     risk_flags: list[str] = []
     blocking_reasons: list[str] = []
     high_risk = False
 
-    if not summary["can_proceed"]:
+    if summary["ai_used"] and not summary["can_proceed"]:
         risk_flags.append("missing_required_fields")
         blocking_reasons.append("Imported lines are missing required rate or currency fields.")
         high_risk = True
@@ -145,11 +268,24 @@ def normalize_source_analysis_summary(value: Any) -> dict[str, Any]:
         review_status = REVIEW_STATUS_NOT_REQUIRED
         reviewed_safe_to_quote = False
 
+    summary["source_findings"] = _derive_source_findings(raw, summary)
+    unresolved_findings = [
+        item for item in summary["source_findings"]
+        if item.get("blocking") and item.get("status") != SOURCE_FINDING_STATUS_RESOLVED
+    ]
+    review_required = bool(unresolved_findings)
+    if review_required:
+        review_status = REVIEW_STATUS_APPROVED if not unresolved_findings else REVIEW_STATUS_PENDING
+        reviewed_safe_to_quote = review_status == REVIEW_STATUS_APPROVED
+    else:
+        review_status = REVIEW_STATUS_NOT_REQUIRED
+        reviewed_safe_to_quote = False
+
     summary["review_required"] = review_required
     summary["review_status"] = review_status
     summary["reviewed_safe_to_quote"] = reviewed_safe_to_quote
     summary["risk_flags"] = risk_flags
-    summary["blocking_reasons"] = blocking_reasons
+    summary["blocking_reasons"] = [item["message"] for item in unresolved_findings]
     summary["risk_level"] = risk_level
     summary["requires_review_note"] = requires_review_note
     return summary
@@ -201,23 +337,33 @@ def mark_source_analysis_review(
     reviewed_by_user_id: str | None,
     reviewed_at: str | None,
     review_note: str | None = None,
+    source_finding_id: str | None = None,
+    resolution_action: str | None = None,
+    charge_line_id: str | None = None,
 ) -> dict[str, Any]:
-    summary = normalize_source_analysis_summary(value)
-    review_required = bool(summary["review_required"])
+    raw = dict(value) if isinstance(value, dict) else {}
+    summary = normalize_source_analysis_summary(raw)
+    note = str(review_note or "").strip() or None
+    finding_id = str(source_finding_id or "").strip() or None
 
-    if review_required:
-        summary["review_status"] = (
-            REVIEW_STATUS_APPROVED if reviewed_safe_to_quote else REVIEW_STATUS_PENDING
-        )
-        summary["reviewed_safe_to_quote"] = bool(reviewed_safe_to_quote)
-    else:
-        summary["review_status"] = REVIEW_STATUS_NOT_REQUIRED
-        summary["reviewed_safe_to_quote"] = False
+    updated_findings = []
+    for finding in summary.get("source_findings", []):
+        item = dict(finding)
+        if reviewed_safe_to_quote and (finding_id is None or item.get("id") == finding_id):
+            item["status"] = SOURCE_FINDING_STATUS_RESOLVED
+            item["resolution_action"] = resolution_action or "source_review_approved"
+            item["review_note"] = note
+            item["resolved_by_user_id"] = str(reviewed_by_user_id or "").strip() or None
+            item["resolved_at"] = reviewed_at or None
+            if charge_line_id:
+                item["charge_line_id"] = str(charge_line_id)
+        updated_findings.append(item)
 
-    summary["reviewed_by_user_id"] = str(reviewed_by_user_id or "").strip() or None
-    summary["reviewed_at"] = reviewed_at or None
-    summary["review_note"] = str(review_note or "").strip() or None
-    return summary
+    raw["source_findings"] = updated_findings
+    raw["reviewed_by_user_id"] = str(reviewed_by_user_id or "").strip() or None
+    raw["reviewed_at"] = reviewed_at or None
+    raw["review_note"] = note
+    return normalize_source_analysis_summary(raw)
 
 
 def sync_source_analysis_summary_counts(

--- a/backend/quotes/intake_safety.py
+++ b/backend/quotes/intake_safety.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any, Iterable
+import hashlib
 import re
 
 
@@ -39,7 +40,13 @@ def _int_value(value: Any) -> int:
 
 def _slug(value: Any) -> str:
     text = re.sub(r"[^a-z0-9]+", "-", str(value or "").strip().lower()).strip("-")
-    return text[:60] or "finding"
+    return text[:48] or "finding"
+
+
+def _content_finding_id(finding_type: str, text: Any) -> str:
+    normalized = re.sub(r"\s+", " ", str(text or "").strip().lower())
+    digest = hashlib.sha256(f"{finding_type}:{normalized}".encode("utf-8")).hexdigest()[:12]
+    return f"{finding_type}-{digest}-{_slug(normalized)}"
 
 
 def _existing_source_findings(raw: dict[str, Any]) -> dict[str, dict[str, Any]]:
@@ -85,18 +92,27 @@ def _derive_source_findings(raw: dict[str, Any], summary: dict[str, Any]) -> lis
             finding_type="missing_required_fields",
             message="Imported lines are missing required rate or currency fields.",
         ))
-    for idx, text in enumerate(summary["critic_missed_charges"]):
+    seen_content_findings: set[str] = set()
+    for text in summary["critic_missed_charges"]:
+        finding_id = _content_finding_id("critic_missed_charges", text)
+        if finding_id in seen_content_findings:
+            continue
+        seen_content_findings.add(finding_id)
         findings.append(_finding_payload(
             raw,
-            finding_id=f"critic-missed-charges-{idx}-{_slug(text)}",
+            finding_id=finding_id,
             finding_type="critic_missed_charges",
             message=f"Possible missed charge: {text}",
             evidence_text=text,
         ))
-    for idx, text in enumerate(summary["critic_hallucinations"]):
+    for text in summary["critic_hallucinations"]:
+        finding_id = _content_finding_id("critic_hallucinations", text)
+        if finding_id in seen_content_findings:
+            continue
+        seen_content_findings.add(finding_id)
         findings.append(_finding_payload(
             raw,
-            finding_id=f"critic-hallucinations-{idx}-{_slug(text)}",
+            finding_id=finding_id,
             finding_type="critic_hallucinations",
             message=f"Questionable extracted mapping or charge: {text}",
             evidence_text=text,
@@ -349,9 +365,9 @@ def mark_source_analysis_review(
     updated_findings = []
     for finding in summary.get("source_findings", []):
         item = dict(finding)
-        if reviewed_safe_to_quote and (finding_id is None or item.get("id") == finding_id):
+        if reviewed_safe_to_quote and finding_id and item.get("id") == finding_id:
             item["status"] = SOURCE_FINDING_STATUS_RESOLVED
-            item["resolution_action"] = resolution_action or "source_review_approved"
+            item["resolution_action"] = resolution_action
             item["review_note"] = note
             item["resolved_by_user_id"] = str(reviewed_by_user_id or "").strip() or None
             item["resolved_at"] = reviewed_at or None

--- a/backend/quotes/services/draft_quote_adapter.py
+++ b/backend/quotes/services/draft_quote_adapter.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 from typing import Any, Dict, List, Optional
 from quotes.spot_models import SpotPricingEnvelopeDB, SPEChargeLineDB
 from quotes.contracts.draft_quote_contract import DraftQuoteSchema
+from quotes.intake_safety import normalize_source_analysis_summary, unresolved_source_findings
 
 VALID_PRODUCT_CODE_DOMAINS = {"IMPORT", "EXPORT", "DOMESTIC"}
 
@@ -419,6 +420,29 @@ def build_draft_quote_payload(spe_db: SpotPricingEnvelopeDB) -> Dict[str, Any]:
             "type": "unclassified_item",
             "message": item['review_reason'] or "Unclassified commercial-looking item requires operator classification"
         })
+    for batch in spe_db.source_batches.all():
+        summary = normalize_source_analysis_summary(batch.analysis_summary_json)
+        for finding in unresolved_source_findings(summary):
+            review_queue.append({
+                "id": f"source:{batch.id}:{finding['id']}",
+                "type": "source_finding",
+                "message": finding["message"],
+                "blocker_reason": finding["message"],
+                "source_batch_id": str(batch.id),
+                "source_batch_label": batch.label or batch.file_name or "Imported source",
+                "source_finding_id": finding["id"],
+                "source_finding_type": finding["type"],
+                "evidence": finding.get("evidence"),
+                "charge_line_id": finding.get("charge_line_id"),
+                "note_required": True,
+                "available_actions": [
+                    "link_existing_charge",
+                    "add_missing_charge",
+                    "confirm_corrected_mapping",
+                    "not_commercially_applicable",
+                    "approve_source",
+                ],
+            })
 
     # 10. Correction Actions
     correction_actions = []

--- a/backend/quotes/services/draft_quote_adapter.py
+++ b/backend/quotes/services/draft_quote_adapter.py
@@ -436,11 +436,8 @@ def build_draft_quote_payload(spe_db: SpotPricingEnvelopeDB) -> Dict[str, Any]:
                 "charge_line_id": finding.get("charge_line_id"),
                 "note_required": True,
                 "available_actions": [
-                    "link_existing_charge",
-                    "add_missing_charge",
-                    "confirm_corrected_mapping",
+                    "resolved_in_workspace",
                     "not_commercially_applicable",
-                    "approve_source",
                 ],
             })
 

--- a/backend/quotes/services/draft_quote_resolve_service.py
+++ b/backend/quotes/services/draft_quote_resolve_service.py
@@ -367,11 +367,8 @@ def _create_product_code_request_for_unclassified(envelope, decision, user):
 
 
 SOURCE_FINDING_RESOLUTION_ACTIONS = {
-    "link_existing_charge",
-    "add_missing_charge",
-    "confirm_corrected_mapping",
+    "resolved_in_workspace",
     "not_commercially_applicable",
-    "approve_source",
 }
 
 

--- a/backend/quotes/services/draft_quote_resolve_service.py
+++ b/backend/quotes/services/draft_quote_resolve_service.py
@@ -8,6 +8,7 @@ from django.db import transaction
 from django.utils import timezone
 
 from pricing_v4.models import ProductCode, ProductCodeCreationRequest
+from quotes.intake_safety import mark_source_analysis_review, normalize_source_analysis_summary, unresolved_source_findings
 from quotes.contracts.draft_quote_contract import (
     DecisionItemSchema,
     DecisionResultSchema,
@@ -365,6 +366,51 @@ def _create_product_code_request_for_unclassified(envelope, decision, user):
     return "skipped", "ProductCode request created and pending admin review.", None, charge_line
 
 
+SOURCE_FINDING_RESOLUTION_ACTIONS = {
+    "link_existing_charge",
+    "add_missing_charge",
+    "confirm_corrected_mapping",
+    "not_commercially_applicable",
+    "approve_source",
+}
+
+
+def _resolve_source_finding(envelope, decision, user):
+    details = decision.details
+    action = str(details.get("action") or "").strip()
+    if action not in SOURCE_FINDING_RESOLUTION_ACTIONS:
+        return "rejected", "Source finding resolution action is not supported.", "SOURCE_FINDING_ACTION_INVALID"
+    note = str(details.get("review_note") or "").strip()
+    if not note:
+        return "rejected", "Source finding resolution requires a non-empty review note.", "REVIEW_NOTE_REQUIRED"
+    batch = envelope.source_batches.select_for_update().filter(id=details.get("source_batch_id")).first()
+    if not batch:
+        return "rejected", "Source batch was not found for this envelope.", "SOURCE_BATCH_NOT_FOUND"
+    finding_id = str(details.get("source_finding_id") or "").strip()
+    current = normalize_source_analysis_summary(batch.analysis_summary_json)
+    if not any(item.get("id") == finding_id for item in current.get("source_findings", [])):
+        return "rejected", "Source finding was not found for this source batch.", "SOURCE_FINDING_NOT_FOUND"
+    if not any(item.get("id") == finding_id for item in unresolved_source_findings(current)):
+        return "skipped", "Source finding was already resolved.", None
+
+    charge_line_id = details.get("charge_line_id")
+    if charge_line_id and not envelope.charge_lines.filter(id=charge_line_id).exists():
+        return "rejected", "Linked charge line was not found for this envelope.", "CHARGE_LINE_NOT_FOUND"
+
+    batch.analysis_summary_json = mark_source_analysis_review(
+        batch.analysis_summary_json,
+        reviewed_safe_to_quote=True,
+        reviewed_by_user_id=str(user.id),
+        reviewed_at=timezone.now().isoformat(),
+        review_note=note,
+        source_finding_id=finding_id,
+        resolution_action=action,
+        charge_line_id=str(charge_line_id) if charge_line_id else None,
+    )
+    batch.save(update_fields=["analysis_summary_json", "updated_at"])
+    return "accepted", "Source finding resolved.", None
+
+
 def _apply_classify_unclassified(envelope, decision, payload, user):
     batch, item = _unclassified_item(envelope, decision.target_id)
     if not item:
@@ -457,6 +503,8 @@ def apply_draft_quote_decisions(
                 status_val, message_val, error_code_val = _apply_edit_charge(charge_line, dec_item, payload, user)
             elif decision_type == "classify_unclassified":
                 status_val, message_val, error_code_val = _apply_classify_unclassified(envelope, dec_item, payload, user)
+            elif decision_type == "resolve_source_finding":
+                status_val, message_val, error_code_val = _resolve_source_finding(envelope, dec_item, user)
             elif decision_type == "request_product_code":
                 if not charge_line:
                     status_val, message_val, error_code_val, charge_line = _create_product_code_request_for_unclassified(envelope, dec_item, user)

--- a/backend/quotes/spot_views.py
+++ b/backend/quotes/spot_views.py
@@ -68,6 +68,7 @@ from quotes.intake_safety import (
     mark_source_analysis_review,
     normalize_source_analysis_summary,
     sync_source_analysis_summary_counts,
+    unresolved_source_findings,
 )
 from quotes.serializers import SpotPricingEnvelopeSerializer, SPEChargeLineSerializer, SpotTemplateValidationReviewSerializer
 from accounts.scope import scoped_queryset_for_user
@@ -3105,9 +3106,38 @@ class SpotSourceBatchReviewAPIView(APIView):
         reviewed_safe_to_quote = bool(request.data.get("reviewed_safe_to_quote", False))
         review_note = str(request.data.get("review_note") or "").strip() or None
         source_finding_id = str(request.data.get("source_finding_id") or "").strip() or None
-        resolution_action = str(request.data.get("resolution_action") or "source_review_approved").strip()
+        resolution_action = str(request.data.get("resolution_action") or "").strip()
         charge_line_id = str(request.data.get("charge_line_id") or "").strip() or None
         summary = normalize_source_analysis_summary(batch.analysis_summary_json)
+        unresolved_findings = unresolved_source_findings(summary)
+
+        if reviewed_safe_to_quote and unresolved_findings and not source_finding_id:
+            return Response(
+                {
+                    "error": "Source findings must be resolved individually; blanket source approval is not allowed.",
+                    "source_batch_id": str(batch.id),
+                    "blocking_reasons": summary["blocking_reasons"],
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if reviewed_safe_to_quote and source_finding_id and not any(item.get("id") == source_finding_id for item in unresolved_findings):
+            return Response(
+                {
+                    "error": "Source finding was not found or is already resolved.",
+                    "source_batch_id": str(batch.id),
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if reviewed_safe_to_quote and source_finding_id and resolution_action not in {"resolved_in_workspace", "not_commercially_applicable"}:
+            return Response(
+                {
+                    "error": "Unsupported source finding resolution action.",
+                    "source_batch_id": str(batch.id),
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         if reviewed_safe_to_quote and summary["requires_review_note"] and not review_note:
             return Response(

--- a/backend/quotes/spot_views.py
+++ b/backend/quotes/spot_views.py
@@ -3104,6 +3104,9 @@ class SpotSourceBatchReviewAPIView(APIView):
         batch = get_object_or_404(spe_db.source_batches, id=source_batch_id)
         reviewed_safe_to_quote = bool(request.data.get("reviewed_safe_to_quote", False))
         review_note = str(request.data.get("review_note") or "").strip() or None
+        source_finding_id = str(request.data.get("source_finding_id") or "").strip() or None
+        resolution_action = str(request.data.get("resolution_action") or "source_review_approved").strip()
+        charge_line_id = str(request.data.get("charge_line_id") or "").strip() or None
         summary = normalize_source_analysis_summary(batch.analysis_summary_json)
 
         if reviewed_safe_to_quote and summary["requires_review_note"] and not review_note:
@@ -3122,9 +3125,14 @@ class SpotSourceBatchReviewAPIView(APIView):
             reviewed_by_user_id=str(request.user.id),
             reviewed_at=timezone.now().isoformat(),
             review_note=review_note,
+            source_finding_id=source_finding_id,
+            resolution_action=resolution_action,
+            charge_line_id=charge_line_id,
         )
         batch.save(update_fields=["analysis_summary_json", "updated_at"])
 
+        from quotes.services.draft_quote_review_service import invalidate_finalized_review
+        invalidate_finalized_review(spe_db, user=request.user, reason="source_review")
         spe_db.refresh_from_db()
         serializer = SpotPricingEnvelopeSerializer(spe_db)
         return Response(serializer.data)

--- a/backend/quotes/tests/test_draft_quote_resolve.py
+++ b/backend/quotes/tests/test_draft_quote_resolve.py
@@ -300,6 +300,111 @@ class DraftQuoteResolveHighValueTests(TestCase):
         self.charge.refresh_from_db()
         self.assertIsNone(self.charge.manual_resolved_product_code_id)
 
+    def test_source_finding_appears_blocks_finalize_and_resolves_with_note(self):
+        self.batch.analysis_summary_json = {
+            **self.batch.analysis_summary_json,
+            "ai_used": True,
+            "can_proceed": True,
+            "imported_charge_count": 1,
+            "critic_missed_charges": ["Destination delivery fee"],
+        }
+        self.batch.save(update_fields=["analysis_summary_json"])
+
+        self.client.force_authenticate(user=self.sales)
+        read = self.client.get(f"/api/v3/spot/envelopes/{self.envelope.id}/draft-quote/")
+        self.assertEqual(read.status_code, status.HTTP_200_OK)
+        source_items = [item for item in read.data["review_queue"] if item["type"] == "source_finding"]
+        self.assertEqual(len(source_items), 1)
+        self.assertIn("Destination delivery fee", source_items[0]["message"])
+        self.assertEqual(self._finalize().status_code, status.HTTP_400_BAD_REQUEST)
+
+        missing_note = self._post([
+            self._decision(
+                "resolve_source_finding",
+                target_id=source_items[0]["id"],
+                details={
+                    "source_batch_id": source_items[0]["source_batch_id"],
+                    "source_finding_id": source_items[0]["source_finding_id"],
+                    "action": "not_commercially_applicable",
+                    "review_note": "",
+                },
+                decision_id="source-missing-note",
+            )
+        ])
+        self.assertEqual(missing_note.status_code, status.HTTP_400_BAD_REQUEST)
+
+        resolved = self._post([
+            self._decision(
+                "resolve_source_finding",
+                target_id=source_items[0]["id"],
+                details={
+                    "source_batch_id": source_items[0]["source_batch_id"],
+                    "source_finding_id": source_items[0]["source_finding_id"],
+                    "action": "not_commercially_applicable",
+                    "review_note": "Reviewed supplier evidence; destination delivery not applicable to A2A quote.",
+                },
+                decision_id="source-resolve",
+            )
+        ])
+        self.assertEqual(resolved.status_code, status.HTTP_200_OK)
+        self.assertEqual(resolved.data["rejected_decisions"], [])
+        self.batch.refresh_from_db()
+        findings = self.batch.analysis_summary_json["source_findings"]
+        self.assertEqual(findings[0]["status"], "resolved")
+        self.assertIn("Destination delivery fee", findings[0]["evidence"]["source_text"])
+
+        reread = self.client.get(f"/api/v3/spot/envelopes/{self.envelope.id}/draft-quote/")
+        self.assertFalse([item for item in reread.data["review_queue"] if item["type"] == "source_finding"])
+
+    def test_source_finding_resolution_clears_only_target_finding_and_is_idempotent(self):
+        self.batch.analysis_summary_json = {
+            **self.batch.analysis_summary_json,
+            "ai_used": True,
+            "can_proceed": True,
+            "imported_charge_count": 1,
+            "critic_missed_charges": ["Destination delivery fee", "Terminal handling"],
+        }
+        self.batch.save(update_fields=["analysis_summary_json"])
+        self.client.force_authenticate(user=self.sales)
+        read = self.client.get(f"/api/v3/spot/envelopes/{self.envelope.id}/draft-quote/")
+        source_items = [item for item in read.data["review_queue"] if item["type"] == "source_finding"]
+        self.assertEqual(len(source_items), 2)
+        key = uuid.uuid4()
+        decision = self._decision(
+            "resolve_source_finding",
+            target_id=source_items[0]["id"],
+            details={
+                "source_batch_id": source_items[0]["source_batch_id"],
+                "source_finding_id": source_items[0]["source_finding_id"],
+                "action": "link_existing_charge",
+                "review_note": "Linked to existing destination charge.",
+                "charge_line_id": str(self.charge.id),
+            },
+            decision_id="source-one",
+        )
+        self._post([decision], key=key)
+        self._post([decision], key=key)
+        reread = self.client.get(f"/api/v3/spot/envelopes/{self.envelope.id}/draft-quote/")
+        remaining = [item for item in reread.data["review_queue"] if item["type"] == "source_finding"]
+        self.assertEqual(len(remaining), 1)
+        self.assertIn("Terminal handling", remaining[0]["message"])
+
+    def test_low_confidence_source_finding_does_not_block_finalize(self):
+        self.batch.analysis_summary_json = {
+            **self.batch.analysis_summary_json,
+            "ai_used": True,
+            "can_proceed": True,
+            "imported_charge_count": 1,
+            "low_confidence_line_count": 1,
+        }
+        self.batch.save(update_fields=["analysis_summary_json"])
+        self._resolve_all_blockers()
+        self.client.force_authenticate(user=self.sales)
+        read = self.client.get(f"/api/v3/spot/envelopes/{self.envelope.id}/draft-quote/")
+        self.assertFalse([item for item in read.data["review_queue"] if item["type"] == "source_finding"])
+        finalize = self._finalize()
+        self.assertEqual(finalize.status_code, status.HTTP_200_OK)
+
     def test_map_to_product_code_replay_is_idempotent(self):
         key = uuid.uuid4()
         decision = self._decision("map_to_product_code", details={"product_code": self.product_code.code})

--- a/backend/quotes/tests/test_draft_quote_resolve.py
+++ b/backend/quotes/tests/test_draft_quote_resolve.py
@@ -316,6 +316,7 @@ class DraftQuoteResolveHighValueTests(TestCase):
         source_items = [item for item in read.data["review_queue"] if item["type"] == "source_finding"]
         self.assertEqual(len(source_items), 1)
         self.assertIn("Destination delivery fee", source_items[0]["message"])
+        self.assertEqual(source_items[0]["available_actions"], ["resolved_in_workspace", "not_commercially_applicable"])
         self.assertEqual(self._finalize().status_code, status.HTTP_400_BAD_REQUEST)
 
         missing_note = self._post([
@@ -376,8 +377,8 @@ class DraftQuoteResolveHighValueTests(TestCase):
             details={
                 "source_batch_id": source_items[0]["source_batch_id"],
                 "source_finding_id": source_items[0]["source_finding_id"],
-                "action": "link_existing_charge",
-                "review_note": "Linked to existing destination charge.",
+                "action": "resolved_in_workspace",
+                "review_note": "Addressed against existing destination charge in the workspace.",
                 "charge_line_id": str(self.charge.id),
             },
             decision_id="source-one",
@@ -388,6 +389,56 @@ class DraftQuoteResolveHighValueTests(TestCase):
         remaining = [item for item in reread.data["review_queue"] if item["type"] == "source_finding"]
         self.assertEqual(len(remaining), 1)
         self.assertIn("Terminal handling", remaining[0]["message"])
+
+    def test_source_finding_ids_are_content_stable_not_index_based(self):
+        self.batch.analysis_summary_json = {
+            **self.batch.analysis_summary_json,
+            "ai_used": True,
+            "can_proceed": True,
+            "imported_charge_count": 1,
+            "critic_missed_charges": ["Destination delivery fee", "Terminal handling"],
+        }
+        self.batch.save(update_fields=["analysis_summary_json"])
+        self.client.force_authenticate(user=self.sales)
+        first = self.client.get(f"/api/v3/spot/envelopes/{self.envelope.id}/draft-quote/")
+        first_ids_by_message = {
+            item["message"]: item["source_finding_id"]
+            for item in first.data["review_queue"]
+            if item["type"] == "source_finding"
+        }
+
+        self.batch.analysis_summary_json = {
+            **self.batch.analysis_summary_json,
+            "critic_missed_charges": ["Terminal handling", "Destination delivery fee", "Terminal handling"],
+        }
+        self.batch.save(update_fields=["analysis_summary_json"])
+        second = self.client.get(f"/api/v3/spot/envelopes/{self.envelope.id}/draft-quote/")
+        second_ids_by_message = {
+            item["message"]: item["source_finding_id"]
+            for item in second.data["review_queue"]
+            if item["type"] == "source_finding"
+        }
+        self.assertEqual(first_ids_by_message, second_ids_by_message)
+        self.assertNotIn("critic-missed-charges-0", " ".join(second_ids_by_message.values()))
+        self.assertEqual(len(second_ids_by_message), 2)
+
+    def test_source_batch_review_rejects_blanket_approval_when_findings_are_open(self):
+        self.batch.analysis_summary_json = {
+            **self.batch.analysis_summary_json,
+            "ai_used": True,
+            "can_proceed": True,
+            "imported_charge_count": 1,
+            "critic_missed_charges": ["Destination delivery fee"],
+        }
+        self.batch.save(update_fields=["analysis_summary_json"])
+        self.client.force_authenticate(user=self.sales)
+        response = self.client.post(
+            f"/api/v3/spot/envelopes/{self.envelope.id}/sources/{self.batch.id}/review/",
+            {"reviewed_safe_to_quote": True, "review_note": "Looks okay."},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("blanket source approval", response.data["error"])
 
     def test_low_confidence_source_finding_does_not_block_finalize(self):
         self.batch.analysis_summary_json = {

--- a/backend/quotes/tests/test_spot_ai_autofill.py
+++ b/backend/quotes/tests/test_spot_ai_autofill.py
@@ -42,6 +42,7 @@ from quotes.spot_models import (
     SPEChargeLineDB,
     SPEAcknowledgementDB,
 )
+from quotes.intake_safety import normalize_source_analysis_summary
 from quotes.spot_services import ReplyAnalysisService, SpotTriggerReason
 
 
@@ -1505,12 +1506,50 @@ def test_ai_source_warnings_block_until_source_review(monkeypatch):
     )
     assert acknowledge_response.status_code == 400
 
-    review_response = client.post(
-        f"/api/v3/spot/envelopes/{spe.id}/sources/{analyze_response.json()['source_batch_id']}/review/",
+    source_batch_id = analyze_response.json()["source_batch_id"]
+    blanket_review_response = client.post(
+        f"/api/v3/spot/envelopes/{spe.id}/sources/{source_batch_id}/review/",
         {"reviewed_safe_to_quote": True, "review_note": "Reviewed source warning."},
         format="json",
     )
+    assert blanket_review_response.status_code == 400
+    assert "blanket source approval" in blanket_review_response.json()["error"]
+
+    source_batch = SPESourceBatchDB.objects.get(id=source_batch_id)
+    source_summary = normalize_source_analysis_summary(source_batch.analysis_summary_json)
+    unresolved_findings = [
+        finding
+        for finding in source_summary["source_findings"]
+        if finding["status"] != "resolved" and finding["blocking"]
+    ]
+    assert len(unresolved_findings) == 1
+    source_finding = unresolved_findings[0]
+    assert source_finding["type"] == "critic_missed_charges"
+    assert source_finding["evidence"]["source_text"] == "Destination delivery fee"
+
+    review_response = client.post(
+        f"/api/v3/spot/envelopes/{spe.id}/sources/{source_batch_id}/review/",
+        {
+            "reviewed_safe_to_quote": True,
+            "source_finding_id": source_finding["id"],
+            "resolution_action": "resolved_in_workspace",
+            "review_note": "Reviewed source warning against workspace charges.",
+        },
+        format="json",
+    )
     assert review_response.status_code == 200
+
+    source_batch.refresh_from_db()
+    resolved_summary = normalize_source_analysis_summary(source_batch.analysis_summary_json)
+    resolved_finding = next(
+        finding for finding in resolved_summary["source_findings"] if finding["id"] == source_finding["id"]
+    )
+    assert resolved_finding["status"] == "resolved"
+    assert resolved_finding["resolution_action"] == "resolved_in_workspace"
+    assert resolved_finding["review_note"] == "Reviewed source warning against workspace charges."
+    assert resolved_finding["resolved_by_user_id"] == str(user.id)
+    assert resolved_finding["resolved_at"]
+    assert resolved_finding["evidence"]["source_text"] == "Destination delivery fee"
 
     acknowledge_response = client.post(
         f"/api/v3/spot/envelopes/{spe.id}/acknowledge/",

--- a/frontend/scripts/spot-workspace-orchestration.test.mjs
+++ b/frontend/scripts/spot-workspace-orchestration.test.mjs
@@ -114,6 +114,10 @@ console.log("✓ Verified ExceptionWorkspace does not locally declare resolution
 // 4. Verify hook owns the API calls
 assert.ok(hookSrc.includes('import("../../../lib/api")'), "useSpotResolutionWorkflow hook must import API functions");
 assert.ok(hookSrc.includes("resolveDraftQuoteDecisions"), "useSpotResolutionWorkflow must call resolveDraftQuoteDecisions");
+assert.ok(hookSrc.includes('type: "resolve_source_finding"'), "Source findings must submit authoritative resolve decisions");
+assert.ok(hookSrc.includes("Source finding resolution requires a non-empty review note"), "Source finding resolution must require a review note");
+assert.ok(workspaceSrc.includes('currentIssue.type === "source_finding"'), "ExceptionWorkspace must render source finding blockers");
+assert.ok(workspaceSrc.includes("Approve Source With Note"), "ExceptionWorkspace must expose source approval with note workflow");
 assert.ok(hookSrc.includes("getDraftQuote"), "useSpotResolutionWorkflow must reload the Draft Quote after live unknown-item decisions");
 assert.ok(hookSrc.includes("finalizeDraftQuoteReview"), "useSpotResolutionWorkflow must call finalizeDraftQuoteReview");
 assert.ok(hookSrc.includes("reopenDraftQuoteReview"), "useSpotResolutionWorkflow must call reopenDraftQuoteReview for authorized live reopen");

--- a/frontend/scripts/spot-workspace-orchestration.test.mjs
+++ b/frontend/scripts/spot-workspace-orchestration.test.mjs
@@ -117,7 +117,10 @@ assert.ok(hookSrc.includes("resolveDraftQuoteDecisions"), "useSpotResolutionWork
 assert.ok(hookSrc.includes('type: "resolve_source_finding"'), "Source findings must submit authoritative resolve decisions");
 assert.ok(hookSrc.includes("Source finding resolution requires a non-empty review note"), "Source finding resolution must require a review note");
 assert.ok(workspaceSrc.includes('currentIssue.type === "source_finding"'), "ExceptionWorkspace must render source finding blockers");
-assert.ok(workspaceSrc.includes("Approve Source With Note"), "ExceptionWorkspace must expose source approval with note workflow");
+assert.ok(workspaceSrc.includes("Mark Finding Addressed"), "ExceptionWorkspace must expose targeted source finding resolution");
+assert.ok(!workspaceSrc.includes("Approve Source With Note"), "ExceptionWorkspace must not expose blanket source approval");
+assert.ok(!workspaceSrc.includes("Link to Existing Charge"), "ExceptionWorkspace must not claim to link charges from source finding resolution");
+assert.ok(!workspaceSrc.includes("Missing Charge Added"), "ExceptionWorkspace must not claim to add charges from source finding resolution");
 assert.ok(hookSrc.includes("getDraftQuote"), "useSpotResolutionWorkflow must reload the Draft Quote after live unknown-item decisions");
 assert.ok(hookSrc.includes("finalizeDraftQuoteReview"), "useSpotResolutionWorkflow must call finalizeDraftQuoteReview");
 assert.ok(hookSrc.includes("reopenDraftQuoteReview"), "useSpotResolutionWorkflow must call reopenDraftQuoteReview for authorized live reopen");

--- a/frontend/src/components/spot/ExceptionWorkspace.tsx
+++ b/frontend/src/components/spot/ExceptionWorkspace.tsx
@@ -311,34 +311,16 @@ export function ExceptionWorkspace({ initialData, isLive = false, envelopeId, en
                                         </div>
                                         <div className="flex flex-wrap gap-2">
                                             <button
-                                                onClick={() => actions.resolveSourceFinding(currentIssue.finding, "link_existing_charge", currentIssue.finding.charge_line_id || null)}
-                                                className="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg text-xs font-semibold transition"
-                                            >
-                                                Link to Existing Charge
-                                            </button>
-                                            <button
-                                                onClick={() => actions.resolveSourceFinding(currentIssue.finding, "add_missing_charge", currentIssue.finding.charge_line_id || null)}
-                                                className="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg text-xs font-semibold transition"
-                                            >
-                                                Missing Charge Added
-                                            </button>
-                                            <button
-                                                onClick={() => actions.resolveSourceFinding(currentIssue.finding, "confirm_corrected_mapping", currentIssue.finding.charge_line_id || null)}
+                                                onClick={() => actions.resolveSourceFinding(currentIssue.finding, "resolved_in_workspace", currentIssue.finding.charge_line_id || null)}
                                                 className="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 text-white rounded-lg text-xs font-semibold transition"
                                             >
-                                                Confirm Corrected Mapping
+                                                Mark Finding Addressed
                                             </button>
                                             <button
                                                 onClick={() => actions.resolveSourceFinding(currentIssue.finding, "not_commercially_applicable")}
                                                 className="px-4 py-2 bg-slate-950 hover:bg-slate-900 border border-slate-800 text-red-400 rounded-lg text-xs font-semibold transition"
                                             >
                                                 Not Commercially Applicable
-                                            </button>
-                                            <button
-                                                onClick={() => actions.resolveSourceFinding(currentIssue.finding, "approve_source")}
-                                                className="px-4 py-2 bg-slate-950 hover:bg-slate-900 border border-slate-800 text-slate-200 rounded-lg text-xs font-semibold transition"
-                                            >
-                                                Approve Source With Note
                                             </button>
                                         </div>
                                     </div>

--- a/frontend/src/components/spot/ExceptionWorkspace.tsx
+++ b/frontend/src/components/spot/ExceptionWorkspace.tsx
@@ -183,6 +183,8 @@ export function ExceptionWorkspace({ initialData, isLive = false, envelopeId, en
                                 <div className="mt-2 bg-slate-950 border border-slate-850 rounded-xl p-3.5 text-xs text-slate-300 leading-relaxed">
                                     {currentIssue.type === "review_item" ? (
                                         "RateEngine extracted this charge from the supplier quote, but it could not safely match a billing code. Choosing the correct billing code ensures accurate reporting, margins, and customer invoicing."
+                                    ) : currentIssue.type === "source_finding" ? (
+                                        "The source-level safety review found a possible missed charge, questionable mapping, or source review blocker. Resolve only this finding with a note so quote creation is not blocked by hidden source evidence."
                                     ) : (
                                         "The quote contains commercial-looking text blocks that did not match standard layout definitions. Decide whether this represents a real charge, a conditions note, or should be ignored."
                                     )}
@@ -297,6 +299,46 @@ export function ExceptionWorkspace({ initialData, isLive = false, envelopeId, en
                                                 className="px-4 py-2 bg-slate-950 hover:bg-slate-900 border border-slate-800 text-red-400 rounded-lg text-xs font-semibold transition"
                                             >
                                                 Ignore as Non-Commercial
+                                            </button>
+                                        </div>
+                                    </div>
+                                ) : currentIssue.type === "source_finding" ? (
+                                    <div className="flex flex-col gap-4">
+                                        <div className="bg-amber-950/20 border border-amber-900/60 rounded-xl p-4 text-xs text-amber-100">
+                                            <div className="font-bold text-amber-300 mb-1">Source batch: {currentIssue.finding.source_batch_label || currentIssue.finding.source_batch_id}</div>
+                                            <div>Finding type: <span className="font-mono">{currentIssue.finding.source_finding_type || "source_finding"}</span></div>
+                                            <div className="mt-2 text-amber-200">A review note is required. Evidence will be preserved after resolution.</div>
+                                        </div>
+                                        <div className="flex flex-wrap gap-2">
+                                            <button
+                                                onClick={() => actions.resolveSourceFinding(currentIssue.finding, "link_existing_charge", currentIssue.finding.charge_line_id || null)}
+                                                className="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg text-xs font-semibold transition"
+                                            >
+                                                Link to Existing Charge
+                                            </button>
+                                            <button
+                                                onClick={() => actions.resolveSourceFinding(currentIssue.finding, "add_missing_charge", currentIssue.finding.charge_line_id || null)}
+                                                className="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg text-xs font-semibold transition"
+                                            >
+                                                Missing Charge Added
+                                            </button>
+                                            <button
+                                                onClick={() => actions.resolveSourceFinding(currentIssue.finding, "confirm_corrected_mapping", currentIssue.finding.charge_line_id || null)}
+                                                className="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 text-white rounded-lg text-xs font-semibold transition"
+                                            >
+                                                Confirm Corrected Mapping
+                                            </button>
+                                            <button
+                                                onClick={() => actions.resolveSourceFinding(currentIssue.finding, "not_commercially_applicable")}
+                                                className="px-4 py-2 bg-slate-950 hover:bg-slate-900 border border-slate-800 text-red-400 rounded-lg text-xs font-semibold transition"
+                                            >
+                                                Not Commercially Applicable
+                                            </button>
+                                            <button
+                                                onClick={() => actions.resolveSourceFinding(currentIssue.finding, "approve_source")}
+                                                className="px-4 py-2 bg-slate-950 hover:bg-slate-900 border border-slate-800 text-slate-200 rounded-lg text-xs font-semibold transition"
+                                            >
+                                                Approve Source With Note
                                             </button>
                                         </div>
                                     </div>

--- a/frontend/src/components/spot/workspace/spotResolutionState.ts
+++ b/frontend/src/components/spot/workspace/spotResolutionState.ts
@@ -1,12 +1,29 @@
 import { DraftCharge, DraftChargeStatus, Evidence, DraftQuote } from "../../../lib/draft-quote-types";
 
+export interface SourceFindingReviewQueueItem {
+    id: string;
+    type: "source_finding";
+    message: string;
+    blocker_reason?: string;
+    source_batch_id: string;
+    source_batch_label?: string;
+    source_finding_id: string;
+    source_finding_type?: string;
+    evidence?: Evidence | null;
+    charge_line_id?: string | null;
+    note_required?: boolean;
+    available_actions?: string[];
+}
+
+export type ReviewQueueItem = { id: string; type: string; message: string; [key: string]: unknown };
+
 export interface Decision {
     id: string; // charge id or item id
-    type: "map" | "request" | "ignore" | "accept" | "add";
+    type: "map" | "request" | "ignore" | "accept" | "add" | "source";
     description: string;
     originalState: {
         suggestedCharges: DraftCharge[];
-        reviewQueue: Array<{ id: string; type: string; message: string }>;
+        reviewQueue: ReviewQueueItem[];
         unclassifiedItems: Array<{ id: string; raw_text: string; evidence: Evidence | null; review_reason: string }>;
         ignoredItems: Array<{ id: string; raw_text: string; ignored_reason: string; evidence: Evidence | null }>;
     };
@@ -28,11 +45,19 @@ export type SpotWorkspaceIssue =
           problem: string;
           evidence: Evidence | null;
           itemDetails: { id: string; raw_text: string; evidence: Evidence | null; review_reason: string };
+      }
+    | {
+          type: "source_finding";
+          id: string;
+          title: string;
+          problem: string;
+          evidence: Evidence | null;
+          finding: SourceFindingReviewQueueItem;
       };
 
 export interface SpotResolutionState {
     suggestedCharges: DraftCharge[];
-    reviewQueue: Array<{ id: string; type: string; message: string }>;
+    reviewQueue: ReviewQueueItem[];
     unclassifiedItems: Array<{ id: string; raw_text: string; evidence: Evidence | null; review_reason: string }>;
     ignoredItems: Array<{ id: string; raw_text: string; ignored_reason: string; evidence: Evidence | null }>;
     decisions: Decision[];
@@ -94,6 +119,7 @@ export type SpotResolutionAction =
     | { type: "DISMISS_ACTION_MESSAGE" }
     | { type: "TOGGLE_PROTOTYPE_OVERRIDE" }
     | { type: "TOGGLE_HELP_TEXT" }
+    | { type: "RESOLVE_SOURCE_FINDING"; payload: { issueId: string; message: string } }
     | { type: "SET_ACTION_MESSAGE"; payload: string };
 
 export function createSpotResolutionState(initialData: DraftQuote): SpotResolutionState {
@@ -428,6 +454,17 @@ export function spotResolutionReducer(state: SpotResolutionState, action: SpotRe
             };
         }
 
+        case "RESOLVE_SOURCE_FINDING": {
+            const snapshot = captureSnapshotHelper(state, action.payload.issueId, "source", action.payload.message);
+            return {
+                ...state,
+                decisions: [...state.decisions.filter(d => d.id !== action.payload.issueId), snapshot],
+                reviewQueue: state.reviewQueue.filter(q => q.id !== action.payload.issueId),
+                actionMessage: action.payload.message,
+                selectedActionType: null
+            };
+        }
+
         case "FINALIZE_REVIEW":
             return {
                 ...state,
@@ -474,6 +511,17 @@ export function spotResolutionReducer(state: SpotResolutionState, action: SpotRe
 export function selectCombinedUnresolved(state: SpotResolutionState): SpotWorkspaceIssue[] {
     return [
         ...state.reviewQueue.map(item => {
+            if (item.type === "source_finding") {
+                const finding = item as unknown as SourceFindingReviewQueueItem;
+                return {
+                    id: item.id,
+                    type: "source_finding" as const,
+                    title: `Source Review: ${finding.source_batch_label || "Imported source"}`,
+                    problem: finding.blocker_reason || finding.message || "Imported source finding requires review.",
+                    evidence: finding.evidence || null,
+                    finding
+                };
+            }
             const charge = state.suggestedCharges.find(c => c.id === item.id);
             return {
                 id: item.id,

--- a/frontend/src/components/spot/workspace/useSpotResolutionWorkflow.ts
+++ b/frontend/src/components/spot/workspace/useSpotResolutionWorkflow.ts
@@ -4,6 +4,7 @@ import { useConfirmDialog } from "../../../context/confirm-dialog-context";
 import { resolveProductCodeDomainFromDraftQuote } from "../../../lib/draft-quote-domain";
 import { DecisionResult, DraftCharge, DraftQuote, DraftQuoteResolveResponse } from "../../../lib/draft-quote-types";
 import {
+    SourceFindingReviewQueueItem,
     createSpotResolutionState,
     spotResolutionReducer,
     selectCombinedUnresolved,
@@ -309,6 +310,44 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
             const errMsg = err instanceof Error ? err.message : String(err);
             dispatch({ type: "SET_ACTION_MESSAGE", payload: `API error classifying unknown item: ${errMsg}` });
         }
+    };
+
+    const resolveSourceFinding = async (finding: SourceFindingReviewQueueItem, action: string, chargeLineId?: string | null) => {
+        if (selectIsReviewLocked(state)) return;
+        const reviewNote = typeof window !== "undefined"
+            ? window.prompt("Add a required source-review note explaining this resolution:")
+            : "Source finding reviewed.";
+        if (!reviewNote || !reviewNote.trim()) {
+            dispatch({ type: "SET_ACTION_MESSAGE", payload: "Source finding resolution requires a non-empty review note." });
+            return;
+        }
+        const decisionId = `dec-${Date.now()}`;
+        const decisionItem = {
+            decision_id: decisionId,
+            type: "resolve_source_finding",
+            target_id: finding.id,
+            details: {
+                source_batch_id: finding.source_batch_id,
+                source_finding_id: finding.source_finding_id,
+                action,
+                review_note: reviewNote.trim(),
+                charge_line_id: chargeLineId || finding.charge_line_id || null
+            },
+            audit_metadata: { user_id: 1, timestamp: new Date().toISOString() }
+        };
+        try {
+            await submitLiveDecision(decisionItem);
+            if (isLive) {
+                await refreshLiveDraftQuote();
+                return;
+            }
+        } catch (err) {
+            console.error("Failed to submit source finding resolution:", err);
+            const errMsg = err instanceof Error ? err.message : String(err);
+            dispatch({ type: "SET_ACTION_MESSAGE", payload: `Backend rejected source finding resolution: ${errMsg}` });
+            return;
+        }
+        dispatch({ type: "RESOLVE_SOURCE_FINDING", payload: { issueId: finding.id, message: "Source finding resolved." } });
     };
 
     const submitProductCodeRequest = async (chargeId: string) => {
@@ -737,6 +776,7 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
             mapProductCode,
             classifyUnknownAsExistingCharge,
             submitProductCodeRequest,
+            resolveSourceFinding,
             useApprovedProductCode,
             acceptSuggestedMapping,
             ignoreCharge,


### PR DESCRIPTION
## Scope

Unifies source-batch review blockers with the Exception Workspace commercial safety gate. Source-batch critic findings now appear in Draft Quote `review_queue`, can be resolved through audited Draft Quote decisions or source-batch review API actions, and block finalization/quote creation while unresolved.

## Changed Files

- `backend/quotes/intake_safety.py`: derives stable structured source findings, preserves evidence/resolution metadata, and exposes unresolved blocking findings as the authoritative source safety blockers.
- `backend/quotes/contracts/draft_quote_contract.py`: adds `resolve_source_finding` decision contract with required non-empty review note.
- `backend/quotes/services/draft_quote_adapter.py`: publishes unresolved source findings into Draft Quote review queue.
- `backend/quotes/services/draft_quote_resolve_service.py`: resolves source findings idempotently with validation, notes, action, user, timestamp, and optional charge link.
- `backend/quotes/spot_views.py`: accepts source-finding resolution metadata on source-batch review and invalidates finalized review after source review changes.
- `backend/quotes/tests/test_draft_quote_resolve.py`: covers source finding visibility, finalization blocking, note validation, idempotency, evidence preservation, and non-blocking informational findings.
- `frontend/src/components/spot/workspace/spotResolutionState.ts`: models source-finding queue entries and converts them into workspace issues.
- `frontend/src/components/spot/workspace/useSpotResolutionWorkflow.ts`: submits source-finding resolution decisions and refreshes live Draft Quote state.
- `frontend/src/components/spot/ExceptionWorkspace.tsx`: renders source-finding blockers and actions without assuming charge-line context.
- `frontend/scripts/spot-workspace-orchestration.test.mjs`: adds contract assertions for source finding workflow ownership and UI exposure.

## What Was Intentionally Not Changed

- No pricing, GST, FX, margin, grouping, inclusion, quote-total, ProductCode approval lifecycle, RBAC, public quote/PDF, or persisted SPE pricing mutation behavior was changed.
- Did not auto-resolve source findings or infer missing commercial structure.
- Did not revive legacy quote-scoped SPOT CRUD.

## Verification

Automated:
- `python manage.py check` — passed.
- `python -m pytest quotes/tests/test_draft_quote_resolve.py -q` — passed, 47 tests.
- `python -m pytest quotes/tests/test_spot_compute_completeness.py -q` — passed, 20 tests.
- `python -m pytest quotes/tests -q` — passed, 711 tests.
- `node scripts/spot-workspace-orchestration.test.mjs` — passed.
- `node scripts/exception-workspace-routing.test.mjs` — passed.
- `node scripts/spot-finalization.test.mjs` — passed.
- `node scripts/draft-quote-normalization.test.mjs` — passed.
- `node scripts/draft-quote-domain.test.mjs` — passed.
- `node scripts/spot-workspace-helpers.test.mjs` — passed.
- `npm run typecheck` — passed.
- `npm run build` — passed with existing lint warnings.
- `git diff --check` — passed.
- `graphify update .` — completed.

Manual:
- Verified source critic missed-charge payload appears as a Draft Quote `source_finding` review queue item.
- Verified Draft Quote finalization rejects while the source finding is unresolved.
- Verified resolving the source finding requires a non-empty note, preserves evidence, records action/user/time, refreshes the workspace, and removes only the targeted blocker.

## Risk

Low-to-moderate launch risk in the SPOT review path. This makes hidden source safety blockers visible and actionable; operators must resolve source findings before finalization/quote creation. Residual risk is limited to source-review UI prompting using a minimal browser prompt for notes.

## Rollback

Revert this commit/PR. Existing source evidence remains in `analysis_summary_json`; rollback removes the new source-finding Draft Quote decision path and restores prior source-review blocker handling.

## Commercial Impact

No quote totals, tax, FX, CAF/GST, margin, rate lookup, grouping, inclusion, ProductCode approval lifecycle, or public quote output changed. The change only prevents quote creation/finalization when unresolved source safety findings exist.

## Data Impact

No migrations or backfills. Writes are limited to source-batch `analysis_summary_json` resolution metadata when an operator resolves a finding.

## Audit Impact

Source finding resolutions preserve evidence and record action, note, user, timestamp, and optional linked charge line.
