### PR TITLE
CRM Removal 3: Detach quote lifecycle from CRM

### DIFF
--- a/backend/quotes/signals.py
+++ b/backend/quotes/signals.py
@@ -4,133 +4,13 @@ Django signals for Quote lifecycle event tracking.
 Auto-creates QuoteEvent entries when quote status changes.
 """
 
-import logging
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 
 from .models import Quote, QuoteEvent
 
-logger = logging.getLogger(__name__)
-
 # Store original status before save
 _original_statuses = {}
-
-
-def _crm_quote_summary(instance: Quote, event_label: str) -> str:
-    quote_label = instance.quote_number or str(instance.id)
-    return f"Quote {quote_label} {event_label}."
-
-
-def _sync_crm_for_quote_event(instance: Quote, event_type: str, user=None) -> None:
-    opportunity = getattr(instance, "opportunity", None)
-    if not opportunity:
-        return
-
-    try:
-        from crm.models import Opportunity
-        from crm.services import (
-            create_quote_system_interaction,
-            mark_opportunity_lost,
-            mark_opportunity_quoted,
-            mark_opportunity_won,
-        )
-        from quotes.state_machine import ACTIVE_STATES
-
-        quote_id_outcome = f"quote_id={instance.id}"
-
-        if event_type == QuoteEvent.EventType.CREATED:
-            create_quote_system_interaction(
-                opportunity,
-                instance,
-                user,
-                "QUOTE_CREATED",
-                _crm_quote_summary(instance, "created"),
-                outcomes=quote_id_outcome,
-            )
-            return
-
-        if event_type == QuoteEvent.EventType.FINALIZED:
-            create_quote_system_interaction(
-                opportunity,
-                instance,
-                user,
-                "QUOTE_FINALIZED",
-                _crm_quote_summary(instance, "finalized"),
-                outcomes=quote_id_outcome,
-            )
-            mark_opportunity_quoted(opportunity, quote=instance, actor=user)
-            return
-
-        if event_type == QuoteEvent.EventType.SENT:
-            create_quote_system_interaction(
-                opportunity,
-                instance,
-                user,
-                "QUOTE_SENT",
-                _crm_quote_summary(instance, "sent"),
-                outcomes=quote_id_outcome,
-            )
-            mark_opportunity_quoted(opportunity, quote=instance, actor=user)
-            return
-
-        if event_type == QuoteEvent.EventType.ACCEPTED:
-            create_quote_system_interaction(
-                opportunity,
-                instance,
-                user,
-                "QUOTE_ACCEPTED",
-                _crm_quote_summary(instance, "accepted"),
-                outcomes=quote_id_outcome,
-            )
-            mark_opportunity_won(
-                opportunity,
-                actor=user,
-                reason=f"Quote {instance.quote_number or instance.id} accepted.",
-                source_type="QUOTE_ACCEPTED",
-                source_id=str(instance.id),
-            )
-            return
-
-        if event_type == QuoteEvent.EventType.LOST:
-            create_quote_system_interaction(
-                opportunity,
-                instance,
-                user,
-                "QUOTE_LOST",
-                _crm_quote_summary(instance, "lost"),
-                outcomes=quote_id_outcome,
-            )
-            opportunity.refresh_from_db()
-            if opportunity.status in {Opportunity.Status.WON, Opportunity.Status.LOST}:
-                return
-            has_other_active_quotes = instance.opportunity.quotes.exclude(pk=instance.pk).filter(
-                status__in=ACTIVE_STATES,
-            ).exists()
-            if not has_other_active_quotes:
-                mark_opportunity_lost(
-                    opportunity,
-                    actor=user,
-                    reason=f"Quote {instance.quote_number or instance.id} marked lost.",
-                )
-            return
-
-        if event_type == QuoteEvent.EventType.EXPIRED:
-            create_quote_system_interaction(
-                opportunity,
-                instance,
-                user,
-                "QUOTE_EXPIRED",
-                _crm_quote_summary(instance, "expired"),
-                outcomes=quote_id_outcome,
-            )
-    except Exception as exc:
-        logger.exception(
-            "CRM event synchronization failed. Quote ID: %s, Customer ID: %s, Event: %s, Error: %s",
-            instance.id,
-            getattr(instance.customer, "id", None),
-            event_type,
-            exc,
-        )
 
 
 @receiver(pre_save, sender=Quote)
@@ -172,14 +52,6 @@ def create_quote_event(sender, instance, created, **kwargs):
             event_type=QuoteEvent.EventType.CREATED,
             metadata={'initial_status': instance.status}
         )
-        try:
-            _sync_crm_for_quote_event(instance, QuoteEvent.EventType.CREATED, user=instance.created_by)
-        except Exception as exc:
-            logger.exception(
-                "CRM post-save sync failed during quote creation. Quote ID: %s, Error: %s",
-                instance.id,
-                exc,
-            )
     elif original_status and original_status != instance.status:
         # Status changed
         event_type = status_to_event.get(instance.status)
@@ -202,12 +74,3 @@ def create_quote_event(sender, instance, created, **kwargs):
                     'new_status': instance.status
                 }
             )
-            try:
-                _sync_crm_for_quote_event(instance, event_type, user=user)
-            except Exception as exc:
-                logger.exception(
-                    "CRM post-save sync failed during status transition. Quote ID: %s, Event: %s, Error: %s",
-                    instance.id,
-                    event_type,
-                    exc,
-                )

--- a/backend/quotes/tests/test_crm_resilience.py
+++ b/backend/quotes/tests/test_crm_resilience.py
@@ -2,7 +2,6 @@
 
 from datetime import date, timedelta
 from decimal import Decimal
-from unittest.mock import patch
 from django.contrib.auth import get_user_model
 from django.test import override_settings
 from rest_framework import status
@@ -14,7 +13,7 @@ from crm.models import Interaction, Opportunity
 from parties.models import Company, Contact
 from pricing_v4.models import Carrier, DomesticCOGS, DomesticSellRate, ProductCode
 from services.models import ServiceComponent
-from quotes.models import Quote
+from quotes.models import Quote, QuoteEvent
 
 
 @override_settings(RBAC_ALLOW_LEGACY_SCOPE_FALLBACK_FOR_TESTS=True)
@@ -180,16 +179,14 @@ class CRMResilienceTests(APITestCase):
         self.assertEqual(Opportunity.objects.count(), 0)
         self.assertEqual(Interaction.objects.count(), 0)
 
-    @patch("quotes.signals.logger")
-    def test_quote_status_transition_succeeds_when_crm_sync_fails(self, mock_logger):
+    def _create_linked_quote(self, title):
         opportunity = Opportunity.objects.create(
             company=self.customer,
-            title="Transition opportunity",
+            title=title,
             service_type="AIR",
             direction="DOMESTIC",
             scope="A2A",
         )
-        # Create a Quote in DRAFT status
         quote = Quote.objects.create(
             customer=self.customer,
             contact=self.contact,
@@ -202,37 +199,75 @@ class CRMResilienceTests(APITestCase):
             created_by=self.user,
             opportunity=opportunity,
         )
+        return quote, opportunity
 
-        # Transition status to FINALIZED while post-save CRM sync raises an exception
-        with patch("quotes.signals._sync_crm_for_quote_event", side_effect=RuntimeError("Simulated Post-Save CRM Event Sync Failure")) as mock_sync:
-            transition_payload = {
-                "action": "finalize",
-            }
-            response = self.client.post(
-                f"/api/v3/quotes/{quote.id}/transition/",
-                transition_payload,
-                format="json",
-            )
-
+    def _transition(self, quote, action, expected_status):
+        response = self.client.post(
+            f"/api/v3/quotes/{quote.id}/transition/",
+            {"action": action},
+            format="json",
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["status"], "FINALIZED")
+        self.assertEqual(response.data["status"], expected_status)
+        quote.refresh_from_db()
 
-        # Now test that the internal post-save signal try-except catch works when NOT mocked from the outside
-        with patch("crm.services.create_quote_system_interaction", side_effect=ValueError("Sync Database Down")):
-            # Reset transition to SENT
-            sent_payload = {
-                "action": "send",
-            }
-            res_sent = self.client.post(
-                f"/api/v3/quotes/{quote.id}/transition/",
-                sent_payload,
-                format="json",
-            )
-            # Should transition successfully despite CRM post-save interaction logging raising ValueError
-            self.assertEqual(res_sent.status_code, status.HTTP_200_OK)
-            self.assertEqual(res_sent.data["status"], "SENT")
-            
-            # Assert the exception was cleanly logged
-            mock_logger.exception.assert_called()
-            log_msg = mock_logger.exception.call_args[0][0]
-            self.assertIn("CRM event synchronization failed", log_msg)
+    def _assert_event(self, quote, event_type, previous_status, new_status):
+        event = quote.events.get(event_type=event_type)
+        self.assertEqual(event.quote, quote)
+        self.assertEqual(event.user, self.user)
+        self.assertEqual(event.metadata["previous_status"], previous_status)
+        self.assertEqual(event.metadata["new_status"], new_status)
+
+    def _assert_crm_unchanged(self, quote, opportunity, opportunity_count):
+        quote.refresh_from_db()
+        opportunity.refresh_from_db()
+        self.assertEqual(quote.opportunity_id, opportunity.id)
+        self.assertEqual(opportunity.status, Opportunity.Status.NEW)
+        self.assertEqual(Opportunity.objects.count(), opportunity_count)
+        self.assertEqual(Interaction.objects.count(), 0)
+
+    def test_quote_creation_preserves_native_event_without_crm_sync(self):
+        quote, opportunity = self._create_linked_quote("Created event opportunity")
+
+        event = quote.events.get(event_type=QuoteEvent.EventType.CREATED)
+        self.assertEqual(event.quote, quote)
+        self.assertEqual(event.user, self.user)
+        self.assertEqual(event.metadata, {"initial_status": Quote.Status.DRAFT})
+        self._assert_crm_unchanged(quote, opportunity, opportunity_count=1)
+
+    def test_finalized_sent_and_accepted_events_do_not_sync_crm(self):
+        quote, opportunity = self._create_linked_quote("Accepted path opportunity")
+        opportunity_count = Opportunity.objects.count()
+
+        self._transition(quote, "finalize", Quote.Status.FINALIZED)
+        self._assert_event(quote, QuoteEvent.EventType.FINALIZED, Quote.Status.DRAFT, Quote.Status.FINALIZED)
+        self._assert_crm_unchanged(quote, opportunity, opportunity_count)
+
+        self._transition(quote, "send", Quote.Status.SENT)
+        self._assert_event(quote, QuoteEvent.EventType.SENT, Quote.Status.FINALIZED, Quote.Status.SENT)
+        self._assert_crm_unchanged(quote, opportunity, opportunity_count)
+
+        self._transition(quote, "mark_won", Quote.Status.ACCEPTED)
+        self._assert_event(quote, QuoteEvent.EventType.ACCEPTED, Quote.Status.SENT, Quote.Status.ACCEPTED)
+        self._assert_crm_unchanged(quote, opportunity, opportunity_count)
+
+    def test_lost_event_does_not_sync_crm(self):
+        quote, opportunity = self._create_linked_quote("Lost path opportunity")
+        opportunity_count = Opportunity.objects.count()
+
+        self._transition(quote, "finalize", Quote.Status.FINALIZED)
+        self._transition(quote, "send", Quote.Status.SENT)
+        self._transition(quote, "mark_lost", Quote.Status.LOST)
+
+        self._assert_event(quote, QuoteEvent.EventType.LOST, Quote.Status.SENT, Quote.Status.LOST)
+        self._assert_crm_unchanged(quote, opportunity, opportunity_count)
+
+    def test_expired_event_does_not_sync_crm(self):
+        quote, opportunity = self._create_linked_quote("Expired path opportunity")
+        opportunity_count = Opportunity.objects.count()
+
+        self._transition(quote, "finalize", Quote.Status.FINALIZED)
+        self._transition(quote, "mark_expired", Quote.Status.EXPIRED)
+
+        self._assert_event(quote, QuoteEvent.EventType.EXPIRED, Quote.Status.FINALIZED, Quote.Status.EXPIRED)
+        self._assert_crm_unchanged(quote, opportunity, opportunity_count)


### PR DESCRIPTION
## Summary

- Native QuoteEvent lifecycle tracking remains intact.
- CRM Interaction mirroring removed.
- Lifecycle events no longer change Opportunity status.
- Existing Quote.opportunity untouched.
- Standard quote/SPOT detachment completed in PR1/PR2.
- No pricing/schema changes.
- Quote.opportunity/opportunity_id temporarily remain for PR4.

## Verification

- python backend/manage.py check
- python backend/manage.py makemigrations --check --dry-run
- python backend/manage.py test quotes.tests.test_crm_resilience (6 passed)
- pytest backend/quotes/tests/test_state_machine.py -q (31 passed)
- python backend/manage.py test quotes.tests --verbosity 1 (531 passed)
- git diff --check
- post-change graphify update and query

## Scope

This PR removes only quote lifecycle CRM side effects from backend/quotes/signals.py while preserving native lifecycle event creation, metadata, user attribution, existing Opportunity links, and all quote state-machine behavior.