### PR TITLE
Phase 2: add commercial verification agent skills

### DIFF
--- a/.codex/skills/pricing-change-verification/SKILL.md
+++ b/.codex/skills/pricing-change-verification/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: pricing-change-verification
+description: Verify RateEngine pricing changes that can affect rates, COGS, SELL, FX, CAF, margin, GST, charge grouping, inclusion, SPOT replacement, persisted quote lines, or customer-facing totals. Use after implementing or reviewing a pricing-impacting change; do not use for documentation-only or clearly non-commercial edits.
+---
+
+# Pricing Change Verification
+
+## Purpose
+
+Prove the commercial effect of a pricing change instead of relying on generic test success. Verification must show what changed, what did not change, and whether any unrelated quote component moved unexpectedly.
+
+## Trigger
+
+Use when work changes or could change:
+
+- rate selection or matching;
+- COGS or SELL values;
+- currency or FX handling;
+- CAF, margin, GST, tax, or rounding;
+- ProductCode or ChargeAlias behavior that affects pricing;
+- charge inclusion, exclusion, grouping, or ordering;
+- SPOT freight replacement;
+- adapter mapping or persisted quote lines; or
+- customer-facing quote totals, PDFs, or public quote output.
+
+Do not invoke for documentation-only edits, isolated styling changes, or code changes that cannot reasonably affect commercial output.
+
+## Required Context
+
+Before verification:
+
+1. Read the root `AGENTS.md` and `backend/pricing_v4/AGENTS.md`.
+2. Identify the exact pricing path changed and the affected quote scenario.
+3. Inspect current selector, engine, adapter, persistence, and output code relevant to the change.
+4. Identify the commercial baseline that should remain unchanged unless the task explicitly changes it.
+
+Do not invent a missing rate, rule, ProductCode, ChargeAlias, currency assumption, or expected total in order to complete verification.
+
+## Workflow
+
+### 1. Define the commercial scenario
+
+Record the smallest realistic scenario that exercises the change, including as applicable:
+
+- origin and destination;
+- import/export direction;
+- mode and service;
+- cargo/commodity;
+- weight, volume, container, or other rating inputs;
+- currency;
+- standard versus SPOT pricing;
+- relevant ProductCodes or charge buckets; and
+- customer-facing output being checked.
+
+Prefer an existing fixture or known test scenario over constructing artificial data.
+
+### 2. Trace the full pricing path
+
+Trace the affected value through:
+
+```text
+normalized quote input
+→ selector criteria
+→ selected COGS / SELL source
+→ pricing engine calculation
+→ FX / CAF / margin / GST / rounding
+→ adapter mapping
+→ persisted quote lines
+→ public / PDF / customer-facing output
+```
+
+Skip stages that genuinely do not apply, but state that they were not applicable.
+
+### 3. Verify rate selection
+
+Where rate selection is involved, prove:
+
+- the intended row is selected deterministically;
+- no broader fallback was introduced;
+- COGS and SELL remain sourced independently;
+- missing coverage remains explicit rather than silently replaced; and
+- commodity or ProductCode behavior comes from canonical definitions rather than name matching or guesswork.
+
+### 4. Verify commercial arithmetic
+
+Check affected values individually rather than validating only the final total. As applicable, capture before/after or expected/actual values for:
+
+```text
+COGS
+SELL
+FX
+CAF
+margin
+GST / tax
+rounding
+charge inclusion
+charge grouping
+bucket subtotal
+quote total
+```
+
+If an item is unchanged, say so explicitly when it is commercially relevant to the change.
+
+### 5. Verify SPOT replacement when applicable
+
+For hybrid/SPOT scenarios, prove that the matching standard freight bucket is replaced rather than stacked. Check both persisted quote lines and customer-facing totals. Domestic freight must not be double-counted when it is part of the replaced bucket.
+
+### 6. Run targeted automated checks
+
+Start with the narrowest relevant checks:
+
+- targeted Ruff for changed Python files;
+- affected pricing or quote tests;
+- exact selector tests where selection changed;
+- focused API or end-to-end quote tests when adapter/persistence/output changed.
+
+Run broader suites only when the scope justifies them. Do not report unrun checks as passed.
+
+### 7. Perform an end-to-end commercial check
+
+When the change can reach a generated quote, execute one realistic end-to-end scenario through the affected path. Confirm the resulting quote lines and total, not merely the HTTP status or absence of an exception.
+
+## Stop Conditions
+
+Stop the affected commercial verification and report the gap when:
+
+- no authoritative expected rate or rule exists;
+- a required ProductCode or ChargeAlias decision is unresolved;
+- mixed-currency behavior cannot be proven;
+- a missing rate is being hidden by fallback behavior;
+- the result depends on production-only data that cannot be safely inspected; or
+- unrelated commercial totals move and the cause is not understood.
+
+Do not change commercial rules merely to make a test pass.
+
+## Output
+
+Report a compact commercial verification record. Example:
+
+```text
+Scenario: CAN → POM, General Cargo, standard freight
+Change exercised: deterministic SELL selector ordering
+
+Commercial result
+- COGS: unchanged
+- SELL: unchanged
+- FX: unchanged
+- CAF: unchanged
+- Margin: unchanged
+- GST: unchanged
+- Freight subtotal: unchanged
+- Quote total delta: K0.00
+- Unrelated buckets changed: none
+
+Verification
+- targeted Ruff: passed
+- selector tests: passed
+- affected pricing tests: passed
+- end-to-end quote scenario: passed
+
+Residual risk: none identified in the exercised path
+```
+
+If values intentionally changed, state the exact before/after values and why they changed. Avoid vague conclusions such as `pricing looks correct`, `smoke tested`, or `tests pass` without the commercial evidence above.

