### PR TITLE
CRM Removal 1: Detach standard quote creation from CRM

### DIFF
--- a/backend/quotes/tests/test_commodity_support.py
+++ b/backend/quotes/tests/test_commodity_support.py
@@ -3,7 +3,6 @@ from decimal import Decimal
 from uuid import uuid4
 
 from django.contrib.auth import get_user_model
-from django.http import Http404
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
@@ -14,7 +13,7 @@ from core.commodity import COMMODITY_CODE_AVI, COMMODITY_CODE_DG, DEFAULT_COMMOD
 from core.dataclasses import CalculatedTotals, QuoteCharges
 from core.models import Country, Currency, FxSnapshot, Policy
 from core.tests.helpers import create_location
-from crm.models import Interaction, Opportunity
+from crm.models import Opportunity
 from parties.models import Company, Contact
 from pricing_v4.models import CommodityChargeRule, ProductCode
 from quotes.models import Quote
@@ -252,7 +251,7 @@ class QuoteCommodityPersistenceTests(TestCase):
         payload.update(overrides)
         return QuoteComputeRequest(**payload)
 
-    def test_save_quote_create_without_opportunity_auto_creates_and_links(self):
+    def test_save_quote_create_without_opportunity_creates_no_crm_records(self):
         payload = self._base_payload()
 
         quote = QuoteComputeV3APIView()._save_quote_v3(
@@ -266,26 +265,12 @@ class QuoteCommodityPersistenceTests(TestCase):
             initial_status=Quote.Status.DRAFT,
         )
 
-        self.assertIsNotNone(quote.opportunity_id)
+        self.assertIsNone(quote.opportunity_id)
         self.assertEqual(quote.customer, self.customer)
-        opportunity = quote.opportunity
-        self.assertEqual(Opportunity.objects.count(), 1)
-        self.assertEqual(opportunity.company, self.customer)
-        self.assertEqual(opportunity.service_type, "AIR")
-        self.assertEqual(opportunity.direction, Quote.ShipmentType.IMPORT)
-        self.assertEqual(opportunity.scope, "A2D")
-        self.assertEqual(opportunity.status, Opportunity.Status.NEW)
-        self.assertIn("AIR IMPORT SYD", opportunity.title)
-        self.assertIn("POM", opportunity.title)
-        self.assertTrue(
-            opportunity.interactions.filter(
-                interaction_type=Interaction.InteractionType.SYSTEM,
-                system_event_type="QUOTE_OPPORTUNITY_CREATED",
-                outcomes__contains=f"quote_id={quote.id}",
-            ).exists()
-        )
+        self.assertEqual(quote.contact, self.contact)
+        self.assertEqual(Opportunity.objects.count(), 0)
 
-    def test_save_quote_update_attaches_valid_opportunity_id(self):
+    def test_save_quote_update_does_not_resolve_supplied_opportunity_id(self):
         quote = Quote.objects.create(
             customer=self.customer,
             contact=self.contact,
@@ -316,7 +301,7 @@ class QuoteCommodityPersistenceTests(TestCase):
         )
 
         updated.refresh_from_db()
-        self.assertEqual(updated.opportunity, opportunity)
+        self.assertIsNone(updated.opportunity_id)
         self.assertEqual(Opportunity.objects.count(), before_count)
 
     def test_save_quote_update_preserves_opportunity_when_opportunity_id_omitted(self):
@@ -353,90 +338,6 @@ class QuoteCommodityPersistenceTests(TestCase):
         updated.refresh_from_db()
         self.assertEqual(updated.opportunity, opportunity)
         self.assertEqual(Opportunity.objects.count(), before_count)
