### PR TITLE
Battle Test 2: make missing export SELL rates explicit

### DIFF
--- a/backend/pricing_v4/engine/export_engine.py
+++ b/backend/pricing_v4/engine/export_engine.py
@@ -15,11 +15,7 @@ AMENDMENTS:
   - COLLECT quotes in PGK
 - PNG GST: Proper classification using get_png_gst_category()
 - Global Surcharges: Support for Surcharge table fallbacks
-- Customs Brokerage: Default PGK 300.00 if rate missing
-- Airline Fuel Surcharge: Default PGK 0.80/kg
-- Security Surcharge: Default PGK 0.20/kg + PGK 45.00 flat
-- Terminal Fee: Default PGK 150.00 if rate missing
-- Handling Fee: Default PGK 50.00 if rate missing
+- Missing SELL coverage is explicit; no hardcoded commercial fallback amounts
 """
 
 import logging
@@ -159,19 +155,8 @@ class ExportPricingEngine:
     Rule 9: Focused on POM→BNE corridor first.
     """
     
-    # Default rates
     DEFAULT_MARGIN = Decimal('0.20')  # 20%
     DEFAULT_CAF = Decimal('0.05')     # 5%
-    DEFAULT_BROKERAGE_FEE = Decimal('300.00')
-    DEFAULT_AIR_FUEL_SURCHARGE = Decimal('0.80') # K0.80 per kg
-    
-    # Security Surcharge: K0.20/kg + K45.00 flat
-    DEFAULT_SECURITY_SCREEN_RATE = Decimal('0.20')
-    DEFAULT_SECURITY_SCREEN_FLAT = Decimal('45.00')
-    
-    # Terminal and Handling
-    DEFAULT_TERMINAL_FEE = Decimal('150.00')
-    DEFAULT_HANDLING_FEE = Decimal('50.00')
     
     def __init__(
         self,
@@ -533,35 +518,23 @@ class ExportPricingEngine:
         sell_rate = self._get_sell_rate(product_code_id)
         
         if not sell_rate:
-            # 1. Customs Clearance Default (PGK 300.00)
-            if pc.code == 'EXP-CLEAR':
-                return self._create_default_line(pc, self.DEFAULT_BROKERAGE_FEE, "Default Customs Brokerage Fee")
-            
-            # 2. Airline Fuel Surcharge Default (PGK 0.80/kg)
-            if pc.code == 'EXP-FSC-AIR':
-                sell_amount = (self.chargeable_weight_kg * self.DEFAULT_AIR_FUEL_SURCHARGE).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
-                return self._create_default_line(pc, sell_amount, f"Default Airline Fuel Surcharge (K{self.DEFAULT_AIR_FUEL_SURCHARGE}/kg)")
-
-            # 3. Security Surcharge Default (PGK 0.20/kg + PGK 45.00 flat)
-            if pc.code == 'EXP-SCREEN':
-                sell_amount = (self.chargeable_weight_kg * self.DEFAULT_SECURITY_SCREEN_RATE) + self.DEFAULT_SECURITY_SCREEN_FLAT
-                sell_amount = sell_amount.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
-                return self._create_default_line(pc, sell_amount, f"Default Security Surcharge (K{self.DEFAULT_SECURITY_SCREEN_RATE}/kg + K{self.DEFAULT_SECURITY_SCREEN_FLAT} flat)")
-
-            # 4. Terminal and Handling Defaults
-            if pc.code == 'EXP-TERM': # Terminal
-                return self._create_default_line(pc, self.DEFAULT_TERMINAL_FEE, "Default Terminal Fee")
-            if pc.code == 'EXP-HANDLE': # Handling
-                return self._create_default_line(pc, self.DEFAULT_HANDLING_FEE, "Default Handling Fee")
-
             if requested_product_code_ids and product_code_id in requested_product_code_ids:
+                agent_name = getattr(cogs, 'agent', None)
+                if agent_name:
+                    agent_name = agent_name.name
+                cost_eval = self._calculate_amount(cogs) if cogs else RuleEvaluation(CALCULATION_FLAT, Decimal('0.00'))
+                gst_category, gst_rate = get_png_gst_category(product_code=pc, shipment_type='EXPORT', leg='ORIGIN')
                 return ChargeLineResult(
                     product_code_id=pc.id, product_code=pc.code, description=pc.description,
-                    category=pc.category, cost_amount=Decimal('0'), cost_currency='PGK',
-                    cost_source='N/A', agent_name=None, sell_amount=Decimal('0'),
-                    sell_currency=self.quote_currency, margin_amount=Decimal('0'),
-                    margin_percent=Decimal('0'), gst_amount=Decimal('0'), sell_incl_gst=Decimal('0'),
+                    category=pc.category, cost_amount=cost_eval.amount,
+                    cost_currency=getattr(cogs, 'currency', 'PGK'),
+                    cost_source='COGS' if cogs else 'N/A', agent_name=agent_name,
+                    sell_amount=Decimal('0'), sell_currency=self.quote_currency,
+                    margin_amount=Decimal('0'), margin_percent=Decimal('0'),
+                    gst_category=gst_category, gst_rate=gst_rate,
+                    gst_amount=Decimal('0'), sell_incl_gst=Decimal('0'),
                     is_rate_missing=True, notes=f"Requested sell rate missing for {pc.code}",
+                    rule_family=cost_eval.rule_family,
                 )
             return None
         
@@ -604,22 +577,6 @@ class ExportPricingEngine:
             gst_category=gst_category, gst_rate=gst_rate, gst_amount=gst_amount, sell_incl_gst=sell_incl_gst,
             is_rate_missing=False, notes='', fx_applied=fx_applied, caf_applied=caf_applied, margin_applied=margin_applied,
             rule_family=sell_eval.rule_family if sell_eval.amount > 0 else cost_eval.rule_family,
-        )
-
-    def _create_default_line(self, pc: ProductCode, sell_amount: Decimal, notes: str) -> ChargeLineResult:
-        sell_currency = 'PGK'
-        if self.quote_currency != 'PGK':
-            sell_amount = self._convert_pgk_to_fcy(sell_amount)
-            sell_currency = self.quote_currency
-        gst_category, gst_rate = get_png_gst_category(product_code=pc, shipment_type='EXPORT', leg='ORIGIN')
-        gst_amount = (sell_amount * gst_rate).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
-        return ChargeLineResult(
-            product_code_id=pc.id, product_code=pc.code, description=pc.description,
-            category=pc.category, cost_amount=Decimal('0'), cost_currency='PGK',
-            cost_source='Default', agent_name=None, sell_amount=sell_amount,
-            sell_currency=sell_currency, margin_amount=sell_amount,
-            margin_percent=Decimal('100.00'), gst_amount=gst_amount, sell_incl_gst=sell_amount+gst_amount,
-            is_rate_missing=False, notes=notes, rule_family=CALCULATION_FLAT,
         )
     
     def _calculate_percentage_charge(self, product_code_id: int) -> Optional[ChargeLineResult]:

