### PR TITLE
CRM Removal 2: Detach SPOT/SPE quote persistence from CRM

### DIFF
--- a/backend/quotes/spot_views.py
+++ b/backend/quotes/spot_views.py
@@ -2748,7 +2748,6 @@ class SpotEnvelopeCreateQuoteAPIView(APIView):
         from core.models import Location
         from quotes.models import Quote, QuoteVersion, QuoteLine, QuoteTotal, ServiceComponent
         from parties.models import Company, Contact
-        from crm.services import create_auto_quote_opportunity_interaction, resolve_quote_opportunity
         from uuid import UUID
         from datetime import date
         
@@ -3002,36 +3001,6 @@ class SpotEnvelopeCreateQuoteAPIView(APIView):
                 status=status.HTTP_400_BAD_REQUEST
             )
 
-        customer = get_object_or_404(scoped_customers, id=cust_id)
-        raw_opportunity_id = (
-            request.data.get('opportunity_id')
-            or quote_data.get('opportunity_id')
-        )
-        if raw_opportunity_id:
-            try:
-                opportunity_id = UUID(str(raw_opportunity_id))
-            except (TypeError, ValueError):
-                return Response(
-                    {'error': f'Invalid opportunity_id: {raw_opportunity_id}'},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-        else:
-            opportunity_id = None
-
-        opportunity, opportunity_was_auto_created = resolve_quote_opportunity(
-            customer=customer,
-            opportunity_id=opportunity_id,
-            existing_quote=spe_db.quote,
-            mode='AIR',
-            shipment_type=shipment_type,
-            service_scope=shipment.service_scope,
-            origin_location=origin_loc,
-            destination_location=dest_loc,
-            actor=request.user,
-            quote_status=Quote.Status.DRAFT,
-            persist=True,
-        )
-
         # --- 2. Create/Update Quote ---
         if spe_db.quote:
             quote = spe_db.quote
@@ -3042,7 +3011,6 @@ class SpotEnvelopeCreateQuoteAPIView(APIView):
             quote.payment_term = shipment.payment_term
             quote.service_scope = shipment.service_scope
             quote.shipment_type = shipment_type
-            quote.opportunity = opportunity
             quote.origin_location = origin_loc
             quote.destination_location = dest_loc
             quote.request_details_json = quote_request_payload
@@ -3054,7 +3022,6 @@ class SpotEnvelopeCreateQuoteAPIView(APIView):
                 'payment_term',
                 'service_scope',
                 'shipment_type',
-                'opportunity',
                 'origin_location',
                 'destination_location',
                 'request_details_json',
@@ -3067,7 +3034,6 @@ class SpotEnvelopeCreateQuoteAPIView(APIView):
                 destination_location=dest_loc,
                 shipment_type=shipment_type,
                 mode='AIR',
-                opportunity=opportunity,
                 incoterm=shipment.incoterm,
                 payment_term=shipment.payment_term,
                 service_scope=shipment.service_scope,
@@ -3080,9 +3046,6 @@ class SpotEnvelopeCreateQuoteAPIView(APIView):
             )
             spe_db.quote = quote
             spe_db.save()
-
-        if opportunity_was_auto_created:
-            create_auto_quote_opportunity_interaction(opportunity, quote, request.user)
 
         # --- 3. Create Version ---
         # Determine version number

--- a/backend/quotes/tests/test_spot_compute_completeness.py
+++ b/backend/quotes/tests/test_spot_compute_completeness.py
@@ -683,7 +683,7 @@ def test_spot_create_quote_rejects_contact_from_another_customer(monkeypatch):
     assert response.json()["error"] == "Selected contact is not available for this customer/user."
 
 
-def test_spot_create_quote_auto_creates_and_links_opportunity(monkeypatch):
+def test_spot_create_quote_does_not_create_crm_records(monkeypatch):
     user, origin, destination = _setup_user_and_locations()
     spe = _create_ready_spe(
         user=user,
@@ -698,7 +698,7 @@ def test_spot_create_quote_auto_creates_and_links_opportunity(monkeypatch):
         "calculate_charges",
         lambda self: _quote_charges_for_buckets(["origin_charges", "airfreight", "destination_charges"]),
     )
-    customer = Company.objects.create(name="Spot Opportunity Customer", is_customer=True, company_type="CUSTOMER")
+    customer = Company.objects.create(name="CRM Independent Spot Customer", is_customer=True, company_type="CUSTOMER")
     client = APIClient()
     client.force_authenticate(user=user)
 