-
-    def test_save_quote_recompute_without_opportunity_id_does_not_duplicate_auto_created_opportunity(self):
-        payload = self._base_payload()
-        view = QuoteComputeV3APIView()
-        quote = view._save_quote_v3(
-            request=self._build_request(),
-            validated_data=payload,
-            shipment_type=Quote.ShipmentType.IMPORT,
-            charges=self._empty_charges(),
-            snapshot=self.fx_snapshot,
-            policy=self.policy,
-            output_currency="PGK",
-            initial_status=Quote.Status.DRAFT,
-        )
-        first_opportunity = quote.opportunity
-
-        updated = view._save_quote_v3(
-            request=self._build_request(),
-            validated_data=self._base_payload(quote_id=quote.id),
-            shipment_type=Quote.ShipmentType.IMPORT,
-            charges=self._empty_charges(),
-            snapshot=self.fx_snapshot,
-            policy=self.policy,
-            output_currency="PGK",
-            initial_status=Quote.Status.DRAFT,
-            quote=quote,
-        )
-
-        updated.refresh_from_db()
-        self.assertEqual(updated.opportunity, first_opportunity)
-        self.assertEqual(Opportunity.objects.count(), 1)
-
-    def test_save_quote_domestic_air_maps_to_air_domestic_opportunity(self):
-        domestic_origin = create_location(
-            code="LAE",
-            name="Lae",
-            country=self.destination.country,
-            is_active=True,
-        )
-        payload = self._base_payload(
-            origin_location_id=domestic_origin.id,
-            destination_location_id=self.destination.id,
-            service_scope="D2D",
-        )
-
-        quote = QuoteComputeV3APIView()._save_quote_v3(
-            request=self._build_request(),
-            validated_data=payload,
-            shipment_type=Quote.ShipmentType.DOMESTIC,
-            charges=self._empty_charges(),
-            snapshot=self.fx_snapshot,
-            policy=self.policy,
-            output_currency="PGK",
-            initial_status=Quote.Status.DRAFT,
-        )
-
-        opportunity = quote.opportunity
-        self.assertEqual(opportunity.service_type, "AIR")
-        self.assertEqual(opportunity.direction, Quote.ShipmentType.DOMESTIC)
-        self.assertEqual(opportunity.scope, "D2D")
-        self.assertFalse(Opportunity.objects.filter(service_type="DOMESTIC").exists())
-
-    def test_save_quote_rejects_opportunity_customer_mismatch(self):
-        other_customer = Company.objects.create(name="Other Customer")
-        opportunity = Opportunity.objects.create(
-            company=other_customer,
-            title="Wrong customer opportunity",
-            service_type="AIR",
-            owner=self.user,
-        )
-        payload = self._base_payload(opportunity_id=opportunity.id)
-
-        with self.assertRaises(Http404):
-            QuoteComputeV3APIView()._save_quote_v3(
-                request=self._build_request(),
-                validated_data=payload,
-                shipment_type=Quote.ShipmentType.IMPORT,
-                charges=self._empty_charges(),
-                snapshot=self.fx_snapshot,
-                policy=self.policy,
-                output_currency="PGK",
-                initial_status=Quote.Status.DRAFT,
-            )
-
 
 @override_settings(RBAC_ALLOW_LEGACY_SCOPE_FALLBACK_FOR_TESTS=True)
 class QuoteCommodityAPITests(APITestCase):

--- a/backend/quotes/tests/test_crm_resilience.py
+++ b/backend/quotes/tests/test_crm_resilience.py
@@ -10,6 +10,7 @@ from rest_framework.test import APITestCase
 
 from core.models import Country, Currency
 from core.tests.helpers import create_location
+from crm.models import Interaction, Opportunity
 from parties.models import Company, Contact
 from pricing_v4.models import Carrier, DomesticCOGS, DomesticSellRate, ProductCode
 from services.models import ServiceComponent
@@ -120,54 +121,67 @@ class CRMResilienceTests(APITestCase):
             "commodity_code": "GCR",
         }
 
-    @patch("quotes.views.calculation.resolve_quote_opportunity")
-    @patch("quotes.views.calculation.logger")
-    def test_quote_creation_succeeds_when_crm_opportunity_resolution_fails(self, mock_logger, mock_resolve):
-        # Mock opportunity resolution to raise an exception
-        mock_resolve.side_effect = RuntimeError("Simulated Opportunity DB Failure")
-
+    def test_standard_quote_creation_has_no_crm_side_effects(self):
         response = self.client.post("/api/v3/quotes/compute/", self._payload(), format="json")
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.data["status"], "DRAFT")
         self.assertIsNone(response.data["opportunity"])
+        self.assertEqual(Opportunity.objects.count(), 0)
+        self.assertEqual(Interaction.objects.count(), 0)
 
-        # Assert the exception was logged
-        mock_logger.exception.assert_called()
-        log_msg = mock_logger.exception.call_args[0][0]
-        self.assertIn("CRM opportunity resolution failed during quote creation", log_msg)
+        quote = Quote.objects.get(id=response.data["id"])
+        self.assertEqual(quote.customer, self.customer)
+        self.assertEqual(quote.contact, self.contact)
+        self.assertEqual(quote.versions.get(version_number=1).lines.count(), 1)
+        totals = response.data["latest_version"]["totals"]
+        self.assertEqual(totals["total_cost_pgk"], "150.00")
+        self.assertEqual(totals["total_sell_pgk"], "225.00")
+        self.assertEqual(totals["total_sell_pgk_incl_gst"], "247.50")
 