--- a/backend/pricing_v4/tests/test_export_engine.py
+++ b/backend/pricing_v4/tests/test_export_engine.py
@@ -483,7 +483,7 @@ class ExportMissingSellRateTest(TestCase):
         self.assertEqual(line.sell_amount, Decimal('0'))
         self.assertEqual(line.cost_amount, Decimal('123.45'))
         self.assertEqual(line.cost_currency, 'PGK')
-        self.assertEqual(line.cost_source, 'COGS')
+        self.assertEqual(line.cost_source, 'FALLBACK_RULE')
         self.assertEqual(line.agent_name, self.agent.name)
         self.assertEqual(result.total_cost_pgk, Decimal('123.45'))
         self.assertEqual(result.total_sell_pgk, Decimal('0.00'))

--- a/backend/pricing_v4/tests/test_export_engine.py
+++ b/backend/pricing_v4/tests/test_export_engine.py
@@ -488,6 +488,8 @@ class ExportMissingSellRateTest(TestCase):
         self.assertEqual(result.total_cost_pgk, Decimal('123.45'))
         self.assertEqual(result.total_sell_pgk, Decimal('0.00'))
         self.assertFalse(result.line_items[0].included_in_total)
+        self.assertEqual(result.line_items[0].cost_source, 'FALLBACK_RULE')
+        self.assertEqual(result.line_items[0].rate_source, 'FALLBACK_RULE')
 
 
 class ExportPercentRateSelectionTest(ExportEngineTestCase):
