### PR TITLE
Protect QuoteLine audit columns during Phase 16E-A migration

### DIFF
--- a/backend/quotes/migrations/0047_quoteline_charge_context_json_and_more.py
+++ b/backend/quotes/migrations/0047_quoteline_charge_context_json_and_more.py
@@ -16,6 +16,44 @@ ROUTE_POLICIES = {
 }
 
 
+def quote_line_preservation_fields():
+    return {
+        'base_exchange_rate': models.DecimalField(
+            blank=True,
+            decimal_places=6,
+            max_digits=12,
+            null=True,
+        ),
+        'caf_percent': models.DecimalField(
+            blank=True,
+            decimal_places=4,
+            max_digits=10,
+            null=True,
+        ),
+        'provider_name': models.CharField(
+            blank=True,
+            help_text='Actual name of the agent or carrier providing the rate.',
+            max_length=255,
+            null=True,
+        ),
+    }
+
+
+def ensure_quote_line_preservation_columns(apps, schema_editor):
+    QuoteLine = apps.get_model('quotes', 'QuoteLine')
+    with schema_editor.connection.cursor() as cursor:
+        existing = {
+            column.name
+            for column in schema_editor.connection.introspection.get_table_description(
+                cursor, QuoteLine._meta.db_table
+            )
+        }
+    for name, field in quote_line_preservation_fields().items():
+        if name not in existing:
+            field.set_attributes_from_name(name)
+            schema_editor.add_field(QuoteLine, field)
+
+
 def seed_disabled_route_policies(apps, schema_editor):
     RouteAutomationPolicyDB = apps.get_model('quotes', 'RouteAutomationPolicyDB')
     for pattern, reason in ROUTE_POLICIES.items():