--- a/.codex/skills/quote-regression-check/SKILL.md
+++ b/.codex/skills/quote-regression-check/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: quote-regression-check
+description: Run a focused RateEngine regression check when a change may affect quote creation, calculation, lifecycle, persisted charge lines, approvals, public quote rendering, PDFs, exports, or adjacent quote workflows. Use after implementing or reviewing quote-impacting changes; do not use for isolated documentation or unrelated infrastructure work.
+---
+
+# Quote Regression Check
+
+## Purpose
+
+Catch quote workflow regressions that targeted unit tests can miss. Verify the smallest set of realistic quote scenarios needed to prove the changed path works without disturbing adjacent commercial behavior.
+
+## Trigger
+
+Use when work changes or could affect:
+
+- quote creation or edit flows;
+- calculation inputs or outputs;
+- quote lifecycle states;
+- pricing adapters or persisted charge lines;
+- customer/party selection required for quoting;
+- approvals, finalization, reopen, or review behavior;
+- public quote rendering;
+- quote PDFs or exports;
+- standard versus SPOT quote integration; or
+- frontend workflow steps that can alter quote data or completion.
+
+Do not invoke for documentation-only edits or changes with no credible path to quote behavior.
+
+## Required Context
+
+Before regression checking:
+
+1. Read root `AGENTS.md` and any nested guide for the affected domain.
+2. Identify the exact user workflow changed.
+3. Identify one primary scenario that must work and adjacent scenarios most likely to regress.
+4. Inspect existing tests, fixtures, scripts, and Playwright flows before inventing new verification steps.
+5. Record whether the requested change is supposed to alter commercial outputs.
+
+## Workflow
+
+### 1. Define the regression surface
+
+Classify the change by affected layer:
+
+```text
+input / UI
+API / serializer / schema
+quote lifecycle
+pricing calculation
+persistence
+approval / authorization
+public rendering
+PDF / export
+```
+
+Select only the scenarios needed to cover the changed layer and its immediate downstream effects.
+
+### 2. Establish a primary scenario
+
+Use a realistic quote path with concrete inputs. Record as applicable:
+
+- customer/party;
+- origin/destination;
+- direction;
+- mode/service;
+- cargo/commodity;
+- rating inputs;
+- standard or SPOT pricing;
+- expected quote state; and
+- expected commercial output.
+
+Prefer repository fixtures or known working scenarios.
+
+### 3. Verify quote creation and persistence
+
+Confirm the quote can be created through the affected path and that key inputs persist correctly. Inspect resulting quote/charge data rather than relying only on a successful response.
+
+Where the change does not affect creation, verify the nearest relevant lifecycle entry point instead.
+
+### 4. Verify calculation behavior
+
+If pricing can be affected, invoke the `pricing-change-verification` skill and use its commercial evidence rather than duplicating its workflow here.
+
+At minimum confirm that unrelated quote buckets do not change unexpectedly.
+
+### 5. Verify lifecycle behavior
+
+Exercise the states touched by the change. Depending on scope, verify transitions such as:
+
+```text
+draft
+→ calculated/reviewable
+→ approved/finalized
+→ public/customer-visible
+```
+
+Include reopen, rejection, expiry, or other states only when the change touches them.
+
+### 6. Verify permissions when applicable
+
+For changes involving approvals, mutations, customer visibility, or object scope, test at least the relevant allowed and denied roles. Record the exact action and outcome.
+
+### 7. Verify customer-facing output
+
+When the path can reach customer output, inspect the actual rendered result:
+
+- charge descriptions;
+- quantities/units;
+- currencies;
+- subtotals/totals;
+- inclusion/exclusion behavior;
+- public quote page;
+- PDF/export content when affected.
+
+Do not assume persistence correctness guarantees rendering correctness.
+
+### 8. Verify adjacent scenarios
+
+Choose a small number of high-risk neighbors based on the change. Examples:
+
+- import versus export;
+- standard versus SPOT;
+- missing-rate versus fully rated;
+- General Cargo versus affected special cargo;
+- permitted versus denied role;
+- quote with versus without optional charge/service.
+
+Do not turn every regression check into the full product test matrix.
+
+### 9. Run targeted automation
+
+Use existing focused tests/scripts first. Depending on scope, run:
+
+- targeted backend tests;
+- relevant frontend lint/typecheck;
+- focused workflow script;
+- focused Playwright flow;
+- exact API request verification.
+
+Run broader suites only when the changed surface is broad enough to justify them.
+
+### 10. Compare intended versus unintended change
+
+Finish by separating:
+
+```text
+INTENDED
+behavior or commercial outputs deliberately changed by this task
+
+UNCHANGED
+important adjacent behavior explicitly verified as stable
+
+UNVERIFIED
+anything material that could not be exercised
+```
+
+## Stop Conditions
+
+Stop and report the affected regression check when:
+
+- the expected commercial result is not authoritative;
+- required fixture/test data is misleading or conflicts with active rules;
+- quote creation succeeds but persisted/commercial output is inconsistent;
+- unrelated quote totals change without explanation;
+- permission behavior conflicts with the active RBAC contract; or
+- customer-facing output differs from persisted quote data and the reason is unknown.
+
+Do not rewrite expected values just to match new output unless the task explicitly authorizes the commercial change.
+
+## Output
+
+Report a concise regression matrix. Example:
+
+```text
+Primary scenario
+- POM import standard quote: passed
+- quote created and inputs persisted: passed
+- calculation: passed
+- finalization: passed
+- public quote output: passed
+
+Adjacent checks
+- SPOT quote path: unchanged / passed
+- missing-rate behavior: unchanged / passed
+- denied approval role: correctly blocked
+
+Commercial impact
+- intended total changes: none
+- unexpected total changes: none
+
+Automation
+- targeted backend tests: passed
+- focused frontend workflow: passed
+
+Unverified
+- PDF export not affected by changed path; not run
+
+Residual risk
+- none identified in exercised workflows
+```
+
+Avoid conclusions such as `all good`, `basic regression passed`, or `tests green` without naming the workflows and commercial effects actually checked.

