### PR TITLE
Phase 16E-A.1A: Trust persisted Quote context in SPOT

### DIFF
--- a/backend/quotes/serializers.py
+++ b/backend/quotes/serializers.py
@@ -19,9 +19,69 @@ from quotes.intake_safety import (
     normalize_source_analysis_summary,
 )
 from quotes.quote_result_contract import build_quote_result_from_quote
+from quotes.services.spot_quote_context import (
+    SpotQuoteContextError,
+    build_trusted_quote_context,
+    derive_missing_components,
+    trusted_context_hash,
+)
 # --- END IMPORTS ---
 
 # --- V3 Serializers ---
+
+SPOT_QUOTE_CONTEXT_CHANGED_MESSAGE = (
+    "The shipment details changed after this SPOT review was created. "
+    "Start a new SPOT review using the updated Quote details."
+)
+
+
+def _spot_negotiation_payload(quote):
+    envelopes = getattr(quote, "spot_envelopes", None)
+    if not envelopes:
+        return None
+    latest = envelopes.order_by("-created_at", "-id").first()
+    if not latest:
+        return None
+    try:
+        context, missing = build_trusted_quote_context(quote)
+    except SpotQuoteContextError as exc:
+        return {
+            "id": str(latest.id),
+            "context_status": exc.code,
+            "can_reopen": False,
+            "message": exc.message,
+            "details": exc.details,
+        }
+    if missing:
+        return {
+            "id": str(latest.id),
+            "context_status": "SPOT_QUOTE_CONTEXT_CHANGED",
+            "can_reopen": False,
+            "message": SPOT_QUOTE_CONTEXT_CHANGED_MESSAGE,
+            "details": {"missing_fields": missing},
+        }
+    missing_components = derive_missing_components(context)
+    if missing_components is None:
+        return {
+            "id": str(latest.id),
+            "context_status": "SPOT_QUOTE_COVERAGE_UNAVAILABLE",
+            "can_reopen": False,
+            "message": "Current SPOT rate coverage could not be verified. Start a new SPOT review.",
+        }
+    context["missing_components"] = missing_components
+    if trusted_context_hash(context) != latest.shipment_context_hash:
+        return {
+            "id": str(latest.id),
+            "context_status": "SPOT_QUOTE_CONTEXT_CHANGED",
+            "can_reopen": False,
+            "message": SPOT_QUOTE_CONTEXT_CHANGED_MESSAGE,
+        }
+    return {
+        "id": str(latest.id),
+        "context_status": "CURRENT",
+        "can_reopen": True,
+        "message": None,
+    }
 
 class V3DimensionInputSerializer(serializers.Serializer):
     """Serializer for the 'dimensions' list in the compute request."""
@@ -454,13 +514,7 @@ class QuoteModelSerializerV3(serializers.ModelSerializer):
         return ", ".join(sorted(providers))
 
     def get_spot_negotiation(self, obj):
-        spe = getattr(obj, 'spot_envelopes', None)
-        if not spe:
-            return None
-        latest = spe.order_by('-created_at', '-id').first()
-        if not latest:
-            return None
-        return {'id': str(latest.id)}
+        return _spot_negotiation_payload(obj)
 
     def get_branding(self, obj):
         request = self.context.get("request")
@@ -815,6 +869,7 @@ class SPEAcknowledgementSerializer(serializers.ModelSerializer):
         return str(obj.acknowledged_by_id) if obj.acknowledged_by_id else None
 
 class SpotPricingEnvelopeSerializer(serializers.ModelSerializer):
+    quote_id = serializers.UUIDField(read_only=True)
     customer_name = serializers.SerializerMethodField()
     shipment = serializers.JSONField(source='shipment_context_json')
     conditions = serializers.JSONField(source='conditions_json')
@@ -832,7 +887,7 @@ class SpotPricingEnvelopeSerializer(serializers.ModelSerializer):
     class Meta:
         model = SpotPricingEnvelopeDB
         fields = (
-            'id', 'status', 'customer_name', 'shipment', 'conditions',
+            'id', 'quote_id', 'status', 'customer_name', 'shipment', 'conditions',
             'spot_trigger_reason_code', 'spot_trigger_reason_text',
             'created_at', 'expires_at', 'is_expired',
             'shipment_context_hash', 'context_integrity_valid',

--- a/backend/quotes/services/spot_quote_context.py
+++ b/backend/quotes/services/spot_quote_context.py
@@ -134,10 +134,9 @@ def derive_missing_components(context: dict) -> list[str] | None:
         )
         return sorted(coverage.missing_required)
     except Exception:
-        logger.exception(
-            "Failed deriving missing components for trusted Quote context %s->%s",
-            context.get("origin_code"),
-            context.get("destination_code"),
+        logger.warning(
+            "Trusted Quote rate-coverage evaluation failed.",
+            exc_info=False,
         )
         return None
 

--- a/backend/quotes/services/spot_quote_context.py
+++ b/backend/quotes/services/spot_quote_context.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from core.business_rules import classify_png_shipment
+from quotes.completeness import ALL_COMPONENTS, evaluate_from_availability
+from quotes.quote_result_contract import shipment_metrics_from_quote
+
+
+logger = logging.getLogger(__name__)
+
+
+class SpotQuoteContextError(ValueError):
+    def __init__(self, code: str, message: str, *, details: dict | None = None):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.details = details or {}
+
+
+def build_trusted_quote_context(quote) -> tuple[dict, list[str]]:
+    origin = quote.origin_location
+    destination = quote.destination_location
+    origin_country = getattr(getattr(origin, "country", None), "code", None)
+    destination_country = getattr(getattr(destination, "country", None), "code", None)
+    try:
+        direction = classify_png_shipment(origin_country, destination_country)
+    except ValueError as exc:
+        raise SpotQuoteContextError(
+            "SPOT_QUOTE_DIRECTION_CONFLICT",
+            str(exc),
+            details={
+                "origin_country": origin_country,
+                "destination_country": destination_country,
+                "quote_shipment_type": quote.shipment_type,
+            },
+        ) from exc
+    if direction != str(quote.shipment_type or "").upper():
+        raise SpotQuoteContextError(
+            "SPOT_QUOTE_DIRECTION_CONFLICT",
+            "Persisted Quote shipment type conflicts with its origin and destination.",
+            details={
+                "origin_country": origin_country,
+                "destination_country": destination_country,
+                "quote_shipment_type": quote.shipment_type,
+                "derived_shipment_type": direction,
+            },
+        )
+
+    request_payload = quote.request_details_json if isinstance(quote.request_details_json, dict) else {}
+    dimensions = request_payload.get("dimensions")
+    dimensions = dimensions if isinstance(dimensions, list) else []
+    required = {
+        "customer": quote.customer_id,
+        "contact": quote.contact_id,
+        "origin_location": origin,
+        "destination_location": destination,
+        "origin_country": origin_country,
+        "destination_country": destination_country,
+        "shipment_type": quote.shipment_type,
+        "mode": quote.mode,
+        "service_scope": quote.service_scope,
+        "payment_term": quote.payment_term,
+        "commodity": quote.commodity_code,
+        "output_currency": quote.output_currency,
+        "dimensions": dimensions,
+    }
+    if direction != "DOMESTIC" and not quote.incoterm:
+        required["incoterm"] = quote.incoterm
+    missing = [field for field, value in required.items() if value in (None, "", [])]
+    if missing:
+        return {}, missing
+
+    metrics = shipment_metrics_from_quote(quote, None)
+    if metrics["pieces"] <= 0 or metrics["chargeable_weight"] <= 0:
+        return {}, ["dimensions"]
+
+    context = {
+        "quote_id": str(quote.id),
+        "customer_id": str(quote.customer_id),
+        "customer_name": quote.customer.name,
+        "contact_id": str(quote.contact_id),
+        "origin_location_id": str(quote.origin_location_id),
+        "destination_location_id": str(quote.destination_location_id),
+        "origin_country": str(origin_country).upper(),
+        "destination_country": str(destination_country).upper(),
+        "origin_code": str(origin.code).upper(),
+        "destination_code": str(destination.code).upper(),
+        "direction": direction,
+        "shipment_type": direction,
+        "mode": str(quote.mode).upper(),
+        "service_scope": str(quote.service_scope).upper(),
+        "incoterm": quote.incoterm,
+        "payment_term": str(quote.payment_term).upper(),
+        "commodity": quote.commodity_code,
+        "is_dangerous_goods": bool(quote.is_dangerous_goods),
+        "dimensions": dimensions,
+        "pieces": metrics["pieces"],
+        "actual_weight_kg": float(metrics["actual_weight"]),
+        "volumetric_weight_kg": float(metrics["volumetric_weight"]),
+        "total_weight_kg": float(metrics["chargeable_weight"]),
+        "output_currency": quote.output_currency,
+        "source_currency": request_payload.get("buy_currency"),
+        "owner_id": str(quote.owner_id) if quote.owner_id else None,
+        "organization_id": str(quote.organization_id) if quote.organization_id else None,
+        "branch_id": str(quote.branch_id) if quote.branch_id else None,
+        "department_id": str(quote.department_id) if quote.department_id else None,
+    }
+    return context, []
+
+
+def derive_missing_components(context: dict) -> list[str] | None:
+    try:
+        from quotes.spot_services import RateAvailabilityService
+
+        outcomes = RateAvailabilityService.get_component_outcomes(
+            origin_airport=context["origin_code"],
+            destination_airport=context["destination_code"],
+            direction=context["direction"],
+            service_scope=context["service_scope"],
+            payment_term=context["payment_term"],
+        )
+        coverage = evaluate_from_availability(
+            component_availability={
+                component: outcome.get("status") in {"covered_exact", "covered_fallback"}
+                for component, outcome in outcomes.items()
+            },
+            shipment_type=context["direction"],
+            service_scope=context["service_scope"],
+        )
+        return sorted(coverage.missing_required)
+    except Exception:
+        logger.exception(
+            "Failed deriving missing components for trusted Quote context %s->%s",
+            context.get("origin_code"),
+            context.get("destination_code"),
+        )
+        return None
+
+
+def trusted_context_hash(context: dict) -> str:
+    return hashlib.sha256(json.dumps(context, sort_keys=True).encode()).hexdigest()
+
+
+def validate_client_context(client_context: dict, trusted_context: dict) -> list[dict]:
+    def text(value: Any) -> str:
+        return str(value).strip()
+
+    def upper(value: Any) -> str:
+        return text(value).upper()
+
+    def lower(value: Any) -> str:
+        return text(value).lower()
+
+    def decimal(value: Any) -> str:
+        try:
+            return str(Decimal(str(value)).normalize())
+        except (InvalidOperation, TypeError, ValueError):
+            return text(value)
+
+    def integer(value: Any) -> int | str:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return text(value)
+
+    def boolean(value: Any) -> bool:
+        if isinstance(value, bool):
+            return value
+        return lower(value) in {"1", "true", "yes"}
+
+    def dimensions(value: Any):
+        if not isinstance(value, list):
+            return value
+        normalized = []
+        for item in value:
+            if not isinstance(item, dict):
+                normalized.append(item)
+                continue
+            normalized.append(tuple(sorted(
+                (
+                    key,
+                    integer(item[key]) if key == "pieces"
+                    else decimal(item[key]) if key in {
+                        "length_cm", "width_cm", "height_cm", "gross_weight_kg"
+                    }
+                    else text(item[key]),
+                )
+                for key in item
+            )))
+        return tuple(normalized)
+
+    normalizers = {
+        "quote_id": text,
+        "customer_id": text,
+        "customer_name": text,
+        "contact_id": text,
+        "origin_location_id": text,
+        "destination_location_id": text,
+        "origin_country": upper,
+        "destination_country": upper,
+        "origin_code": upper,
+        "destination_code": upper,
+        "direction": upper,
+        "shipment_type": upper,
+        "mode": upper,
+        "service_scope": lower,
+        "incoterm": upper,
+        "payment_term": lower,
+        "commodity": upper,
+        "is_dangerous_goods": boolean,
+        "dangerous_goods": boolean,
+        "dimensions": dimensions,
+        "pieces": integer,
+        "actual_weight_kg": decimal,
+        "volumetric_weight_kg": decimal,
+        "total_weight_kg": decimal,
+        "chargeable_weight_kg": decimal,
+        "chargeable_weight": decimal,
+        "output_currency": upper,
+        "source_currency": upper,
+        "owner_id": text,
+        "organization_id": text,
+        "operating_entity_id": text,
+        "branch_id": text,
+        "department_id": text,
+    }
+    aliases = {
+        "dangerous_goods": "is_dangerous_goods",
+        "chargeable_weight_kg": "total_weight_kg",
+        "chargeable_weight": "total_weight_kg",
+    }
+    conflicts = []
+    for field, normalize in normalizers.items():
+        if field not in client_context or client_context[field] in (None, ""):
+            continue
+        trusted_field = aliases.get(field, field)
+        client_value = normalize(client_context[field])
+        trusted_value = normalize(trusted_context.get(trusted_field))
+        if client_value != trusted_value:
+            conflicts.append({
+                "field": field,
+                "client_value": client_value,
+                "trusted_value": trusted_value,
+            })
+
+    if "missing_components" in client_context:
+        raw = client_context["missing_components"]
+        supplied = [upper(item) for item in raw] if isinstance(raw, list) else []
+        invalid = sorted(set(supplied) - ALL_COMPONENTS)
+        trusted = [upper(item) for item in trusted_context.get("missing_components") or []]
+        if invalid or set(supplied) != set(trusted):
+            conflicts.append({
+                "field": "missing_components",
+                "client_value": supplied,
+                "trusted_value": trusted,
+                "invalid_values": invalid,
+            })
+    return conflicts

--- a/backend/quotes/spot_views.py
+++ b/backend/quotes/spot_views.py
@@ -83,6 +83,13 @@ from quotes.services.spot_learning_service import (
     record_manual_resolution_event,
     record_conditional_resolution_event,
 )
+from quotes.services.spot_quote_context import (
+    SpotQuoteContextError,
+    build_trusted_quote_context,
+    derive_missing_components,
+    trusted_context_hash,
+    validate_client_context,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -1504,14 +1511,20 @@ class SpotEnvelopeListCreateAPIView(APIView):
                     quote = get_quote_for_user(request.user, quote_id)
                 except (ValueError, AttributeError, TypeError, DjangoValidationError):
                      return Response(
-                        {'error': f"Invalid quote_id format: {quote_id}"},
+                        {
+                            'error': f"Invalid quote_id format: {quote_id}",
+                            'error_code': 'SPOT_QUOTE_ID_INVALID',
+                        },
                         status=status.HTTP_400_BAD_REQUEST
                     )
                 except Exception as e:
                     from django.http import Http404
                     if isinstance(e, Http404):
                         return Response(
-                            {'error': f"Quote not found: {quote_id}"},
+                            {
+                                'error': f"Quote not found: {quote_id}",
+                                'error_code': 'SPOT_QUOTE_NOT_FOUND',
+                            },
                             status=status.HTTP_404_NOT_FOUND
                         )
                     raise e
@@ -1519,12 +1532,17 @@ class SpotEnvelopeListCreateAPIView(APIView):
                 from quotes.state_machine import is_quote_editable
                 if not is_quote_editable(quote):
                     return Response(
-                        {'error': f"Cannot create SPE for locked quote ({quote.status})."},
+                        {
+                            'error': f"Cannot create SPE for locked quote ({quote.status}).",
+                            'error_code': 'SPOT_QUOTE_NOT_EDITABLE',
+                        },
                         status=status.HTTP_403_FORBIDDEN
                     )
             
             # Validate required fields
-            required = ['shipment_context', 'trigger_code', 'trigger_text']
+            required = ['trigger_code', 'trigger_text']
+            if quote is None:
+                required.append('shipment_context')
             for field in required:
                 if field not in data:
                     return Response(
@@ -1537,28 +1555,72 @@ class SpotEnvelopeListCreateAPIView(APIView):
                         status=status.HTTP_400_BAD_REQUEST
                     )
             
-            if not isinstance(data['shipment_context'], dict):
+            client_context = data.get('shipment_context') or {}
+            if not isinstance(client_context, dict):
                 return Response(
                     {'error': 'shipment_context must be a dictionary'},
                     status=status.HTTP_400_BAD_REQUEST
                 )
 
-            # Create DB record
-            try:
-                ctx = _normalize_shipment_context(data['shipment_context'])
-            except Exception as e:
-                return Response(
-                    {'error': f"Failed to normalize shipment context: {str(e)}"},
-                    status=status.HTTP_400_BAD_REQUEST
-                )
-
             if quote is not None:
-                ctx.setdefault("customer_id", str(quote.customer_id) if quote.customer_id else None)
-                ctx.setdefault("contact_id", str(quote.contact_id) if quote.contact_id else None)
-                ctx.setdefault("incoterm", quote.incoterm)
-                ctx.setdefault("service_scope", quote.service_scope)
-                ctx.setdefault("payment_term", str(quote.payment_term).upper() if quote.payment_term else None)
-                ctx.setdefault("output_currency", quote.output_currency)
+                try:
+                    ctx, missing_context = build_trusted_quote_context(quote)
+                except SpotQuoteContextError as exc:
+                    return Response(
+                        {
+                            'error': exc.message,
+                            'error_code': exc.code,
+                            'details': exc.details,
+                        },
+                        status=status.HTTP_409_CONFLICT,
+                    )
+                if missing_context:
+                    return Response(
+                        {
+                            'error': 'Persisted Quote is missing trusted context required for SPOT intake.',
+                            'error_code': 'SPOT_QUOTE_CONTEXT_INCOMPLETE',
+                            'missing_fields': missing_context,
+                        },
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
+                missing_components = derive_missing_components(ctx)
+                if missing_components is None:
+                    return Response(
+                        {
+                            'error': 'Unable to derive current SPOT rate coverage from the persisted Quote.',
+                            'error_code': 'SPOT_QUOTE_COVERAGE_UNAVAILABLE',
+                        },
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
+                ctx["missing_components"] = missing_components
+                conflicts = validate_client_context(client_context, ctx)
+                if conflicts:
+                    return Response(
+                        {
+                            'error': 'Client shipment context conflicts with the persisted Quote.',
+                            'error_code': 'SPOT_QUOTE_CONTEXT_CONFLICT',
+                            'conflicts': conflicts,
+                        },
+                        status=status.HTTP_409_CONFLICT,
+                    )
+            else:
+                try:
+                    ctx = _normalize_shipment_context(client_context)
+                    SPEShipmentContext(
+                        **{
+                            **ctx,
+                            "service_scope": ctx["service_scope"].lower(),
+                            "payment_term": ctx.get("payment_term", "").lower() or None,
+                        }
+                    )
+                except Exception as e:
+                    return Response(
+                        {
+                            'error': f"Standalone SPOT context is incomplete or invalid: {str(e)}",
+                            'error_code': 'SPOT_STANDALONE_CONTEXT_INCOMPLETE',
+                        },
+                        status=status.HTTP_400_BAD_REQUEST
+                    )
 
             if (
                 not ctx.get("payment_term")
@@ -1587,6 +1649,18 @@ class SpotEnvelopeListCreateAPIView(APIView):
                     status=status.HTTP_400_BAD_REQUEST
                 )
 
+            context_hash = trusted_context_hash(ctx)
+            if quote is not None and not data.get("charges"):
+                retry = get_spes_for_user(request.user, _spe_queryset()).filter(
+                    quote=quote,
+                    status=SpotPricingEnvelopeDB.Status.DRAFT,
+                    shipment_context_hash=context_hash,
+                    spot_trigger_reason_code=data['trigger_code'],
+                    spot_trigger_reason_text=data['trigger_text'],
+                ).order_by('-created_at', '-id').first()
+                if retry is not None:
+                    return Response(SpotPricingEnvelopeSerializer(retry).data, status=status.HTTP_200_OK)
+
             try:
                 spe_db = SpotPricingEnvelopeDB.objects.create(
                     status='draft',
@@ -1597,6 +1671,10 @@ class SpotEnvelopeListCreateAPIView(APIView):
                     created_by=request.user,
                     expires_at=now + timedelta(hours=validity_hours),
                     quote=quote,
+                    owner=quote.owner if quote is not None else None,
+                    organization=quote.organization if quote is not None else None,
+                    branch=quote.branch if quote is not None else None,
+                    department=quote.department if quote is not None else None,
                 )
             except Exception as e:
                 logger.error("Database error creating SPE: %s", str(e), exc_info=True)

--- a/backend/quotes/spot_views.py
+++ b/backend/quotes/spot_views.py
@@ -1613,10 +1613,10 @@ class SpotEnvelopeListCreateAPIView(APIView):
                             "payment_term": ctx.get("payment_term", "").lower() or None,
                         }
                     )
-                except Exception as e:
+                except Exception:
                     return Response(
                         {
-                            'error': f"Standalone SPOT context is incomplete or invalid: {str(e)}",
+                            'error': 'Standalone SPOT context is incomplete or invalid.',
                             'error_code': 'SPOT_STANDALONE_CONTEXT_INCOMPLETE',
                         },
                         status=status.HTTP_400_BAD_REQUEST

--- a/backend/quotes/tests/test_spot_regression_d2d_collect.py
+++ b/backend/quotes/tests/test_spot_regression_d2d_collect.py
@@ -1,7 +1,7 @@
 from rest_framework.test import APITestCase, APIClient
 from django.contrib.auth import get_user_model
 from rest_framework import status
-from parties.models import Company
+from parties.models import Company, Contact
 from core.models import Country
 from core.tests.helpers import create_location
 from quotes.models import Quote
@@ -19,6 +19,12 @@ class SPOTRegressionD2DCollectTests(APITestCase):
         self.client = APIClient()
         self.client.force_authenticate(user=self.user)
         self.customer = Company.objects.create(name="Seed Customer Pty Ltd")
+        self.contact = Contact.objects.create(
+            company=self.customer,
+            first_name="Seed",
+            last_name="Contact",
+            email="seed@example.com",
+        )
         
         # Create Countries
         self.cn = Country.objects.create(code="CN", name="China")
@@ -57,6 +63,7 @@ class SPOTRegressionD2DCollectTests(APITestCase):
         # Create a real quote
         quote = Quote.objects.create(
             customer=self.customer,
+            contact=self.contact,
             mode="AIR",
             shipment_type="IMPORT",
             origin_location=self.origin,
@@ -64,7 +71,17 @@ class SPOTRegressionD2DCollectTests(APITestCase):
             status="DRAFT",
             service_scope="D2D",
             payment_term="COLLECT",
+            incoterm="EXW",
             commodity_code="GCR",
+            request_details_json={
+                "dimensions": [{
+                    "pieces": 1,
+                    "length_cm": 100,
+                    "width_cm": 100,
+                    "height_cm": 60,
+                    "gross_weight_kg": 100,
+                }],
+            },
             created_by=self.user
         )
 

--- a/backend/quotes/tests/test_spot_trusted_quote_context.py
+++ b/backend/quotes/tests/test_spot_trusted_quote_context.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.test import override_settings
@@ -347,3 +348,48 @@ class TrustedQuoteSpotContextTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertIsNone(response.data["quote_id"])
+
+    @patch(
+        "quotes.spot_services.RateAvailabilityService.get_component_outcomes",
+        side_effect=RuntimeError("SENSITIVE_SENTINEL"),
+    )
+    def test_coverage_failure_response_and_logs_are_sanitized(self, _mock_outcomes):
+        with self.assertLogs("quotes.services.spot_quote_context", level="WARNING") as captured:
+            response = self._post()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error_code"], "SPOT_QUOTE_COVERAGE_UNAVAILABLE")
+        response_text = str(response.data)
+        log_text = "\n".join(captured.output)
+        self.assertNotIn("SENSITIVE_SENTINEL", response_text)
+        self.assertNotIn("SENSITIVE_SENTINEL", log_text)
+        for value in ("CAN", "POM", "COLLECT", "Trusted Context Customer"):
+            self.assertNotIn(value, log_text)
+
+    @patch(
+        "quotes.spot_views._normalize_shipment_context",
+        side_effect=ValueError("SENSITIVE_SENTINEL"),
+    )
+    def test_standalone_validation_response_and_logs_are_sanitized(self, _mock_normalize):
+        payload = self._payload()
+        payload.pop("quote_id")
+        payload["shipment_context"] = {
+            "origin_code": "SUBMITTED_CONTEXT_SENTINEL",
+        }
+
+        with self.assertLogs("django.request", level="WARNING") as captured:
+            response = self._post(payload=payload)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data,
+            {
+                "error": "Standalone SPOT context is incomplete or invalid.",
+                "error_code": "SPOT_STANDALONE_CONTEXT_INCOMPLETE",
+            },
+        )
+        response_text = str(response.data)
+        log_text = "\n".join(captured.output)
+        self.assertNotIn("SENSITIVE_SENTINEL", response_text)
+        self.assertNotIn("SENSITIVE_SENTINEL", log_text)
+        self.assertNotIn("SUBMITTED_CONTEXT_SENTINEL", log_text)

--- a/backend/quotes/tests/test_spot_trusted_quote_context.py
+++ b/backend/quotes/tests/test_spot_trusted_quote_context.py
@@ -1,0 +1,349 @@
+from copy import deepcopy
+
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from core.models import Country
+from core.tests.helpers import create_location
+from parties.models import Company, Contact
+from quotes.models import Quote
+from quotes.quote_result_contract import shipment_metrics_from_quote
+from quotes.spot_models import SpotPricingEnvelopeDB
+
+
+@override_settings(PASSWORD_HASHERS=["django.contrib.auth.hashers.MD5PasswordHasher"])
+class TrustedQuoteSpotContextTests(APITestCase):
+    def setUp(self):
+        user_model = get_user_model()
+        self.sales = user_model.objects.create_user(
+            username="trusted-context-sales",
+            password="test",
+            role="sales",
+            department="AIR",
+        )
+        self.other_sales = user_model.objects.create_user(
+            username="trusted-context-other",
+            password="test",
+            role="sales",
+            department="SEA",
+        )
+        self.manager = user_model.objects.create_user(
+            username="trusted-context-manager",
+            password="test",
+            role="manager",
+            department="AIR",
+        )
+        self.admin = user_model.objects.create_user(
+            username="trusted-context-admin",
+            password="test",
+            role="admin",
+        )
+        customer = Company.objects.create(name="Trusted Context Customer", is_customer=True)
+        contact = Contact.objects.create(company=customer, first_name="Quote", last_name="Owner")
+        china = Country.objects.create(code="CN", name="China")
+        png = Country.objects.create(code="PG", name="Papua New Guinea")
+        australia = Country.objects.create(code="AU", name="Australia")
+        self.can = create_location(code="CAN", name="Guangzhou", country=china)
+        self.pom = create_location(code="POM", name="Port Moresby", country=png)
+        self.bne = create_location(code="BNE", name="Brisbane", country=australia)
+        self.dimensions = [{
+            "pieces": 1,
+            "length_cm": "100",
+            "width_cm": "100",
+            "height_cm": "60",
+            "gross_weight_kg": "100",
+            "package_type": "Pallet",
+        }]
+        self.quote = Quote.objects.create(
+            customer=customer,
+            contact=contact,
+            mode="AIR",
+            shipment_type="IMPORT",
+            origin_location=self.can,
+            destination_location=self.pom,
+            status="INCOMPLETE",
+            service_scope="D2D",
+            incoterm="EXW",
+            payment_term="COLLECT",
+            commodity_code="GCR",
+            output_currency="PGK",
+            request_details_json={
+                "dimensions": self.dimensions,
+                "buy_currency": "USD",
+            },
+            created_by=self.sales,
+        )
+        self.url = "/api/v3/spot/envelopes/"
+
+    def _payload(self, **context):
+        return {
+            "quote_id": str(self.quote.id),
+            "shipment_context": context,
+            "charges": [],
+            "trigger_code": "MISSING_SCOPE_RATES",
+            "trigger_text": "Missing required rate components",
+            "conditions": {"rate_validity_hours": 72},
+        }
+
+    def _post(self, user=None, payload=None):
+        self.client.force_authenticate(user=user or self.sales)
+        return self.client.post(self.url, payload or self._payload(), format="json")
+
+    def test_quote_owner_creates_server_owned_can_pom_snapshot(self):
+        response = self._post()
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        envelope = SpotPricingEnvelopeDB.objects.get(id=response.data["id"])
+        context = envelope.shipment_context_json
+        self.assertEqual(envelope.quote_id, self.quote.id)
+        self.assertEqual(response.data["quote_id"], str(self.quote.id))
+        self.assertEqual(context["quote_id"], str(self.quote.id))
+        self.assertEqual(context["direction"], "IMPORT")
+        self.assertEqual(context["origin_code"], "CAN")
+        self.assertEqual(context["destination_code"], "POM")
+        self.assertEqual(context["origin_country"], "CN")
+        self.assertEqual(context["destination_country"], "PG")
+        self.assertEqual(context["service_scope"], "D2D")
+        self.assertEqual(context["payment_term"], "COLLECT")
+        self.assertEqual(context["incoterm"], "EXW")
+        self.assertEqual(context["pieces"], 1)
+        self.assertEqual(context["total_weight_kg"], 100.0)
+        self.assertEqual(context["dimensions"], self.dimensions)
+        self.assertEqual(context["source_currency"], "USD")
+        self.assertEqual(
+            set(context["missing_components"]),
+            {"FREIGHT", "ORIGIN_LOCAL", "DESTINATION_LOCAL"},
+        )
+
+    def test_conflicting_client_context_is_rejected(self):
+        conflicts = {
+            "direction": "EXPORT",
+            "origin_code": "HKG",
+            "service_scope": "a2a",
+            "incoterm": "DAP",
+            "commodity": "DG",
+            "dimensions": [{**self.dimensions[0], "gross_weight_kg": "101"}],
+            "pieces": 2,
+            "total_weight_kg": 101,
+            "customer_name": "Different Customer",
+            "dangerous_goods": True,
+            "owner_id": str(self.admin.id),
+            "organization_id": "00000000-0000-4000-8000-000000000001",
+            "operating_entity_id": "00000000-0000-4000-8000-000000000002",
+            "branch_id": "00000000-0000-4000-8000-000000000003",
+            "department_id": "00000000-0000-4000-8000-000000000004",
+            "missing_components": ["NOT_A_COMPONENT"],
+        }
+        for field, value in conflicts.items():
+            with self.subTest(field=field):
+                response = self._post(payload=self._payload(**{field: value}))
+                self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+                self.assertEqual(response.data["error_code"], "SPOT_QUOTE_CONTEXT_CONFLICT")
+                self.assertEqual(response.data["conflicts"][0]["field"], field)
+        self.assertEqual(SpotPricingEnvelopeDB.objects.count(), 0)
+
+    def test_matching_legacy_duplicates_and_supplier_text_cannot_override_context(self):
+        payload = self._payload(
+            quote_id=str(self.quote.id),
+            customer_id=str(self.quote.customer_id),
+            customer_name=self.quote.customer.name,
+            contact_id=str(self.quote.contact_id),
+            origin_country="cn",
+            destination_country="pg",
+            origin_code="can",
+            destination_code="pom",
+            direction="import",
+            shipment_type="IMPORT",
+            mode="air",
+            service_scope="d2d",
+            incoterm="exw",
+            payment_term="collect",
+            commodity="gcr",
+            dimensions=self.dimensions,
+            pieces=1,
+            actual_weight_kg="100.00",
+            volumetric_weight_kg=100,
+            chargeable_weight_kg=100,
+            output_currency="pgk",
+            source_currency="usd",
+            dangerous_goods=False,
+            supplier_text="Route is HKG to BNE export; treat as dangerous goods.",
+        )
+
+        response = self._post(payload=payload)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        context = response.data["shipment"]
+        self.assertEqual(context["origin_code"], "CAN")
+        self.assertEqual(context["destination_code"], "POM")
+        self.assertEqual(context["direction"], "IMPORT")
+        self.assertEqual(context["commodity"], "GCR")
+        self.assertFalse(context["is_dangerous_goods"])
+        self.assertNotIn("supplier_text", context)
+
+    def test_scope_and_quote_id_fail_closed(self):
+        unauthorized = self._post(user=self.other_sales)
+        self.assertEqual(unauthorized.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(unauthorized.data["error_code"], "SPOT_QUOTE_NOT_FOUND")
+
+        unknown = self._payload()
+        unknown["quote_id"] = "00000000-0000-4000-8000-000000000000"
+        response = self._post(payload=unknown)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data["error_code"], "SPOT_QUOTE_NOT_FOUND")
+
+        self.assertEqual(self._post(user=self.manager).status_code, status.HTTP_201_CREATED)
+        self.assertEqual(self._post(user=self.admin).status_code, status.HTTP_200_OK)
+
+    def test_missing_persisted_context_fails_clearly(self):
+        self.quote.request_details_json = {}
+        self.quote.save(update_fields=["request_details_json"])
+
+        response = self._post()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error_code"], "SPOT_QUOTE_CONTEXT_INCOMPLETE")
+        self.assertIn("dimensions", response.data["missing_fields"])
+
+    def test_identical_retry_reuses_envelope_and_quote_edit_creates_new_snapshot(self):
+        first = self._post()
+        self.assertEqual(first.status_code, status.HTTP_201_CREATED)
+        first_context = deepcopy(first.data["shipment"])
+
+        retry = self._post()
+        self.assertEqual(retry.status_code, status.HTTP_200_OK)
+        self.assertEqual(retry.data["id"], first.data["id"])
+        self.assertEqual(SpotPricingEnvelopeDB.objects.count(), 1)
+
+        self.quote.service_scope = "A2D"
+        self.quote.updated_at = timezone.now()
+        self.quote.save(update_fields=["service_scope", "updated_at"])
+        second = self._post()
+
+        self.assertEqual(second.status_code, status.HTTP_201_CREATED)
+        self.assertNotEqual(second.data["id"], first.data["id"])
+        self.assertEqual(SpotPricingEnvelopeDB.objects.count(), 2)
+        original = SpotPricingEnvelopeDB.objects.get(id=first.data["id"])
+        self.assertEqual(original.shipment_context_json, first_context)
+        self.assertEqual(second.data["shipment"]["service_scope"], "A2D")
+
+    def test_quote_detail_blocks_stale_reopen_and_fresh_review_uses_updated_context(self):
+        first = self._post()
+        first_id = first.data["id"]
+        first_snapshot = deepcopy(first.data["shipment"])
+
+        unchanged = self.client.get(f"/api/v3/quotes/{self.quote.id}/")
+        self.assertEqual(unchanged.status_code, status.HTTP_200_OK)
+        self.assertEqual(unchanged.data["spot_negotiation"]["id"], first_id)
+        self.assertEqual(unchanged.data["spot_negotiation"]["context_status"], "CURRENT")
+        self.assertTrue(unchanged.data["spot_negotiation"]["can_reopen"])
+
+        self.quote.service_scope = "A2D"
+        self.quote.save(update_fields=["service_scope", "updated_at"])
+        changed = self.client.get(f"/api/v3/quotes/{self.quote.id}/")
+        self.assertEqual(changed.status_code, status.HTTP_200_OK)
+        self.assertEqual(changed.data["spot_negotiation"]["id"], first_id)
+        self.assertEqual(
+            changed.data["spot_negotiation"]["context_status"],
+            "SPOT_QUOTE_CONTEXT_CHANGED",
+        )
+        self.assertFalse(changed.data["spot_negotiation"]["can_reopen"])
+        self.assertEqual(
+            SpotPricingEnvelopeDB.objects.get(id=first_id).shipment_context_json,
+            first_snapshot,
+        )
+
+        fresh = self._post()
+        self.assertEqual(fresh.status_code, status.HTTP_201_CREATED)
+        self.assertNotEqual(fresh.data["id"], first_id)
+        self.assertEqual(fresh.data["shipment"]["service_scope"], "A2D")
+
+    def test_canonical_quote_weight_metrics_match_spe_snapshot(self):
+        cases = [
+            [{
+                "pieces": 1, "length_cm": "10", "width_cm": "10", "height_cm": "10",
+                "gross_weight_kg": "20", "package_type": "Box",
+            }],
+            [{
+                "pieces": 1, "length_cm": "120", "width_cm": "100", "height_cm": "100",
+                "gross_weight_kg": "20", "package_type": "Box",
+            }],
+            [
+                {
+                    "pieces": 2, "length_cm": "50", "width_cm": "40", "height_cm": "30",
+                    "gross_weight_kg": "20", "package_type": "Box",
+                },
+                {
+                    "pieces": 1, "length_cm": "100", "width_cm": "80", "height_cm": "60",
+                    "gross_weight_kg": "10", "package_type": "Pallet",
+                },
+            ],
+        ]
+        for index, dimensions in enumerate(cases):
+            with self.subTest(index=index):
+                self.quote.request_details_json = {"dimensions": dimensions, "buy_currency": "USD"}
+                self.quote.save(update_fields=["request_details_json", "updated_at"])
+                expected = shipment_metrics_from_quote(self.quote, None)
+                response = self._post()
+                self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+                shipment = response.data["shipment"]
+                self.assertEqual(shipment["pieces"], expected["pieces"])
+                self.assertEqual(shipment["actual_weight_kg"], float(expected["actual_weight"]))
+                self.assertEqual(
+                    shipment["volumetric_weight_kg"],
+                    float(expected["volumetric_weight"]),
+                )
+                self.assertEqual(
+                    shipment["total_weight_kg"],
+                    float(expected["chargeable_weight"]),
+                )
+
+    def test_direction_is_derived_from_route_and_conflicts_fail_closed(self):
+        import_response = self._post()
+        self.assertEqual(import_response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(import_response.data["shipment"]["direction"], "IMPORT")
+
+        self.quote.origin_location = self.pom
+        self.quote.destination_location = self.bne
+        self.quote.shipment_type = "EXPORT"
+        self.quote.save(update_fields=["origin_location", "destination_location", "shipment_type", "updated_at"])
+        export_response = self._post()
+        self.assertEqual(export_response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(export_response.data["shipment"]["direction"], "EXPORT")
+
+        self.quote.shipment_type = "IMPORT"
+        self.quote.save(update_fields=["shipment_type", "updated_at"])
+        conflict = self._post()
+        self.assertEqual(conflict.status_code, status.HTTP_409_CONFLICT)
+        self.assertEqual(conflict.data["error_code"], "SPOT_QUOTE_DIRECTION_CONFLICT")
+
+        self.quote.origin_location = self.bne
+        self.quote.destination_location = self.can
+        self.quote.shipment_type = "EXPORT"
+        self.quote.save(update_fields=["origin_location", "destination_location", "shipment_type", "updated_at"])
+        unsupported = self._post()
+        self.assertEqual(unsupported.status_code, status.HTTP_409_CONFLICT)
+        self.assertEqual(unsupported.data["error_code"], "SPOT_QUOTE_DIRECTION_CONFLICT")
+
+    def test_standalone_complete_context_remains_supported(self):
+        payload = self._payload()
+        payload.pop("quote_id")
+        payload["shipment_context"] = {
+            "origin_country": "CN",
+            "destination_country": "PG",
+            "origin_code": "CAN",
+            "destination_code": "POM",
+            "commodity": "GCR",
+            "total_weight_kg": 100,
+            "pieces": 1,
+            "service_scope": "d2d",
+            "payment_term": "collect",
+        }
+
+        response = self._post(payload=payload)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertIsNone(response.data["quote_id"])

--- a/frontend/scripts/trusted-spot-context.test.mjs
+++ b/frontend/scripts/trusted-spot-context.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const quoteHook = fs.readFileSync(new URL("../src/hooks/useQuoteLogic.ts", import.meta.url), "utf8");
+const quoteDetail = fs.readFileSync(new URL("../src/app/quotes/[id]/page.tsx", import.meta.url), "utf8");
+
+assert.match(
+  quoteHook,
+  /const persistedQuote = await onSubmit\(data\);[\s\S]*quote_id: persistedQuote\.quoteId/,
+  "New Quote must be persisted before its SPOT envelope is created with quote_id.",
+);
+assert.match(
+  quoteDetail,
+  /createSpotEnvelope\(\{[\s\S]*quote_id: quote\.id/,
+  "Quote Detail must create a SPOT envelope with the persisted quote_id.",
+);
+assert.doesNotMatch(
+  quoteDetail,
+  /createSpotEnvelope\(\{[\s\S]{0,300}shipment_context:/,
+  "Quote Detail must not send a client-authored shipment snapshot.",
+);
+assert.match(
+  quoteDetail,
+  /quote\.spot_negotiation\?\.can_reopen === false/,
+  "Quote Detail must not automatically reopen an SPE whose trusted context is stale.",
+);
+assert.match(
+  quoteDetail,
+  /contextChanged=\{spotContextChanged\}/,
+  "Quote Detail must show the fresh-review state for a stale SPE.",
+);
+assert.match(
+  quoteDetail,
+  /function buildSpotWorkflowParams[\s\S]*origin_code: context\.originCode,[\s\S]*dest_code: context\.destinationCode/,
+  "Quote Detail reopen must retain the trusted route display.",
+);
+
+console.log("trusted SPOT context launch checks passed");

--- a/frontend/src/app/quotes/[id]/page.tsx
+++ b/frontend/src/app/quotes/[id]/page.tsx
@@ -73,7 +73,7 @@ export default function QuoteDetailPage() {
     const currentStatus = getEffectiveQuoteStatus(quote.status, quote.valid_until);
     if (currentStatus !== "INCOMPLETE") return null;
     const existingSpotEnvelopeId = quote.spot_negotiation?.id;
-    if (!existingSpotEnvelopeId) return null;
+    if (!existingSpotEnvelopeId || quote.spot_negotiation?.can_reopen === false) return null;
     const params = buildSpotWorkflowParams(quote);
     params.set("returnTo", `/quotes/${quote.id}`);
     return `/quotes/spot/${existingSpotEnvelopeId}?${params.toString()}`;
@@ -127,7 +127,10 @@ export default function QuoteDetailPage() {
     }
 
     const currentStatus = getEffectiveQuoteStatus(quote.status, quote.valid_until);
-    if (currentStatus !== "INCOMPLETE" || quote.spot_negotiation?.id) {
+    if (
+      currentStatus !== "INCOMPLETE"
+      || (quote.spot_negotiation?.id && quote.spot_negotiation.can_reopen !== false)
+    ) {
       setSpotTriggerResult(null);
       setSpotTriggerChecking(false);
       setSpotTriggerChecked(false);
@@ -186,19 +189,7 @@ export default function QuoteDetailPage() {
       }
 
       const spe = await createSpotEnvelope({
-        shipment_context: {
-          origin_country: context.originCountry,
-          destination_country: context.destinationCountry,
-          origin_code: context.originCode,
-          destination_code: context.destinationCode,
-          customer_name: context.customerName,
-          commodity: context.commodity,
-          total_weight_kg: context.chargeableWeight,
-          pieces: context.pieces,
-          service_scope: context.serviceScope.toLowerCase(),
-          payment_term: context.paymentTerm === "COLLECT" ? "collect" : "prepaid",
-          missing_components: triggerResult.trigger.missing_components,
-        },
+        quote_id: quote.id,
         charges: [],
         trigger_code: triggerResult.trigger.code,
         trigger_text: triggerResult.trigger.text,
@@ -215,6 +206,8 @@ export default function QuoteDetailPage() {
       setSpotLaunching(false);
     }
   };
+
+  const spotContextChanged = quote?.spot_negotiation?.can_reopen === false;
 
 
   if (loading) {
@@ -455,9 +448,10 @@ export default function QuoteDetailPage() {
             <SpotWorkflowRequiredCard
               quote={quote}
               spotLaunching={spotLaunching}
-              spotLaunchError={spotLaunchError}
+              spotLaunchError={spotContextChanged ? quote.spot_negotiation?.message || null : spotLaunchError}
               onLaunchSpot={handleLaunchSpotWorkflow}
               onReturnToEdit={() => router.push(`/quotes/${quote.id}/edit`)}
+              contextChanged={spotContextChanged}
             />
           ) : canEditQuotes ? (
             <IncompleteQuoteCard
@@ -520,7 +514,7 @@ async function evaluateLatestSpotTrigger(
 }
 
 function buildQuoteEditHref(quote: V3QuoteComputeResponse): string {
-  if (quote.spot_negotiation?.id) {
+  if (quote.spot_negotiation?.id && quote.spot_negotiation.can_reopen !== false) {
     const params = buildSpotWorkflowParams(quote);
     params.set("returnTo", `/quotes/${quote.id}`);
     return `/quotes/spot/${quote.spot_negotiation.id}?${params.toString()}`;
@@ -532,6 +526,9 @@ function buildQuoteEditHref(quote: V3QuoteComputeResponse): string {
 function buildSpotWorkflowParams(quote: V3QuoteComputeResponse): URLSearchParams {
   const context = buildSpotResumeContext(quote);
   return new URLSearchParams({
+    origin_code: context.originCode,
+    dest_code: context.destinationCode,
+    commodity: context.commodity,
     customer_name: context.customerName,
     service_scope: context.serviceScope,
     payment_term: context.paymentTerm,

--- a/frontend/src/app/quotes/new/page.tsx
+++ b/frontend/src/app/quotes/new/page.tsx
@@ -166,7 +166,7 @@ function NewQuoteContent() {
           setPendingQuoteId(response.id);
           setShowMissingRatesModal(true);
           setIsSubmitting(false);
-          return;
+          return { quoteId: response.id, holdNavigation: true };
         }
       }
 
@@ -176,7 +176,7 @@ function NewQuoteContent() {
         variant: "success",
       });
 
-      router.push(`/quotes/${response.id}`);
+      return { quoteId: response.id };
     } catch (error: unknown) {
       console.error("API Error:", error);
       const message = error instanceof Error ? error.message : "An unexpected error occurred.";

--- a/frontend/src/components/forms/QuoteForm.tsx
+++ b/frontend/src/components/forms/QuoteForm.tsx
@@ -21,6 +21,7 @@ import { SummaryCard, SummaryStack, type SummaryLine } from "@/components/ui/sum
 import { Button } from "@/components/ui/button";
 import { Form } from "@/components/ui/form";
 import { useQuoteLogic } from "@/hooks/useQuoteLogic";
+import type { QuoteSubmitResult } from "@/hooks/useQuoteLogic";
 import {
   formatIncoterm,
   formatPaymentTerm,
@@ -65,7 +66,7 @@ interface QuoteFormProps {
   initialOrigin?: LocationSearchResult;
   initialDestination?: LocationSearchResult;
   user?: User | null;
-  onSubmit: (data: QuoteFormSchemaV3) => Promise<void>;
+  onSubmit: (data: QuoteFormSchemaV3) => Promise<QuoteSubmitResult | void>;
   isSubmitting?: boolean;
   serverError?: string | null;
   isEditMode?: boolean;

--- a/frontend/src/components/quotes/SpotTriggerCards.tsx
+++ b/frontend/src/components/quotes/SpotTriggerCards.tsx
@@ -9,6 +9,7 @@ export interface SpotWorkflowRequiredCardProps {
   spotLaunchError: string | null;
   onLaunchSpot: () => void | Promise<void>;
   onReturnToEdit: () => void;
+  contextChanged?: boolean;
 }
 
 export function SpotWorkflowRequiredCard({
@@ -17,14 +18,16 @@ export function SpotWorkflowRequiredCard({
   spotLaunchError,
   onLaunchSpot,
   onReturnToEdit,
+  contextChanged = false,
 }: SpotWorkflowRequiredCardProps) {
   return (
     <Card className="border-amber-200 bg-amber-50/40">
       <CardHeader>
         <CardTitle className="text-lg text-amber-800">SPOT Workflow Required</CardTitle>
         <CardDescription>
-          This quote is incomplete and is not linked to an active SPOT envelope yet.
-          Launch the current SPOT workflow from here, or return to edit if you need to refresh the quote inputs.
+          {contextChanged
+            ? "The linked SPOT review uses older shipment details. Start a new SPOT review from the current Quote."
+            : "This quote is incomplete and is not linked to an active SPOT envelope yet. Launch the current SPOT workflow from here, or return to edit if you need to refresh the quote inputs."}
         </CardDescription>
       </CardHeader>
       <CardContent className="flex items-center justify-between gap-4">
@@ -49,7 +52,7 @@ export function SpotWorkflowRequiredCard({
                 Opening SPOT...
               </>
             ) : (
-              "Open SPOT Workflow"
+              contextChanged ? "Start New SPOT Review" : "Open SPOT Workflow"
             )}
           </Button>
         </div>

--- a/frontend/src/hooks/useQuoteLogic.ts
+++ b/frontend/src/hooks/useQuoteLogic.ts
@@ -59,8 +59,13 @@ interface UseQuoteLogicProps {
     initialOrigin?: LocationSearchResult;
     initialDestination?: LocationSearchResult;
     user?: User | null; // Auth user
-    onSubmit: (data: QuoteFormSchemaV3) => Promise<void>;
+    onSubmit: (data: QuoteFormSchemaV3) => Promise<QuoteSubmitResult | void>;
     isEditMode?: boolean; // Skip SPOT validation when editing existing quotes
+}
+
+export interface QuoteSubmitResult {
+    quoteId: string;
+    holdNavigation?: boolean;
 }
 
 export function useQuoteLogic({
@@ -236,6 +241,11 @@ export function useQuoteLogic({
                 return;
             }
 
+            const persistedQuote = await onSubmit(data);
+            if (!persistedQuote?.quoteId) {
+                return;
+            }
+
             const originCode = (data.origin_airport || originLocation?.code || '').toUpperCase();
             const destinationCode = (data.destination_airport || destinationLocation?.code || '').toUpperCase();
             const originCountry = resolveCountryCode(originLocation, originCode);
@@ -275,8 +285,6 @@ export function useQuoteLogic({
                 const commodity = mapCargoToSPECommodity(data.cargo_type);
                 const paymentTermUpper: 'PREPAID' | 'COLLECT' =
                     data.payment_term === 'COLLECT' ? 'COLLECT' : 'PREPAID';
-                const paymentTermLower: 'prepaid' | 'collect' =
-                    paymentTermUpper === 'COLLECT' ? 'collect' : 'prepaid';
                 const selectedCounterparty = parsePricingCounterparty(data.pricing_counterparty);
                 const triggerResult = await evaluateSpotTrigger({
                     origin_country: originCountry,
@@ -294,23 +302,7 @@ export function useQuoteLogic({
                 if (triggerResult.is_spot_required && triggerResult.trigger) {
                     setSpotMode(true);
                     const spe = await createSpotEnvelope({
-                        shipment_context: {
-                            origin_country: originCountry,
-                            destination_country: destCountry,
-                            origin_code: originCode,
-                            destination_code: destinationCode,
-                            customer_name: selectedCustomer?.name || undefined,
-                            customer_id: data.customer_id,
-                            contact_id: data.contact_id || undefined,
-                            incoterm: data.incoterm || undefined,
-                            output_currency: data.output_currency || 'PGK',
-                            commodity: commodity as SPECommodity,
-                            total_weight_kg: Number(cargoMetrics.chargeableWeight || 1.0),
-                            pieces: Number(cargoMetrics.pieces || 1),
-                            service_scope: (data.service_scope || 'P2P').toLowerCase(),
-                            payment_term: paymentTermLower,
-                            missing_components: triggerResult.trigger?.missing_components,
-                        },
+                        quote_id: persistedQuote.quoteId,
                         charges: [],
                         trigger_code: triggerResult.trigger.code,
                         trigger_text: triggerResult.trigger.text,
@@ -350,7 +342,9 @@ export function useQuoteLogic({
             }
 
             setSpotMode(false);
-            await onSubmit(data);
+            if (!persistedQuote.holdNavigation) {
+                router.push(`/quotes/${persistedQuote.quoteId}`);
+            }
         } finally {
             submitLockRef.current = false;
         }

--- a/frontend/src/lib/spot-types.ts
+++ b/frontend/src/lib/spot-types.ts
@@ -250,7 +250,7 @@ export interface SPEIntakeSafety {
 
 /** Create SPE request */
 export interface CreateSPERequest {
-    shipment_context: SPEShipmentContext;
+    shipment_context?: Partial<SPEShipmentContext>;
     charges: Omit<SPEChargeLine, 'id'>[];
     conditions?: Partial<SPEConditions>;
     trigger_code: string;
@@ -296,6 +296,7 @@ export interface TemplateValidation {
 /** Full SPE response from API */
 export interface SpotPricingEnvelope {
     id: string;
+    quote_id?: string | null;
     status: SPEStatus;
     shipment: SPEShipmentContext;
     shipment_context_hash?: string;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -538,7 +538,13 @@ export interface V3QuoteComputeResponse {
   branding?: QuoteBrandingRef | null;
   mode: string;
   shipment_type: string; // The backend calculates and returns this
-  spot_negotiation?: { id: string } | null;
+  spot_negotiation?: {
+    id: string;
+    context_status?: "CURRENT" | "SPOT_QUOTE_CONTEXT_CHANGED" | "SPOT_QUOTE_DIRECTION_CONFLICT" | "SPOT_QUOTE_COVERAGE_UNAVAILABLE";
+    can_reopen?: boolean;
+    message?: string | null;
+    details?: Record<string, unknown>;
+  } | null;
   incoterm: string;
   payment_term: string;
   service_scope: string;


### PR DESCRIPTION
## Scope

Adds the Phase 16E-A.1A trusted Quote-to-SPOT context foundation.

- Persists the Quote before creating a linked SPOT envelope.
- Hydrates linked SPE shipment context from the authorized persisted Quote.
- Derives missing rate components server-side.
- Reuses canonical Quote shipment metrics for actual, volumetric, and chargeable weight.
- Validates persisted shipment direction with the canonical PNG classifier.
- Rejects conflicting legacy client duplicates.
- Prevents a stale SPE from reopening after trusted Quote details change and offers a fresh review without mutating the historical snapshot.

## Root Cause

New Quote and Quote Detail previously launched SPOT without consistently supplying `quote_id`, so the frontend reconstructed shipment context and the latest linked SPE could reopen even after its Quote changed. Client-supplied missing components also lacked a single server-owned coverage derivation path.

## Changed Files

- `backend/quotes/services/spot_quote_context.py`: canonical trusted snapshot, server-side coverage derivation, hashing, direction validation, legacy-client conflict checks, and sanitised coverage-failure logging.
- `backend/quotes/spot_views.py`: linked Quote hydration, stable validation responses, and sanitised standalone validation errors.
- `backend/quotes/serializers.py`: current/stale SPE read state.
- `backend/quotes/tests/test_spot_trusted_quote_context.py`: focused trusted-context, conflict, weight, direction, access, retry, stale-snapshot, standalone, and security regression coverage.
- `backend/quotes/tests/test_spot_regression_d2d_collect.py`: complete persisted linked-Quote fixture.
- `frontend/src/app/quotes/[id]/page.tsx`: current reopen, stale refusal, fresh review, and retained route display.
- `frontend/src/app/quotes/new/page.tsx`: linked Quote launch contract.
- `frontend/src/components/forms/QuoteForm.tsx`: persisted Quote handoff.
- `frontend/src/components/quotes/SpotTriggerCards.tsx`: stale-context message and fresh-review action.
- `frontend/src/hooks/useQuoteLogic.ts`: persist Quote before creating a linked SPE.
- `frontend/src/lib/spot-types.ts`: optional linked shipment-context request type.
- `frontend/src/lib/types.ts`: SPOT context workflow response fields.
- `frontend/scripts/trusted-spot-context.test.mjs`: frontend launch and stale-reopen contract checks.

## What Was Intentionally Not Changed

- Parser prompts or source classification.
- ProductCode or ChargeAlias behavior.
- Journey planning, persistence, or route-policy enablement.
- Local-rate calculations, pricing, totals, GST, FX, CAF, margins, or public quote output.
- Finalization behavior.
- Database schema or migrations.
- Standalone SPOT compatibility.
- Phase 16E-A.1B.

## Final Verification

Automated:

- `python manage.py check` — passed.
- `python manage.py makemigrations --check --dry-run` — no changes.
- Focused trusted-context tests — **12 passed**.
- `python -m pytest quotes/tests -q` — **776 passed**.
- `python -m pytest pricing_v4/tests -q` — **276 passed**.
- `node frontend/scripts/trusted-spot-context.test.mjs` — passed.
- `node frontend/scripts/spot-resolution-state.test.mjs` — passed.
- `node frontend/scripts/exception-workspace-routing.test.mjs` — passed.
- `npm run typecheck` — passed.
- `npm run build` — passed with existing lint and browser-data warnings.
- `git diff --check` — passed.

GitHub CI:

- Backend Tests — passed.
- Frontend Checks — passed.
- Backend Container Validation — passed.
- Frontend Container Validation — passed.
- CodeQL language analyses for Python, JavaScript/TypeScript, and Actions — passed.
- Semgrep — passed.
- All three PR-specific CodeQL findings were cleared after the focused security correction.
- The aggregate CodeQL check still reports three pre-existing logging findings unchanged from `main`; they are outside this PR’s scope.

Unavailable checks under the explicitly approved Phase 16E-A.1A waiver:

- Ruff unavailable.
- Vulture unavailable.
- Graphify report/wiki absent from current base.
- Fallow missing-`node_modules` accuracy warning accepted as an environment limitation.

Manual browser verification:

- Created CAN to POM, Import, D2D, Collect, EXW, 100 kg through New Quote.
- Confirmed one Quote and one linked SPE, correct `quote_id`, server-owned CN/PG route, D2D/Collect terms, and canonical 100 kg weight.
- Confirmed refresh and unchanged Quote Detail reopen the existing SPE.
- Changed the Quote to 120 kg and confirmed `SPOT_QUOTE_CONTEXT_CHANGED` prevents stale reopen.
- Confirmed the historical SPE remained unchanged and a fresh SPE received 120 kg context.
- Created a POM to LAE domestic Standard Quote and confirmed normal direct Quote Detail navigation without SPOT.

## Risk

Linked SPE creation now fails closed when persisted Quote context is incomplete, direction is inconsistent, rate coverage cannot be evaluated, or a legacy client conflicts with trusted fields. Existing standalone SPOT creation remains available.

A pre-existing wizard review-label inconsistency was observed during manual testing; persisted backend direction classifications remained correct and this unrelated display issue was not changed.

## Rollback

Revert this PR. No schema or data migration rollback is required. Existing SPE snapshots are not rewritten by this change.

## Commercial Impact

No charge amounts, ProductCodes, pricing, totals, GST, FX, CAF, margins, inclusion rules, or public quote output changed.

## Data Impact

No migration or backfill. New linked SPEs store a server-derived immutable snapshot of their persisted Quote context. A changed Quote creates a fresh SPE instead of rewriting the prior audit snapshot.

## Audit Impact

Preserves historical SPE snapshots, records stable conflict/stale states, prevents client-authored context from silently overriding persisted Quote data, and sanitises failure logging and API error responses.