-    @patch("quotes.views.calculation.create_auto_quote_opportunity_interaction")
-    @patch("quotes.views.calculation.logger")
-    def test_quote_creation_succeeds_when_crm_interaction_auto_creation_fails(self, mock_logger, mock_create):
-        # Mock auto interaction creation to raise an exception
-        mock_create.side_effect = ValueError("Simulated Interaction Validation Error")
-
-        # Mock resolve_quote_opportunity to return a dummy opportunity and opportunity_was_auto_created = True
-        from crm.models import Opportunity
-        dummy_opportunity = Opportunity.objects.create(
-            company=self.customer,
-            title="POM to LAE CRM opportunity",
-            service_type="AIR",
-            direction="DOMESTIC",
-            scope="A2A",
+    def test_standard_quote_recalculation_has_no_crm_side_effects_or_total_changes(self):
+        payload = self._payload()
+        created = self.client.post("/api/v3/quotes/compute/", payload, format="json")
+        self.assertEqual(created.status_code, status.HTTP_201_CREATED)
+        quote = Quote.objects.get(id=created.data["id"])
+        first_version = quote.versions.get(version_number=1)
+        first_totals = (
+            first_version.totals.total_cost_pgk,
+            first_version.totals.total_sell_pgk,
+            first_version.totals.total_sell_pgk_incl_gst,
+            first_version.totals.total_sell_fcy,
+            first_version.totals.total_sell_fcy_incl_gst,
+            first_version.totals.total_sell_fcy_currency,
         )
+        first_line_count = first_version.lines.count()
 
-        with patch("quotes.views.calculation.resolve_quote_opportunity", return_value=(dummy_opportunity, True)):
-            response = self.client.post("/api/v3/quotes/compute/", self._payload(), format="json")
+        payload["quote_id"] = str(quote.id)
+        recalculated = self.client.post("/api/v3/quotes/compute/", payload, format="json")
 
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.data["status"], "DRAFT")
-        self.assertEqual(str(response.data["opportunity"]), str(dummy_opportunity.id))
-
-        # Assert the exception was logged
-        mock_logger.exception.assert_called()
-        log_msg = mock_logger.exception.call_args[0][0]
-        self.assertIn("CRM opportunity interaction auto-creation failed", log_msg)
+        self.assertEqual(recalculated.status_code, status.HTTP_201_CREATED)
+        quote.refresh_from_db()
+        self.assertEqual(quote.versions.count(), 2)
+        self.assertEqual(quote.customer, self.customer)
+        self.assertEqual(quote.contact, self.contact)
+        self.assertIsNone(quote.opportunity_id)
+        second_version = quote.versions.get(version_number=2)
+        self.assertEqual(second_version.lines.count(), first_line_count)
+        self.assertEqual(
+            (
+                second_version.totals.total_cost_pgk,
+                second_version.totals.total_sell_pgk,
+                second_version.totals.total_sell_pgk_incl_gst,
+                second_version.totals.total_sell_fcy,
+                second_version.totals.total_sell_fcy_incl_gst,
+                second_version.totals.total_sell_fcy_currency,
+            ),
+            first_totals,
+        )
+        self.assertEqual(Opportunity.objects.count(), 0)
+        self.assertEqual(Interaction.objects.count(), 0)
 
     @patch("quotes.signals.logger")
     def test_quote_status_transition_succeeds_when_crm_sync_fails(self, mock_logger):