@@ -42,6 +80,18 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunPython(
+                    ensure_quote_line_preservation_columns,
+                    migrations.RunPython.noop,
+                ),
+            ],
+            state_operations=[
+                migrations.AddField(model_name='quoteline', name=name, field=field)
+                for name, field in quote_line_preservation_fields().items()
+            ],
+        ),
         migrations.AddField(
             model_name='quoteline',
             name='charge_context_json',

--- a/backend/quotes/migrations/0048_restore_quoteline_preservation_columns.py
+++ b/backend/quotes/migrations/0048_restore_quoteline_preservation_columns.py
@@ -1,0 +1,42 @@
+import warnings
+
+from django.db import migrations
+
+
+PRESERVED_COLUMNS = ('base_exchange_rate', 'caf_percent', 'provider_name')
+
+
+def restore_missing_quote_line_columns(apps, schema_editor):
+    QuoteLine = apps.get_model('quotes', 'QuoteLine')
+    with schema_editor.connection.cursor() as cursor:
+        existing = {
+            column.name
+            for column in schema_editor.connection.introspection.get_table_description(
+                cursor, QuoteLine._meta.db_table
+            )
+        }
+    missing = [name for name in PRESERVED_COLUMNS if name not in existing]
+    for name in missing:
+        schema_editor.add_field(QuoteLine, QuoteLine._meta.get_field(name))
+    if missing:
+        warnings.warn(
+            'Restored missing quotes_quoteline columns: '
+            f'{", ".join(missing)}. Schema is repaired, but previously populated '
+            'values can only be recovered from a pre-0047 database backup.',
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('quotes', '0047_quoteline_charge_context_json_and_more'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            restore_missing_quote_line_columns,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/backend/quotes/models.py
+++ b/backend/quotes/models.py
@@ -609,6 +609,21 @@ class QuoteLine(models.Model):
     sell_fcy_currency = models.CharField(max_length=3, null=True, blank=True)
 
     exchange_rate = models.DecimalField(max_digits=12, decimal_places=6, null=True, blank=True)
+    # Preservation-only fields from the historical 0037 migration. They remain
+    # outside pricing and API output paths pending a separate audited decision.
+    base_exchange_rate = models.DecimalField(
+        max_digits=12,
+        decimal_places=6,
+        null=True,
+        blank=True,
+    )
+    caf_percent = models.DecimalField(max_digits=10, decimal_places=4, null=True, blank=True)
+    provider_name = models.CharField(
+        max_length=255,
+        null=True,
+        blank=True,
+        help_text="Actual name of the agent or carrier providing the rate.",
+    )
 
     # --- V3 Categorization Fields ---
     description = models.CharField(

--- a/backend/quotes/tests/test_migration_0047_quoteline_preservation.py
+++ b/backend/quotes/tests/test_migration_0047_quoteline_preservation.py
@@ -1,0 +1,215 @@
+import uuid
+import warnings
+from decimal import Decimal
+
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+from django.test import TransactionTestCase
+
+
+MIGRATE_FROM = ('quotes', '0046_draftquotedecisiondb')
+MIGRATE_0047 = ('quotes', '0047_quoteline_charge_context_json_and_more')
+MIGRATE_TO = ('quotes', '0048_restore_quoteline_preservation_columns')
+PRESERVED_COLUMNS = {
+    'base_exchange_rate': ('DecimalField', Decimal('1.234567')),
+    'caf_percent': ('DecimalField', Decimal('0.1250')),
+    'provider_name': ('CharField', 'Sentinel Provider'),
+}
+
+
+class QuoteLineMigrationSafetyTests(TransactionTestCase):
+    def tearDown(self):
+        MigrationExecutor(connection).migrate([MIGRATE_TO])
+        super().tearDown()
+        connection.close()
+
+    @staticmethod
+    def _column_description():
+        with connection.cursor() as cursor:
+            return {
+                column.name: column
+                for column in connection.introspection.get_table_description(
+                    cursor, 'quotes_quoteline'
+                )
+            }
+
+    @staticmethod
+    def _create_quote_snapshot(apps):
+        Company = apps.get_model('parties', 'Company')
+        Quote = apps.get_model('quotes', 'Quote')
+        QuoteVersion = apps.get_model('quotes', 'QuoteVersion')
+        QuoteLine = apps.get_model('quotes', 'QuoteLine')
+        QuoteTotal = apps.get_model('quotes', 'QuoteTotal')
+
+        company = Company.objects.create(
+            name=f'Migration Safety {uuid.uuid4()}',
+            is_customer=True,
+        )
+        quote = Quote.objects.create(
+            customer=company,
+            mode='AIR',
+            shipment_type='IMPORT',
+        )
+        version = QuoteVersion.objects.create(quote=quote, version_number=1)
+        line = QuoteLine.objects.create(
+            quote_version=version,
+            service_component=None,
+            cost_pgk=Decimal('80.00'),
+            sell_pgk=Decimal('100.00'),
+            sell_pgk_incl_gst=Decimal('110.00'),
+            sell_fcy=Decimal('100.00'),
+            sell_fcy_incl_gst=Decimal('110.00'),
+        )
+        total = QuoteTotal.objects.create(
+            quote_version=version,
+            total_cost_pgk=Decimal('80.00'),
+            total_sell_pgk=Decimal('100.00'),
+            total_sell_pgk_incl_gst=Decimal('110.00'),
+            total_sell_fcy=Decimal('100.00'),
+            total_sell_fcy_incl_gst=Decimal('110.00'),
+        )
+        with connection.cursor() as cursor:
+            cursor.execute(
+                'UPDATE quotes_quoteline '
+                'SET base_exchange_rate = %s, caf_percent = %s, provider_name = %s '
+                'WHERE id = %s',
+                [
+                    PRESERVED_COLUMNS['base_exchange_rate'][1],
+                    PRESERVED_COLUMNS['caf_percent'][1],
+                    PRESERVED_COLUMNS['provider_name'][1],
+                    line.pk.hex,
+                ],
+            )
+        return line.pk, total.pk
+
+    def _assert_preserved_schema(self):
+        descriptions = self._column_description()
+        with connection.cursor() as cursor:
+            constraints = connection.introspection.get_constraints(
+                cursor, 'quotes_quoteline'
+            )
+        for name, (field_type, _) in PRESERVED_COLUMNS.items():
+            column = descriptions[name]
+            self.assertTrue(column.null_ok)
+            self.assertIsNone(column.default)
+            self.assertEqual(
+                connection.introspection.get_field_type(column.type_code, column),
+                field_type,
+            )
+            self.assertFalse(any(
+                name in constraint['columns']
+                and (
+                    constraint['index']
+                    or constraint['unique']
+                    or constraint['primary_key']
+                    or constraint['foreign_key']
+                )
+                for constraint in constraints.values()
+            ))
+
+        if connection.vendor == 'sqlite':
+            with connection.cursor() as cursor:
+                sqlite_types = {
+                    row[1]: row[2].lower()
+                    for row in cursor.execute('PRAGMA table_info(quotes_quoteline)')
+                }
+            self.assertEqual(sqlite_types['base_exchange_rate'], 'decimal')
+            self.assertEqual(sqlite_types['caf_percent'], 'decimal')
+            self.assertEqual(sqlite_types['provider_name'], 'varchar(255)')
+        elif connection.vendor == 'postgresql':
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    "SELECT column_name, data_type, numeric_precision, numeric_scale, "
+                    "character_maximum_length FROM information_schema.columns "
+                    "WHERE table_name = 'quotes_quoteline' AND column_name IN %s",
+                    [tuple(PRESERVED_COLUMNS)],
+                )
+                physical = {row[0]: row[1:] for row in cursor.fetchall()}
+            self.assertEqual(physical['base_exchange_rate'], ('numeric', 12, 6, None))
+            self.assertEqual(physical['caf_percent'], ('numeric', 10, 4, None))
+            self.assertEqual(
+                physical['provider_name'],
+                ('character varying', None, None, 255),
+            )
+
+    def test_pre_0047_upgrade_preserves_columns_values_rows_ids_and_totals(self):
+        executor = MigrationExecutor(connection)
+        executor.migrate([MIGRATE_FROM])
+        old_apps = executor.loader.project_state([MIGRATE_FROM]).apps
+        line_id, total_id = self._create_quote_snapshot(old_apps)
+        line_count = old_apps.get_model('quotes', 'QuoteLine').objects.count()
+        total_before = old_apps.get_model('quotes', 'QuoteTotal').objects.get(pk=total_id)
+        total_values = (
+            total_before.total_cost_pgk,
+            total_before.total_sell_pgk,
+            total_before.total_sell_pgk_incl_gst,
+            total_before.total_sell_fcy,
+            total_before.total_sell_fcy_incl_gst,
+        )
+
+        executor = MigrationExecutor(connection)
+        executor.migrate([MIGRATE_TO])
+        apps = executor.loader.project_state([MIGRATE_TO]).apps
+
+        self._assert_preserved_schema()
+        self.assertEqual(apps.get_model('quotes', 'QuoteLine').objects.count(), line_count)
+        line = apps.get_model('quotes', 'QuoteLine').objects.get(pk=line_id)
+        self.assertEqual(line.base_exchange_rate, PRESERVED_COLUMNS['base_exchange_rate'][1])
+        self.assertEqual(line.caf_percent, PRESERVED_COLUMNS['caf_percent'][1])
+        self.assertEqual(line.provider_name, PRESERVED_COLUMNS['provider_name'][1])
+        total = apps.get_model('quotes', 'QuoteTotal').objects.get(pk=total_id)
+        self.assertEqual(
+            (
+                total.total_cost_pgk,
+                total.total_sell_pgk,
+                total.total_sell_pgk_incl_gst,
+                total.total_sell_fcy,
+                total.total_sell_fcy_incl_gst,
+            ),
+            total_values,
+        )
+        self.assertEqual(apps.get_model('quotes', 'ShipmentJourneyDB').objects.count(), 0)
+        self.assertEqual(apps.get_model('quotes', 'ShipmentLegDB').objects.count(), 0)
+        policies = apps.get_model('quotes', 'RouteAutomationPolicyDB').objects.all()
+        self.assertEqual(policies.count(), 6)
+        self.assertFalse(policies.filter(enabled=True).exists())
+
+    def test_already_applied_0047_restores_missing_schema_and_warns_about_data(self):
+        executor = MigrationExecutor(connection)
+        executor.migrate([MIGRATE_0047])
+        apps = executor.loader.project_state([MIGRATE_0047]).apps
+        line_id, total_id = self._create_quote_snapshot(apps)
+        with connection.cursor() as cursor:
+            for name in PRESERVED_COLUMNS:
+                cursor.execute(f'ALTER TABLE quotes_quoteline DROP COLUMN {name}')
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            executor = MigrationExecutor(connection)
+            executor.migrate([MIGRATE_TO])
+
+        self._assert_preserved_schema()
+        warning_text = ' '.join(str(item.message) for item in caught)
+        self.assertIn('pre-0047 database backup', warning_text)
+        apps = executor.loader.project_state([MIGRATE_TO]).apps
+        line = apps.get_model('quotes', 'QuoteLine').objects.get(pk=line_id)
+        self.assertIsNone(line.base_exchange_rate)
+        self.assertIsNone(line.caf_percent)
+        self.assertIsNone(line.provider_name)
+        self.assertTrue(
+            apps.get_model('quotes', 'QuoteTotal').objects.filter(pk=total_id).exists()
+        )
+
+    def test_fresh_database_migrates_from_zero(self):
+        executor = MigrationExecutor(connection)
+        executor.migrate([('quotes', None)])
+        executor = MigrationExecutor(connection)
+        executor.migrate([MIGRATE_TO])
+        apps = executor.loader.project_state([MIGRATE_TO]).apps
+
+        self._assert_preserved_schema()
+        self.assertEqual(apps.get_model('quotes', 'ShipmentJourneyDB').objects.count(), 0)
+        self.assertEqual(apps.get_model('quotes', 'ShipmentLegDB').objects.count(), 0)
+        policies = apps.get_model('quotes', 'RouteAutomationPolicyDB').objects.all()
+        self.assertEqual(policies.count(), 6)
+        self.assertFalse(policies.filter(enabled=True).exists())

--- a/backend/quotes/tests/test_migration_0047_quoteline_preservation.py
+++ b/backend/quotes/tests/test_migration_0047_quoteline_preservation.py
@@ -121,8 +121,8 @@ class QuoteLineMigrationSafetyTests(TransactionTestCase):
                 cursor.execute(
                     "SELECT column_name, data_type, numeric_precision, numeric_scale, "
                     "character_maximum_length FROM information_schema.columns "
-                    "WHERE table_name = 'quotes_quoteline' AND column_name IN %s",
-                    [tuple(PRESERVED_COLUMNS)],
+                    "WHERE table_name = 'quotes_quoteline' AND column_name = ANY(%s)",
+                    [list(PRESERVED_COLUMNS)],
                 )
                 physical = {row[0]: row[1:] for row in cursor.fetchall()}
             self.assertEqual(physical['base_exchange_rate'], ('numeric', 12, 6, None))

--- a/docs/architecture/phase-16c-air-freight-journey-productcode-architecture.md
+++ b/docs/architecture/phase-16c-air-freight-journey-productcode-architecture.md
@@ -1,7 +1,7 @@
 # RateEngine Phase 16C — International Air Journey and Leg-Aware ProductCode Architecture
 
 **Document ID:** RE-ARCH-16C-AIR-001
-**Version:** 1.2
+**Version:** 1.3
 **Architecture date:** 21 July 2026
 **Status:** Authoritative design baseline
 **Source rules:** `docs/business-rules/phase-16a-air-freight-journey-productcode-rules.md` version 1.1
@@ -23,6 +23,16 @@ This document fixes the architecture for:
 - line, leg, journey and customer-output reconciliation.
 
 It is a design document only. It does not alter pricing, ProductCodes, rates, GST, FX, margins, SPOT decisions or production behaviour.
+
+### Phase 16E-A migration safety
+
+`quotes.0047` preserves the nullable historical
+`QuoteLine.base_exchange_rate`, `QuoteLine.caf_percent`, and
+`QuoteLine.provider_name` columns before any table rebuild. Migration `0048`
+repairs an already-applied schema when those columns are missing, but populated
+values lost during an earlier `0047` run must be restored from a pre-0047
+backup. These preservation-only fields are not connected to pricing, totals,
+output, or journey automation.
 
 ## 2. Architecture decisions
 


### PR DESCRIPTION
## Scope

Repairs the migration-safety defect introduced by merged PR #306 without changing pricing or runtime workflow behavior.

- Amends `quotes.0047` so the historical nullable `QuoteLine` columns are represented in migration state before any SQLite table rebuild and are conditionally created on fresh schemas.
- Adds `quotes.0048` to detect and restore the columns for databases where `0047` is already marked applied.
- Restores model state only; the fields remain outside serializers, pricing, reports, exports, and quote output.
- Adds SQLite/PostgreSQL-aware migration regression coverage and documents backup-restoration requirements.

## Root Cause

Commit `895b953c920cce47749a483e86215b8e2809e99b` introduced the three fields and a `0037` migration on the divergent `feature/draft-quote-calculation-review-isolated` branch. That commit is not an ancestor of `main`, but databases that ran it retained the physical columns. Current `main` migration state therefore did not know about those columns. `quotes.0047` added `QuoteLine` fields and SQLite rebuilt `quotes_quoteline` from that incomplete state, silently omitting the three physical columns.

## Field Definitions

- `base_exchange_rate`: `DecimalField(max_digits=12, decimal_places=6, null=True, blank=True)`; SQLite `decimal NULL`; PostgreSQL `numeric(12,6) NULL`; no default, index, uniqueness, FK, or other column constraint.
- `caf_percent`: `DecimalField(max_digits=10, decimal_places=4, null=True, blank=True)`; SQLite `decimal NULL`; PostgreSQL `numeric(10,4) NULL`; no default, index, uniqueness, FK, or other column constraint.
- `provider_name`: `CharField(max_length=255, null=True, blank=True)`; SQLite `varchar(255) NULL`; PostgreSQL `varchar(255) NULL`; no default, index, uniqueness, FK, or other column constraint.

Current-source search found no `QuoteLine` reads/writes in serializers, deterministic pricing, reports, exports, PDF/public output, or audit workflows. Other `caf_percent` symbols are independent FX contract/snapshot values. The restored fields are preservation-only.

## Changed Files

- `backend/quotes/migrations/0047_quoteline_charge_context_json_and_more.py`: preserve/create the three columns and align migration state before any `QuoteLine` rebuild.
- `backend/quotes/migrations/0048_restore_quoteline_preservation_columns.py`: conditionally restore missing columns on already-applied databases and emit a backup-restoration warning.
- `backend/quotes/models.py`: align current Django state with the preserved schema without wiring the fields into behavior.
- `backend/quotes/tests/test_migration_0047_quoteline_preservation.py`: cover pre-0047 sentinels, already-applied remediation, fresh-zero migration, schema details, IDs/counts/totals, policies, and zero historical journey backfill.
- `docs/architecture/phase-16c-air-freight-journey-productcode-architecture.md`: document preservation and backup recovery semantics.

## What Was Intentionally Not Changed

- Pricing, totals, GST, FX, CAF calculation, margins, ProductCodes, charge mapping, or quote output.
- PR #304 source-review blockers or safety gates.
- Phase 16E-A dark-mode journey behavior, route policies, or live SPOT journey.
- Legacy behavior, UAT execution, or Phase 16E-B.
- Any original/local database; all migration verification used disposable copies or test databases.

## Verification

Automated:
- `python manage.py check` — passed, 0 issues.
- `python manage.py makemigrations --check --dry-run` — passed, no changes detected.
- Focused SQLite: `python manage.py test quotes.tests.test_migration_0047_quoteline_preservation --verbosity 1` — 3 passed in 57.045s.
- Focused PostgreSQL: the same 3 tests passed within GitHub PostgreSQL 15 Backend Tests on head `e8168458ed5478bcf06b402b247ffa3dcc00c3eb`.
- `python -m pytest quotes/tests -q` — 762 passed in 839.55s.
- `python -m pytest pricing_v4/tests -q` — 276 passed in 332.69s.
- GitHub CI run #721 — success: PostgreSQL Backend Tests and Frontend Checks.
- GitHub Container Integrity run #674 — success: backend and frontend container validation.
- `git diff --check` — passed.
- `graphify update .` — completed; 10,357 nodes / 26,705 edges.
- Fallow baseline — existing findings only (109 dead-code findings; 9.96% duplication; existing health findings). Ruff and Vulture are not installed in the available backend environment.

Manual:
- Copied a real pre-0047 SQLite database, set distinct sentinels (`1.234567`, `0.1250`, `Sentinel Provider`), and migrated to head. All sentinels survived; QuoteLine count stayed 1021; QuoteTotal count stayed 74; total cost/sell/GST aggregates were unchanged; journeys/legs stayed 0; six policies remained disabled.
- Copied the known local UAT database where `0047` was applied and the columns were missing. `0048` restored all three nullable columns and emitted the explicit warning that populated values require a pre-0047 backup. QuoteLine count stayed 1021; QuoteTotal count stayed 74; journeys/legs stayed 0; six policies remained disabled.

## PostgreSQL Assessment

The migration uses Django schema introspection and `schema_editor.add_field`. GitHub CI run #721 completed successfully against PostgreSQL 15 on head `e8168458ed5478bcf06b402b247ffa3dcc00c3eb`: Django checks, migrations, and the full `pytest -v --tb=short` step all passed, including all three focused migration-safety tests and their PostgreSQL physical-type assertions. The local PostgreSQL service was reachable but its configured credentials were unavailable, so the authoritative PostgreSQL result is the green CI job. Unlike SQLite, PostgreSQL normally adds the `0047` columns without rebuilding `quotes_quoteline`; `0048` still conditionally repairs drift if columns are absent.

## Risk

Low behavioral risk: nullable preservation-only columns are restored to model/migration state but remain excluded from API serializers and calculation/output paths. Schema risk is limited to conditional column creation. An already-applied environment that lost populated values still requires backup restoration; schema recreation cannot reconstruct deleted data.

Known environment requiring restoration review: the disposable local Phase 16E-A UAT copy had applied `0047` with all three columns missing, but its pre-0047 source contained only nulls. No populated-value loss was observed locally. Production/staging migration state and PostgreSQL drift remain unverified and must be checked before UAT resumes.

## Commercial Impact

None. Quote totals, tax, GST, FX, CAF computation, margins, grouping, inclusion, ProductCode decisions, and public output are unchanged.

## Data Impact

Pre-0047 upgrades preserve existing values. Already-applied databases receive nullable schema columns only; lost populated values are not invented and must be restored from backup.

## Audit Impact

Improves audit preservation by preventing silent loss and explicitly warning when schema repair cannot restore historical values.

## Rollback

Revert this commit before deployment. After deployment, do not drop the restored columns as a rollback: preserve them until a separate audited removal migration establishes that their data is disposable. Restore any confirmed populated-value loss from a pre-0047 backup.

UAT remains stopped. Do not begin Phase 16E-B.