### PR TITLE
Final tuning: harden verification skills from battle tests

### DIFF
--- a/.codex/skills/pricing-change-verification/SKILL.md
+++ b/.codex/skills/pricing-change-verification/SKILL.md
@@ -33,6 +33,7 @@ Before verification:
 2. Identify the exact pricing path changed and the affected quote scenario.
 3. Inspect current selector, engine, adapter, persistence, and output code relevant to the change.
 4. Identify the commercial baseline that should remain unchanged unless the task explicitly changes it.
+5. Identify which layer owns each expected field: raw engine result, adapter/canonical quote result, persisted `QuoteLine`, or customer-facing output. Do not compare differently normalized layers as if their metadata vocabulary must be identical.
 
 Do not invent a missing rate, rule, ProductCode, ChargeAlias, currency assumption, or expected total in order to complete verification.
 
@@ -81,7 +82,20 @@ Where rate selection is involved, prove:
 - missing coverage remains explicit rather than silently replaced; and
 - commodity or ProductCode behavior comes from canonical definitions rather than name matching or guesswork.
 
-### 4. Verify commercial arithmetic
+### 4. Verify source semantics by layer
+
+When source metadata is asserted, distinguish commercial truth from normalized representation. A known COGS may remain commercially authoritative even when a canonical quote line intentionally uses a different `rate_source` to describe missing SELL coverage.
+
+For each affected layer, record the expected meaning of fields such as:
+
+- `cost_source` / `canonical_cost_source`;
+- `rate_source`;
+- `is_rate_missing`;
+- `included_in_total`.
+
+If a test disagrees with current canonical normalization but the commercial values and documented contract are correct, fix the stale expectation rather than changing runtime pricing logic to satisfy the test.
+
+### 5. Verify commercial arithmetic
 
 Check affected values individually rather than validating only the final total. As applicable, capture before/after or expected/actual values for:
 
@@ -101,11 +115,11 @@ quote total
 
 If an item is unchanged, say so explicitly when it is commercially relevant to the change.
 
-### 5. Verify SPOT replacement when applicable
+### 6. Verify SPOT replacement when applicable
 
 For hybrid/SPOT scenarios, prove that the matching standard freight bucket is replaced rather than stacked. Check both persisted quote lines and customer-facing totals. Domestic freight must not be double-counted when it is part of the replaced bucket.
 
-### 6. Run targeted automated checks
+### 7. Run targeted automated checks
 
 Start with the narrowest relevant checks:
 
@@ -114,9 +128,9 @@ Start with the narrowest relevant checks:
 - exact selector tests where selection changed;
 - focused API or end-to-end quote tests when adapter/persistence/output changed.
 
-Run broader suites only when the scope justifies them. Do not report unrun checks as passed.
+Run broader suites only when the scope justifies them. Do not report unrun checks as passed. Before merge, use CI from the current branch head as the authoritative broader regression result.
 
-### 7. Perform an end-to-end commercial check
+### 8. Perform an end-to-end commercial check
 
 When the change can reach a generated quote, execute one realistic end-to-end scenario through the affected path. Confirm the resulting quote lines and total, not merely the HTTP status or absence of an exception.
 
@@ -128,7 +142,8 @@ Stop the affected commercial verification and report the gap when:
 - a required ProductCode or ChargeAlias decision is unresolved;
 - mixed-currency behavior cannot be proven;
 - a missing rate is being hidden by fallback behavior;
-- the result depends on production-only data that cannot be safely inspected; or
+- the result depends on production-only data that cannot be safely inspected;
+- source metadata expectations mix raw-engine and canonical/persisted semantics without an identified contract; or
 - unrelated commercial totals move and the cause is not understood.
 
 Do not change commercial rules merely to make a test pass.
@@ -152,11 +167,17 @@ Commercial result
 - Quote total delta: K0.00
 - Unrelated buckets changed: none
 
+Contract result
+- raw engine source semantics: verified
+- canonical/persisted source semantics: verified
+- missing/inclusion flags: verified
+
 Verification
 - targeted Ruff: passed
 - selector tests: passed
 - affected pricing tests: passed
 - end-to-end quote scenario: passed
