### PR TITLE
Fail closed on unsafe SPOT finalization

### DIFF
--- a/backend/quotes/contracts/draft_quote_contract.py
+++ b/backend/quotes/contracts/draft_quote_contract.py
@@ -100,6 +100,7 @@ class DraftQuoteReviewSessionSchema(BaseModel):
     finalized_by: Optional[int] = Field(None, description="User ID that finalized this review")
     finalized_at: Optional[str] = Field(None, description="ISO timestamp when review was finalized")
     remaining_blockers: int = Field(0, description="Critical blockers that must be cleared before finalization")
+    blockers: List[Dict[str, Any]] = Field(default_factory=list, description="Blocking items preventing finalization")
     available_actions: List[str] = Field(default_factory=list, description="Available review session actions")
 
     @model_validator(mode="after")
@@ -335,6 +336,7 @@ class DraftQuoteFinalizeSchema(BaseModel):
 
 class DraftQuoteFinalizeResponseSchema(BaseModel):
     status: str = Field(..., description="accepted or rejected")
+    error_code: Optional[str] = Field(None, description="Stable programmatic error code")
     idempotency_key: UUID = Field(..., description="The finalize idempotency key")
     envelope_id: UUID = Field(..., description="Target SPOT envelope ID")
     review_status: str = Field(..., description="Current review status")

--- a/backend/quotes/intake_safety.py
+++ b/backend/quotes/intake_safety.py
@@ -67,6 +67,9 @@ def _finding_payload(
     blocking: bool = True,
 ) -> dict[str, Any]:
     existing = _existing_source_findings(raw).get(finding_id, {})