@@ -710,18 +710,70 @@ def test_spot_create_quote_auto_creates_and_links_opportunity(monkeypatch):
 
     assert response.status_code == 200
     quote = Quote.objects.get(id=response.json()["quote_id"])
-    opportunity = quote.opportunity
-    assert opportunity is not None
-    assert opportunity.company == customer
-    assert opportunity.service_type == "AIR"
-    assert opportunity.direction == Quote.ShipmentType.IMPORT
-    assert opportunity.scope == "D2D"
-    assert opportunity.interactions.filter(
-        interaction_type=Interaction.InteractionType.SYSTEM,
-        system_event_type="QUOTE_OPPORTUNITY_CREATED",
-        outcomes__contains=f"quote_id={quote.id}",
-    ).exists()
-    assert not Opportunity.objects.filter(service_type="DOMESTIC").exists()
+    version = quote.versions.get(version_number=1)
+    totals = version.totals
+
+    assert quote.opportunity_id is None
+    assert Opportunity.objects.count() == 0
+    assert Interaction.objects.count() == 0
+    assert version.lines.count() == 3
+    assert totals.total_cost_pgk == Decimal("0.00")
+    assert totals.total_sell_pgk == Decimal("30.00")
+    assert totals.total_sell_pgk_incl_gst == Decimal("30.00")
+    assert totals.total_sell_fcy == Decimal("30.00")
+    assert totals.total_sell_fcy_incl_gst == Decimal("30.00")
+
+
+def test_spot_create_quote_preserves_existing_opportunity_link(monkeypatch):
+    user, origin, destination = _setup_user_and_locations()
+    customer = Company.objects.create(name="Linked Spot Customer", is_customer=True, company_type="CUSTOMER")
+    opportunity = Opportunity.objects.create(
+        company=customer,
+        title="Existing SPOT opportunity",
+        service_type="AIR",
+    )
+    quote = Quote.objects.create(
+        customer=customer,
+        origin_location=origin,
+        destination_location=destination,
+        shipment_type=Quote.ShipmentType.IMPORT,
+        mode="AIR",
+        opportunity=opportunity,
+        status=Quote.Status.INCOMPLETE,
+        created_by=user,
+    )
+    spe = _create_ready_spe(
+        user=user,
+        origin_code=origin.code,
+        dest_code=destination.code,
+        origin_country="AU",
+        dest_country="PG",
+        service_scope="D2D",
+    )
+    spe.quote = quote
+    spe.save(update_fields=["quote"])
+    monkeypatch.setattr(
+        PricingServiceV4Adapter,
+        "calculate_charges",
+        lambda self: _quote_charges_for_buckets(["origin_charges", "airfreight", "destination_charges"]),
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+    initial_opportunity_count = Opportunity.objects.count()
+    initial_interaction_count = Interaction.objects.count()
+
+    response = client.post(
+        f"/api/v3/spot/envelopes/{spe.id}/create-quote/",
+        {"quote_request": {"service_scope": "D2D", "payment_term": "PREPAID"}},
+        format="json",
+    )
+
+    assert response.status_code == 200
+    quote.refresh_from_db()
+    assert quote.opportunity_id == opportunity.id
+    assert Opportunity.objects.count() == initial_opportunity_count
+    assert Interaction.objects.count() == initial_interaction_count
+    assert quote.versions.get(version_number=1).lines.count() == 3
 
 
 def test_spot_create_quote_allows_matched_exact_alias_line(monkeypatch):


### PR DESCRIPTION
## Summary

- Detaches active SPOT/SPE quote persistence from CRM Opportunity resolution and creation.
- Removes automatic CRM Interaction logging from the SPOT persistence endpoint.
- Preserves any existing `Quote.opportunity` relationship without replacing or detaching it.

## Intentionally unchanged

- V4 pricing, quote lines, totals, GST, FX, CAF, margins, and customer-specific pricing
- ProductCode mapping and requests, source evidence, trusted quote context, Exception Workspace, and safety gates
- Draft quote and finalization behavior
- Quote lifecycle CRM signals in `backend/quotes/signals.py` (reserved for PR 3)
- Database schema, CRM models/APIs/frontend/RBAC, public quote output, and PDF output

## Verification

- `python backend/manage.py check` — passed
- `python backend/manage.py makemigrations --check --dry-run` — no changes detected
- Focused SPOT persistence module — 21 passed
- Trusted context, Exception Workspace, SPOT flow/regression, and Draft Quote suites — 47 passed
- Full `quotes.tests` suite — 528 passed
- `git diff --check` — passed
- Graphify update — completed (10,388 nodes, 26,869 edges)

No schema changes. This is PR 2 only; PR 3 has not been started.
