### PR TITLE
SPOT baseline: persist live Quote-linked journey snapshots

### DIFF
--- a/backend/quotes/signals.py
+++ b/backend/quotes/signals.py
@@ -1,13 +1,14 @@
 # backend/quotes/signals.py
 """
-Django signals for Quote lifecycle event tracking.
-Auto-creates QuoteEvent entries when quote status changes.
+Django signals for Quote lifecycle event tracking and Quote-linked SPOT journey snapshots.
 """
 
+from django.db import connection, transaction
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 
 from .models import Quote, QuoteEvent
+from .spot_models import SpotPricingEnvelopeDB
 
 # Store original status before save
 _original_statuses = {}
@@ -74,3 +75,38 @@ def create_quote_event(sender, instance, created, **kwargs):
                     'new_status': instance.status
                 }
             )
+
+
+@receiver(post_save, sender=SpotPricingEnvelopeDB)
+def persist_quote_linked_spot_journey(sender, instance, created, **kwargs):
+    """Persist the deterministic dark-mode journey for a newly created live Quote-linked SPE.
+
+    Only server-owned Quote snapshots carry a matching ``quote_id`` inside the
+    immutable shipment context. Historical/manual fixtures without that marker
+    are deliberately left untouched rather than guessed or backfilled.
+    """
+    if not created or not instance.quote_id:
+        return
+
+    context = instance.shipment_context_json if isinstance(instance.shipment_context_json, dict) else {}
+    if str(context.get("quote_id") or "") != str(instance.quote_id):
+        return
+
+    from quotes.services.air_journey_planner import AirJourneyPlanner
+    from quotes.services.journey_persistence import ShipmentJourneyPersistenceService
+
+    try:
+        plan = AirJourneyPlanner().plan(context)
+        ShipmentJourneyPersistenceService().persist_plan(
+            plan=plan,
+            quote=instance.quote,
+            spot_envelope=instance,
+            created_by=instance.created_by,
+        )
+    except Exception:
+        # Quote-linked SPE creation is atomic in the live API. If journey
+        # persistence fails, mark that transaction for rollback so we do not
+        # commit a new live SPE without its required journey snapshot.
+        if connection.in_atomic_block:
+            transaction.set_rollback(True)
+        raise

--- a/backend/quotes/tests/test_spot_journey_contract_baseline.py
+++ b/backend/quotes/tests/test_spot_journey_contract_baseline.py
@@ -1,17 +1,25 @@
 from django.contrib.auth import get_user_model
 from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
 
 from core.models import Country
 from core.tests.helpers import create_location
 from parties.models import Company, Contact
-from quotes.models import Quote
+from quotes.models import Quote, ShipmentJourneyDB
 from quotes.services.air_journey_planner import AirJourneyPlanner
 from quotes.services.spot_quote_context import build_trusted_quote_context
+from quotes.spot_models import SpotPricingEnvelopeDB
 
 
 class SpotJourneyContractBaselineTests(TestCase):
     def setUp(self):
-        user = get_user_model().objects.create_user(username="spot-journey-baseline", password="x")
+        self.user = get_user_model().objects.create_user(
+            username="spot-journey-baseline",
+            password="x",
+            role="sales",
+            department="AIR",
+        )
         customer = Company.objects.create(name="SPOT Journey Baseline", is_customer=True)
         contact = Contact.objects.create(company=customer, first_name="SPOT", last_name="Owner")
         china = Country.objects.create(code="CN", name="China")
@@ -41,7 +49,7 @@ class SpotJourneyContractBaselineTests(TestCase):
                 }],
                 "buy_currency": "USD",
             },
-            created_by=user,
+            created_by=self.user,
         )
 
     def test_trusted_spot_snapshot_is_directly_plannable_without_client_reconstruction(self):
@@ -81,3 +89,40 @@ class SpotJourneyContractBaselineTests(TestCase):
                     (context["pickup_requested"], context["delivery_requested"]),
                     expected,
                 )
+
+    def test_live_quote_linked_spot_creation_persists_one_dark_mode_journey(self):
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        payload = {
+            "quote_id": str(self.quote.id),
+            "shipment_context": {},
+            "charges": [],
+            "trigger_code": "MISSING_SCOPE_RATES",
+            "trigger_text": "Missing required rate components",
+            "conditions": {"rate_validity_hours": 72},
+        }
+
+        first = client.post("/api/v3/spot/envelopes/", payload, format="json")
+        self.assertEqual(first.status_code, status.HTTP_201_CREATED)
+
+        envelope = SpotPricingEnvelopeDB.objects.get(id=first.data["id"])
+        journeys = ShipmentJourneyDB.objects.filter(spot_envelope=envelope)
+        self.assertEqual(journeys.count(), 1)
+
+        journey = journeys.get()
+        self.assertEqual(journey.quote_id, self.quote.id)
+        self.assertEqual(journey.pattern, "IMP_POM")
+        self.assertEqual(journey.status, ShipmentJourneyDB.Status.NEEDS_REVIEW)
+        self.assertIn("ROUTE_AUTOMATION_DISABLED", journey.blockers_json)
+        self.assertEqual(
+            list(journey.legs.values_list("leg_key", flat=True)),
+            ["01:INTERNATIONAL_IMPORT:CAN:POM"],
+        )
+        self.assertEqual(self.quote.versions.count(), 0)
+        self.assertEqual(envelope.charge_lines.count(), 0)
+
+        retry = client.post("/api/v3/spot/envelopes/", payload, format="json")
+        self.assertEqual(retry.status_code, status.HTTP_200_OK)
+        self.assertEqual(retry.data["id"], first.data["id"])
+        self.assertEqual(ShipmentJourneyDB.objects.filter(spot_envelope=envelope).count(), 1)
+        self.assertEqual(journey.legs.count(), 1)


