### PR TITLE
Fix Quote-linked SPOT draft loading

### DIFF
--- a/backend/quotes/services/draft_quote_adapter.py
+++ b/backend/quotes/services/draft_quote_adapter.py
@@ -24,8 +24,6 @@ def build_draft_quote_payload(spe_db: SpotPricingEnvelopeDB) -> Dict[str, Any]:
     
     # Resolve supplier name
     supplier_name = shipment_ctx.get('supplier_name')
-    if not supplier_name and spe_db.quote and spe_db.quote.carrier:
-        supplier_name = spe_db.quote.carrier.name
     if not supplier_name:
         first_batch = spe_db.source_batches.first()
         if first_batch:

--- a/backend/quotes/tests/test_spot_trusted_quote_context.py
+++ b/backend/quotes/tests/test_spot_trusted_quote_context.py
@@ -12,7 +12,8 @@ from core.tests.helpers import create_location
 from parties.models import Company, Contact
 from quotes.models import Quote
 from quotes.quote_result_contract import shipment_metrics_from_quote
-from quotes.spot_models import SpotPricingEnvelopeDB
+from quotes.services.draft_quote_adapter import get_validated_draft_quote
+from quotes.spot_models import SPESourceBatchDB, SpotPricingEnvelopeDB
 
 
 @override_settings(PASSWORD_HASHERS=["django.contrib.auth.hashers.MD5PasswordHasher"])
@@ -117,6 +118,34 @@ class TrustedQuoteSpotContextTests(APITestCase):
         self.assertEqual(
             set(context["missing_components"]),
             {"FREIGHT", "ORIGIN_LOCAL", "DESTINATION_LOCAL"},
+        )
+
+    def test_quote_linked_envelope_draft_quote_uses_source_batch_supplier(self):
+        envelope = SpotPricingEnvelopeDB.objects.create(
+            quote=self.quote,
+            status=SpotPricingEnvelopeDB.Status.DRAFT,
+            shipment_context_json={
+                "origin_code": "CAN",
+                "destination_code": "POM",
+                "origin_country": "CN",
+                "destination_country": "PG",
+                "mode": "AIR",
+            },
+            shipment_context_hash="quote-linked-draft-regression",
+            expires_at=timezone.now() + timezone.timedelta(days=7),
+            created_by=self.sales,
+        )
+        SPESourceBatchDB.objects.create(
+            envelope=envelope,
+            source_kind=SPESourceBatchDB.SourceKind.AGENT,
+            source_type=SPESourceBatchDB.SourceType.TEXT,
+            label="Uploaded rates",
+        )
+
+        draft_quote = get_validated_draft_quote(envelope)
+        self.assertEqual(
+            draft_quote.supplier_context["supplier_name"],
+            "Uploaded rates",
         )
 
     def test_conflicting_client_context_is_rejected(self):


### PR DESCRIPTION
## Superseded

This July branch is intentionally closed without merge.

The defect and regression were re-evaluated under the Phase 2 agent-skill battle test and ported onto a fresh branch from current `main`.

Replacement: #321 — **Fix quote-linked SPOT draft supplier fallback**

Why this PR is not being merged:
- its original fix was sound and historical CI was green;
- the branch predates substantial subsequent RateEngine work;
- #321 carries the same narrow semantic fix and regression on the current codebase, where current CI is the authoritative verification.

Use #321 for review and merge.