+- current-head CI: passed
 
 Residual risk: none identified in the exercised path
 ```

--- a/.codex/skills/quote-regression-check/SKILL.md
+++ b/.codex/skills/quote-regression-check/SKILL.md
@@ -35,6 +35,7 @@ Before regression checking:
 3. Identify one primary scenario that must work and adjacent scenarios most likely to regress.
 4. Inspect existing tests, fixtures, scripts, and Playwright flows before inventing new verification steps.
 5. Record whether the requested change is supposed to alter commercial outputs.
+6. Identify any lifecycle decision that depends on aggregate/summary fields and the underlying persisted records that should agree with them.
 
 ## Workflow
 
@@ -96,6 +97,10 @@ draft
 
 Include reopen, rejection, expiry, or other states only when the change touches them.
 
+For safety-critical lifecycle gates, do not trust only a denormalized summary flag. Cross-check the underlying latest-version records that represent the same truth. Examples include missing-rate totals versus persisted `QuoteLine.is_rate_missing` values. A stale aggregate must not permit a transition that the underlying records should block.
+
+When the same lifecycle rule can be reached through multiple entry points, prefer enforcing the invariant in the shared state/service layer and keep API/UI checks as additional guardrails rather than the sole protection.
+
 ### 6. Verify permissions when applicable
 
 For changes involving approvals, mutations, customer visibility, or object scope, test at least the relevant allowed and denied roles. Record the exact action and outcome.
@@ -121,6 +126,7 @@ Choose a small number of high-risk neighbors based on the change. Examples:
 - import versus export;
 - standard versus SPOT;
 - missing-rate versus fully rated;
+- stale aggregate versus consistent persisted records;
 - General Cargo versus affected special cargo;
 - permitted versus denied role;
 - quote with versus without optional charge/service.
@@ -137,7 +143,7 @@ Use existing focused tests/scripts first. Depending on scope, run:
 - focused Playwright flow;
 - exact API request verification.
 
-Run broader suites only when the changed surface is broad enough to justify them.
+Run broader suites only when the changed surface is broad enough to justify them. Before merge, treat CI from the current branch head as the authoritative broad regression result.
 
 ### 10. Compare intended versus unintended change
 
@@ -161,6 +167,7 @@ Stop and report the affected regression check when:
 - the expected commercial result is not authoritative;
 - required fixture/test data is misleading or conflicts with active rules;
 - quote creation succeeds but persisted/commercial output is inconsistent;
+- a lifecycle summary flag conflicts with the underlying persisted records and the safe interpretation is unclear;
 - unrelated quote totals change without explanation;
 - permission behavior conflicts with the active RBAC contract; or
 - customer-facing output differs from persisted quote data and the reason is unknown.
@@ -179,6 +186,11 @@ Primary scenario
 - finalization: passed
 - public quote output: passed
 
+Lifecycle consistency
+- aggregate completeness flag: consistent
+- persisted missing-rate lines: none
+- shared finalization invariant: enforced
+
 Adjacent checks
 - SPOT quote path: unchanged / passed
 - missing-rate behavior: unchanged / passed
@@ -191,6 +203,7 @@ Commercial impact
 Automation
 - targeted backend tests: passed
 - focused frontend workflow: passed
+- current-head CI: passed
 
 Unverified
 - PDF export not affected by changed path; not run

--- a/.codex/skills/spot-workflow-verification/SKILL.md
+++ b/.codex/skills/spot-workflow-verification/SKILL.md
@@ -35,6 +35,7 @@ Before verification:
 2. Read the applicable maintained SPOT contracts, especially `docs/spot-draft-quote-contract.md` and `docs/spot-draft-quote-resolve-contract.md`.
 3. Inspect the current source and tests for the exact workflow path being changed.
 4. Identify the operator role(s), expected state transition, and intended commercial effect.
+5. Confirm the branch is based on current `main` or explicitly account for branch age. Historical green CI on a stale branch is not sufficient evidence for merge.
 
 Treat proposal/history documents as supporting context only unless current source confirms the behavior.
 
@@ -66,7 +67,11 @@ Confirm that:
 - mapping, currency, unit, rate, and coverage uncertainty is surfaced to the operator; and
 - ignored or rejected information remains auditable where the workflow contract requires it.
 
-### 3. Verify AI versus operator authority
+### 3. Verify model and fallback assumptions
+
+For changed lookup or fallback paths, confirm every referenced relationship/field exists on the active model before relying on it. Exercise the fallback order with the exact missing-data condition that triggers it; do not assume an earlier fallback is harmless merely because a later fallback is valid.
+
+### 4. Verify AI versus operator authority
 
 Confirm AI is limited to extraction, structuring, and suggestion. Prove that unresolved commercial decisions are not silently:
 
@@ -78,7 +83,7 @@ Confirm AI is limited to extraction, structuring, and suggestion. Prove that unr
 
 Where ProductCode requests are involved, verify that request creation is not treated as approval and that pending/rejected requests remain unresolved mappings.
 
-### 4. Verify state transitions
+### 5. Verify state transitions
 
 Exercise the affected transition and assert exact before/after state. Depending on scope, check:
 
@@ -94,19 +99,19 @@ intake
 
 Verify finalized-review mutation locks and idempotent retries where applicable. Reopen behavior must remain manager/admin controlled according to the active contract.
 
-### 5. Verify RBAC and object scope
+### 6. Verify RBAC and object scope
 
 For changed mutation or read paths, test the relevant permitted and denied roles. Record exact request/action and result. Do not treat frontend button visibility as authorization evidence.
 
-### 6. Verify SPE persistence
+### 7. Verify SPE persistence
 
 Confirm the intended active persistence path is used and deprecated quote-scoped SPOT CRUD is not revived. Where applicable verify the correct envelope, source batch, charge line, acknowledgement, audit, or resolution records are linked to the workflow.
 
-### 7. Verify V4 computation
+### 8. Verify V4 computation
 
 Confirm quote calculation uses the intended SPE envelope through `PricingServiceV4Adapter` and `spot_envelope_id`. Check that resolved operator decisions are represented correctly in the calculation input.
 
-### 8. Prove SPOT replacement
+### 9. Prove SPOT replacement
 
 For any SPOT freight charge:
 
@@ -117,13 +122,13 @@ For any SPOT freight charge:
 
 Include Domestic freight when it belongs to the matching bucket.
 
-### 9. Verify quote creation and output
+### 10. Verify quote creation and output
 
 When the workflow reaches quote creation, inspect the resulting quote lines and customer-facing/public output. Verify the commercial result, not just HTTP success or a non-403 response.
 
-### 10. Run targeted checks
+### 11. Run targeted checks
 
-Use the narrowest relevant quote/SPOT tests first, then expand only when required by scope. Include exact status/error assertions and state transition assertions rather than generic smoke tests.
+Use the narrowest relevant quote/SPOT tests first, then expand only when required by scope. Include exact status/error assertions and state transition assertions rather than generic smoke tests. Before merge, rely on CI from the current branch head rather than historical results from an older base.
 
 ## Stop Conditions
 
@@ -135,7 +140,8 @@ Stop the affected verification and report the unresolved issue when:
 - ProductCode approval state is ambiguous;
 - finalized mutation controls or RBAC cannot be proven;
 - the workflow uses a deprecated SPOT persistence/API path;
-- the envelope used for calculation cannot be identified; or
+- the envelope used for calculation cannot be identified;
+- a fallback path dereferences a model field/relationship that is not part of the active model; or
 - standard and SPOT freight appear to stack for the same bucket.
 
 Do not weaken safety or audit controls merely to complete the scenario.
@@ -173,6 +179,7 @@ Checks
 - focused SPOT tests: passed
 - exact endpoint/state assertions: passed
 - end-to-end quote output: passed
+- branch freshness/current-head CI: passed
 
 Residual risk: none identified in the exercised path
 ```