### PR DESCRIPTION
## Summary

Continues the current-main SPOT end-to-end baseline by wiring the already-merged AirJourneyPlanner and ShipmentJourneyPersistenceService into newly created live Quote-linked SPOT envelopes, while keeping route automation dark and pricing untouched.

## Root Cause / Rationale

PR #330 made the server-owned Quote→SPOT snapshot directly consumable by `AirJourneyPlanner`, but live SPE creation still stopped before journey persistence. The Phase 16E-A journey tables and persistence service therefore remained dark infrastructure rather than part of the live Quote-linked SPOT audit trail.

## Scope of Change

- On creation of a new Quote-linked SPE with a matching server-owned `quote_id` snapshot, deterministically plan its air journey and persist that journey against both the Quote and SPE.
- Preserve historical/manual SPE fixtures that do not carry the server-owned linked-Quote marker; no guessed backfill is performed.
- Keep every route policy disabled. A clean CAN→POM plan persists as `NEEDS_REVIEW` with `ROUTE_AUTOMATION_DISABLED`, which is the intended dark-mode state.
- Add API regression coverage proving creation, parent linkage, expected leg, dark-mode blocker, zero pricing side effects, and idempotent SPE retry.

No ProductCode assignment, rate resolution, pricing orchestration, totals, GST, FX, CAF, margin, inclusion, public output, or route enablement is introduced.

## Verification Routing

- [ ] `pricing-change-verification`
- [x] `spot-workflow-verification`
- [x] `quote-regression-check`
- [ ] `seed-data-change`
- [ ] `structural-audit`
- [ ] No verification skill triggered

Routing rationale: live SPOT creation/persistence changes and adjacent Quote lifecycle/audit behavior are affected; commercial pricing is intentionally untouched.

## Verification

Automated on final head `255fe922f8f4319ef77ea1d1558612a06b8abfc6`:

- CI run #768 — **success**.
- Backend Tests — **success**, including Django checks, migrations, and full backend test step.
- Frontend Checks — **success**, including lint, type-check, and build.
- Container Integrity run #721 — **success**.
- Focused API regression: `backend/quotes/tests/test_spot_journey_contract_baseline.py` proves one live Quote-linked SPE creates one journey and one `INTERNATIONAL_IMPORT:CAN:POM` leg, with route automation still blocked.
- The regression proves identical SPE retry returns the same envelope without duplicate journey or leg rows.
- The regression proves no QuoteVersion and no SPE charge lines are created as a side effect.

Workflow / commercial evidence:

- CAN→POM Import/D2D planning remains `IMP_POM`.
- Persisted journey status is `NEEDS_REVIEW` because route policy remains disabled.
- No commercial calculation layer is invoked by this wiring.

Manual / inspection:

- Current `ShipmentJourneyPersistenceService` is idempotent by parent/fingerprint and adds the disabled-route blocker without pricing side effects.
- Live Quote-linked snapshots are identified by the immutable context `quote_id` matching the SPE parent, so older/manual fixtures are not guessed into Phase 16 journeys.
- Gemini Dispatch run #425 failed because the repository Gemini workflow still has no configured Gemini/Google authentication; it produced no application regression or review finding.
- Initial PR Readiness run #9 failed because this evidence block was still awaiting current CI. The concrete final-head evidence is now recorded and PR Readiness is being rerun.

Final-head evidence:

- Final head SHA: `255fe922f8f4319ef77ea1d1558612a06b8abfc6`
- Required CI gates on that SHA: CI #768 success; Backend Tests success; Frontend Checks success; Container Integrity #721 success.

## Intended / Unchanged / Unverified

**INTENDED**

- Newly created live Quote-linked SPEs persist one deterministic journey snapshot and ordered legs.
- Journey is linked to both Quote and SPE.
- Disabled route policy remains visible as a blocker rather than silently enabling automation.
- Identical live SPE retry remains idempotent.

**UNCHANGED**

- Charge extraction and resolution.
- ProductCode selection.
- Pricing, totals, GST, FX, CAF and margins.
- SPOT finalization rules.
- Customer-facing quote output.
- Historical/manual SPEs without the server-owned Quote marker.

**UNVERIFIED**

- Charge lines are not yet assigned to journey legs.
- Leg-aware ProductCode resolution is not yet wired into live SPOT.
- Multi-leg pricing orchestration and granular SPOT replacement remain later baseline gaps.
- Real staging UAT remains a separate launch evidence gate.

## Risk

Moderate audit-path risk because a new synchronous persistence side effect now occurs during live Quote-linked SPE creation. It remains non-commercial and dark-mode only. If journey persistence fails inside the live atomic request, the transaction is marked for rollback so a new live SPE is not intentionally committed without its journey snapshot.

## Rollback

Revert this PR. No migration or data rollback is required; no historical backfill is performed.

## Definition of Done

- [x] Intended behavior is proven, not merely implemented.
- [x] High-risk adjacent behavior is protected by evidence.
- [x] Applicable commercial/safety invariants were checked at the correct layer.
- [x] Required CI gates are green on the final head SHA.
- [x] No unresolved review findings or unexplained blockers remain.
- [x] Scope, residual risk, and rollback are accurately recorded.