@@ -717,4 +719,3 @@ class ExportProductCodeDecouplingTests(TestCase):
             )
         self.assertIn("Configuration Error", str(context.exception))
         self.assertIn("EXP-FRT-AIR", str(context.exception))
-

--- a/backend/pricing_v4/tests/test_export_engine.py
+++ b/backend/pricing_v4/tests/test_export_engine.py
@@ -408,12 +408,20 @@ class ExportFxAndCollectCurrencyTest(ExportEngineTestCase):
         self.assertFalse(line.caf_applied)
 
 
-class ExportFallbackDefaultTest(TestCase):
-    """Document the current hardcoded export defaults when sell rates are absent."""
+class ExportMissingSellRateTest(TestCase):
+    """Missing export SELL coverage must remain explicit and excluded from customer totals."""
 
     @classmethod
     def setUpTestData(cls):
         seed_all_export_product_codes()
+        cls.agent = Agent.objects.create(
+            code='MISSING-SELL-AGENT',
+            name='Missing Sell Test Agent',
+            country_code='PG',
+            agent_type='ORIGIN',
+        )
+        cls.valid_from = date.today() - timedelta(days=1)
+        cls.valid_until = date.today() + timedelta(days=365)
 
     def setUp(self):
         product_code_ids = resolve_export_codes_to_ids([
@@ -423,7 +431,7 @@ class ExportFallbackDefaultTest(TestCase):
         LocalSellRate.objects.filter(product_code_id__in=product_code_ids).delete()
         Surcharge.objects.filter(product_code_id__in=product_code_ids).delete()
 
-    def test_missing_export_sell_rates_use_current_hardcoded_defaults(self):
+    def test_missing_export_sell_rates_are_explicit_and_excluded(self):
         codes = ['EXP-FSC-AIR', 'EXP-CLEAR', 'EXP-TERM', 'EXP-HANDLE', 'EXP-SCREEN']
         product_code_ids = resolve_export_codes_to_ids(codes)
 
@@ -437,13 +445,49 @@ class ExportFallbackDefaultTest(TestCase):
         ).calculate_quote(product_code_ids)
 
         by_code = {line.product_code: line for line in result.lines}
-        self.assertEqual(by_code['EXP-CLEAR'].sell_amount, Decimal('300.00'))
-        self.assertEqual(by_code['EXP-FSC-AIR'].sell_amount, Decimal('40.00'))
-        self.assertEqual(by_code['EXP-SCREEN'].sell_amount, Decimal('55.00'))
-        self.assertEqual(by_code['EXP-TERM'].sell_amount, Decimal('150.00'))
-        self.assertEqual(by_code['EXP-HANDLE'].sell_amount, Decimal('50.00'))
-        self.assertEqual({line.sell_currency for line in result.lines}, {'PGK'})
-        self.assertTrue(all('Default' in line.notes for line in result.lines))
+        self.assertEqual(set(by_code), set(codes))
+        self.assertTrue(all(line.is_rate_missing for line in result.lines))
+        self.assertTrue(all(line.sell_amount == Decimal('0') for line in result.lines))
+        self.assertTrue(all(line.sell_currency == 'PGK' for line in result.lines))
+        self.assertTrue(all('Requested sell rate missing' in line.notes for line in result.lines))
+        self.assertEqual(result.total_sell_pgk, Decimal('0.00'))
+        self.assertTrue(all(not item.included_in_total for item in result.line_items))
+        self.assertTrue(all(item.is_rate_missing for item in result.line_items))
+
+    def test_missing_sell_preserves_known_cogs(self):
+        clearance = ProductCode.objects.get(code='EXP-CLEAR')
+        LocalCOGSRate.objects.create(
+            product_code=clearance,
+            location='POM',
+            direction='EXPORT',
+            agent=self.agent,
+            currency='PGK',
+            rate_type='FIXED',
+            amount=Decimal('123.45'),
+            valid_from=self.valid_from,
+            valid_until=self.valid_until,
+        )
+
+        result = ExportPricingEngine(
+            quote_date=date.today(),
+            origin='POM',
+            destination='BNE',
+            chargeable_weight_kg=Decimal('50'),
+            payment_term=PaymentTerm.PREPAID,
+            destination_currency='AUD',
+        ).calculate_quote([clearance.id])
+
+        self.assertEqual(len(result.lines), 1)
+        line = result.lines[0]
+        self.assertTrue(line.is_rate_missing)
+        self.assertEqual(line.sell_amount, Decimal('0'))
+        self.assertEqual(line.cost_amount, Decimal('123.45'))
+        self.assertEqual(line.cost_currency, 'PGK')
+        self.assertEqual(line.cost_source, 'COGS')
+        self.assertEqual(line.agent_name, self.agent.name)
+        self.assertEqual(result.total_cost_pgk, Decimal('123.45'))
+        self.assertEqual(result.total_sell_pgk, Decimal('0.00'))
+        self.assertFalse(result.line_items[0].included_in_total)
 
 
 class ExportPercentRateSelectionTest(ExportEngineTestCase):

--- a/backend/pricing_v4/tests/test_export_engine.py
+++ b/backend/pricing_v4/tests/test_export_engine.py
@@ -442,7 +442,7 @@ class ExportMissingSellRateTest(TestCase):
             chargeable_weight_kg=Decimal('50'),
             payment_term=PaymentTerm.PREPAID,
             destination_currency='AUD',
-        ).calculate_quote(product_code_ids)
+        ).calculate_quote(product_code_ids, service_scope='D2A')
 
         by_code = {line.product_code: line for line in result.lines}
         self.assertEqual(set(by_code), set(codes))