### PR DESCRIPTION
## Summary

Final tuning pass for the three Phase 2 commercial verification skills after Battle Tests #1–#3.

### Battle Test #1 lesson — SPOT workflow verification
- require current-main/current-head verification rather than trusting historical green CI on a stale branch;
- verify fallback/model assumptions against the active model before relying on them.

### Battle Test #2 lesson — pricing change verification
- distinguish raw engine metadata from canonical/persisted quote metadata;
- verify source semantics by layer so stale test expectations do not drive runtime commercial changes;
- keep commercial truth (COGS/SELL/missing/inclusion/totals) separate from normalized metadata vocabulary.

### Battle Test #3 lesson — quote regression check
- cross-check lifecycle summary flags against underlying persisted records;
- enforce safety-critical lifecycle invariants in the shared state/service layer when multiple entry points exist;
- keep adjacent complete-quote behavior explicitly covered.

## Scope

Documentation/agent-workflow only. Exactly three `.codex/skills/*/SKILL.md` files changed. No runtime code, migrations, pricing logic, quote logic, SPOT logic, UI, or data changes.

## Definition of done

- lessons from all three battle tests incorporated without speculative expansion;
- branch based on current `main`;
- diff limited to the three intended skills;
- GitHub CI and Container Integrity green on the final branch head;
- no unresolved review findings;
- merged to `main`.