+    identity = hashlib.sha256(
+        f"{finding_id}:{finding_type}:{message}:{evidence_text or message}".encode("utf-8")
+    ).hexdigest()
     status = existing.get("status") or SOURCE_FINDING_STATUS_OPEN
     return {
         "id": finding_id,
@@ -80,6 +83,9 @@ def _finding_payload(
         "review_note": existing.get("review_note"),
         "resolved_by_user_id": existing.get("resolved_by_user_id"),
         "resolved_at": existing.get("resolved_at"),
+        "finding_identity": identity,
+        "resolved_source_batch_id": existing.get("resolved_source_batch_id"),
+        "resolved_finding_identity": existing.get("resolved_finding_identity"),
     }
 
 
@@ -144,7 +150,6 @@ def _derive_source_findings(raw: dict[str, Any], summary: dict[str, Any]) -> lis
             finding_id="source-low-confidence-lines",
             finding_type="low_confidence_lines",
             message=f"{summary['low_confidence_line_count']} extracted charge line(s) were low-confidence.",
-            blocking=False,
         ))
     if summary["pdf_fallback_used"]:
         findings.append(_finding_payload(
@@ -157,12 +162,27 @@ def _derive_source_findings(raw: dict[str, Any], summary: dict[str, Any]) -> lis
     return findings
 
 
-def unresolved_source_findings(value: Any) -> list[dict[str, Any]]:
+def unresolved_source_findings(
+    value: Any,
+    *,
+    source_batch_id: str | None = None,
+) -> list[dict[str, Any]]:
     summary = normalize_source_analysis_summary(value)
-    return [
-        item for item in summary.get("source_findings", [])
-        if item.get("blocking") and item.get("status") != SOURCE_FINDING_STATUS_RESOLVED
-    ]
+    unresolved = []
+    for item in summary.get("source_findings", []):
+        if not item.get("blocking"):
+            continue
+        stale_resolution = (
+            item.get("status") == SOURCE_FINDING_STATUS_RESOLVED
+            and source_batch_id
+            and (
+                item.get("resolved_source_batch_id") != source_batch_id
+                or item.get("resolved_finding_identity") != item.get("finding_identity")
+            )
+        )
+        if item.get("status") != SOURCE_FINDING_STATUS_RESOLVED or stale_resolution:
+            unresolved.append({**item, "stale_resolution": bool(stale_resolution)})
+    return unresolved
 
 
 def _derive_blocking_reasons(summary: dict[str, Any]) -> tuple[list[str], list[str], str, bool]:
@@ -268,10 +288,8 @@ def normalize_source_analysis_summary(value: Any) -> dict[str, Any]:
         "pdf_fallback_used": bool(raw.get("pdf_fallback_used", False)),
     }
     risk_flags, blocking_reasons, risk_level, requires_review_note = _derive_blocking_reasons(summary)
-    # Only high-risk extraction findings require explicit source review before
-    # acknowledgement/final quote creation. Medium-risk audit signals such as
-    # low-confidence lines or scanned-PDF fallback stay visible as warnings, but
-    # they must not turn a proceedable SPOT envelope into a dead final button.
+    # High-risk summaries require a review note. Individual blocking findings,
+    # including low-confidence extraction, must also be resolved explicitly.
     review_required = bool(requires_review_note)
     reviewed_safe_to_quote = bool(raw.get("reviewed_safe_to_quote", False)) if review_required else False
     raw_review_status = str(raw.get("review_status") or "").strip().upper()
@@ -295,7 +313,10 @@ def normalize_source_analysis_summary(value: Any) -> dict[str, Any]:
         reviewed_safe_to_quote = review_status == REVIEW_STATUS_APPROVED
     else:
         review_status = REVIEW_STATUS_NOT_REQUIRED
-        reviewed_safe_to_quote = False
+        reviewed_safe_to_quote = bool(
+            raw.get("reviewed_safe_to_quote")
+            and str(raw.get("review_note") or "").strip()
+        )
 
     summary["review_required"] = review_required
     summary["review_status"] = review_status
@@ -356,6 +377,7 @@ def mark_source_analysis_review(
     source_finding_id: str | None = None,
     resolution_action: str | None = None,
     charge_line_id: str | None = None,
+    source_batch_id: str | None = None,
 ) -> dict[str, Any]:
     raw = dict(value) if isinstance(value, dict) else {}
     summary = normalize_source_analysis_summary(raw)
@@ -371,6 +393,8 @@ def mark_source_analysis_review(
             item["review_note"] = note
             item["resolved_by_user_id"] = str(reviewed_by_user_id or "").strip() or None
             item["resolved_at"] = reviewed_at or None
+            item["resolved_source_batch_id"] = source_batch_id
+            item["resolved_finding_identity"] = item.get("finding_identity")
             if charge_line_id:
                 item["charge_line_id"] = str(charge_line_id)
         updated_findings.append(item)
@@ -379,6 +403,7 @@ def mark_source_analysis_review(
     raw["reviewed_by_user_id"] = str(reviewed_by_user_id or "").strip() or None
     raw["reviewed_at"] = reviewed_at or None
     raw["review_note"] = note
+    raw["reviewed_safe_to_quote"] = bool(reviewed_safe_to_quote)
     return normalize_source_analysis_summary(raw)
 
 

--- a/backend/quotes/services/draft_quote_adapter.py
+++ b/backend/quotes/services/draft_quote_adapter.py
@@ -274,7 +274,9 @@ def build_draft_quote_payload(spe_db: SpotPricingEnvelopeDB) -> Dict[str, Any]:
             "minimum_charge": Decimal(str(line.min_charge)) if line.min_charge is not None else None,
             "percentage_base": line.percent_basis or None,
             "quantity": quantity,
-            "include_in_totals": not line.exclude_from_totals,
+            "include_in_totals": not line.exclude_from_totals and not (
+                line.conditional and not line.conditional_acknowledged
+            ),
             "conditions": [line.note] if line.note else [],
             "warnings": line_warnings,
             "review_reason": review_reason,
@@ -422,12 +424,18 @@ def build_draft_quote_payload(spe_db: SpotPricingEnvelopeDB) -> Dict[str, Any]:
         })
     for batch in spe_db.source_batches.all():
         summary = normalize_source_analysis_summary(batch.analysis_summary_json)
-        for finding in unresolved_source_findings(summary):
+        for finding in unresolved_source_findings(
+            summary,
+            source_batch_id=str(batch.id),
+        ):
+            message = finding["message"]
+            if finding.get("stale_resolution"):
+                message = f"{message} A historical resolution is stale and must be re-confirmed."
             review_queue.append({
                 "id": f"source:{batch.id}:{finding['id']}",
                 "type": "source_finding",
-                "message": finding["message"],
-                "blocker_reason": finding["message"],
+                "message": message,
+                "blocker_reason": message,
                 "source_batch_id": str(batch.id),
                 "source_batch_label": batch.label or batch.file_name or "Imported source",
                 "source_finding_id": finding["id"],
@@ -435,6 +443,7 @@ def build_draft_quote_payload(spe_db: SpotPricingEnvelopeDB) -> Dict[str, Any]:
                 "evidence": finding.get("evidence"),
                 "charge_line_id": finding.get("charge_line_id"),
                 "note_required": True,
+                "stale_resolution": bool(finding.get("stale_resolution")),
                 "available_actions": [
                     "resolved_in_workspace",
                     "not_commercially_applicable",

--- a/backend/quotes/services/draft_quote_resolve_service.py
+++ b/backend/quotes/services/draft_quote_resolve_service.py
@@ -387,7 +387,10 @@ def _resolve_source_finding(envelope, decision, user):
     current = normalize_source_analysis_summary(batch.analysis_summary_json)
     if not any(item.get("id") == finding_id for item in current.get("source_findings", [])):
         return "rejected", "Source finding was not found for this source batch.", "SOURCE_FINDING_NOT_FOUND"
-    if not any(item.get("id") == finding_id for item in unresolved_source_findings(current)):
+    if not any(
+        item.get("id") == finding_id
+        for item in unresolved_source_findings(current, source_batch_id=str(batch.id))
+    ):
         return "skipped", "Source finding was already resolved.", None
 
     charge_line_id = details.get("charge_line_id")
@@ -403,6 +406,7 @@ def _resolve_source_finding(envelope, decision, user):
         source_finding_id=finding_id,
         resolution_action=action,
         charge_line_id=str(charge_line_id) if charge_line_id else None,
+        source_batch_id=str(batch.id),
     )
     batch.save(update_fields=["analysis_summary_json", "updated_at"])
     return "accepted", "Source finding resolved.", None

--- a/backend/quotes/services/draft_quote_review_service.py
+++ b/backend/quotes/services/draft_quote_review_service.py
@@ -6,6 +6,7 @@ from uuid import UUID
 from django.utils import timezone
 
 from quotes.contracts.draft_quote_contract import DraftQuoteSchema
+from quotes.intake_safety import normalize_source_analysis_summary
 from quotes.spot_models import DraftQuoteDecisionDB, SpotPricingEnvelopeDB
 
 
@@ -47,16 +48,80 @@ def invalidate_finalized_review(envelope: SpotPricingEnvelopeDB, user=None, reas
     return True
 
 
-def unresolved_blockers(draft_quote: DraftQuoteSchema) -> list[dict[str, Any]]:
-    blockers: list[dict[str, Any]] = []
-    for item in draft_quote.review_queue:
-        blockers.append(item)
+def unresolved_blockers(
+    envelope: SpotPricingEnvelopeDB,
+    draft_quote: DraftQuoteSchema,
+) -> list[dict[str, Any]]:
+    blockers = [
+        {
+            **item,
+            "code": str(item.get("code") or "DRAFT_QUOTE_REVIEW_ITEM"),
+        }
+        for item in draft_quote.review_queue
+    ]
+    for batch in envelope.source_batches.all():
+        summary = normalize_source_analysis_summary(batch.analysis_summary_json)
+        source_context = {
+            "source_batch_id": str(batch.id),
+            "source_batch_label": batch.label or batch.file_name or "Imported source",
+        }
+        if summary["risk_flags"] and not summary["reviewed_safe_to_quote"]:
+            blockers.append({
+                "code": "SOURCE_REVIEW_NOT_SAFE",
+                "message": "Imported source review is not marked safe to quote.",
+                **source_context,
+            })
+        if summary["requires_review_note"] and not summary["review_note"]:
+            blockers.append({
+                "code": "SOURCE_REVIEW_NOTE_REQUIRED",
+                "message": "A non-empty source-review note is required.",
+                **source_context,
+            })
+        if summary["risk_level"] == "HIGH" and not summary["reviewed_safe_to_quote"]:
+            blockers.append({
+                "code": "SOURCE_REVIEW_RISK_BLOCKING",
+                "message": "High source-review risk remains unresolved.",
+                "risk_level": summary["risk_level"],
+                **source_context,
+            })
+
+    for line in envelope.charge_lines.filter(conditional=True):
+        context = {
+            "charge_line_id": str(line.id),
+            "charge_label": line.description or line.source_label or "Conditional charge",
+        }
+        if not line.conditional_acknowledged:
+            blockers.append({
+                "code": "CONDITIONAL_ACKNOWLEDGEMENT_REQUIRED",
+                "message": "Conditional charge applicability is unresolved and must be acknowledged by the quote owner.",
+                **context,
+            })
+        elif not line.exclude_from_totals:
+            blockers.append({
+                "code": "CONDITIONAL_FIRM_TOTAL_OVERRIDE_REQUIRED",
+                "message": "A conditional charge cannot remain in the firm total without an authorized override.",
+                **context,
+            })
+
+    deduplicated: list[dict[str, Any]] = []
+    seen: set[tuple[Any, ...]] = set()
+    for blocker in blockers:
+        key = (
+            blocker.get("code"),
+            blocker.get("id"),
+            blocker.get("source_batch_id"),
+            blocker.get("charge_line_id"),
+        )
+        if key not in seen:
+            deduplicated.append(blocker)
+            seen.add(key)
+    blockers = deduplicated
     return blockers
 
 
 def review_session_payload(envelope: SpotPricingEnvelopeDB, draft_quote: DraftQuoteSchema) -> dict[str, Any]:
     state = get_review_state(envelope)
-    blockers = unresolved_blockers(draft_quote)
+    blockers = unresolved_blockers(envelope, draft_quote)
     status = state.get("status", "draft")
     actions = []
     if status == "finalized":
@@ -68,6 +133,7 @@ def review_session_payload(envelope: SpotPricingEnvelopeDB, draft_quote: DraftQu
         "finalized_by": state.get("finalized_by"),
         "finalized_at": state.get("finalized_at"),
         "remaining_blockers": len(blockers),
+        "blockers": blockers,
         "available_actions": actions,
     }
 
@@ -77,7 +143,7 @@ def finalize_review(envelope: SpotPricingEnvelopeDB, draft_quote: DraftQuoteSche
     if state.get("status") == "finalized" and state.get("idempotency_key") == str(idempotency_key):
         return True, state, []
 
-    blockers = unresolved_blockers(draft_quote)
+    blockers = unresolved_blockers(envelope, draft_quote)
     if blockers:
         return False, state, blockers
 

--- a/backend/quotes/spot_views.py
+++ b/backend/quotes/spot_views.py
@@ -1954,8 +1954,8 @@ class SpotChargeLineConditionalResolutionAPIView(APIView):
 
     Resolve a conditional-charge blocker without erasing the original conditional
     audit flag. Supported actions:
-    - KEEP: acknowledge the conditional charge and leave it in the quote
-    - REMOVE: delete the charge line from the draft SPE
+    - KEEP: quote owner acknowledges unresolved applicability and excludes it from the firm total
+    - REMOVE: manager/admin confirms removal from the draft SPE
     """
 
     permission_classes = [IsAuthenticated]
@@ -1988,6 +1988,23 @@ class SpotChargeLineConditionalResolutionAPIView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
+        if action == "KEEP" and request.user.id not in {spe_db.owner_id, spe_db.created_by_id}:
+            return Response(
+                {
+                    "error": "Only the quote owner can acknowledge unresolved conditional applicability.",
+                    "error_code": "QUOTE_OWNER_ACKNOWLEDGEMENT_REQUIRED",
+                },
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        if action == "REMOVE" and not _user_is_manager_or_admin(request.user):
+            return Response(
+                {
+                    "error": "Manager authority is required to remove a conditional charge.",
+                    "error_code": "MANAGER_OVERRIDE_REQUIRED",
+                },
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
         # Record learning event BEFORE potential delete (REMOVE deletes the line)
         try:
             record_conditional_resolution_event(
@@ -2003,15 +2020,35 @@ class SpotChargeLineConditionalResolutionAPIView(APIView):
             charge_line.conditional_acknowledged = True
             charge_line.conditional_acknowledged_by = request.user
             charge_line.conditional_acknowledged_at = timezone.now()
+            charge_line.exclude_from_totals = True
+            conditional_note = (
+                "Applicability remains unresolved; excluded from the current firm total."
+            )
+            if conditional_note not in (charge_line.note or ""):
+                charge_line.note = " ".join(
+                    value for value in (charge_line.note, conditional_note) if value
+                )
             charge_line.save(
                 update_fields=[
                     "conditional_acknowledged",
                     "conditional_acknowledged_by",
                     "conditional_acknowledged_at",
+                    "exclude_from_totals",
+                    "note",
                 ]
             )
             if charge_line.source_batch:
                 _sync_batch_analysis_summary(charge_line.source_batch)
+                charge_line.source_batch.refresh_from_db()
+                charge_line.source_batch.analysis_summary_json = mark_source_analysis_review(
+                    charge_line.source_batch.analysis_summary_json,
+                    reviewed_safe_to_quote=True,
+                    reviewed_by_user_id=str(request.user.id),
+                    reviewed_at=timezone.now().isoformat(),
+                    review_note=conditional_note,
+                    source_batch_id=str(charge_line.source_batch.id),
+                )
+                charge_line.source_batch.save(update_fields=["analysis_summary_json", "updated_at"])
         elif action == "REMOVE":
             batch = charge_line.source_batch
             charge_line.delete()
@@ -3158,6 +3195,7 @@ class SpotSourceBatchReviewAPIView(APIView):
             source_finding_id=source_finding_id,
             resolution_action=resolution_action,
             charge_line_id=charge_line_id,
+            source_batch_id=str(batch.id),
         )
         batch.save(update_fields=["analysis_summary_json", "updated_at"])
 
@@ -3638,6 +3676,7 @@ class SpotEnvelopeDraftQuoteFinalizeAPIView(APIView):
 
         response_payload = DraftQuoteFinalizeResponseSchema(
             status="accepted" if accepted else "rejected",
+            error_code=None if accepted else "DRAFT_QUOTE_FINALIZATION_BLOCKED",
             idempotency_key=payload.idempotency_key,
             envelope_id=spe_db.id,
             review_status=state.get("status", "draft"),

--- a/backend/quotes/tests/test_draft_quote_resolve.py
+++ b/backend/quotes/tests/test_draft_quote_resolve.py
@@ -10,6 +10,7 @@ from rest_framework.test import APIClient
 from accounts.models import Role, UserMembership
 from parties.models import Branch, Department, Organization
 from pricing_v4.models import ProductCode, ProductCodeCreationRequest
+from quotes.intake_safety import normalize_source_analysis_summary
 from quotes.spot_models import DraftQuoteDecisionDB, SPEChargeLineDB, SPESourceBatchDB, SpotPricingEnvelopeDB
 
 
@@ -440,7 +441,7 @@ class DraftQuoteResolveHighValueTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("blanket source approval", response.data["error"])
 
-    def test_low_confidence_source_finding_does_not_block_finalize(self):
+    def test_low_confidence_source_finding_blocks_until_resolved(self):
         self.batch.analysis_summary_json = {
             **self.batch.analysis_summary_json,
             "ai_used": True,
@@ -452,9 +453,87 @@ class DraftQuoteResolveHighValueTests(TestCase):
         self._resolve_all_blockers()
         self.client.force_authenticate(user=self.sales)
         read = self.client.get(f"/api/v3/spot/envelopes/{self.envelope.id}/draft-quote/")
-        self.assertFalse([item for item in read.data["review_queue"] if item["type"] == "source_finding"])
+        findings = [item for item in read.data["review_queue"] if item["type"] == "source_finding"]
+        self.assertEqual(len(findings), 1)
         finalize = self._finalize()
-        self.assertEqual(finalize.status_code, status.HTTP_200_OK)
+        self.assertEqual(finalize.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(finalize.data["error_code"], "DRAFT_QUOTE_FINALIZATION_BLOCKED")
+        self.assertTrue(finalize.data["blockers"])
+
+        resolved = self._post([self._decision(
+            "resolve_source_finding",
+            target_id=findings[0]["id"],
+            details={
+                "source_batch_id": findings[0]["source_batch_id"],
+                "source_finding_id": findings[0]["source_finding_id"],
+                "action": "resolved_in_workspace",
+                "review_note": "Verified the low-confidence extraction against the supplier source.",
+                "charge_line_id": str(self.charge.id),
+            },
+            decision_id="resolve-low-confidence",
+        )])
+        self.assertEqual(resolved.status_code, status.HTTP_200_OK)
+        self.assertEqual(self._finalize().status_code, status.HTTP_200_OK)
+
+    def test_conditional_acknowledgement_excludes_charge_and_clears_only_its_blocker(self):
+        self._resolve_all_blockers()
+        self.charge.conditional = True
+        self.charge.exclude_from_totals = False
+        self.charge.note = "Export License: USD 50 (if application)"
+        self.charge.save(update_fields=["conditional", "exclude_from_totals", "note"])
+
+        blocked = self._finalize()
+        self.assertEqual(blocked.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(
+            "CONDITIONAL_ACKNOWLEDGEMENT_REQUIRED",
+            {item["code"] for item in blocked.data["blockers"]},
+        )
+
+        self.client.force_authenticate(user=self.sales)
+        acknowledged = self.client.patch(
+            f"/api/v3/spot/envelopes/{self.envelope.id}/charges/{self.charge.id}/conditional-resolution/",
+            {"action": "KEEP"},
+            format="json",
+        )
+        self.assertEqual(acknowledged.status_code, status.HTTP_200_OK)
+        self.charge.refresh_from_db()
+        self.assertTrue(self.charge.conditional)
+        self.assertTrue(self.charge.conditional_acknowledged)
+        self.assertTrue(self.charge.exclude_from_totals)
+        self.assertIn("excluded from the current firm total", self.charge.note)
+        self.assertEqual(self._finalize().status_code, status.HTTP_200_OK)
+
+    def test_stale_source_finding_resolution_requires_reconfirmation(self):
+        self.batch.analysis_summary_json = {
+            **self.batch.analysis_summary_json,
+            "ai_used": True,
+            "can_proceed": True,
+            "imported_charge_count": 1,
+            "critic_missed_charges": ["Ex-work charge"],
+        }
+        self.batch.save(update_fields=["analysis_summary_json"])
+        self.client.force_authenticate(user=self.sales)
+        first = self.client.get(f"/api/v3/spot/envelopes/{self.envelope.id}/draft-quote/")
+        finding = next(item for item in first.data["review_queue"] if item["type"] == "source_finding")
+        self.batch.refresh_from_db()
+        summary = normalize_source_analysis_summary(self.batch.analysis_summary_json)
+        summary["source_findings"][0].update({
+            "status": "resolved",
+            "review_note": "Historical generic decision.",
+            "resolved_source_batch_id": str(uuid.uuid4()),
+            "resolved_finding_identity": summary["source_findings"][0]["finding_identity"],
+        })
+        summary["reviewed_safe_to_quote"] = True
+        summary["review_note"] = "Historical generic decision."
+        self.batch.analysis_summary_json = summary
+        self.batch.save(update_fields=["analysis_summary_json"])
+
+        reread = self.client.get(f"/api/v3/spot/envelopes/{self.envelope.id}/draft-quote/")
+        stale = next(item for item in reread.data["review_queue"] if item["type"] == "source_finding")
+        self.assertTrue(stale["stale_resolution"])
+        blocked = self._finalize()
+        self.assertEqual(blocked.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(finding["source_finding_id"], {item.get("source_finding_id") for item in blocked.data["blockers"]})
 
     def test_map_to_product_code_replay_is_idempotent(self):
         key = uuid.uuid4()

--- a/backend/quotes/tests/test_draft_quote_resolve.py
+++ b/backend/quotes/tests/test_draft_quote_resolve.py
@@ -477,6 +477,14 @@ class DraftQuoteResolveHighValueTests(TestCase):
 
     def test_conditional_acknowledgement_excludes_charge_and_clears_only_its_blocker(self):
         self._resolve_all_blockers()
+        self.batch.analysis_summary_json = {
+            **self.batch.analysis_summary_json,
+            "ai_used": True,
+            "can_proceed": True,
+            "imported_charge_count": 1,
+            "low_confidence_line_count": 1,
+        }
+        self.batch.save(update_fields=["analysis_summary_json"])
         self.charge.conditional = True
         self.charge.exclude_from_totals = False
         self.charge.note = "Export License: USD 50 (if application)"
@@ -484,10 +492,9 @@ class DraftQuoteResolveHighValueTests(TestCase):
 
         blocked = self._finalize()
         self.assertEqual(blocked.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn(
-            "CONDITIONAL_ACKNOWLEDGEMENT_REQUIRED",
-            {item["code"] for item in blocked.data["blockers"]},
-        )
+        initial_codes = {item["code"] for item in blocked.data["blockers"]}
+        self.assertIn("CONDITIONAL_ACKNOWLEDGEMENT_REQUIRED", initial_codes)
+        self.assertIn("SOURCE_REVIEW_NOT_SAFE", initial_codes)
 
         self.client.force_authenticate(user=self.sales)
         acknowledged = self.client.patch(
@@ -500,7 +507,48 @@ class DraftQuoteResolveHighValueTests(TestCase):
         self.assertTrue(self.charge.conditional)
         self.assertTrue(self.charge.conditional_acknowledged)
         self.assertTrue(self.charge.exclude_from_totals)
+        self.assertIn("Export License: USD 50 (if application)", self.charge.note)
         self.assertIn("excluded from the current firm total", self.charge.note)
+
+        read = self.client.get(f"/api/v3/spot/envelopes/{self.envelope.id}/draft-quote/")
+        conditional = next(item for item in read.data["suggested_charges"] if item["id"] == str(self.charge.id))
+        finding = next(item for item in read.data["review_queue"] if item["type"] == "source_finding")
+        self.assertFalse(conditional["include_in_totals"])
+        self.assertTrue(
+            any(
+                "Export License: USD 50 (if application)" in note
+                for note in conditional["conditions"]
+            )
+        )
+        self.batch.refresh_from_db()
+        self.assertFalse(self.batch.analysis_summary_json["reviewed_safe_to_quote"])
+
+        still_blocked = self._finalize()
+        remaining_codes = {item["code"] for item in still_blocked.data["blockers"]}
+        self.assertEqual(still_blocked.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertNotIn("CONDITIONAL_ACKNOWLEDGEMENT_REQUIRED", remaining_codes)
+        self.assertIn("SOURCE_REVIEW_NOT_SAFE", remaining_codes)
+
+        create_quote = self.client.post(
+            f"/api/v3/spot/envelopes/{self.envelope.id}/create-quote/",
+            {"quote_request": {}},
+            format="json",
+        )
+        self.assertEqual(create_quote.status_code, status.HTTP_400_BAD_REQUEST)
+
+        resolved = self._post([self._decision(
+            "resolve_source_finding",
+            target_id=finding["id"],
+            details={
+                "source_batch_id": finding["source_batch_id"],
+                "source_finding_id": finding["source_finding_id"],
+                "action": "resolved_in_workspace",
+                "review_note": "Verified the low-confidence charge against the supplier source.",
+                "charge_line_id": str(self.charge.id),
+            },
+            decision_id="resolve-low-confidence-after-conditional",
+        )])
+        self.assertEqual(resolved.status_code, status.HTTP_200_OK)
         self.assertEqual(self._finalize().status_code, status.HTTP_200_OK)
 
     def test_stale_source_finding_resolution_requires_reconfirmation(self):

--- a/backend/quotes/tests/test_spot_compute_completeness.py
+++ b/backend/quotes/tests/test_spot_compute_completeness.py
@@ -962,7 +962,7 @@ def test_spot_create_quote_blocks_risky_source_batch_until_reviewed(monkeypatch)
     assert response.json()["intake_safety"]["is_safe_to_quote"] is False
 
 
-def test_spot_create_quote_allows_low_confidence_source_warning(monkeypatch):
+def test_spot_create_quote_requires_low_confidence_source_resolution(monkeypatch):
     user, origin, destination = _setup_user_and_locations()
     spe = _create_ready_spe(
         user=user,
@@ -971,8 +971,11 @@ def test_spot_create_quote_allows_low_confidence_source_warning(monkeypatch):
         origin_country="AU",
         dest_country="PG",
         service_scope="A2D",
+        finalized_review=False,
     )
-    SPESourceBatchDB.objects.create(
+    spe.status = SpotPricingEnvelopeDB.Status.DRAFT
+    spe.save(update_fields=["status"])
+    batch = SPESourceBatchDB.objects.create(
         envelope=spe,
         source_kind=SPESourceBatchDB.SourceKind.AGENT,
         source_type=SPESourceBatchDB.SourceType.TEXT,
@@ -988,7 +991,18 @@ def test_spot_create_quote_allows_low_confidence_source_warning(monkeypatch):
         },
         created_by=user,
     )
-    SPEChargeLineDB.objects.create(
+    product_code = ProductCode.objects.create(
+        id=2998,
+        code="IMP-LOW-CONFIDENCE-DEST",
+        description="Low-confidence destination fee",
+        domain=ProductCode.DOMAIN_IMPORT,
+        category=ProductCode.CATEGORY_HANDLING,
+        is_gst_applicable=False,
+        gl_revenue_code="4000",
+        gl_cost_code="5000",
+        default_unit=ProductCode.UNIT_SHIPMENT,
+    )
+    charge_line = SPEChargeLineDB.objects.create(
         envelope=spe,
         code="DESTINATION_LOCAL",
         description="Destination fee",
@@ -999,6 +1013,7 @@ def test_spot_create_quote_allows_low_confidence_source_warning(monkeypatch):
         source_reference="Uploaded rates",
         normalization_status=SPEChargeLineDB.NormalizationStatus.MATCHED,
         normalization_method=SPEChargeLineDB.NormalizationMethod.EXACT_ALIAS,
+        resolved_product_code=product_code,
         entered_at=timezone.now(),
     )
     monkeypatch.setattr(
@@ -1012,15 +1027,71 @@ def test_spot_create_quote_allows_low_confidence_source_warning(monkeypatch):
 
     detail_response = client.get(f"/api/v3/spot/envelopes/{spe.id}/")
     assert detail_response.status_code == 200
-    assert detail_response.json()["intake_safety"]["is_safe_to_quote"] is True
-    assert detail_response.json()["sources"][0]["review_status"] == "NOT_REQUIRED"
+    assert detail_response.json()["intake_safety"]["is_safe_to_quote"] is False
+    assert detail_response.json()["sources"][0]["review_status"] == "PENDING"
 
+    draft_response = client.get(f"/api/v3/spot/envelopes/{spe.id}/draft-quote/")
+    assert draft_response.status_code == 200
+    finding = next(
+        item
+        for item in draft_response.json()["review_queue"]
+        if item["type"] == "source_finding"
+    )
+    assert finding["source_finding_type"] == "low_confidence_lines"
+
+    finalize_blocked = client.post(
+        f"/api/v3/spot/envelopes/{spe.id}/draft-quote/finalize/",
+        {"idempotency_key": str(uuid.uuid4()), "audit_metadata": {}},
+        format="json",
+    )
+    assert finalize_blocked.status_code == 400
+    assert finalize_blocked.json()["error_code"] == "DRAFT_QUOTE_FINALIZATION_BLOCKED"
+    source_blocker = next(
+        item
+        for item in finalize_blocked.json()["blockers"]
+        if item["code"] == "SOURCE_REVIEW_NOT_SAFE"
+    )
+    assert source_blocker["source_batch_id"] == str(batch.id)
+    assert source_blocker["message"]
+
+    create_blocked = client.post(
+        f"/api/v3/spot/envelopes/{spe.id}/create-quote/",
+        {"quote_request": {"service_scope": "A2D", "payment_term": "PREPAID", "customer_id": str(customer.id)}},
+        format="json",
+    )
+    assert create_blocked.status_code == 400
+    assert create_blocked.json()["intake_safety"]["is_safe_to_quote"] is False
+
+    resolved = client.post(
+        f"/api/v3/spot/envelopes/{spe.id}/sources/{batch.id}/review/",
+        {
+            "reviewed_safe_to_quote": True,
+            "source_finding_id": finding["source_finding_id"],
+            "resolution_action": "resolved_in_workspace",
+            "review_note": "Verified the destination fee against the uploaded supplier rate evidence.",
+            "charge_line_id": str(charge_line.id),
+        },
+        format="json",
+    )
+    assert resolved.status_code == 200
+    batch.refresh_from_db()
+    assert batch.analysis_summary_json["reviewed_safe_to_quote"] is True
+
+    finalized = client.post(
+        f"/api/v3/spot/envelopes/{spe.id}/draft-quote/finalize/",
+        {"idempotency_key": str(uuid.uuid4()), "audit_metadata": {}},
+        format="json",
+    )
+    assert finalized.status_code == 200
+    assert finalized.json()["remaining_blockers"] == 0
+
+    spe.status = SpotPricingEnvelopeDB.Status.READY
+    spe.save(update_fields=["status"])
     response = client.post(
         f"/api/v3/spot/envelopes/{spe.id}/create-quote/",
         {"quote_request": {"service_scope": "A2D", "payment_term": "PREPAID", "customer_id": str(customer.id)}},
         format="json",
     )
-
     assert response.status_code == 200
     assert response.json()["success"] is True
 

--- a/backend/quotes/tests/test_spot_flow_api.py
+++ b/backend/quotes/tests/test_spot_flow_api.py
@@ -398,6 +398,12 @@ class SpotEnvelopeFlowAPITest(APITestCase):
         )
 
         response = self.client.patch(conditional_url, {"action": "REMOVE"}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.json()["error_code"], "MANAGER_OVERRIDE_REQUIRED")
+
+        self.user.role = "manager"
+        self.user.save(update_fields=["role"])
+        response = self.client.patch(conditional_url, {"action": "REMOVE"}, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["charges"], [])
         self.assertFalse(SPEChargeLineDB.objects.filter(id=charge_line_id).exists())

--- a/backend/quotes/tests/test_spot_learning_events.py
+++ b/backend/quotes/tests/test_spot_learning_events.py
@@ -380,7 +380,7 @@ class ConditionalResolutionLearningEventTest(SpotLearningEventCaptureBaseTest):
         self.assertEqual(event.resolved_by, self.sales_user)
 
     def test_conditional_remove_creates_learning_event(self):
-        """Conditional charge → REMOVE → CONDITIONAL_REMOVE learning event."""
+        """Only manager removal records one CONDITIONAL_REMOVE learning event."""
         spe, batch, charge_line = self._create_spe_with_charge(
             self.sales_user,
             normalization_status='MATCHED',
@@ -397,9 +397,21 @@ class ConditionalResolutionLearningEventTest(SpotLearningEventCaptureBaseTest):
             'action': 'REMOVE',
         }, format='json')
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data['error_code'], 'MANAGER_OVERRIDE_REQUIRED')
+        self.assertTrue(SPEChargeLineDB.objects.filter(id=charge_line_id).exists())
+        self.assertFalse(
+            SpotResolutionLearningEvent.objects.filter(
+                envelope=spe,
+                resolution_type='CONDITIONAL_REMOVE',
+            ).exists()
+        )
 
-        # Charge line was deleted, but learning event was recorded BEFORE delete
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.patch(url, {'action': 'REMOVE'}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(SPEChargeLineDB.objects.filter(id=charge_line_id).exists())
+
         events = SpotResolutionLearningEvent.objects.filter(
             envelope=spe,
             resolution_type='CONDITIONAL_REMOVE',
@@ -409,7 +421,7 @@ class ConditionalResolutionLearningEventTest(SpotLearningEventCaptureBaseTest):
         event = events.first()
         self.assertEqual(event.normalized_label, 'optional storage fee')
         self.assertIsNone(event.resolved_product_code)  # REMOVE has no product code
-        self.assertEqual(event.resolved_by, self.sales_user)
+        self.assertEqual(event.resolved_by, self.admin_user)
 
     def test_conditional_keep_captures_shipment_context(self):
         """Verify conditional resolution captures full shipment context."""
@@ -502,7 +514,7 @@ class LearningEventDoesNotAffectResolutionTest(SpotLearningEventCaptureBaseTest)
         self.assertEqual(charge_line.conditional_acknowledged_by, self.sales_user)
 
     def test_conditional_remove_still_deletes_charge(self):
-        """Conditional REMOVE still deletes the charge line."""
+        """Denied sales removal is inert; manager removal deletes exactly once."""
         spe, batch, charge_line = self._create_spe_with_charge(
             self.sales_user,
             conditional=True,
@@ -513,8 +525,23 @@ class LearningEventDoesNotAffectResolutionTest(SpotLearningEventCaptureBaseTest)
 
         self.client.force_authenticate(user=self.sales_user)
         url = f'/api/v3/spot/envelopes/{spe.id}/charges/{charge_line_id}/conditional-resolution/'
-        self.client.patch(url, {'action': 'REMOVE'}, format='json')
-
+        denied = self.client.patch(url, {'action': 'REMOVE'}, format='json')
+        self.assertEqual(denied.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(denied.data['error_code'], 'MANAGER_OVERRIDE_REQUIRED')
+        self.assertTrue(SPEChargeLineDB.objects.filter(id=charge_line_id).exists())
         self.assertFalse(
-            SPEChargeLineDB.objects.filter(id=charge_line_id).exists()
+            SpotResolutionLearningEvent.objects.filter(
+                envelope=spe,
+                resolution_type='CONDITIONAL_REMOVE',
+            ).exists()
         )
+
+        self.client.force_authenticate(user=self.admin_user)
+        removed = self.client.patch(url, {'action': 'REMOVE'}, format='json')
+        self.assertEqual(removed.status_code, status.HTTP_200_OK)
+        self.assertFalse(SPEChargeLineDB.objects.filter(id=charge_line_id).exists())
+        event = SpotResolutionLearningEvent.objects.get(
+            envelope=spe,
+            resolution_type='CONDITIONAL_REMOVE',
+        )
+        self.assertEqual(event.resolved_by, self.admin_user)

--- a/frontend/scripts/spot-resolution-state.test.mjs
+++ b/frontend/scripts/spot-resolution-state.test.mjs
@@ -305,6 +305,18 @@ console.log("✓ Initial state created successfully.");
     assert.equal(selectChecklistNoUnknown(resolvedState), true);
     assert.equal(selectChecklistProductCodesVerified(resolvedState), true);
     assert.equal(selectCanFinishReview(resolvedState), true);
+    const backendBlockedState = {
+        ...resolvedState,
+        reviewSession: {
+            ...resolvedState.reviewSession,
+            remaining_blockers: 2,
+            blockers: [
+                { code: "SOURCE_REVIEW_NOT_SAFE", message: "Imported source review is not marked safe to quote." },
+                { code: "CONDITIONAL_ACKNOWLEDGEMENT_REQUIRED", message: "Conditional charge acknowledgement is required." }
+            ]
+        }
+    };
+    assert.equal(selectCanFinishReview(backendBlockedState), false);
     assert.equal(selectNextStepGuidance(resolvedState), "Review the remaining commercial term before finishing.");
 
     // Test multiple currencies totals splitting

--- a/frontend/src/components/spot/ExceptionWorkspace.tsx
+++ b/frontend/src/components/spot/ExceptionWorkspace.tsx
@@ -135,7 +135,7 @@ export function ExceptionWorkspace({ initialData, isLive = false, envelopeId, en
                     </div>
                     <div className="bg-slate-950 border border-slate-800 px-4 py-2.5 rounded-xl shrink-0 text-center sm:text-right">
                         <span className="text-xs text-slate-500 block">Remaining Blockers</span>
-                        <span className="text-lg font-bold text-amber-400">{combinedUnresolved.length} Issues Left</span>
+                        <span className="text-lg font-bold text-amber-400">{Math.max(combinedUnresolved.length, reviewSession.remaining_blockers)} Issues Left</span>
                     </div>
                 </div>
 
@@ -616,6 +616,7 @@ export function ExceptionWorkspace({ initialData, isLive = false, envelopeId, en
                     checklistNoUnknown={checklistNoUnknown}
                     checklistProductCodesVerified={checklistProductCodesVerified}
                     unresolvedCount={combinedUnresolved.length}
+                    blockerDetails={reviewSession.blockers}
                     canFinishReview={canFinishReview}
                     canUsePrototypeOverride={canUsePrototypeOverride}
                     isLive={isLive}

--- a/frontend/src/components/spot/workspace/FinalReviewPanel.tsx
+++ b/frontend/src/components/spot/workspace/FinalReviewPanel.tsx
@@ -3,6 +3,7 @@ interface FinalReviewPanelProps {
   checklistNoUnknown: boolean;
   checklistProductCodesVerified: boolean;
   unresolvedCount: number;
+  blockerDetails: Array<{ code: string; message: string }>;
   canFinishReview: boolean;
   canUsePrototypeOverride: boolean;
   isLive: boolean;
@@ -20,6 +21,7 @@ export function FinalReviewPanel({
   checklistNoUnknown,
   checklistProductCodesVerified,
   unresolvedCount,
+  blockerDetails,
   canFinishReview,
   canUsePrototypeOverride,
   isLive,
@@ -114,6 +116,16 @@ export function FinalReviewPanel({
             Resolve all pending issues and verify ProductCode mappings to
             complete review.
           </span>
+          {blockerDetails.length > 0 && (
+            <ul className="mt-2 list-disc space-y-1 pl-5">
+              {blockerDetails.map((blocker, index) => (
+                <li key={`${blocker.code}-${index}`}>
+                  <span className="font-semibold">{blocker.code}:</span>{" "}
+                  {blocker.message}
+                </li>
+              ))}
+            </ul>
+          )}
         </div>
       )}
 

--- a/frontend/src/components/spot/workspace/spotResolutionState.ts
+++ b/frontend/src/components/spot/workspace/spotResolutionState.ts
@@ -66,6 +66,7 @@ export interface SpotResolutionState {
         finalized_by: number | null;
         finalized_at: string | null;
         remaining_blockers: number;
+        blockers: Array<{ code: string; message: string; [key: string]: unknown }>;
         available_actions: string[];
     };
     activeIssueId: string | null;
@@ -115,7 +116,7 @@ export type SpotResolutionAction =
     | { type: "ADD_UNKNOWN_AS_CHARGE"; payload: { itemId: string; newChargeId: string; chargeName: string; chargeBucket: string; chargeCurrency: string; chargeAmount: number; chargeUnit: string; chargeProductCode: string; evidence: Evidence | null } }
     | { type: "TOGGLE_INCLUDE_IN_TOTALS"; payload: { chargeId: string } }
     | { type: "UNDO_DECISION"; payload: { decisionId: string } }
-    | { type: "FINALIZE_REVIEW"; payload: { status: "draft" | "finalized" | "in_review"; finalized_by: number | null; finalized_at: string | null; remaining_blockers: number; available_actions: string[] } }
+    | { type: "FINALIZE_REVIEW"; payload: { status: "draft" | "finalized" | "in_review"; finalized_by: number | null; finalized_at: string | null; remaining_blockers: number; blockers: Array<{ code: string; message: string; [key: string]: unknown }>; available_actions: string[] } }
     | { type: "DISMISS_ACTION_MESSAGE" }
     | { type: "TOGGLE_PROTOTYPE_OVERRIDE" }
     | { type: "TOGGLE_HELP_TEXT" }
@@ -135,6 +136,7 @@ export function createSpotResolutionState(initialData: DraftQuote): SpotResoluti
             finalized_by: null,
             finalized_at: null,
             remaining_blockers: reviewQueue.length,
+            blockers: [],
             available_actions: []
         },
         activeIssueId: reviewQueue[0]?.id || initialData.unclassified_items?.[0]?.id || null,
@@ -473,6 +475,7 @@ export function spotResolutionReducer(state: SpotResolutionState, action: SpotRe
                     finalized_by: action.payload.finalized_by,
                     finalized_at: action.payload.finalized_at,
                     remaining_blockers: action.payload.remaining_blockers,
+                    blockers: action.payload.blockers,
                     available_actions: action.payload.available_actions
                 },
                 actionMessage: "Draft Quote review finalized and locked."
@@ -584,7 +587,8 @@ export function selectCanFinishReview(state: SpotResolutionState): boolean {
     return (
         selectChecklistIssuesResolved(state) &&
         selectChecklistNoUnknown(state) &&
-        selectChecklistProductCodesVerified(state)
+        selectChecklistProductCodesVerified(state) &&
+        state.reviewSession.blockers.length === 0
     );
 }
 

--- a/frontend/src/components/spot/workspace/useSpotResolutionWorkflow.ts
+++ b/frontend/src/components/spot/workspace/useSpotResolutionWorkflow.ts
@@ -638,6 +638,7 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
                         finalized_by: result.finalized_by ?? null,
                         finalized_at: result.finalized_at ?? null,
                         remaining_blockers: result.remaining_blockers,
+                        blockers: result.blockers,
                         available_actions: ["reopen"]
                     }
                 });
@@ -654,6 +655,7 @@ export function useSpotResolutionWorkflow({ initialData, isLive, envelopeId }: U
                     finalized_by: null,
                     finalized_at: new Date().toISOString(),
                     remaining_blockers: 0,
+                    blockers: [],
                     available_actions: ["reopen"]
                 }
             });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -851,7 +851,16 @@ export async function finalizeDraftQuoteReview(
 
   const data = await response.json();
   if (!response.ok) {
-    throw new Error(data?.message || data?.error || 'Failed to finalize draft quote review.');
+    const blockers = Array.isArray(data?.blockers)
+      ? data.blockers.map((item: { code?: string; message?: string }) =>
+          [item.code, item.message].filter(Boolean).join(': ')
+        ).join('; ')
+      : '';
+    throw new Error(
+      [data?.error_code, data?.message || data?.error, blockers]
+        .filter(Boolean)
+        .join(' — ') || 'Failed to finalize draft quote review.'
+    );
   }
   return data as DraftQuoteFinalizeResponse;
 }

--- a/frontend/src/lib/draft-quote-types.ts
+++ b/frontend/src/lib/draft-quote-types.ts
@@ -138,6 +138,7 @@ export interface DraftQuote {
         finalized_by: number | null;
         finalized_at: string | null;
         remaining_blockers: number;
+        blockers: Array<{ code: string; message: string; [key: string]: unknown }>;
         available_actions: string[];
     };
 }
@@ -182,6 +183,8 @@ export interface DraftQuoteFinalizeResponse {
     status: 'accepted' | 'rejected';
     review_status: 'draft' | 'in_review' | 'finalized';
     remaining_blockers: number;
+    error_code?: string | null;
+    blockers: Array<{ code: string; message: string; [key: string]: unknown }>;
     finalized_by?: number | null;
     finalized_at?: string | null;
     message: string;


### PR DESCRIPTION
## Scope

Fail SPOT Exception Workspace finalization closed when source-review or conditional-charge blockers remain. The backend now returns stable `DRAFT_QUOTE_FINALIZATION_BLOCKED` errors with the complete blocker list, and the frontend uses and displays the same blocker payload before enabling Finalize Review.

Root cause: finalization considered only `draft_quote.review_queue`; source review state and conditional acknowledgement were not authoritative inputs. Low-confidence findings were explicitly non-blocking, and historical source resolutions lacked source-batch/finding-identity scope.

## Changed Files

- `backend/quotes/intake_safety.py`: make low-confidence findings blocking and bind resolutions to source batch plus stable finding identity.
- `backend/quotes/services/draft_quote_adapter.py`: surface stale source decisions and exclude unacknowledged conditional charges from the firm-total view.
- `backend/quotes/services/draft_quote_resolve_service.py`: require current batch/finding identity when resolving source findings.
- `backend/quotes/services/draft_quote_review_service.py`: central authoritative finalization blocker evaluation and blocker payload.
- `backend/quotes/contracts/draft_quote_contract.py`: expose review blockers and stable finalize error code.
- `backend/quotes/spot_views.py`: enforce quote-owner conditional acknowledgement, manager-only removal, conditional exclusion note, source-batch resolution scope, and stable finalize error code.
- `backend/quotes/tests/test_draft_quote_resolve.py`: regression coverage for partial/low-confidence/conditional/stale decisions, whitespace notes, blocker details, idempotency, and combined conditional plus low-confidence blocking.
- `backend/quotes/tests/test_spot_compute_completeness.py`: require evidence-supported low-confidence resolution before finalization and quote creation.
- `backend/quotes/tests/test_spot_flow_api.py`: enforce manager authority for forced conditional removal.
- `backend/quotes/tests/test_spot_learning_events.py`: prove denied ordinary-user removal is inert and admin removal creates exactly one event.
- `frontend/src/lib/draft-quote-types.ts`: type blocker details and error code.
- `frontend/src/lib/api.ts`: surface every backend blocker in finalize errors.
- `frontend/src/components/spot/workspace/spotResolutionState.ts`: include backend blockers in finalization eligibility.
- `frontend/src/components/spot/workspace/useSpotResolutionWorkflow.ts`: preserve blocker state across finalization.
- `frontend/src/components/spot/workspace/FinalReviewPanel.tsx`: display all blocker codes/messages.
- `frontend/src/components/spot/ExceptionWorkspace.tsx`: show authoritative blocker count/details.
- `frontend/scripts/spot-resolution-state.test.mjs`: prove backend blockers keep Finalize Review disabled.

## What Was Intentionally Not Changed

- Pricing formulas, charge amounts, source evidence, totals, GST, FX, CAF, margins, or ProductCodes.
- Route policies, Phase 16E-A journey behavior, quote creation/finalization calculations, or PR #304 source-review safeguards.
- Original/local databases or the dirty Phase 14D checkout.

## Verification

Automated:
- `python manage.py check` — passed, 0 issues.
- `python manage.py makemigrations --check --dry-run` — no changes detected.
- focused regression tests for low-confidence finalization/quote creation, conditional removal authority/learning events, and combined conditional plus source blockers — 4 passed.
- `python -m pytest quotes/tests -q` — 764 passed, 329 warnings in 1330.62s.
- `python -m pytest pricing_v4/tests -q` — 276 passed, 77 warnings in 490.83s.
- `node frontend/scripts/spot-resolution-state.test.mjs` — passed.
- `node frontend/scripts/exception-workspace-routing.test.mjs` — passed.
- `npm run typecheck` — passed.
- `npm run build` — passed (pre-existing lint/data-age warnings only).
- `git diff --check` — passed.
- `graphify update .` — 10,361 nodes / 26,718 edges / 773 communities.

Manual:
- Exercised finalization through API tests with review-safe false/high-risk, unresolved low-confidence, blank notes, partial resolution, missing conditional acknowledgement, stale inherited decisions, and idempotent replay.
- Confirmed quote creation remains protected by the existing backend finalized-review gate.
- Confirmed conditional KEEP retains the visible charge and customer-facing note, excludes it from the firm total, and clears only the conditional acknowledgement blocker while source review remains unsafe.
- Confirmed sales removal returns `403 MANAGER_OVERRIDE_REQUIRED`, leaves the line intact, and creates no learning event; admin removal deletes it and creates exactly one event.

Unavailable baseline tools: Ruff and Vulture are not installed in the repository/runtime Python environment.

## Risk

The intended commercial change is that an unresolved conditional charge is visible but excluded from the current firm total only after explicit quote-owner acknowledgement. Forced removal requires manager/admin authority. Existing historical resolutions without current batch/identity metadata reappear as stale blockers and require reconfirmation; audit history is retained.

Residual UAT: after merge, reproduce envelope `bbd91412-4969-4d0f-83f4-b5bcb5529e7c` on a disposable database copy and confirm the exact blocker list, conditional note, legitimate finalization, and downstream quote creation.

## Rollback

Revert commits `ba5d5ba5` and `08fd2dab`. No migration or data rollback is required.

## Commercial Impact

No pricing algorithm changed. Conditional applicability is no longer treated as firm: the charge stays visible and is excluded from the firm total after owner acknowledgement until applicability is confirmed. Other totals, GST, FX, CAF, margins, and ProductCode behavior are unchanged.

## Data Impact

No migration or backfill. Conditional acknowledgement records the existing actor/timestamp fields, sets the existing exclusion flag, and appends a customer-facing conditional note. Source finding resolutions now retain batch and stable identity metadata.

## Audit Impact

Historical decisions remain stored. A stale or inherited decision cannot silently resolve a current finding; it is surfaced as stale and requires explicit reconfirmation.