--- a/.codex/skills/spot-workflow-verification/SKILL.md
+++ b/.codex/skills/spot-workflow-verification/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: spot-workflow-verification
+description: Verify RateEngine SPE/SPOT workflow changes across intake, raw evidence, normalization, unresolved findings, operator resolution, ProductCode requests, finalization/reopen controls, V4 computation, quote creation, and SPOT freight replacement. Use after changing or reviewing SPOT workflow behavior; do not use for unrelated standard-quote work.
+---
+
+# SPOT Workflow Verification
+
+## Purpose
+
+Verify that a SPOT workflow change preserves evidence, operator control, auditability, state integrity, RBAC, and correct commercial calculation from intake through final quote output.
+
+## Trigger
+
+Use when work changes or could affect:
+
+- supplier response intake or parsing;
+- raw evidence persistence or retrieval;
+- normalized SPOT charge lines;
+- Draft Quote / Exception Workspace findings;
+- mapping, ignore, edit, classify, request, resolve, finalize, or reopen actions;
+- ProductCode request lifecycle;
+- review locks or idempotency;
+- SPE envelope persistence;
+- V4 computation using `spot_envelope_id`;
+- SPOT-to-standard freight replacement; or
+- quote creation/public output derived from SPOT.
+
+Do not use for unrelated standard quote changes that do not touch SPE/SPOT behavior.
+
+## Required Context
+
+Before verification:
+
+1. Read root `AGENTS.md` and `backend/quotes/AGENTS.md`.
+2. Read the applicable maintained SPOT contracts, especially `docs/spot-draft-quote-contract.md` and `docs/spot-draft-quote-resolve-contract.md`.
+3. Inspect the current source and tests for the exact workflow path being changed.
+4. Identify the operator role(s), expected state transition, and intended commercial effect.
+
+Treat proposal/history documents as supporting context only unless current source confirms the behavior.
+
+## Workflow
+
+### 1. Define the exercised SPOT scenario
+
+Describe one realistic scenario, including as applicable:
+
+- supplier/source input;
+- quote lane/mode/direction;
+- relevant raw charge text;
+- normalized charge values;
+- unresolved findings;
+- operator role;
+- expected resolution action;
+- expected final state; and
+- pricing bucket expected to be replaced.
+
+Prefer existing fixtures and known workflow tests.
+
+### 2. Verify evidence preservation
+
+Confirm that:
+
+- original supplier/source evidence remains available and unchanged;
+- normalization does not rewrite raw evidence;
+- parser uncertainty remains visible rather than being silently cleaned up;
+- mapping, currency, unit, rate, and coverage uncertainty is surfaced to the operator; and
+- ignored or rejected information remains auditable where the workflow contract requires it.
+
+### 3. Verify AI versus operator authority
+
+Confirm AI is limited to extraction, structuring, and suggestion. Prove that unresolved commercial decisions are not silently:
+
+- auto-mapped;
+- auto-approved;
+- auto-ignored;
+- auto-resolved; or
+- auto-finalized.
+
+Where ProductCode requests are involved, verify that request creation is not treated as approval and that pending/rejected requests remain unresolved mappings.
+
+### 4. Verify state transitions
+
+Exercise the affected transition and assert exact before/after state. Depending on scope, check:
+
+```text
+intake
+→ normalized
+→ unresolved/reviewable
+→ operator decision
+→ resolved
+→ finalized
+→ reopened (if authorized)
+```
+
+Verify finalized-review mutation locks and idempotent retries where applicable. Reopen behavior must remain manager/admin controlled according to the active contract.
+
+### 5. Verify RBAC and object scope
+
+For changed mutation or read paths, test the relevant permitted and denied roles. Record exact request/action and result. Do not treat frontend button visibility as authorization evidence.
+
+### 6. Verify SPE persistence
+
+Confirm the intended active persistence path is used and deprecated quote-scoped SPOT CRUD is not revived. Where applicable verify the correct envelope, source batch, charge line, acknowledgement, audit, or resolution records are linked to the workflow.
+
+### 7. Verify V4 computation
+
+Confirm quote calculation uses the intended SPE envelope through `PricingServiceV4Adapter` and `spot_envelope_id`. Check that resolved operator decisions are represented correctly in the calculation input.
+
+### 8. Prove SPOT replacement
+
+For any SPOT freight charge:
+
+- identify the matching standard freight bucket;
+- prove the standard freight in that bucket is replaced;
+- prove no duplicate freight line survives in persisted output; and
+- prove customer-facing totals do not contain both standard and SPOT freight for the same bucket.
+
+Include Domestic freight when it belongs to the matching bucket.
+
+### 9. Verify quote creation and output
+
+When the workflow reaches quote creation, inspect the resulting quote lines and customer-facing/public output. Verify the commercial result, not just HTTP success or a non-403 response.
+
+### 10. Run targeted checks
+
+Use the narrowest relevant quote/SPOT tests first, then expand only when required by scope. Include exact status/error assertions and state transition assertions rather than generic smoke tests.
+
+## Stop Conditions
+
+Stop the affected verification and report the unresolved issue when:
+
+- raw evidence has been lost or mutated;
+- a commercial decision lacks operator authority;
+- unresolved information is being silently accepted;
+- ProductCode approval state is ambiguous;
+- finalized mutation controls or RBAC cannot be proven;
+- the workflow uses a deprecated SPOT persistence/API path;
+- the envelope used for calculation cannot be identified; or
+- standard and SPOT freight appear to stack for the same bucket.
+
+Do not weaken safety or audit controls merely to complete the scenario.
+
+## Output
+
+Report the verification as a workflow record. Example:
+
+```text
+Scenario: supplier air-freight reply → SPOT Draft Quote → operator resolution → final quote
+Operator role: Commercial Manager
+
+Evidence
+- raw source preserved: yes
+- parser uncertainty surfaced: yes
+- unresolved mapping auto-resolved: no
+
+State
+- initial: REVIEW_REQUIRED
+- action: operator mapped charge + finalized review
+- final: FINALIZED
+- retry idempotent: yes
+
+Authority
+- permitted role: exact action returned expected success
+- denied role: exact action returned expected denial
+
+Pricing
+- SPE envelope used by V4: yes
+- matching standard freight replaced: yes
+- duplicate freight lines: none
+- unrelated quote totals changed: none
+
+Checks
+- focused SPOT tests: passed
+- exact endpoint/state assertions: passed
+- end-to-end quote output: passed
+
+Residual risk: none identified in the exercised path
+```
+
+Never summarize SPOT verification only as `endpoint works`, `not 403`, `smoke test passed`, or `quote generated`.