-        from crm.models import Opportunity
         opportunity = Opportunity.objects.create(
             company=self.customer,
             title="Transition opportunity",

--- a/backend/quotes/views/calculation.py
+++ b/backend/quotes/views/calculation.py
@@ -38,7 +38,6 @@ from pricing_v4.services.rate_selector import (
     build_rate_selection_error_payload,
 )
 
-from crm.services import create_auto_quote_opportunity_interaction, resolve_quote_opportunity
 from services.models import ServiceComponent
 from core.models import FxSnapshot, Policy, Location
 from core.commodity import DEFAULT_COMMODITY_CODE
@@ -502,41 +501,12 @@ class QuoteComputeV3APIView(generics.CreateAPIView):
             request_payload['resolved_dimensions'] = serialize_resolved_rate_dimensions(resolved_dimensions)
 
         is_new_quote = quote is None
-        origin_location = Location.objects.filter(id=validated_data.origin_location_id).first()
-        destination_location = Location.objects.filter(id=validated_data.destination_location_id).first()
-        opportunity = None
-        opportunity_was_auto_created = False
-        try:
-            opportunity, opportunity_was_auto_created = resolve_quote_opportunity(
-                customer=customer,
-                opportunity_id=validated_data.opportunity_id,
-                existing_quote=quote,
-                mode=validated_data.mode,
-                shipment_type=shipment_type,
-                service_scope=validated_data.service_scope,
-                origin_location=origin_location,
-                destination_location=destination_location,
-                actor=request.user,
-                quote_status=initial_status,
-                persist=True,
-            )
-        except Http404:
-            raise
-        except Exception as exc:
-            logger.exception(
-                "CRM opportunity resolution failed during quote creation. Proceeding without opportunity link. Customer ID: %s, Shipment Type: %s, Error: %s",
-                validated_data.customer_id,
-                shipment_type,
-                exc,
-            )
-
         if is_new_quote:
             create_scope = resolve_create_scope_for_user(request.user)
             # --- Create the Quote object ---
             quote = Quote.objects.create(
                 customer=customer,
                 contact=contact,
-                opportunity=opportunity,
                 mode=validated_data.mode,
                 shipment_type=shipment_type, # <-- Save calculated type
                 incoterm=validated_data.incoterm,
@@ -562,7 +532,6 @@ class QuoteComputeV3APIView(generics.CreateAPIView):
             # Update the existing quote details and append a new version
             quote.customer = customer
             quote.contact = contact
-            quote.opportunity = opportunity
             quote.mode = validated_data.mode
             quote.shipment_type = shipment_type
             quote.incoterm = validated_data.incoterm
@@ -589,7 +558,6 @@ class QuoteComputeV3APIView(generics.CreateAPIView):
             quote.save(update_fields=[
                 'customer',
                 'contact',
-                'opportunity',
                 'mode',
                 'shipment_type',
                 'incoterm',
@@ -612,17 +580,6 @@ class QuoteComputeV3APIView(generics.CreateAPIView):
 
             latest_version = quote.versions.order_by('-version_number').first()
             version_number = 1 if latest_version is None else latest_version.version_number + 1
-
-        if opportunity and opportunity_was_auto_created:
-            try:
-                create_auto_quote_opportunity_interaction(opportunity, quote, request.user)
-            except Exception as exc:
-                logger.exception(
-                    "CRM opportunity interaction auto-creation failed. Quote ID: %s, Opportunity ID: %s, Error: %s",
-                    getattr(quote, "id", None),
-                    opportunity.id,
-                    exc,
-                )
 
         # Create the QuoteVersion
         version = QuoteVersion.objects.create(


### PR DESCRIPTION
## Scope

Detach standard/non-SPOT quote creation and recalculation from CRM Opportunity resolution/creation and automatic CRM Interaction logging.

## Changed Files

- `backend/quotes/views/calculation.py`: remove CRM Opportunity resolution/assignment and automatic Interaction logging from standard quote persistence.
- `backend/quotes/tests/test_crm_resilience.py`: prove standard creation/recalculation perform no CRM writes while preserving customer, contact, lines, and exact totals.
- `backend/quotes/tests/test_commodity_support.py`: align persistence tests with CRM-independent standard quoting and verify existing Opportunity links remain untouched.

## Behaviour Changed

Standard quote creation now proceeds directly from validated customer/contact data into normal Quote/QuoteVersion persistence without CRM Opportunity or Interaction side effects.

Standard recalculation no longer resolves or changes an Opportunity. Existing Opportunity relationships already stored on Quotes remain untouched.

## What Was Intentionally Not Changed

- `Quote.opportunity` and `opportunity_id`
- Quote lifecycle CRM signals
- SPOT/SPE CRM coupling
- CRM models, APIs, frontend, RBAC, or migrations
- ProductCodes or ChargeAlias
- Pricing, customer-specific rates, FX, CAF, GST, margins, rounding, minimums, or quote totals
- Public quote or PDF rendering

## Verification

Automated:

- `python manage.py check` — PASS
- Focused CRM/commodity tests — 18 PASS
- Pricing/FX/selector regressions — 46 PASS
- Full quote suite — 528 PASS
- `makemigrations --check --dry-run` — PASS, no changes detected
- `git diff --check` — PASS
- Graphify update — PASS, 10,388 nodes / 26,866 edges / 776 communities
- Targeted Ruff — unavailable in this environment (`No module named ruff`)

Exact standard quote regression values:

- Cost: `150.00`
- Sell: `225.00`
- Sell including GST: `247.50`

Recalculation tests verify line count and every persisted PGK/foreign-currency total remain identical.

Manual:

- Exercised standard quote creation through `/api/v3/quotes/compute/`; confirmed customer/contact persistence, one line, exact totals, and zero Opportunity/Interaction rows.
- Recalculated the persisted quote through the same endpoint; confirmed two QuoteVersions, unchanged line count and totals, unchanged customer/contact, and zero CRM rows.

## Commercial Impact

None. No rate, pricing, FX, CAF, GST, margin, or quote-total behavior changed.

## Data Impact

None. No migration or model change.

## Risk

Low and contained to the standard quote orchestration layer. Existing quote Opportunity links are preserved during recalculation.

## Rollback

Revert commit `f39860f9`.