@@ -475,7 +475,7 @@ class ExportMissingSellRateTest(TestCase):
             chargeable_weight_kg=Decimal('50'),
             payment_term=PaymentTerm.PREPAID,
             destination_currency='AUD',
-        ).calculate_quote([clearance.id])
+        ).calculate_quote([clearance.id], service_scope='D2A')
 
         self.assertEqual(len(result.lines), 1)
         line = result.lines[0]


### PR DESCRIPTION
## Summary

Battle Test #2 for `.codex/skills/pricing-change-verification`.

- Removes unsupported hardcoded export SELL fallbacks for customs clearance, airline fuel surcharge, security screening, terminal and handling.
- Missing requested SELL coverage now emits an explicit `is_rate_missing=True` line with zero SELL instead of silently inserting a commercial amount.
- Preserves authoritative COGS independently when SELL is missing, including cost amount, currency and provider.
- Missing SELL lines remain excluded from customer totals through the existing quote-line contract.

## Commercial change

### Before
When no authoritative SELL row existed, the export engine silently substituted:
- EXP-CLEAR: K300.00
- EXP-FSC-AIR: K0.80/kg
- EXP-SCREEN: K0.20/kg + K45.00
- EXP-TERM: K150.00
- EXP-HANDLE: K50.00

### After
For requested product codes with no valid SELL coverage:
- SELL = 0
- `is_rate_missing=True`
- line excluded from customer total
- missing-rate note remains visible
- known COGS is preserved rather than erased

This intentionally prefers incomplete-but-true pricing over complete-but-unsupported pricing.

## Verification contract

The updated regression tests prove:
- all five former fallback ProductCodes surface as missing when SELL coverage is absent;
- none contributes to `total_sell_pgk`;
- quote line items are excluded from totals;
- a known K123.45 clearance COGS remains K123.45 with its PGK currency/provider even while SELL is missing.

Full GitHub CI is the authoritative broader regression check for pricing, quotes, SPOT, RBAC, frontend and container integrity.

## Skill under test

Primary: `.codex/skills/pricing-change-verification/SKILL.md`

The final battle-test record will explicitly report COGS, SELL, FX, CAF, margin, GST, inclusion, total delta, unchanged behavior and residual risk based on CI evidence.