### PR DESCRIPTION
## Summary

Adds three reusable Codex skills for repeatable RateEngine engineering workflows:

- `pricing-change-verification` — proves commercial pricing effects instead of relying on generic test success.
- `spot-workflow-verification` — verifies SPE/SPOT evidence, operator authority, state transitions, RBAC, V4 calculation, and freight replacement.
- `quote-regression-check` — runs a focused end-to-end quote regression check and delegates detailed pricing verification to the pricing skill.

## Scope

Governance/agent workflow only. No application source, pricing logic, quote logic, database, UI, or root `AGENTS.md` behavior changed.

## Design principles

- Thin root agent guidance; detailed repeatable procedures live in skills.
- Skills describe jobs, not architecture encyclopedias.
- Each skill has a trigger, required context, workflow, stop conditions, and evidence-based output.
- Commercial verification reports exact affected values/workflows rather than vague `tests passed` conclusions.
- Skills reuse each other instead of duplicating workflows.

## Intentionally unchanged

- Root `AGENTS.md`
- `backend/pricing_v4/AGENTS.md`
- `backend/quotes/AGENTS.md`
- Existing `structural-audit` and `seed-data-change` skills
- All runtime/application code

## Verification

Documentation-only skill addition. Verified that the new paths follow the existing `.codex/skills/<skill>/SKILL.md` convention and that each skill points to the current nested agent guides/canonical workflow documents rather than introducing new architectural sources of truth.

## Risk

Low runtime risk because no executable application behavior changes. Main risk is agent-workflow quality; these skills should be exercised on real pricing/SPOT/quote tasks and refined from observed use rather than expanded speculatively.